### PR TITLE
Improve cross-package navigation

### DIFF
--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "lib": ["es2019", "DOM"],
     "declaration": false,
+    "declarationMap": false,
     "outDir": "build"
   }
 }

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["es2019", "DOM"],
-    "declaration": false,
-    "declarationMap": false,
     "outDir": "build"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react",
-    "declaration": true
+    "declaration": true,
+    "declarationMap": true
   }
 }


### PR DESCRIPTION
Inspired by https://github.com/l2beat/dydx-state-explorer/pull/103

> This should allow clicking on symbols imported from a different, internal package and navigating to the sourcecode rather than to .d.ts file. Goes best with additional vscode settings:

```
// https://twitter.com/krzKaczor/status/1120631267781951488
  "editor.gotoLocation.multipleDefinitions": "goto",
  "editor.gotoLocation.multipleImplementations": "goto",
  "editor.gotoLocation.multipleTypeDefinitions": "goto",
  "editor.gotoLocation.multipleDeclarations": "goto",
  "editor.gotoLocation.multipleReferences": "goto"
```