### PR TITLE
Fix TaskQueue flaky tests

### DIFF
--- a/packages/common/test/tools/queue/TaskQueue.test.ts
+++ b/packages/common/test/tools/queue/TaskQueue.test.ts
@@ -154,5 +154,6 @@ describe(TaskQueue.name, () => {
   })
 })
 
+// Unfortunately fake-timers do not work well with timers/promises
 const wait = (delay: number) =>
   new Promise((resolve) => setTimeout(resolve, delay))

--- a/packages/common/test/tools/queue/TaskQueue.test.ts
+++ b/packages/common/test/tools/queue/TaskQueue.test.ts
@@ -1,17 +1,26 @@
+import { install, InstalledClock } from '@sinonjs/fake-timers'
 import { expect } from 'earljs'
-import { setTimeout } from 'timers/promises'
-import waitForExpect from 'wait-for-expect'
 
 import { Logger } from '../../../src/tools/Logger'
 import { Retries } from '../../../src/tools/queue/Retries'
 import { TaskQueue } from '../../../src/tools/queue/TaskQueue'
 
 describe(TaskQueue.name, () => {
+  let time: InstalledClock
+
+  beforeEach(() => {
+    time = install()
+  })
+
+  afterEach(() => {
+    time.uninstall()
+  })
+
   it('executes all jobs', async () => {
     const completed: number[] = []
 
     async function execute(value: number) {
-      await setTimeout(1)
+      await wait(1)
       completed.push(value)
     }
 
@@ -21,9 +30,9 @@ describe(TaskQueue.name, () => {
       queue.addToBack(i)
     }
 
-    await waitForExpect(() => {
-      expect(completed).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    })
+    await time.runAllAsync()
+
+    expect(completed).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
   })
 
   it('can handle occasional failure', async () => {
@@ -31,7 +40,7 @@ describe(TaskQueue.name, () => {
     let failures = 10
 
     async function execute(i: number) {
-      await setTimeout(1)
+      await wait(1)
       if (failures > 0) {
         failures--
         throw new Error('oops')
@@ -42,20 +51,21 @@ describe(TaskQueue.name, () => {
     const queue = new TaskQueue(execute, Logger.SILENT, {
       shouldRetry: Retries.always,
     })
+
     for (let i = 0; i < 10; i++) {
       queue.addToBack(i)
     }
 
-    await waitForExpect(() => {
-      expect(completed).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    })
+    await time.runAllAsync()
+
+    expect(completed).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
   })
 
   it('can add jobs to front', async () => {
     const completed: number[] = []
 
     async function execute(value: number) {
-      await setTimeout(1)
+      await wait(1)
       completed.push(value)
     }
 
@@ -65,16 +75,16 @@ describe(TaskQueue.name, () => {
       queue.addToFront(i)
     }
 
-    await waitForExpect(() => {
-      expect(completed).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
-    })
+    await time.runAllAsync()
+
+    expect(completed).toEqual([9, 8, 7, 6, 5, 4, 3, 2, 1, 0])
   })
 
   it('can add jobs only if empty', async () => {
     const completed: number[] = []
 
     async function execute(value: number) {
-      await setTimeout(1)
+      await wait(1)
       completed.push(value)
     }
 
@@ -85,9 +95,9 @@ describe(TaskQueue.name, () => {
     }
     queue.addToBack(420)
 
-    await waitForExpect(() => {
-      expect(completed).toEqual([0, 420])
-    })
+    await time.runAllAsync()
+
+    expect(completed).toEqual([0, 420])
   })
 
   it('can accept only positive integers for workers', async () => {
@@ -103,7 +113,7 @@ describe(TaskQueue.name, () => {
     const completed: number[] = []
 
     async function execute(value: number) {
-      await setTimeout(value * 10)
+      await wait(value)
       completed.push(value)
     }
 
@@ -115,16 +125,16 @@ describe(TaskQueue.name, () => {
     queue.addToBack(1)
     queue.addToBack(2)
 
-    await waitForExpect(() => {
-      expect(completed).toEqual([1, 1, 3, 2, 5])
-    })
+    await time.runAllAsync()
+
+    expect(completed).toEqual([1, 1, 3, 2, 5])
   })
 
   it('can wait until it is empty', async () => {
     const completed: number[] = []
 
     async function execute(value: number) {
-      await setTimeout(value * 10)
+      await wait(value * 10)
       completed.push(value)
     }
 
@@ -136,8 +146,13 @@ describe(TaskQueue.name, () => {
     queue.addToBack(1)
     queue.addToBack(2)
 
+    await time.runAllAsync()
+
     await queue.waitTilEmpty()
 
     expect(queue.length).toEqual(0)
   })
 })
+
+const wait = (delay: number) =>
+  new Promise((resolve) => setTimeout(resolve, delay))


### PR DESCRIPTION
Use `sinonjs/fake-timers` to mock timers. This way we make tests deterministic as well as speed them up a lot.