### PR TITLE
Update Arbitrum sequencer description

### DIFF
--- a/packages/config/src/projects/arbitrum.ts
+++ b/packages/config/src/projects/arbitrum.ts
@@ -231,7 +231,7 @@ export const arbitrum: Project = {
               type: 'EOA',
             },
           ],
-          description: 'Central actor allowed to commit L2 transactions to L1.',
+          description: 'Central actor allowed to sequence L2 transactions.',
         },
         {
           name: 'Validators',


### PR DESCRIPTION
The previous text makes it seem as if the Sequencer is the only one able to post commitments of L2 txs to the L1.
It does commit to them, but anyone can do so through the delayed inbox - which is then sequenced by the sequencer.