### PR TITLE
Add more activity statistics

### DIFF
--- a/packages/backend/src/core/transaction-count/StarkexTransactionUpdater.ts
+++ b/packages/backend/src/core/transaction-count/StarkexTransactionUpdater.ts
@@ -103,13 +103,9 @@ export class StarkexTransactionUpdater implements TransactionCounter {
   }
 
   async getStatus() {
-    return {
+    return Promise.resolve({
       queuedJobsCount: this.daysQueue.length,
-      missingRanges:
-        await this.starkexTransactionCountRepository.getMissingRangesByProject(
-          this.projectId,
-        ),
       busyWorkers: this.daysQueue.getBusyWorkers(),
-    }
+    })
   }
 }

--- a/packages/backend/src/core/transaction-count/ZksyncTransactionUpdater.ts
+++ b/packages/backend/src/core/transaction-count/ZksyncTransactionUpdater.ts
@@ -19,6 +19,7 @@ export class ZksyncTransactionUpdater implements TransactionCounter {
 
   private readonly updateQueue: TaskQueue<void>
   private readonly blockQueue: TaskQueue<number>
+  private latestBlock?: number
 
   constructor(
     private readonly zksyncClient: ZksyncClient,
@@ -84,6 +85,7 @@ export class ZksyncTransactionUpdater implements TransactionCounter {
     const missingRanges =
       await this.zksyncTransactionRepository.getMissingRanges()
     const latestBlock = await this.zksyncClient.getLatestBlock()
+    this.latestBlock = latestBlock
 
     for (const [start, end] of missingRanges) {
       for (
@@ -105,8 +107,10 @@ export class ZksyncTransactionUpdater implements TransactionCounter {
   async getStatus() {
     return {
       queuedJobsCount: this.blockQueue.length,
-      missingRanges: await this.zksyncTransactionRepository.getMissingRanges(),
       busyWorkers: this.blockQueue.getBusyWorkers(),
+      latestBlock: this.latestBlock ?? null,
+      latestFetchedBlock: await this.zksyncTransactionRepository.getMaxBlock(),
+      totalBlocks: await this.zksyncTransactionRepository.getBlockCount(),
     }
   }
 }

--- a/packages/backend/src/peripherals/database/BlockTransactionCountRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockTransactionCountRepository.ts
@@ -30,6 +30,8 @@ export class BlockTransactionCountRepository extends BaseRepository {
     this.addMany = this.wrapAddMany(this.addMany)
     this.deleteAll = this.wrapDelete(this.deleteAll)
     this.getDailyTransactionCount = this.wrapGet(this.getDailyTransactionCount)
+    this.getMaxBlock = this.wrapAny(this.getMaxBlock)
+    this.getBlockCount = this.wrapAny(this.getBlockCount)
 
     /* eslint-enable @typescript-eslint/unbound-method */
   }
@@ -141,6 +143,22 @@ export class BlockTransactionCountRepository extends BaseRepository {
   async deleteAll() {
     const knex = await this.knex()
     return await knex('transactions.block').delete()
+  }
+
+  async getMaxBlock(projectId: ProjectId): Promise<number> {
+    const knex = await this.knex()
+    const [{ max }] = await knex('transactions.block')
+      .max('block_number')
+      .where('project_id', projectId.toString())
+    return max as number
+  }
+
+  async getBlockCount(projectId: ProjectId): Promise<number> {
+    const knex = await this.knex()
+    const [{ count }] = await knex('transactions.block')
+      .count()
+      .where('project_id', projectId.toString())
+    return count as number
   }
 }
 

--- a/packages/backend/src/peripherals/database/ZksyncTransactionRepository.ts
+++ b/packages/backend/src/peripherals/database/ZksyncTransactionRepository.ts
@@ -29,6 +29,8 @@ export class ZksyncTransactionRepository extends BaseRepository {
     this.add = this.wrapAdd(this.add)
     this.addMany = this.wrapAddMany(this.addMany)
     this.deleteAll = this.wrapDelete(this.deleteAll)
+    this.getBlockCount = this.wrapAny(this.getBlockCount)
+    this.getMaxBlock = this.wrapAny(this.getMaxBlock)
 
     /* eslint-enable @typescript-eslint/unbound-method */
   }
@@ -143,6 +145,20 @@ export class ZksyncTransactionRepository extends BaseRepository {
   async deleteAll() {
     const knex = await this.knex()
     return await knex('transactions.zksync').delete()
+  }
+
+  async getMaxBlock(): Promise<number> {
+    const knex = await this.knex()
+    const [{ max }] = await knex('transactions.zksync').max('block_number')
+    return max as number
+  }
+
+  async getBlockCount(): Promise<number> {
+    const knex = await this.knex()
+    const [{ count }] = await knex('transactions.zksync').countDistinct(
+      'block_number',
+    )
+    return count as number
   }
 }
 

--- a/packages/backend/src/setup/createStarkexTransactionUpdaters.ts
+++ b/packages/backend/src/setup/createStarkexTransactionUpdaters.ts
@@ -2,7 +2,7 @@ import { Logger } from '@l2beat/common'
 
 import { Config } from '../config'
 import { Clock } from '../core/Clock'
-import { StarkexTransactionUpdater } from '../core/transaction-count/StarkexTransactionCountUpdater'
+import { StarkexTransactionUpdater } from '../core/transaction-count/StarkexTransactionUpdater'
 import { StarkexTransactionCountRepository } from '../peripherals/database/StarkexTransactionCountRepository'
 import { StarkexClient } from '../peripherals/starkex'
 import { assert } from '../tools/assert'

--- a/packages/backend/test/api/controllers/ActivityController.test.ts
+++ b/packages/backend/test/api/controllers/ActivityController.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'earljs'
 
 import { ActivityController } from '../../../src/api/controllers/ActivityController'
 import { RpcTransactionUpdater } from '../../../src/core/transaction-count/RpcTransactionUpdater'
-import { StarkexTransactionUpdater } from '../../../src/core/transaction-count/StarkexTransactionCountUpdater'
+import { StarkexTransactionUpdater } from '../../../src/core/transaction-count/StarkexTransactionUpdater'
 import { TransactionCounter } from '../../../src/core/transaction-count/TransactionCounter'
 import { ZksyncTransactionUpdater } from '../../../src/core/transaction-count/ZksyncTransactionUpdater'
 

--- a/packages/backend/test/core/transaction-count/StarkexTransactionUpdater.test.ts
+++ b/packages/backend/test/core/transaction-count/StarkexTransactionUpdater.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'earljs'
 import waitForExpect from 'wait-for-expect'
 
 import { Clock } from '../../../src/core/Clock'
-import { StarkexTransactionUpdater } from '../../../src/core/transaction-count/StarkexTransactionCountUpdater'
+import { StarkexTransactionUpdater } from '../../../src/core/transaction-count/StarkexTransactionUpdater'
 import { StarkexTransactionCountRepository } from '../../../src/peripherals/database/StarkexTransactionCountRepository'
 import { StarkexClient } from '../../../src/peripherals/starkex'
 


### PR DESCRIPTION
Changes the status endpoint to something like the following:

```
[
  {
    "projectId": "arbitrum",
    "status": {
      "queuedJobsCount": 9970,
      "busyWorkers": 1,
      "startBlock": 0,
      "latestBlock": "28539024",
      "latestFetchedBlock": 939,
      "totalBlocks": "940"
    }
  },
  {
    "projectId": "bobanetwork",
    "status": {
      "queuedJobsCount": 9991,
      "busyWorkers": 1,
      "startBlock": 0,
      "latestBlock": "831846",
      "latestFetchedBlock": 579,
      "totalBlocks": "580"
    }
  },
  {
    "projectId": "metis",
    "status": {
      "queuedJobsCount": 9980,
      "busyWorkers": 1,
      "startBlock": 0,
      "latestBlock": "3716569",
      "latestFetchedBlock": 1798,
      "totalBlocks": "1799"
    }
  },
  {
    "projectId": "nova",
    "status": {
      "queuedJobsCount": 9987,
      "busyWorkers": 1,
      "startBlock": 0,
      "latestBlock": "540903",
      "latestFetchedBlock": 708,
      "totalBlocks": "709"
    }
  },
  {
    "projectId": "optimism",
    "status": {
      "queuedJobsCount": 9971,
      "busyWorkers": 1,
      "startBlock": 0,
      "latestBlock": "27593057",
      "latestFetchedBlock": 865,
      "totalBlocks": "866"
    }
  },
  {
    "projectId": "dydx",
    "status": {
      "queuedJobsCount": 0,
      "busyWorkers": 0
    }
  },
  {
    "projectId": "zksync",
    "status": {
      "queuedJobsCount": 107723,
      "busyWorkers": 1,
      "latestBlock": 109140,
      "latestFetchedBlock": 1416,
      "totalBlocks": "1416"
    }
  },
  {
    "projectId": "loopring",
    "status": {
      "queuedJobsCount": 30260,
      "busyWorkers": 1,
      "latestBlock": 30452,
      "latestFetchedBlock": 191,
      "totalBlocks": "191"
    }
  },
  {
    "projectId": "ethereum",
    "status": {
      "queuedJobsCount": 9992,
      "busyWorkers": 1,
      "startBlock": 8929324,
      "latestBlock": "15682876",
      "latestFetchedBlock": 8931223,
      "totalBlocks": "1900"
    }
  }
]```