### PR TITLE
Fix activity db queries

### DIFF
--- a/packages/backend/src/peripherals/database/BlockTransactionCountRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockTransactionCountRepository.ts
@@ -104,13 +104,13 @@ export class BlockTransactionCountRepository extends BaseRepository {
     const tip = await this.findTipByProject(projectId)
     const { rows } = (await knex.raw(
       `
-      SELECT NULL prev, min(block_number) next FROM transactions.block WHERE project_id = :projectId
+      SELECT NULL AS prev, min(block_number) AS next FROM transactions.block WHERE project_id = :projectId
       UNION
-      SELECT block_number prev, next
+      SELECT block_number AS prev, next
       FROM (
         SELECT
           block_number,
-          lead(block_number) over (order by block_number) next
+          lead(block_number) over (order by block_number) AS next
         FROM transactions.block WHERE block_number >= :blockNumber AND project_id = :projectId
       ) with_lead
       WHERE next > block_number + 1 OR next IS NULL

--- a/packages/backend/src/peripherals/database/StarkexTransactionCountRepository.ts
+++ b/packages/backend/src/peripherals/database/StarkexTransactionCountRepository.ts
@@ -91,13 +91,13 @@ export class StarkexTransactionCountRepository extends BaseRepository {
     const knex = await this.knex()
     const { rows } = (await knex.raw(
       `
-      SELECT NULL prev, min(unix_timestamp) next FROM transactions.starkex WHERE project_id = :projectId
+      SELECT NULL AS prev, min(unix_timestamp) AS next FROM transactions.starkex WHERE project_id = :projectId
       UNION
-      SELECT unix_timestamp prev, next
+      SELECT unix_timestamp AS prev, next
       FROM (
         SELECT
           unix_timestamp,
-          lead(unix_timestamp) over (order by unix_timestamp) next
+          lead(unix_timestamp) over (order by unix_timestamp) AS next
         FROM transactions.starkex where project_id = :projectId
       ) with_lead
       WHERE next > unix_timestamp + interval '24 hours' OR next IS NULL

--- a/packages/backend/src/peripherals/database/ZksyncTransactionRepository.ts
+++ b/packages/backend/src/peripherals/database/ZksyncTransactionRepository.ts
@@ -86,13 +86,13 @@ export class ZksyncTransactionRepository extends BaseRepository {
     const tip = await this.findTip()
     const { rows } = (await knex.raw(
       `
-      SELECT NULL prev, min(block_number) next FROM transactions.zksync
+      SELECT NULL AS prev, min(block_number) AS next FROM transactions.zksync
       UNION
-      SELECT block_number prev, next
+      SELECT block_number AS prev, next
       FROM (
         SELECT
           block_number,
-          lead(block_number) over (order by block_number) next
+          lead(block_number) over (order by block_number) AS next
         FROM transactions.zksync WHERE block_number >= :blockNumber
       ) with_lead
       WHERE next > block_number + 1 OR next IS NULL


### PR DESCRIPTION
For some reason heroku postgres does not like simple (without `as`) aliasing for activity queries near or around `next` alias. I unified it to use `as` in all these queries.