### PR TITLE
Update Rainbow Bridge information

### DIFF
--- a/packages/config/src/bridges/near.ts
+++ b/packages/config/src/bridges/near.ts
@@ -18,7 +18,7 @@ export const near: Bridge = {
       socialMedia: ['https://twitter.com/auroraisnear'],
     },
     description:
-      'Rainbow bridge is an light client based bridge between NEAR/AURORA and Ethereum that allows for asset and data movement between these chains. For better gas efficiency from NEAR to Ethereum it leverages optimistic validation which adds some trust assumption and latency.',
+      'Rainbow bridge is a light client based bridge between NEAR/AURORA and Ethereum that allows for asset and data movement between these chains. For better gas efficiency from NEAR to Ethereum, it leverages optimistic validation, which adds some trust assumption and latency.',
   },
   config: {
     associatedTokens: ['AURORA'],
@@ -64,23 +64,23 @@ export const near: Bridge = {
   },
   technology: {
     canonical: true,
-    category: 'Token Bridge',
+    category: 'Generic Bridge',
     destination: ['Near', 'Aurora'],
     principleOfOperation: {
       name: 'Principle of operation',
       description:
-        'Rainbow is a Token Bridge that locks tokens in the escrow contracts on Ethereum and mints tokens on the Aurora or NEAR network. When bridging back to Ethereum tokens are burned on Aurora / NEAR and then released from the escrow on Ethereum.',
+        'Rainbow is a Generic Bridge that allows transferring assets and passing arbitrary messages between Ethereum, NEAR, and Aurora chains. During token transfers, Rainbow Bridge locks tokens in the escrow contracts on Ethereum and mints tokens on the Aurora or NEAR networks. When bridging back to Ethereum, tokens are burned on Aurora / NEAR and then released from the escrow on Ethereum.',
       references: [],
       risks: [],
     },
     validation: {
       name: 'Both inbound and outbound transfers are verified by the light client',
       description:
-        'Near Rainbow bridge implements light client for both inbound and outbound transfers. For inbound transfers, checkpoints of near state are submitted every 4 hours. \
+        'Near Rainbow bridge implements a light client for both inbound and outbound transfers. For inbound transfers, checkpoints of NEAR state are submitted every 4 hours. \
         These are optimistically assumed to be signed by 2/3 of Near Validators. The signatures are not immediately verified by Ethereum due to a different signature scheme \
         used on NEAR and - as a result - very high gas cost on Ethereum. If signatures are found to be invalid, checkpoints can be permissionlessly challenged. \
-        Users can withdraw funds by submitting a merkle proof of a burn event against the checkpoint. \
-        For outbound transfers, Ethereum light client is implemented on NEAR and a merkle proof of a lock event must be presented.',
+        Users can withdraw funds by submitting a Merkle proof of a burn event against the checkpoint. \
+        For outbound transfers, Ethereum light client is implemented on NEAR and a Merkle proof of a lock event must be presented.',
       references: [],
       risks: [
         {
@@ -118,6 +118,16 @@ export const near: Bridge = {
         description: 'Escrow contract for ERC20 tokens.',
       },
       {
+        address: '0x6BFaD42cFC4EfC96f529D786D643Ff4A8B89FA52',
+        name: 'EthCustodian',
+        description: 'Escrow contract for ETH tokens.',
+      },
+      {
+        address: '0x85F17Cf997934a597031b2E18a9aB6ebD4B9f6a4',
+        name: 'NEAR token',
+        description: 'Escrow contract for NEAR tokens.',
+      },
+      {
         address: '0x051AD3F020274910065Dcb421629cd2e6E5b46c4',
         name: 'NearProver',
         description: 'Contract verifying merkle proofs, used for withdrawals.',
@@ -133,7 +143,7 @@ export const near: Bridge = {
         description: 'Contract storing Near state checkpoints.',
       },
     ],
-    risks: [CONTRACTS.UPGRADE_NO_DELAY_RISK],
+    risks: [],
   },
   permissions: [
     {


### PR DESCRIPTION
* Add EthCustodian and NEAR Token contract addresses.
* Remove upgradeability risks from Ethereum contracts as they are not upgradeable.
* Change bridge type to Generic Bridge.
* Minor text fixes.

Closes #853.
Closes #854.
Closes #855.