### PR TITLE
Add staging config support

### DIFF
--- a/packages/backend/src/config/config.staging.ts
+++ b/packages/backend/src/config/config.staging.ts
@@ -1,0 +1,41 @@
+import { LogLevel } from '@l2beat/common'
+import { bridges, layer2s, tokenList } from '@l2beat/config'
+import { UnixTime } from '@l2beat/types'
+
+import { bridgeToProject, layer2ToProject } from '../model'
+import { Config } from './Config'
+import { getEnv } from './getEnv'
+
+export function getStagingConfig(): Config {
+  const name = 'Backend/Staging'
+  return {
+    name,
+    logger: {
+      logLevel: getEnv.integer('LOG_LEVEL', LogLevel.INFO),
+      format: 'json',
+    },
+    port: getEnv.integer('PORT'),
+    coingeckoApiKey: getEnv('COINGECKO_API_KEY'),
+    alchemyApiKey: getEnv('ALCHEMY_API_KEY'),
+    etherscanApiKey: getEnv('ETHERSCAN_API_KEY'),
+    databaseConnection: {
+      connectionString: getEnv('DATABASE_URL'),
+      ssl: { rejectUnauthorized: false },
+      application_name: name,
+    },
+    core: {
+      minBlockTimestamp: UnixTime.fromDate(new Date('2019-11-14T00:00:00Z')),
+      safeBlockRefreshIntervalMs: 5 * 60 * 1000,
+      safeTimeOffsetSeconds: 60 * 60,
+    },
+    tokens: tokenList.map((token) => ({
+      ...token,
+      priceStrategy: { type: 'market' },
+    })),
+    projects: layer2s.map(layer2ToProject).concat(bridges.map(bridgeToProject)),
+    syncEnabled: !getEnv.boolean('SYNC_DISABLED', false),
+    freshStart: false,
+    eventsSyncEnabled: true,
+    transactionCountSyncEnabled: false,
+  }
+}

--- a/packages/backend/src/config/index.ts
+++ b/packages/backend/src/config/index.ts
@@ -1,6 +1,7 @@
 import { Config } from './Config'
 import { getLocalConfig } from './config.local'
 import { getProductionConfig } from './config.production'
+import { getStagingConfig } from './config.staging'
 import { getTestConfig } from './config.test'
 
 export type { Config }
@@ -9,6 +10,8 @@ export function getConfig(env: string): Config {
   switch (env) {
     case 'local':
       return getLocalConfig()
+    case 'staging':
+      return getStagingConfig()
     case 'production':
       return getProductionConfig()
     case 'test':


### PR DESCRIPTION
The only change between this and production config is that I turned on `eventsSyncEnabled`. 

Once merged I will tweak env variables on staging environment so this config is used. 