### PR TITLE
Update tokens for Boba Network

### DIFF
--- a/packages/config/src/projects/bobanetwork.ts
+++ b/packages/config/src/projects/bobanetwork.ts
@@ -16,7 +16,21 @@ export const bobanetwork: Project = {
       // Proxy__OVM_L1StandardBridge
       address: '0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00',
       sinceBlock: 13012048,
-      tokens: ['ETH', 'USDC', 'OMG', 'DAI', 'SUSHI', 'UNI', 'USDT', 'FRAX', 'WBTC', 'FTM', 'MATIC', 'BAT', 'UST', 'ZRX'],
+      tokens: [
+        'ETH',
+        'USDC',
+        'OMG',
+        'DAI',
+        'SUSHI',
+        'UNI',
+        'USDT',
+        'FRAX',
+        'WBTC',
+        'FTM',
+        'MATIC',
+        'BAT',
+        'ZRX',
+      ],
     },
     {
       // Proxy__L1LiquidityPool

--- a/packages/config/src/projects/bobanetwork.ts
+++ b/packages/config/src/projects/bobanetwork.ts
@@ -16,7 +16,7 @@ export const bobanetwork: Project = {
       // Proxy__OVM_L1StandardBridge
       address: '0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00',
       sinceBlock: 13012048,
-      tokens: ['ETH', 'USDC', 'OMG', 'DAI', 'SUSHI', 'UNI', 'USDT', 'FRAX'],
+      tokens: ['ETH', 'USDC', 'OMG', 'DAI', 'SUSHI', 'UNI', 'USDT', 'FRAX', 'WBTC', 'FTM', 'MATIC', 'BAT', 'UST', 'ZRX'],
     },
     {
       // Proxy__L1LiquidityPool

--- a/packages/config/src/tokens.ts
+++ b/packages/config/src/tokens.ts
@@ -221,6 +221,20 @@ export const tokenList: TokenInfo[] = [
     sinceBlock: 0,
   },
   {
+    name: 'Fantom Token',
+    symbol: 'FTM',
+    address: '0x4e15361fd6b4bb609fa63c81a2be19d873717870',
+    decimals: 18,
+    sinceBlock: 5792340,
+  },
+  {
+    name: 'Frax Share',
+    symbol: 'FXS',
+    address: '0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0',
+    decimals: 18,
+    sinceBlock: 11465584,
+  },
+  {
     name: 'Ethfinex Nectar Token',
     symbol: 'NEC',
     address: '0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e',
@@ -445,6 +459,13 @@ export const tokenList: TokenInfo[] = [
     sinceBlock: 4634748,
   },
   {
+    name: 'Wrapped UST Token',
+    symbol: 'UST',
+    address: '0xa47c8bf37f92abed4a126bda807a7b7498661acd',
+    decimals: 18,
+    sinceBlock: 11540758,
+  },
+  {
     name: 'THORChain ETH.RUNE',
     symbol: 'RUNE',
     address: '0x3155BA85D5F96b2d030a4966AF206230e46849cb',
@@ -506,27 +527,6 @@ export const tokenList: TokenInfo[] = [
     address: '0xe4815AE53B124e7263F08dcDBBB757d41Ed658c6',
     decimals: 18,
     sinceBlock: 11305469,
-  },
-  {
-    name: 'Fantom Token',
-    symbol: 'FTM',
-    address: '0x4e15361fd6b4bb609fa63c81a2be19d873717870',
-    decimals: 18,
-    sinceBlock: 5792340,
-  },
-  {
-    name: 'Wrapped UST Token',
-    symbol: 'UST',
-    address: '0xa47c8bf37f92abed4a126bda807a7b7498661acd',
-    decimals: 18,
-    sinceBlock: 11540758,
-  },
-  {
-    name: 'Frax Share',
-    symbol: 'FXS',
-    address: '0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0',
-    decimals: 18,
-    sinceBlock: 11465584,
   },
 ]
 

--- a/packages/config/src/tokens.ts
+++ b/packages/config/src/tokens.ts
@@ -221,25 +221,18 @@ export const tokenList: TokenInfo[] = [
     sinceBlock: 0,
   },
   {
-    name: 'Fantom Token',
-    symbol: 'FTM',
-    address: '0x4e15361fd6b4bb609fa63c81a2be19d873717870',
-    decimals: 18,
-    sinceBlock: 5792340,
-  },
-  {
-    name: 'Frax Share',
-    symbol: 'FXS',
-    address: '0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0',
-    decimals: 18,
-    sinceBlock: 11465584,
-  },
-  {
     name: 'Ethfinex Nectar Token',
     symbol: 'NEC',
     address: '0xCc80C051057B774cD75067Dc48f8987C4Eb97A5e',
     decimals: 18,
     sinceBlock: 5072026,
+  },
+  {
+    name: 'Fantom Token',
+    symbol: 'FTM',
+    address: '0x4E15361FD6b4BB609Fa63C81A2be19d873717870',
+    decimals: 18,
+    sinceBlock: 5792340,
   },
   {
     name: 'Frax',
@@ -457,13 +450,6 @@ export const tokenList: TokenInfo[] = [
     address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
     decimals: 6,
     sinceBlock: 4634748,
-  },
-  {
-    name: 'Wrapped UST Token',
-    symbol: 'UST',
-    address: '0xa47c8bf37f92abed4a126bda807a7b7498661acd',
-    decimals: 18,
-    sinceBlock: 11540758,
   },
   {
     name: 'THORChain ETH.RUNE',

--- a/packages/config/src/tokens.ts
+++ b/packages/config/src/tokens.ts
@@ -507,6 +507,27 @@ export const tokenList: TokenInfo[] = [
     decimals: 18,
     sinceBlock: 11305469,
   },
+  {
+    name: 'Fantom Token',
+    symbol: 'FTM',
+    address: '0x4e15361fd6b4bb609fa63c81a2be19d873717870',
+    decimals: 18,
+    sinceBlock: 5792340,
+  },
+  {
+    name: 'Wrapped UST Token',
+    symbol: 'UST',
+    address: '0xa47c8bf37f92abed4a126bda807a7b7498661acd',
+    decimals: 18,
+    sinceBlock: 11540758,
+  },
+  {
+    name: 'Frax Share',
+    symbol: 'FXS',
+    address: '0x3432b6a60d23ca0dfca7761b7ab56459d9c964d0',
+    decimals: 18,
+    sinceBlock: 11465584,
+  },
 ]
 
 const tokenMap = new Map(tokenList.map((t) => [t.symbol, t] as const))

--- a/packages/config/test/tokens.test.ts
+++ b/packages/config/test/tokens.test.ts
@@ -11,7 +11,7 @@ describe('tokens', () => {
   describe('every addresses is valid and formatted', () => {
     for (const address of addresses) {
       it(address, () => {
-        expect(utils.getAddress(address)).to.equal(address)
+        expect(address).to.equal(utils.getAddress(address))
       })
     }
   })


### PR DESCRIPTION
Adds the WBTC, FTM, MATIC, BAT, UST, ZRX and FXS tokens to the token list, and updates the list of tokens tracked for the two bridges for Boba Network.