### PR TITLE
Modify activity tip update query

### DIFF
--- a/packages/backend/src/peripherals/database/BlockTipRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockTipRepository.ts
@@ -1,0 +1,53 @@
+import { Logger } from '@l2beat/common'
+import { ProjectId, UnixTime } from '@l2beat/types'
+
+import { BaseRepository } from './shared/BaseRepository'
+import { Database } from './shared/Database'
+
+export class BlockTipRepository extends BaseRepository {
+  constructor(database: Database, logger: Logger) {
+    super(database, logger)
+    /* eslint-disable @typescript-eslint/unbound-method */
+    this.findByProject = this.wrapFind(this.findByProject)
+    this.updateByProject = this.wrapAny(this.updateByProject)
+    this.deleteAll = this.wrapAny(this.deleteAll)
+    /* eslint-enable @typescript-eslint/unbound-method */
+  }
+
+  async findByProject(projectId: ProjectId) {
+    const knex = await this.knex()
+    const row = await knex('transactions.block_tip')
+      .where('project_id', projectId.toString())
+      .first()
+
+    if (!row || row.block_number === null || row.unix_timestamp === null) {
+      return undefined
+    }
+
+    return {
+      projectId,
+      blockNumber: row.block_number,
+      timestamp: UnixTime.fromDate(row.unix_timestamp),
+    }
+  }
+
+  async updateByProject(
+    projectId: ProjectId,
+    tip: { blockNumber: number; timestamp: UnixTime } | undefined,
+  ) {
+    const knex = await this.knex()
+    await knex('transactions.block_tip')
+      .insert({
+        project_id: projectId.toString(),
+        block_number: tip?.blockNumber,
+        unix_timestamp: tip?.timestamp.toDate(),
+      })
+      .onConflict('project_id')
+      .merge()
+  }
+
+  async deleteAll() {
+    const knex = await this.knex()
+    await knex('transactions.block_tip').delete()
+  }
+}

--- a/packages/backend/src/peripherals/database/migrations/037_transactions_tips_update.ts
+++ b/packages/backend/src/peripherals/database/migrations/037_transactions_tips_update.ts
@@ -1,0 +1,35 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema
+    .withSchema('transactions')
+    .alterTable('block_tip', function (table) {
+      table.setNullable('unix_timestamp')
+      table.setNullable('block_number')
+      table.dropColumn('count')
+    })
+}
+
+export async function down(knex: Knex) {
+  await knex.raw('DELETE FROM transactions.block_tip')
+  await knex.schema
+    .withSchema('transactions')
+    .alterTable('block_tip', function (table) {
+      table.dropNullable('unix_timestamp')
+      table.dropNullable('block_number')
+      table.integer('count').notNullable()
+    })
+}

--- a/packages/backend/src/peripherals/database/migrations/038_transactions_zksync_view_with_block_tip.ts
+++ b/packages/backend/src/peripherals/database/migrations/038_transactions_zksync_view_with_block_tip.ts
@@ -1,0 +1,36 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+import * as oldView from './035_tipped_transaction_count_view_zksync'
+
+export async function up(knex: Knex) {
+  await knex.schema.raw('DROP MATERIALIZED VIEW transactions.zksync_count_view')
+  await knex.schema.raw(
+    `
+    CREATE MATERIALIZED VIEW transactions.zksync_count_view AS
+      SELECT
+        date_trunc('day', zksync.unix_timestamp) unix_timestamp,
+        count(*) count
+      FROM transactions.zksync zksync
+      INNER JOIN transactions.block_tip tip ON tip.project_id = 'zksync'
+      WHERE zksync.unix_timestamp < date_trunc('day', tip.unix_timestamp)
+      GROUP BY date_trunc('day', zksync.unix_timestamp)
+  `,
+  )
+}
+
+export async function down(knex: Knex) {
+  await oldView.up(knex)
+}

--- a/packages/backend/src/peripherals/database/shared/types.ts
+++ b/packages/backend/src/peripherals/database/shared/types.ts
@@ -78,6 +78,12 @@ declare module 'knex/types/tables' {
     unix_timestamp: Date
   }
 
+  interface BlockTipRow {
+    project_id: string
+    block_number: number | null
+    unix_timestamp: Date | null
+  }
+
   interface Tables {
     block_numbers: BlockNumberRow
     coingecko_prices: PriceRow
@@ -89,10 +95,9 @@ declare module 'knex/types/tables' {
     events: EventRow
     'transactions.block': BlockTransactionCountRow
     'transactions.block_count_view': TransactionCountViewRow
-    'transactions.block_tip': BlockTransactionCountRow
+    'transactions.block_tip': BlockTipRow
     'transactions.zksync': ZksyncTransactionRow
     'transactions.zksync_count_view': TransactionCountViewRow
-    'transactions.zksync_tip': ZksyncTransactionRow
     'transactions.starkex': StarkexTransactionCountRow
   }
 }

--- a/packages/backend/src/setup/ActivityModule.ts
+++ b/packages/backend/src/setup/ActivityModule.ts
@@ -8,6 +8,7 @@ import { Clock } from '../core/Clock'
 import { LoopringTransactionUpdater } from '../core/transaction-count/LoopringTransactionUpdater'
 import { MaterializedViewRefresher } from '../core/transaction-count/MaterializedViewRefresher'
 import { ZksyncTransactionUpdater } from '../core/transaction-count/ZksyncTransactionUpdater'
+import { BlockTipRepository } from '../peripherals/database/BlockTipRepository'
 import { BlockTransactionCountRepository } from '../peripherals/database/BlockTransactionCountRepository'
 import { Database } from '../peripherals/database/shared/Database'
 import { StarkexTransactionCountRepository } from '../peripherals/database/StarkexTransactionCountRepository'
@@ -46,15 +47,18 @@ export function getActivityModule(
     callsPerMinute: config.transactionCountSync.loopringCallsPerMinute,
   })
 
+  const blockTipRepository = new BlockTipRepository(database, logger)
   const blockTransactionCountRepository = new BlockTransactionCountRepository(
     database,
     logger,
+    blockTipRepository,
   )
   const starkexTransactionCountRepository =
     new StarkexTransactionCountRepository(database, logger)
   const zksyncTransactionRepository = new ZksyncTransactionRepository(
     database,
     logger,
+    blockTipRepository,
   )
 
   const layer2RpcTransactionUpdaters = createLayer2RpcTransactionUpdaters(

--- a/packages/backend/test/peripherals/database/BlockTipRepository.test.ts
+++ b/packages/backend/test/peripherals/database/BlockTipRepository.test.ts
@@ -1,0 +1,66 @@
+import { Logger } from '@l2beat/common'
+import { ProjectId, UnixTime } from '@l2beat/types'
+import { expect } from 'earljs'
+
+import { BlockTipRepository } from '../../../src/peripherals/database/BlockTipRepository'
+import { setupDatabaseTestSuite } from './shared/setup'
+
+const PROJECT_A = ProjectId('a')
+const PROJECT_B = ProjectId('b')
+
+describe(BlockTipRepository.name, () => {
+  const { database } = setupDatabaseTestSuite()
+  const repository = new BlockTipRepository(database, Logger.SILENT)
+
+  beforeEach(async () => {
+    await repository.deleteAll()
+  })
+
+  it('works with no data', async () => {
+    expect(await repository.findByProject(PROJECT_A)).not.toBeDefined()
+  })
+
+  it('finds single project', async () => {
+    const blockNumber = 1
+    const timestamp = UnixTime.now()
+
+    await repository.updateByProject(PROJECT_A, { blockNumber, timestamp })
+    expect(await repository.findByProject(PROJECT_A)).toEqual({
+      blockNumber,
+      timestamp,
+      projectId: PROJECT_A,
+    })
+  })
+
+  it('finds within multiple project', async () => {
+    const tipA = { blockNumber: 1, timestamp: UnixTime.now().add(1, 'days') }
+    const tipB = { blockNumber: 2, timestamp: UnixTime.now().add(2, 'days') }
+
+    await repository.updateByProject(PROJECT_A, tipA)
+    await repository.updateByProject(PROJECT_B, tipB)
+
+    expect(await repository.findByProject(PROJECT_A)).toEqual({
+      ...tipA,
+      projectId: PROJECT_A,
+    })
+    expect(await repository.findByProject(PROJECT_B)).toEqual({
+      ...tipB,
+      projectId: PROJECT_B,
+    })
+  })
+
+  it('removes when updating to undefined', async () => {
+    const tip = { blockNumber: 1, timestamp: UnixTime.now().add(1, 'days') }
+
+    await repository.updateByProject(PROJECT_A, tip)
+
+    expect(await repository.findByProject(PROJECT_A)).toEqual({
+      ...tip,
+      projectId: PROJECT_A,
+    })
+
+    await repository.updateByProject(PROJECT_A, undefined)
+
+    expect(await repository.findByProject(PROJECT_A)).toEqual(undefined)
+  })
+})

--- a/packages/backend/test/peripherals/database/BlockTransactionCountRepository.test.ts
+++ b/packages/backend/test/peripherals/database/BlockTransactionCountRepository.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@l2beat/common'
 import { ProjectId, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
+import { BlockTipRepository } from '../../../src/peripherals/database/BlockTipRepository'
 import {
   BlockTransactionCountRecord,
   BlockTransactionCountRepository,
@@ -13,6 +14,7 @@ describe(BlockTransactionCountRepository.name, () => {
   const repository = new BlockTransactionCountRepository(
     database,
     Logger.SILENT,
+    new BlockTipRepository(database, Logger.SILENT),
   )
 
   const PROJECT_A = ProjectId('project-a')

--- a/packages/backend/test/peripherals/database/ZksyncTransactionRepository.test.ts
+++ b/packages/backend/test/peripherals/database/ZksyncTransactionRepository.test.ts
@@ -3,6 +3,7 @@ import { UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 import { range } from 'lodash'
 
+import { BlockTipRepository } from '../../../src/peripherals/database/BlockTipRepository'
 import {
   ZksyncTransactionRecord,
   ZksyncTransactionRepository,
@@ -11,7 +12,11 @@ import { setupDatabaseTestSuite } from './shared/setup'
 
 describe(ZksyncTransactionRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new ZksyncTransactionRepository(database, Logger.SILENT)
+  const repository = new ZksyncTransactionRepository(
+    database,
+    Logger.SILENT,
+    new BlockTipRepository(database, Logger.SILENT),
+  )
 
   beforeEach(async () => {
     await repository.deleteAll()


### PR DESCRIPTION
`DELETE` and `INSERT` even inside transaction caused race conditions. Make it a single query to prevent that.