### PR TITLE
Add FRAX and update tokens tracked for Boba Network

### DIFF
--- a/packages/config/src/projects/bobanetwork.ts
+++ b/packages/config/src/projects/bobanetwork.ts
@@ -16,13 +16,13 @@ export const bobanetwork: Project = {
       // Proxy__OVM_L1StandardBridge
       address: '0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00',
       sinceBlock: 13012048,
-      tokens: ['ETH', 'USDC', 'OMG', 'DAI', 'SUSHI', 'UNI', 'USDT'],
+      tokens: ['ETH', 'USDC', 'OMG', 'DAI', 'SUSHI', 'UNI', 'USDT', 'FRAX'],
     },
     {
       // Proxy__L1LiquidityPool
       address: '0x1A26ef6575B7BBB864d984D9255C069F6c361a14',
       sinceBlock: 13013879,
-      tokens: ['ETH', 'USDC', 'OMG', 'DAI', 'SUSHI', 'USDT'],
+      tokens: ['ETH', 'USDC', 'OMG', 'DAI', 'SUSHI', 'USDT', 'ZRX'],
     },
   ],
   associatedToken: 'OMG',

--- a/packages/config/src/tokens.ts
+++ b/packages/config/src/tokens.ts
@@ -228,6 +228,13 @@ export const tokenList: TokenInfo[] = [
     sinceBlock: 5072026,
   },
   {
+    name: 'Frax',
+    symbol: 'FRAX',
+    address: '0x853d955aCEf822Db058eb8505911ED77F175b99e',
+    decimals: 18,
+    sinceBlock: 11465581,
+  },
+  {
     name: 'GateChainToken',
     symbol: 'GT',
     address: '0xE66747a101bFF2dBA3697199DCcE5b743b454759',


### PR DESCRIPTION
Adds the FRAX token to the token list, and updates the list of tokens tracked for the two bridges for Boba Network.