### PR TITLE
Optionally show layer2s on bridge tvl view

### DIFF
--- a/packages/config/src/bridges/avalanche.ts
+++ b/packages/config/src/bridges/avalanche.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const avalanche: Bridge = {
+  type: 'bridge',
   id: ProjectId('avalanche'),
   display: {
     name: 'Avalanche Bridge',

--- a/packages/config/src/bridges/cBridge.ts
+++ b/packages/config/src/bridges/cBridge.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const cBridge: Bridge = {
+  type: 'bridge',
   id: ProjectId('cbridge'),
   display: {
     name: 'Celer V2 cBridge',

--- a/packages/config/src/bridges/connext.ts
+++ b/packages/config/src/bridges/connext.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const connext: Bridge = {
+  type: 'bridge',
   id: ProjectId('connext'),
   display: {
     name: 'Connext',

--- a/packages/config/src/bridges/gravity.ts
+++ b/packages/config/src/bridges/gravity.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const gravity: Bridge = {
+  type: 'bridge',
   id: ProjectId('gravity'),
   display: {
     name: 'Gravity',

--- a/packages/config/src/bridges/harmony.ts
+++ b/packages/config/src/bridges/harmony.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const harmony: Bridge = {
+  type: 'bridge',
   id: ProjectId('harmony'),
   display: {
     name: 'Harmony',

--- a/packages/config/src/bridges/hop.ts
+++ b/packages/config/src/bridges/hop.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const hop: Bridge = {
+  type: 'bridge',
   id: ProjectId('hop'),
   display: {
     name: 'Hop',

--- a/packages/config/src/bridges/hyphen.ts
+++ b/packages/config/src/bridges/hyphen.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const hyphen: Bridge = {
+  type: 'bridge',
   id: ProjectId('hyphen'),
   display: {
     name: 'Hyphen',

--- a/packages/config/src/bridges/multichain.ts
+++ b/packages/config/src/bridges/multichain.ts
@@ -7,6 +7,7 @@ Note: Timestamp is entered manually as all these accounts are EOAs
 */
 
 export const multichain: Bridge = {
+  type: 'bridge',
   id: ProjectId('multichain'),
   display: {
     name: 'Multichain',

--- a/packages/config/src/bridges/near.ts
+++ b/packages/config/src/bridges/near.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const near: Bridge = {
+  type: 'bridge',
   id: ProjectId('near'),
   display: {
     name: 'Rainbow Bridge',

--- a/packages/config/src/bridges/nomad.ts
+++ b/packages/config/src/bridges/nomad.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const nomad: Bridge = {
+  type: 'bridge',
   id: ProjectId('nomad'),
   display: {
     name: 'Nomad',

--- a/packages/config/src/bridges/omni.ts
+++ b/packages/config/src/bridges/omni.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const omni: Bridge = {
+  type: 'bridge',
   id: ProjectId('omni'),
   display: {
     name: 'xDai Omni',

--- a/packages/config/src/bridges/orbit.ts
+++ b/packages/config/src/bridges/orbit.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const orbit: Bridge = {
+  type: 'bridge',
   id: ProjectId('orbit'),
   display: {
     name: 'Orbit Bridge',

--- a/packages/config/src/bridges/orbiter.ts
+++ b/packages/config/src/bridges/orbiter.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const orbiter: Bridge = {
+  type: 'bridge',
   id: ProjectId('orbiter'),
   display: {
     name: 'Orbiter',

--- a/packages/config/src/bridges/polygon.ts
+++ b/packages/config/src/bridges/polygon.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const polygon: Bridge = {
+  type: 'bridge',
   id: ProjectId('polygon'),
   display: {
     name: 'Polygon PoS',

--- a/packages/config/src/bridges/polynetwork.ts
+++ b/packages/config/src/bridges/polynetwork.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const polynetwork: Bridge = {
+  type: 'bridge',
   id: ProjectId('polynetwork'),
   display: {
     name: 'Polynetwork',

--- a/packages/config/src/bridges/ronin.ts
+++ b/packages/config/src/bridges/ronin.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const ronin: Bridge = {
+  type: 'bridge',
   id: ProjectId('ronin'),
   display: {
     name: 'Ronin',

--- a/packages/config/src/bridges/satellite.ts
+++ b/packages/config/src/bridges/satellite.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const satellite: Bridge = {
+  type: 'bridge',
   id: ProjectId('satellite'),
   display: {
     name: 'Satellite Bridge',

--- a/packages/config/src/bridges/sollet.ts
+++ b/packages/config/src/bridges/sollet.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const sollet: Bridge = {
+  type: 'bridge',
   id: ProjectId('sollet'),
   display: {
     name: 'Sollet Sol',

--- a/packages/config/src/bridges/stargate.ts
+++ b/packages/config/src/bridges/stargate.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const stargate: Bridge = {
+  type: 'bridge',
   id: ProjectId('stargate'),
   display: {
     name: 'StarGate',

--- a/packages/config/src/bridges/synapse.ts
+++ b/packages/config/src/bridges/synapse.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const synapse: Bridge = {
+  type: 'bridge',
   id: ProjectId('synapse'),
   display: {
     name: 'Synapse',

--- a/packages/config/src/bridges/types/Bridge.ts
+++ b/packages/config/src/bridges/types/Bridge.ts
@@ -11,6 +11,7 @@ import {
 import { Layer2Permission } from '../../layer2s'
 
 export interface Bridge {
+  type: 'bridge'
   id: ProjectId
   display: BridgeDisplay
   config: BridgeConfig

--- a/packages/config/src/bridges/wormhole.ts
+++ b/packages/config/src/bridges/wormhole.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const wormhole: Bridge = {
+  type: 'bridge',
   id: ProjectId('wormhole'),
   display: {
     name: 'Wormhole V2',

--- a/packages/config/src/bridges/wormholeV1.ts
+++ b/packages/config/src/bridges/wormholeV1.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Bridge } from './types'
 
 export const wormholeV1: Bridge = {
+  type: 'bridge',
   id: ProjectId('wormholeV1'),
   display: {
     name: 'Wormhole V1',

--- a/packages/config/src/layer2s/apex.ts
+++ b/packages/config/src/layer2s/apex.ts
@@ -14,6 +14,7 @@ import {
 import { Layer2 } from './types'
 
 export const apex: Layer2 = {
+  type: 'layer2',
   id: ProjectId('apex'),
   display: {
     name: 'ApeX',

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -11,6 +11,7 @@ import {
 import { Layer2 } from './types'
 
 export const arbitrum: Layer2 = {
+  type: 'layer2',
   id: ProjectId('arbitrum'),
   display: {
     name: 'Arbitrum One',

--- a/packages/config/src/layer2s/aztec.ts
+++ b/packages/config/src/layer2s/aztec.ts
@@ -12,6 +12,7 @@ import {
 import { Layer2 } from './types'
 
 export const aztec: Layer2 = {
+  type: 'layer2',
   id: ProjectId('aztec'),
   display: {
     name: 'Aztec',

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -13,6 +13,7 @@ import {
 import { Layer2 } from './types'
 
 export const aztecconnect: Layer2 = {
+  type: 'layer2',
   id: ProjectId('aztecconnect'),
   display: {
     name: 'Aztec Connect',

--- a/packages/config/src/layer2s/bobanetwork.ts
+++ b/packages/config/src/layer2s/bobanetwork.ts
@@ -11,6 +11,7 @@ import {
 import { Layer2 } from './types'
 
 export const bobanetwork: Layer2 = {
+  type: 'layer2',
   id: ProjectId('bobanetwork'),
   display: {
     name: 'Boba Network',

--- a/packages/config/src/layer2s/dydx.ts
+++ b/packages/config/src/layer2s/dydx.ts
@@ -13,6 +13,7 @@ import {
 import { Layer2 } from './types'
 
 export const dydx: Layer2 = {
+  type: 'layer2',
   id: ProjectId('dydx'),
   display: {
     name: 'dYdX',

--- a/packages/config/src/layer2s/fuelv1.ts
+++ b/packages/config/src/layer2s/fuelv1.ts
@@ -11,6 +11,7 @@ import {
 import { Layer2 } from './types'
 
 export const fuelv1: Layer2 = {
+  type: 'layer2',
   id: ProjectId('fuelv1'),
   display: {
     name: 'Fuel v1',

--- a/packages/config/src/layer2s/gluon.ts
+++ b/packages/config/src/layer2s/gluon.ts
@@ -12,6 +12,7 @@ import {
 import { Layer2 } from './types'
 
 export const gluon: Layer2 = {
+  type: 'layer2',
   id: ProjectId('gluon'),
   display: {
     name: 'Gluon',

--- a/packages/config/src/layer2s/hermez.ts
+++ b/packages/config/src/layer2s/hermez.ts
@@ -13,6 +13,7 @@ import {
 import { Layer2 } from './types'
 
 export const hermez: Layer2 = {
+  type: 'layer2',
   id: ProjectId('hermez'),
   display: {
     name: 'Polygon Hermez',

--- a/packages/config/src/layer2s/immutablex.ts
+++ b/packages/config/src/layer2s/immutablex.ts
@@ -14,6 +14,7 @@ import {
 import { Layer2 } from './types'
 
 export const immutablex: Layer2 = {
+  type: 'layer2',
   id: ProjectId('immutablex'),
   display: {
     name: 'Immutable X',

--- a/packages/config/src/layer2s/layer2finance.ts
+++ b/packages/config/src/layer2s/layer2finance.ts
@@ -10,6 +10,7 @@ import {
 import { Layer2 } from './types'
 
 export const layer2finance: Layer2 = {
+  type: 'layer2',
   id: ProjectId('layer2finance'),
   display: {
     name: 'Layer2.Finance',

--- a/packages/config/src/layer2s/layer2financezk.ts
+++ b/packages/config/src/layer2s/layer2financezk.ts
@@ -15,6 +15,7 @@ import { layer2finance } from './layer2finance'
 import { Layer2 } from './types'
 
 export const layer2financezk: Layer2 = {
+  type: 'layer2',
   id: ProjectId('layer2financezk'),
   display: {
     name: 'Layer2.Finance-zk',

--- a/packages/config/src/layer2s/loopring.ts
+++ b/packages/config/src/layer2s/loopring.ts
@@ -13,6 +13,7 @@ import {
 import { Layer2 } from './types'
 
 export const loopring: Layer2 = {
+  type: 'layer2',
   id: ProjectId('loopring'),
   display: {
     name: 'Loopring',

--- a/packages/config/src/layer2s/metis.ts
+++ b/packages/config/src/layer2s/metis.ts
@@ -10,6 +10,7 @@ import {
 import { Layer2 } from './types'
 
 export const metis: Layer2 = {
+  type: 'layer2',
   id: ProjectId('metis'),
   display: {
     name: 'Metis Andromeda',

--- a/packages/config/src/layer2s/myria.ts
+++ b/packages/config/src/layer2s/myria.ts
@@ -14,6 +14,7 @@ import {
 import { Layer2 } from './types'
 
 export const myria: Layer2 = {
+  type: 'layer2',
   id: ProjectId('myria'),
   display: {
     name: 'Myria',

--- a/packages/config/src/layer2s/nova.ts
+++ b/packages/config/src/layer2s/nova.ts
@@ -12,6 +12,7 @@ import {
 import { Layer2 } from './types'
 
 export const nova: Layer2 = {
+  type: 'layer2',
   id: ProjectId('nova'),
   display: {
     name: 'Arbitrum Nova',

--- a/packages/config/src/layer2s/omgnetwork.ts
+++ b/packages/config/src/layer2s/omgnetwork.ts
@@ -12,6 +12,7 @@ import {
 import { Layer2 } from './types'
 
 export const omgnetwork: Layer2 = {
+  type: 'layer2',
   id: ProjectId('omgnetwork'),
   display: {
     name: 'OMG Network',

--- a/packages/config/src/layer2s/optimism.ts
+++ b/packages/config/src/layer2s/optimism.ts
@@ -11,6 +11,7 @@ import {
 import { Layer2 } from './types'
 
 export const optimism: Layer2 = {
+  type: 'layer2',
   id: ProjectId('optimism'),
   display: {
     name: 'Optimism',

--- a/packages/config/src/layer2s/rhinofi.ts
+++ b/packages/config/src/layer2s/rhinofi.ts
@@ -14,6 +14,7 @@ import {
 import { Layer2 } from './types'
 
 export const rhinofi: Layer2 = {
+  type: 'layer2',
   id: ProjectId('deversifi'),
   display: {
     name: 'rhino.fi',

--- a/packages/config/src/layer2s/sorare.ts
+++ b/packages/config/src/layer2s/sorare.ts
@@ -14,6 +14,7 @@ import {
 import { Layer2 } from './types'
 
 export const sorare: Layer2 = {
+  type: 'layer2',
   id: ProjectId('sorare'),
   display: {
     name: 'Sorare',

--- a/packages/config/src/layer2s/starknet.ts
+++ b/packages/config/src/layer2s/starknet.ts
@@ -14,6 +14,7 @@ import {
 import { Layer2 } from './types'
 
 export const starknet: Layer2 = {
+  type: 'layer2',
   id: ProjectId('starknet'),
   display: {
     name: 'StarkNet',

--- a/packages/config/src/layer2s/types/Layer2.ts
+++ b/packages/config/src/layer2s/types/Layer2.ts
@@ -13,6 +13,7 @@ import { Layer2Technology } from './Layer2Technology'
 import { Layer2TransactionApi } from './Layer2TransactionApi'
 
 export interface Layer2 {
+  type: 'layer2'
   /** Unique, readable id, will be used in DB. DO NOT EDIT THIS PROPERTY */
   id: ProjectId
   /** Information displayed about the layer2 on the frontend */

--- a/packages/config/src/layer2s/zkspace.ts
+++ b/packages/config/src/layer2s/zkspace.ts
@@ -5,6 +5,7 @@ import { Layer2 } from './types'
 import { zkswap } from './zkswap'
 
 export const zkspace: Layer2 = {
+  type: 'layer2',
   id: ProjectId('zkspace'),
   display: {
     name: 'ZKSpace',

--- a/packages/config/src/layer2s/zkswap.ts
+++ b/packages/config/src/layer2s/zkswap.ts
@@ -13,6 +13,7 @@ import {
 import { Layer2 } from './types'
 
 export const zkswap: Layer2 = {
+  type: 'layer2',
   id: ProjectId('zkswap'),
   display: {
     name: 'ZKSwap 1.0',

--- a/packages/config/src/layer2s/zkswap2.ts
+++ b/packages/config/src/layer2s/zkswap2.ts
@@ -5,6 +5,7 @@ import { Layer2 } from './types'
 import { zkswap } from './zkswap'
 
 export const zkswap2: Layer2 = {
+  type: 'layer2',
   id: ProjectId('zkswap2'),
   display: {
     name: 'ZKSwap 2.0',

--- a/packages/config/src/layer2s/zksync.ts
+++ b/packages/config/src/layer2s/zksync.ts
@@ -13,6 +13,7 @@ import {
 import { Layer2 } from './types'
 
 export const zksync: Layer2 = {
+  type: 'layer2',
   id: ProjectId('zksync'),
   display: {
     name: 'zkSync',

--- a/packages/frontend/src/components/TableView.tsx
+++ b/packages/frontend/src/components/TableView.tsx
@@ -11,7 +11,7 @@ export interface Column<T> {
   name: ReactNode
   shortName?: ReactNode
   alignRight?: true
-  getValue: (value: T) => ReactNode
+  getValue: (value: T, index: number) => ReactNode
 }
 
 export function TableView<T>({ className, items, columns }: Props<T>) {
@@ -20,7 +20,6 @@ export function TableView<T>({ className, items, columns }: Props<T>) {
       <table className="TableView-Table">
         <thead className="TableView-Header">
           <tr>
-            <th>No.</th>
             {columns.map((column, i) => (
               <th key={i} className={column.alignRight ? 'right' : undefined}>
                 <span data-wide={column.shortName ? true : undefined}>
@@ -36,10 +35,9 @@ export function TableView<T>({ className, items, columns }: Props<T>) {
         <tbody className="TableView-Body">
           {items.map((item, i) => (
             <tr key={i}>
-              <td>{i + 1}.</td>
               {columns.map((column, j) => (
                 <td key={j} className={column.alignRight ? 'right' : undefined}>
-                  {column.getValue(item)}
+                  {column.getValue(item, i)}
                 </td>
               ))}
             </tr>

--- a/packages/frontend/src/components/TableView.tsx
+++ b/packages/frontend/src/components/TableView.tsx
@@ -1,20 +1,25 @@
 import cx from 'classnames'
-import React, { ReactNode } from 'react'
+import React, { HTMLAttributes, ReactNode } from 'react'
 
 interface Props<T> {
   className?: string
   items: T[]
-  columns: Column<T>[]
+  columns: ColumnConfig<T>[]
+  rows?: RowConfig<T>
 }
 
-export interface Column<T> {
+export interface ColumnConfig<T> {
   name: ReactNode
   shortName?: ReactNode
   alignRight?: true
   getValue: (value: T, index: number) => ReactNode
 }
 
-export function TableView<T>({ className, items, columns }: Props<T>) {
+export interface RowConfig<T> {
+  getProps: (value: T, index: number) => HTMLAttributes<HTMLTableRowElement>
+}
+
+export function TableView<T>({ className, items, columns, rows }: Props<T>) {
   return (
     <div className={cx('TableView', className)}>
       <table className="TableView-Table">
@@ -34,7 +39,7 @@ export function TableView<T>({ className, items, columns }: Props<T>) {
         </thead>
         <tbody className="TableView-Body">
           {items.map((item, i) => (
-            <tr key={i}>
+            <tr key={i} {...rows?.getProps(item, i)}>
               {columns.map((column, j) => (
                 <td key={j} className={column.alignRight ? 'right' : undefined}>
                   {column.getValue(item, i)}

--- a/packages/frontend/src/pages/bridges-risk/BridgesRiskView.tsx
+++ b/packages/frontend/src/pages/bridges-risk/BridgesRiskView.tsx
@@ -2,7 +2,7 @@ import { ProjectRiskViewEntry } from '@l2beat/config'
 import React from 'react'
 
 import { ProjectLink } from '../../components/ProjectLink'
-import { Column, TableView } from '../../components/TableView'
+import { ColumnConfig, TableView } from '../../components/TableView'
 import { RiskCell } from './RiskCell'
 
 export interface BridgesRiskViewProps {
@@ -20,7 +20,7 @@ export interface BridgesRiskViewEntry {
 }
 
 export function BridgesRiskView({ items }: BridgesRiskViewProps) {
-  const columns: Column<BridgesRiskViewEntry>[] = [
+  const columns: ColumnConfig<BridgesRiskViewEntry>[] = [
     {
       name: 'No.',
       getValue: (entry, index) => `${index + 1}.`,

--- a/packages/frontend/src/pages/bridges-risk/BridgesRiskView.tsx
+++ b/packages/frontend/src/pages/bridges-risk/BridgesRiskView.tsx
@@ -22,6 +22,10 @@ export interface BridgesRiskViewEntry {
 export function BridgesRiskView({ items }: BridgesRiskViewProps) {
   const columns: Column<BridgesRiskViewEntry>[] = [
     {
+      name: 'No.',
+      getValue: (entry, index) => `${index + 1}.`,
+    },
+    {
       name: 'Name',
       getValue: (entry) => <ProjectLink type="bridge" project={entry} />,
     },

--- a/packages/frontend/src/pages/bridges-tvl/BridgesTvlPage.tsx
+++ b/packages/frontend/src/pages/bridges-tvl/BridgesTvlPage.tsx
@@ -14,8 +14,10 @@ import { Page } from '../../components/Page'
 import { BridgesTvlView, BridgesTvlViewProps } from './BridgesTvlView'
 
 export interface BridgesTvlPageProps {
-  tvl: string
-  sevenDayChange: string
+  bridgesTvl: string
+  bridgesTvlSevenDayChange: string
+  combinedTvl: string
+  combinedTvlSevenDayChange: string
   apiEndpoint: string
   tvlView: BridgesTvlViewProps
   footer: FooterProps
@@ -27,11 +29,24 @@ export function BridgesTvlPage(props: BridgesTvlPageProps) {
     <Page navbar={props.navbar}>
       <BridgesPageSelection selected="tvl" />
       <main>
-        <Header
-          title="Value locked"
-          tvl={props.tvl}
-          tvlWeeklyChange={props.sevenDayChange}
-        />
+        <label>
+          <input id="combined-bridges" type="checkbox" />{' '}
+          <span>Include Layer2s as bridges</span>
+        </label>
+        <div data-bridges-only>
+          <Header
+            title="Value locked"
+            tvl={props.bridgesTvl}
+            tvlWeeklyChange={props.bridgesTvlSevenDayChange}
+          />
+        </div>
+        <div data-combined-only className="hidden">
+          <Header
+            title="Value locked"
+            tvl={props.combinedTvl}
+            tvlWeeklyChange={props.combinedTvlSevenDayChange}
+          />
+        </div>
         <Chart endpoint={props.apiEndpoint} />
         <BridgesTvlView {...props.tvlView} />
         <OtherSites />

--- a/packages/frontend/src/pages/bridges-tvl/BridgesTvlView.tsx
+++ b/packages/frontend/src/pages/bridges-tvl/BridgesTvlView.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { PercentChange } from '../../components'
 import { ProjectLink } from '../../components/ProjectLink'
-import { Column, TableView } from '../../components/TableView'
+import { ColumnConfig, RowConfig, TableView } from '../../components/TableView'
 import { TVLBreakdown, TVLBreakdownProps } from '../../components/TVLBreakdown'
 
 export interface BridgesTvlViewProps {
@@ -10,21 +10,32 @@ export interface BridgesTvlViewProps {
 }
 
 export interface BridgesTvlViewEntry {
+  type: 'bridge' | 'layer2'
   name: string
   slug: string
   tvl: string
   tvlBreakdown: TVLBreakdownProps
   oneDayChange: string
   sevenDayChange: string
-  marketShare: string
-  type: string
+  bridgesMarketShare: string
+  combinedMarketShare: string
+  category: string
 }
 
 export function BridgesTvlView({ items }: BridgesTvlViewProps) {
-  const columns: Column<BridgesTvlViewEntry>[] = [
+  const onlyBridges = items.filter((x) => x.type === 'bridge')
+
+  const columns: ColumnConfig<BridgesTvlViewEntry>[] = [
     {
       name: 'No.',
-      getValue: (entry, index) => `${index + 1}.`,
+      getValue: (entry, index) => (
+        <>
+          <span data-bridges-only>{onlyBridges.indexOf(entry) + 1}.</span>
+          <span data-combined-only className="hidden">
+            {index + 1}.
+          </span>
+        </>
+      ),
     },
     {
       name: 'Name',
@@ -48,12 +59,19 @@ export function BridgesTvlView({ items }: BridgesTvlViewProps) {
     {
       name: 'Market share',
       alignRight: true,
-      getValue: (entry) => entry.marketShare,
+      getValue: (entry) => (
+        <>
+          <span data-bridges-only>{entry.bridgesMarketShare}</span>
+          <span data-combined-only className="hidden">
+            {entry.combinedMarketShare}
+          </span>
+        </>
+      ),
     },
     {
       name: 'Validation',
       alignRight: true,
-      getValue: (entry) => entry.type,
+      getValue: (entry) => entry.category,
     },
     {
       name: 'Type',
@@ -62,9 +80,19 @@ export function BridgesTvlView({ items }: BridgesTvlViewProps) {
     },
   ]
 
+  const rows: RowConfig<BridgesTvlViewEntry> = {
+    getProps: (entry) =>
+      entry.type === 'bridge'
+        ? {}
+        : {
+            ['data-combined-only']: true,
+            className: 'hidden',
+          },
+  }
+
   return (
     <section className="mt-4">
-      <TableView items={items} columns={columns} />
+      <TableView items={items} columns={columns} rows={rows} />
     </section>
   )
 }

--- a/packages/frontend/src/pages/bridges-tvl/BridgesTvlView.tsx
+++ b/packages/frontend/src/pages/bridges-tvl/BridgesTvlView.tsx
@@ -23,6 +23,10 @@ export interface BridgesTvlViewEntry {
 export function BridgesTvlView({ items }: BridgesTvlViewProps) {
   const columns: Column<BridgesTvlViewEntry>[] = [
     {
+      name: 'No.',
+      getValue: (entry, index) => `${index + 1}.`,
+    },
+    {
       name: 'Name',
       getValue: (entry) => <ProjectLink type="bridge" project={entry} />,
     },

--- a/packages/frontend/src/pages/bridges-tvl/props/getBridgesTvlView.ts
+++ b/packages/frontend/src/pages/bridges-tvl/props/getBridgesTvlView.ts
@@ -1,4 +1,4 @@
-import { Bridge } from '@l2beat/config'
+import { Bridge, Layer2 } from '@l2beat/config'
 import { TvlApiResponse } from '@l2beat/types'
 
 import { getTvlStats } from '../../../utils/tvl/getTvlStats'
@@ -6,17 +6,21 @@ import { formatPercent, formatUSD } from '../../../utils/utils'
 import { BridgesTvlViewEntry } from '../BridgesTvlView'
 
 export function getBridgesTvlView(
-  projects: Bridge[],
+  projects: (Bridge | Layer2)[],
   tvlApiResponse: TvlApiResponse,
-  tvl: number,
+  bridgesTvl: number,
+  combinedTvl: number,
 ): BridgesTvlViewEntry[] {
-  return projects.map((x) => getBridgesTvlViewEntry(x, tvlApiResponse, tvl))
+  return projects.map((x) =>
+    getBridgesTvlViewEntry(x, tvlApiResponse, bridgesTvl, combinedTvl),
+  )
 }
 
 function getBridgesTvlViewEntry(
-  project: Bridge,
+  project: Bridge | Layer2,
   tvlApiResponse: TvlApiResponse,
-  aggregateTvl: number,
+  bridgesTvl: number,
+  combinedTvl: number,
 ): BridgesTvlViewEntry {
   const associatedTokens = project.config.associatedTokens ?? []
   const apiProject = tvlApiResponse.projects[project.id.toString()]
@@ -26,13 +30,18 @@ function getBridgesTvlViewEntry(
   const stats = getTvlStats(apiProject, project.display.name, associatedTokens)
 
   return {
+    type: project.type,
     name: project.display.name,
     slug: project.display.slug,
     tvl: formatUSD(stats.tvl),
     tvlBreakdown: stats.tvlBreakdown,
     oneDayChange: stats.oneDayChange,
     sevenDayChange: stats.sevenDayChange,
-    marketShare: formatPercent(stats.tvl / aggregateTvl),
-    type: project.technology.type,
+    bridgesMarketShare: formatPercent(stats.tvl / bridgesTvl),
+    combinedMarketShare: formatPercent(stats.tvl / combinedTvl),
+    category:
+      project.type === 'bridge'
+        ? project.technology.type
+        : project.technology.category,
   }
 }

--- a/packages/frontend/src/pages/bridges-tvl/props/getProps.ts
+++ b/packages/frontend/src/pages/bridges-tvl/props/getProps.ts
@@ -13,21 +13,42 @@ export function getProps(
   config: Config,
   tvlApiResponse: TvlApiResponse,
 ): Wrapped<BridgesTvlPageProps> {
-  const tvl = tvlApiResponse.bridges.hourly.data.at(-1)?.[1] ?? 0
-  const tvlSevenDaysAgo = tvlApiResponse.bridges.hourly.data[0]?.[1] ?? 0
-  const sevenDayChange = getPercentageChange(tvl, tvlSevenDaysAgo)
+  const bridgesTvl = tvlApiResponse.bridges.hourly.data.at(-1)?.[1] ?? 0
+  const bridgesTvlSevenDaysAgo = tvlApiResponse.bridges.hourly.data[0]?.[1] ?? 0
+  const bridgesTvlSevenDayChange = getPercentageChange(
+    bridgesTvl,
+    bridgesTvlSevenDaysAgo,
+  )
 
-  const included = getIncludedProjects(config.bridges, tvlApiResponse)
+  const combinedTvl = tvlApiResponse.combined.hourly.data.at(-1)?.[1] ?? 0
+  const combinedTvlSevenDaysAgo =
+    tvlApiResponse.combined.hourly.data[0]?.[1] ?? 0
+  const combinedTvlSevenDayChange = getPercentageChange(
+    combinedTvl,
+    combinedTvlSevenDaysAgo,
+  )
+
+  const included = getIncludedProjects(
+    [...config.bridges, ...config.layer2s],
+    tvlApiResponse,
+  )
   const ordering = orderByTvl(included, tvlApiResponse)
 
   return {
     props: {
       navbar: getNavbarProps(config),
-      tvl: formatUSD(tvl),
-      sevenDayChange,
+      bridgesTvl: formatUSD(bridgesTvl),
+      bridgesTvlSevenDayChange,
+      combinedTvl: formatUSD(combinedTvl),
+      combinedTvlSevenDayChange,
       apiEndpoint: '/api/bridges-tvl.json',
       tvlView: {
-        items: getBridgesTvlView(ordering, tvlApiResponse, tvl),
+        items: getBridgesTvlView(
+          ordering,
+          tvlApiResponse,
+          bridgesTvl,
+          combinedTvl,
+        ),
       },
       footer: getFooterProps(config),
     },

--- a/packages/frontend/src/pages/scaling-activity/view/ActivityView.tsx
+++ b/packages/frontend/src/pages/scaling-activity/view/ActivityView.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames'
 import React from 'react'
 
 import { PercentChange } from '../../../components'
-import { Column, TableView } from '../../../components/TableView'
+import { ColumnConfig, TableView } from '../../../components/TableView'
 
 export interface ActivityViewProps {
   items: ActivityViewEntry[]
@@ -18,7 +18,7 @@ export interface ActivityViewEntry {
 }
 
 export function ActivityView({ items, className }: ActivityViewProps) {
-  const columns: Column<ActivityViewEntry>[] = [
+  const columns: ColumnConfig<ActivityViewEntry>[] = [
     {
       name: 'No.',
       getValue: (entry, index) => `${index + 1}.`,

--- a/packages/frontend/src/pages/scaling-activity/view/ActivityView.tsx
+++ b/packages/frontend/src/pages/scaling-activity/view/ActivityView.tsx
@@ -20,6 +20,10 @@ export interface ActivityViewEntry {
 export function ActivityView({ items, className }: ActivityViewProps) {
   const columns: Column<ActivityViewEntry>[] = [
     {
+      name: 'No.',
+      getValue: (entry, index) => `${index + 1}.`,
+    },
+    {
       name: 'Name',
       getValue: (project) => project.name,
     },

--- a/packages/frontend/src/pages/scaling-risk/view/ScalingRiskView.tsx
+++ b/packages/frontend/src/pages/scaling-risk/view/ScalingRiskView.tsx
@@ -8,7 +8,7 @@ import {
   ZkSyncIcon,
 } from '../../../components/icons'
 import { ProjectLink } from '../../../components/ProjectLink'
-import { Column, TableView } from '../../../components/TableView'
+import { ColumnConfig, TableView } from '../../../components/TableView'
 import { RiskCell } from './RiskCell'
 
 export interface ScalingRiskViewProps {
@@ -23,7 +23,7 @@ export interface ScalingRiskViewEntry extends Layer2RiskView {
 }
 
 export function ScalingRiskView({ items, className }: ScalingRiskViewProps) {
-  const columns: Column<ScalingRiskViewEntry>[] = [
+  const columns: ColumnConfig<ScalingRiskViewEntry>[] = [
     {
       name: 'No.',
       getValue: (entry, index) => `${index + 1}.`,

--- a/packages/frontend/src/pages/scaling-risk/view/ScalingRiskView.tsx
+++ b/packages/frontend/src/pages/scaling-risk/view/ScalingRiskView.tsx
@@ -25,6 +25,10 @@ export interface ScalingRiskViewEntry extends Layer2RiskView {
 export function ScalingRiskView({ items, className }: ScalingRiskViewProps) {
   const columns: Column<ScalingRiskViewEntry>[] = [
     {
+      name: 'No.',
+      getValue: (entry, index) => `${index + 1}.`,
+    },
+    {
       name: 'Name',
       getValue: (project) => <ProjectLink type="layer2" project={project} />,
     },

--- a/packages/frontend/src/pages/scaling-tvl/view/ScalingTvlView.tsx
+++ b/packages/frontend/src/pages/scaling-tvl/view/ScalingTvlView.tsx
@@ -9,7 +9,7 @@ import {
   ZkSyncIcon,
 } from '../../../components/icons'
 import { ProjectLink } from '../../../components/ProjectLink'
-import { Column, TableView } from '../../../components/TableView'
+import { ColumnConfig, TableView } from '../../../components/TableView'
 import {
   TVLBreakdown,
   TVLBreakdownProps,
@@ -34,7 +34,7 @@ export interface ScalingTvlViewEntry {
 }
 
 export function ScalingTvlView({ items }: ScalingTvlViewProps) {
-  const columns: Column<ScalingTvlViewEntry>[] = [
+  const columns: ColumnConfig<ScalingTvlViewEntry>[] = [
     {
       name: 'No.',
       getValue: (entry, index) => `${index + 1}.`,

--- a/packages/frontend/src/pages/scaling-tvl/view/ScalingTvlView.tsx
+++ b/packages/frontend/src/pages/scaling-tvl/view/ScalingTvlView.tsx
@@ -36,6 +36,10 @@ export interface ScalingTvlViewEntry {
 export function ScalingTvlView({ items }: ScalingTvlViewProps) {
   const columns: Column<ScalingTvlViewEntry>[] = [
     {
+      name: 'No.',
+      getValue: (entry, index) => `${index + 1}.`,
+    },
+    {
       name: 'Name',
       getValue: (project) => <ProjectLink type="layer2" project={project} />,
     },

--- a/packages/frontend/src/scripts/configureCombinedBridges.ts
+++ b/packages/frontend/src/scripts/configureCombinedBridges.ts
@@ -1,0 +1,10 @@
+export function configureCombinedBridges() {
+  const checkbox = document.querySelector<HTMLInputElement>('#combined-bridges')
+  const bridgesOnly = document.querySelectorAll('[data-bridges-only]')
+  const combinedOnly = document.querySelectorAll('[data-combined-only]')
+
+  checkbox?.addEventListener('change', () => {
+    bridgesOnly.forEach((x) => x.classList.toggle('hidden', checkbox.checked))
+    combinedOnly.forEach((x) => x.classList.toggle('hidden', !checkbox.checked))
+  })
+}

--- a/packages/frontend/src/scripts/index.ts
+++ b/packages/frontend/src/scripts/index.ts
@@ -1,8 +1,10 @@
 import { configureChart } from '../components/chart/configure'
 import { configureDarkThemeToggle } from '../components/navbar/configureDarkThemeToggle'
 import { configureSidebarMenu } from '../components/navbar/configureSidebarMenu'
+import { configureCombinedBridges } from './configureCombinedBridges'
 import { configureTooltips } from './configureTooltips'
 
+configureCombinedBridges()
 configureDarkThemeToggle()
 configureSidebarMenu()
 configureTooltips()


### PR DESCRIPTION
Resolves L2B-146

I needed make `Layer2 | Bridge` a discriminated union so that's why all of them now have a `type` member.

This PR uses `data-bridges-only` and `data-combined-only` to toggle visibility of elements depending on the checkbox state. The one thing this PR doesn't update is the chart, which will probably be the subject of the next PR.