### PR TITLE
Prevent aggregate reports from being lost on update

### DIFF
--- a/packages/backend/src/peripherals/database/migrations/023_ease_bridge_transition.ts
+++ b/packages/backend/src/peripherals/database/migrations/023_ease_bridge_transition.ts
@@ -25,6 +25,6 @@ export async function up(knex: Knex) {
   }
 }
 
-export async function down(knex: Knex) {
+export async function down() {
   // intentionally empty as resync actually will fix it automatically
 }

--- a/packages/backend/src/peripherals/database/migrations/023_ease_bridge_transition.ts
+++ b/packages/backend/src/peripherals/database/migrations/023_ease_bridge_transition.ts
@@ -1,0 +1,30 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { ProjectId } from '@l2beat/types'
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  const hasLayer2Already = !!(await knex('aggregate_reports')
+    .where('project_id', ProjectId.LAYER2S.toString())
+    .first())
+  if (!hasLayer2Already) {
+    await knex('aggregate_reports')
+      .where('project_id', ProjectId.ALL.toString())
+      .update('project_id', ProjectId.LAYER2S.toString())
+  }
+}
+
+export async function down(knex: Knex) {
+  // intentionally empty as resync actually will fix it automatically
+}

--- a/packages/config/src/bridges/orbit.ts
+++ b/packages/config/src/bridges/orbit.ts
@@ -34,7 +34,16 @@ export const orbit: Bridge = {
     {
       address: '0x1Bf68A9d1EaEe7826b3593C20a0ca93293cb489a',
       sinceTimestamp: new UnixTime(1603950507),
-      tokens: ['ETH', 'USDT', 'ORC', 'DAI', 'USDC', 'WBTC', 'HANDY', 'MATIC'], // TODO: there are more tokens
+      tokens: [
+        'ETH',
+        'USDT',
+        // 'ORC',
+        'DAI',
+        'USDC',
+        'WBTC',
+        // 'HANDY',
+        'MATIC',
+      ],
     },
   ],
 

--- a/packages/config/test/bridges.test.ts
+++ b/packages/config/test/bridges.test.ts
@@ -1,0 +1,44 @@
+import { expect } from 'earljs'
+import { utils } from 'ethers'
+
+import { bridges } from '../src/bridges'
+import { getTokenBySymbol } from '../src/tokens'
+
+describe('bridges', () => {
+  describe('every slug is valid', () => {
+    for (const bridge of bridges) {
+      it(bridge.slug, () => {
+        expect(bridge.slug).toEqual(expect.stringMatching(/^[a-z\d]+$/))
+      })
+    }
+  })
+
+  describe('addresses', () => {
+    describe('every addresses is valid and formatted', () => {
+      const testAddress = (address: string) =>
+        it(address, () => {
+          expect(utils.getAddress(address)).toEqual(address)
+        })
+
+      describe('escrows', () => {
+        const escrows = bridges.flatMap((x) => x.escrows.map((x) => x.address))
+        for (const address of escrows) {
+          testAddress(address)
+        }
+      })
+    })
+  })
+
+  describe('every token is valid', () => {
+    const symbols = bridges
+      .flatMap((x) =>
+        x.escrows.filter((x) => x.tokens !== '*').flatMap((x) => x.tokens),
+      )
+      .filter((x, i, a) => a.indexOf(x) === i)
+    for (const symbol of symbols) {
+      it(symbol, () => {
+        expect(() => getTokenBySymbol(symbol)).not.toThrow()
+      })
+    }
+  })
+})

--- a/packages/config/test/layer2s.test.ts
+++ b/packages/config/test/layer2s.test.ts
@@ -55,12 +55,6 @@ describe('layer2s', () => {
         }
       })
     })
-
-    it('every escrow has a unique address', () => {
-      const escrows = layer2s.flatMap((x) => x.escrows.map((x) => x.address))
-      const everyUnique = escrows.every((x, i, a) => a.indexOf(x) === i)
-      expect(everyUnique).toEqual(true)
-    })
   })
 
   describe('sentences', () => {


### PR DESCRIPTION
The goal of this migration is to prevent a partially empty aggregated chart to appear on the website.

I have tested it locally by doing the following:
1. Checkout `00522090` which is the latest commit deployed on production
2. Sync locally to one week before
3. Checkout this PR
4. Run backend with sync disabled
5. Run frontend against the local backend and see that the the data is displayed correctly
6. Run backend with sync enabled and sync to one week before
7. Run frontend against the local backend and see that the the data is displayed correctly