### PR TITLE
Record when activity is inserted into database

### DIFF
--- a/packages/backend/src/peripherals/database/migrations/030_record_transactions_insert_time.ts
+++ b/packages/backend/src/peripherals/database/migrations/030_record_transactions_insert_time.ts
@@ -1,0 +1,40 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+const makeAddInsertAt =
+  (knex: Knex) =>
+  (table: Knex.CreateTableBuilder): void => {
+    table.dateTime('inserted_at').defaultTo(knex.fn.now())
+  }
+const dropInsertAt = (table: Knex.CreateTableBuilder): void => {
+  table.dropColumn('inserted_at')
+}
+
+export async function up(knex: Knex) {
+  const addInsertAt = makeAddInsertAt(knex)
+  await knex.schema
+    .withSchema('transactions')
+    .alterTable('block', addInsertAt)
+    .alterTable('starkex', addInsertAt)
+    .alterTable('zksync', addInsertAt)
+}
+
+export async function down(knex: Knex) {
+  await knex.schema
+    .withSchema('transactions')
+    .alterTable('block', dropInsertAt)
+    .alterTable('starkex', dropInsertAt)
+    .alterTable('zksync', dropInsertAt)
+}


### PR DESCRIPTION
This allows us to retrospectively calculate sync speed. Ideally we used logs processing for this, but it would require more setup from us and at the moment we don't have that time. This will be used mostly for optimism and arbitrum only.