### PR TITLE
Api activity improvements

### DIFF
--- a/packages/backend/src/core/transaction-count/MaterializedViewRefresher.ts
+++ b/packages/backend/src/core/transaction-count/MaterializedViewRefresher.ts
@@ -1,6 +1,7 @@
 import { Logger, TaskQueue } from '@l2beat/common'
 
 import { BlockTransactionCountRepository } from '../../peripherals/database/BlockTransactionCountRepository'
+import { ZksyncTransactionRepository } from '../../peripherals/database/ZksyncTransactionRepository'
 import { Clock } from '../Clock'
 
 export class MaterializedViewRefresher {
@@ -8,6 +9,7 @@ export class MaterializedViewRefresher {
 
   constructor(
     private readonly blockTransactionCountRepository: BlockTransactionCountRepository,
+    private readonly zksyncTransactionRepository: ZksyncTransactionRepository,
     private readonly clock: Clock,
     private readonly logger: Logger,
   ) {
@@ -29,6 +31,7 @@ export class MaterializedViewRefresher {
   async update() {
     this.logger.info('Refresh started')
     await this.blockTransactionCountRepository.refresh()
+    await this.zksyncTransactionRepository.refresh()
     this.logger.info('Refresh finished')
   }
 }

--- a/packages/backend/src/peripherals/database/StarkexTransactionCountRepository.ts
+++ b/packages/backend/src/peripherals/database/StarkexTransactionCountRepository.ts
@@ -111,24 +111,12 @@ export class StarkexTransactionCountRepository extends BaseRepository {
     projectId: ProjectId,
   ): Promise<{ timestamp: UnixTime; count: number }[]> {
     const knex = await this.knex()
-    const { rows } = (await knex.raw(
-      `
-      SELECT
-        date_trunc('day', unix_timestamp) AS unix_timestamp,
-        sum(count) as count
-      FROM
-        transactions.starkex
-      WHERE
-        project_id = ?
-      GROUP BY
-        date_trunc('day', unix_timestamp)
-      ORDER BY 
-        unix_timestamp
-    `,
-      projectId.toString(),
-    )) as unknown as {
-      rows: Pick<StarkexTransactionCountRow, 'unix_timestamp' | 'count'>[]
-    }
+    const rows = (await knex('transactions.starkex')
+      .where('project_id', projectId.toString())
+      .orderBy('unix_timestamp')) as Pick<
+      StarkexTransactionCountRow,
+      'unix_timestamp' | 'count'
+    >[]
 
     return rows.map((r) => ({
       timestamp: UnixTime.fromDate(r.unix_timestamp),

--- a/packages/backend/src/peripherals/database/migrations/031_transaction_count_view_zksync.ts
+++ b/packages/backend/src/peripherals/database/migrations/031_transaction_count_view_zksync.ts
@@ -1,0 +1,40 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema
+    .withSchema('transactions')
+    .createMaterializedView('zksync_count_view', function (view) {
+      view.columns(['unix_timestamp', 'count'])
+      view.as(
+        knex
+          .withSchema('transactions')
+          .select(
+            knex.raw(`
+              date_trunc('day', unix_timestamp) as unix_timestamp,
+              count(*) as count
+              `),
+          )
+          .from('zksync')
+          .groupByRaw("date_trunc('day', unix_timestamp)"),
+      )
+    })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema
+    .withSchema('transactions')
+    .dropMaterializedView('zksync_count_view')
+}

--- a/packages/backend/src/setup/ActivityModule.ts
+++ b/packages/backend/src/setup/ActivityModule.ts
@@ -60,6 +60,7 @@ export function getActivityModule(
 
   const materializedViewRefresher = new MaterializedViewRefresher(
     blockTransactionCountRepository,
+    zksyncTransactionRepository,
     clock,
     logger,
   )

--- a/packages/backend/test/peripherals/database/StarkexTransactionCountRepository.test.ts
+++ b/packages/backend/test/peripherals/database/StarkexTransactionCountRepository.test.ts
@@ -131,112 +131,32 @@ describe(StarkexTransactionCountRepository.name, () => {
         const start = UnixTime.now().toStartOf('day')
         const aCounts = [
           fakeTransactionCount({
-            timestamp: start.add(1, 'hours'),
+            timestamp: start,
             projectId: PROJECT_A,
+            count: 100,
           }),
           fakeTransactionCount({
-            timestamp: start.add(2, 'hours'),
+            timestamp: start.add(1, 'days'),
             projectId: PROJECT_A,
+            count: 101,
           }),
         ]
         const bCounts = [
           fakeTransactionCount({
-            timestamp: start.add(1, 'hours'),
+            timestamp: start,
 
             projectId: PROJECT_B,
           }),
           fakeTransactionCount({
-            timestamp: start.add(3, 'hours'),
+            timestamp: start.add(1, 'days'),
             projectId: PROJECT_B,
           }),
         ]
         await repository.addMany([...aCounts, ...bCounts])
 
-        expect(await repository.getDailyTransactionCount(PROJECT_A)).toEqual([
-          {
-            timestamp: start,
-            count: aCounts.reduce((acc, record) => acc + record.count, 0),
-          },
-        ])
-      })
-
-      it('groups by day', async () => {
-        const today = UnixTime.now().toStartOf('day')
-
-        await repository.addMany([
-          fakeTransactionCount({
-            timestamp: today.add(1, 'hours'),
-            projectId: PROJECT_A,
-            count: 1,
-          }),
-          fakeTransactionCount({
-            timestamp: today.add(1, 'days').add(-1, 'seconds'),
-            projectId: PROJECT_A,
-            count: 2,
-          }),
-          fakeTransactionCount({
-            timestamp: today.add(1, 'days').add(1, 'hours'),
-            projectId: PROJECT_A,
-            count: 3,
-          }),
-          fakeTransactionCount({
-            timestamp: today.add(2, 'days'),
-            projectId: PROJECT_A,
-            count: 4,
-          }),
-        ])
-
-        expect(await repository.getDailyTransactionCount(PROJECT_A)).toEqual([
-          {
-            count: 3,
-            timestamp: today,
-          },
-          {
-            count: 3,
-            timestamp: today.add(1, 'days'),
-          },
-          {
-            count: 4,
-            timestamp: today.add(2, 'days'),
-          },
-        ])
-      })
-
-      it('orders by day', async () => {
-        const today = UnixTime.now().toStartOf('day')
-
-        await repository.addMany([
-          fakeTransactionCount({
-            timestamp: today.add(1, 'days').add(1, 'hours'),
-            projectId: PROJECT_A,
-            count: 3,
-          }),
-          fakeTransactionCount({
-            timestamp: today,
-            projectId: PROJECT_A,
-            count: 1,
-          }),
-          fakeTransactionCount({
-            timestamp: today.add(2, 'days'),
-            projectId: PROJECT_A,
-            count: 4,
-          }),
-        ])
-
-        expect(await repository.getDailyTransactionCount(PROJECT_A)).toEqual([
-          {
-            count: 1,
-            timestamp: today,
-          },
-          {
-            count: 3,
-            timestamp: today.add(1, 'days'),
-          },
-          {
-            count: 4,
-            timestamp: today.add(2, 'days'),
-          },
-        ])
+        expect(await repository.getDailyTransactionCount(PROJECT_A)).toEqual(
+          aCounts.map(({ timestamp, count }) => ({ timestamp, count })),
+        )
       })
     },
   )

--- a/packages/backend/test/peripherals/database/ZksyncTransactionRepository.test.ts
+++ b/packages/backend/test/peripherals/database/ZksyncTransactionRepository.test.ts
@@ -119,6 +119,7 @@ describe(ZksyncTransactionRepository.name, () => {
     ZksyncTransactionRepository.prototype.getDailyTransactionCount.name,
     () => {
       it('works with empty repository', async () => {
+        await repository.refresh()
         expect(
           await repository.getDailyTransactionCount(UnixTime.now()),
         ).toEqual([])
@@ -145,6 +146,7 @@ describe(ZksyncTransactionRepository.name, () => {
           }),
         ])
 
+        await repository.refresh()
         expect(
           await repository.getDailyTransactionCount(start.add(2, 'days')),
         ).toEqual([
@@ -171,6 +173,7 @@ describe(ZksyncTransactionRepository.name, () => {
           }),
         ])
 
+        await repository.refresh()
         expect(
           await repository.getDailyTransactionCount(start.add(2, 'days')),
         ).toEqual([
@@ -197,6 +200,7 @@ describe(ZksyncTransactionRepository.name, () => {
           }),
         ])
 
+        await repository.refresh()
         expect(await repository.getDailyTransactionCount(today)).toEqual([
           {
             count: 1,


### PR DESCRIPTION
After creating a view for blocks, zksync table seems to be the bottleneck. This PR reduces local /api/activity response time (with backend sync on) from ~2s to ~400ms. 