### PR TITLE
Make main table sortable (#219)

### DIFF
--- a/packages/frontend/src/content/common/head/Preload.tsx
+++ b/packages/frontend/src/content/common/head/Preload.tsx
@@ -24,6 +24,19 @@ export function Preload(props: Props) {
         type="font/woff2"
         crossOrigin="anonymous"
       />
+      {/* <link
+        rel="stylesheet"
+        type="text/css"
+        href="https://cdn.datatables.net/1.12.1/css/jquery.dataTables.min.css"
+      /> */}
+      <script
+        type="text/javascript"
+        src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"
+      />
+      <script
+        type="text/javascript"
+        src="https://cdn.datatables.net/1.12.1/js/jquery.dataTables.min.js"
+      />
     </>
   )
 }

--- a/packages/frontend/src/scripts/configureTableView.ts
+++ b/packages/frontend/src/scripts/configureTableView.ts
@@ -1,0 +1,11 @@
+export function configureTableView() {
+
+  document.addEventListener('DOMContentLoaded', function () {
+    // eslint-disable-next-line
+    // @ts-ignore
+    new DataTable('.TableView-Table', {paging: false, searching:false, columnDefs: [
+      { orderable: false, targets: 2 },
+      { orderable: false, targets: 3 }
+    ],});
+  });
+}

--- a/packages/frontend/src/scripts/configureTableView.ts
+++ b/packages/frontend/src/scripts/configureTableView.ts
@@ -1,11 +1,14 @@
 export function configureTableView() {
-
   document.addEventListener('DOMContentLoaded', function () {
     // eslint-disable-next-line
     // @ts-ignore
-    new DataTable('.TableView-Table', {paging: false, searching:false, columnDefs: [
-      { orderable: false, targets: 2 },
-      { orderable: false, targets: 3 }
-    ],});
-  });
+    new DataTable('.TableView-Table', {
+      paging: false,
+      searching: false,
+      columnDefs: [
+        { orderable: false, targets: 2 },
+        { orderable: false, targets: 3 },
+      ],
+    })
+  })
 }

--- a/packages/frontend/src/scripts/index.ts
+++ b/packages/frontend/src/scripts/index.ts
@@ -1,9 +1,11 @@
 import { configureChart } from './chart'
 import { configureDarkMode } from './configureDarkMode'
 import { configureRiskView } from './configureRiskView'
+import { configureTableView } from './configureTableView'
 import { configureTooltips } from './configureTooltips'
 
 configureDarkMode()
 configureTooltips()
 configureChart()
+configureTableView()
 configureRiskView()


### PR DESCRIPTION
Minimally intrusive solution (codebase-wise), does include jQuery/client-side JS though. 

I put the commented out stylesheet in there so you can toggle it and check out the styling that comes with Datatables, also see: 
- https://datatables.net/examples/styling/
- https://datatables.net/manual/styling/

Without the stylesheet, the headers are not styled at all. Will probably need a little icon or at least the normal mouse-over cursor change. But I thought you guys may have some thoughts on that, so I didn't implement it yet.