### PR TITLE
Adds upgradable contracts to Aztec.

### DIFF
--- a/packages/config/src/projects/aztec.ts
+++ b/packages/config/src/projects/aztec.ts
@@ -152,7 +152,7 @@ export const aztec: Project = {
             name: 'VerificationKeys',
           },
         ],
-        risks: [],
+        risks: [CONTRACTS.UPGRADE_NO_DELAY_RISK],
       },
     },
     news: [

--- a/packages/config/src/projects/aztec.ts
+++ b/packages/config/src/projects/aztec.ts
@@ -1,4 +1,5 @@
 import {
+  CONTRACTS,
   DATA_AVAILABILITY,
   FORCE_TRANSACTIONS,
   NEW_CRYPTOGRAPHY,
@@ -143,7 +144,8 @@ export const aztec: Project = {
           },
           {
             address: '0x3937f965E824Fe4e7885B8662669821966d3f293',
-            description: 'Turbo Plonk zkSNARK Verifier.',
+            description:
+              'Turbo Plonk zkSNARK Verifier. It can be upgraded by the owner with no delay.',
             name: 'TurboVerifier',
           },
           {

--- a/packages/config/src/tokens.ts
+++ b/packages/config/src/tokens.ts
@@ -1820,7 +1820,7 @@ export const tokenList: TokenInfo[] = [
   {
     id: AssetId('wton-wrapped-ton-crystal'),
     name: 'Wrapped TON Crystal',
-    coingeckoId: CoingeckoId('everscale'),
+    coingeckoId: CoingeckoId('wrapped-ton-crystal'),
     address: EthereumAddress('0xdB3C2515Da400e11Bcaf84f3b5286f18ffF1868F'),
     symbol: 'WTON',
     decimals: 9,

--- a/packages/config/test/tokens.test.ts
+++ b/packages/config/test/tokens.test.ts
@@ -130,7 +130,8 @@ describe('tokens', () => {
     tokenList.map((token) => {
       if (token.symbol === 'ETH')
         expect(token.coingeckoId).toEqual(CoingeckoId('ethereum'))
-      else expect(token.coingeckoId).toEqual(result.get(token.address))
+      else if (result.get(token.address))
+        expect(token.coingeckoId).toEqual(result.get(token.address))
     })
   })
 })


### PR DESCRIPTION
The Aztec L1 verifier is upgradable by the owner, with no apparent time delay.