### PR TITLE
Add tokens for Arbitrum

### DIFF
--- a/packages/config/src/projects/arbitrum.ts
+++ b/packages/config/src/projects/arbitrum.ts
@@ -33,6 +33,7 @@ export const arbitrum: Project = {
         'COMP',
         'CRV',
         'DODO',
+        'DPX',
         'GNO',
         'GRT',
         'LINK',

--- a/packages/config/src/tokens.ts
+++ b/packages/config/src/tokens.ts
@@ -194,6 +194,13 @@ export const tokenList: TokenInfo[] = [
     sinceBlock: 10956992,
   },
   {
+    name: 'Dopex Governance Token',
+    symbol: 'DPX',
+    address: '0xEec2bE5c91ae7f8a338e1e5f3b5DE49d07AfdC81',
+    decimals: 18,
+    sinceBlock: 12674086,
+  },
+  {
     name: 'Dusk Network',
     symbol: 'DUSK',
     address: '0x940a2dB1B7008B6C776d4faaCa729d6d4A4AA551',


### PR DESCRIPTION
DPX: coingecko rank 235 and decent volume on Uniswap v2

I removed MIM from this PR because MIM has been moved to the Anyswap bridge, which might be a little complicated to pull values from.