### PR TITLE
Update zkSync implementation contracts

### DIFF
--- a/packages/config/src/projects/zksync.ts
+++ b/packages/config/src/projects/zksync.ts
@@ -144,7 +144,7 @@ export const zksync: Project = {
             upgradeability: {
               type: 'EIP1967',
               admin: '0x38A43F4330f24fe920F943409709fc9A6084C939',
-              implementation: '0x204c6BADaD00Ef326dE0921A940D8267060d1033',
+              implementation: '0x59a5E7c08be8356193Cd9F92CA8Ac95C42aB0Bdd',
             },
           },
           {
@@ -154,7 +154,7 @@ export const zksync: Project = {
             upgradeability: {
               type: 'EIP1967',
               admin: '0x38A43F4330f24fe920F943409709fc9A6084C939',
-              implementation: '0xEF974376054490C8d87b8438b4cEC00391ac05b9',
+              implementation: '0xf7Bd436a05678B647D74a88ffcf4445Efc43BDfC',
             },
           },
           {


### PR DESCRIPTION
Apart from ZkSync (which has been updated in a previous PR) also Governance and Verifier implementation contracts have been updated.

**Verifier**
- proxy: https://etherscan.io/address/0x5290e9582b4fb706eadf87bb1c129e897e04d06d
- previous: https://etherscan.io/address/0xef974376054490c8d87b8438b4cec00391ac05b9
- current: https://etherscan.io/address/0xf7bd436a05678b647d74a88ffcf4445efc43bdfc

**Governance**
- proxy: https://etherscan.io/address/0x34460c0eb5074c29a9f6fe13b8e7e23a0d08af01
- previous: https://etherscan.io/address/0x934ef5836e78d93125317034f5cf855a97b13f43
- current: https://etherscan.io/address/0x9a97008cccbdec3413f9304602427e66895996a0