### PR TITLE
Change block number to a simple number

### DIFF
--- a/packages/backend/src/core/BlockNumberUpdater.ts
+++ b/packages/backend/src/core/BlockNumberUpdater.ts
@@ -7,7 +7,7 @@ import { EtherscanClient } from '../peripherals/etherscan'
 import { Clock } from './Clock'
 
 export class BlockNumberUpdater {
-  private readonly blocksByTimestamp = new Map<number, bigint>()
+  private readonly blocksByTimestamp = new Map<number, number>()
   private readonly taskQueue: TaskQueue<UnixTime>
 
   constructor(
@@ -41,10 +41,10 @@ export class BlockNumberUpdater {
     from: UnixTime,
     to: UnixTime,
     refreshIntervalMs = 1000,
-  ): Promise<{ timestamp: UnixTime; blockNumber: bigint }[]> {
+  ): Promise<{ timestamp: UnixTime; blockNumber: number }[]> {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     while (true) {
-      const blocks: { timestamp: UnixTime; blockNumber: bigint }[] = []
+      const blocks: { timestamp: UnixTime; blockNumber: number }[] = []
       let noHoles = true
       for (let t = from; t.lte(to); t = t.add(1, 'hours')) {
         const blockNumber = this.blocksByTimestamp.get(t.toNumber())

--- a/packages/backend/src/core/events/findCorrespondingBlocks.ts
+++ b/packages/backend/src/core/events/findCorrespondingBlocks.ts
@@ -5,7 +5,7 @@ import { assert } from '../../tools/assert'
 
 interface BlockInfo {
   timestamp: UnixTime
-  blockNumber: bigint
+  blockNumber: number
 }
 
 export function findCorrespondingBlocks<T extends { blockNumber: number }>(

--- a/packages/backend/src/core/transaction-count/RpcClient.ts
+++ b/packages/backend/src/core/transaction-count/RpcClient.ts
@@ -1,5 +1,5 @@
 export interface RpcClient {
-  getBlockNumber(): Promise<bigint>
+  getBlockNumber(): Promise<number>
   getBlock(number: number): Promise<{
     number: number
     timestamp: number

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -7,7 +7,7 @@ import { Database } from './shared/Database'
 
 export interface BlockNumberRecord {
   timestamp: UnixTime
-  blockNumber: bigint
+  blockNumber: number
 }
 
 export class BlockNumberRepository extends BaseRepository {
@@ -58,13 +58,13 @@ export class BlockNumberRepository extends BaseRepository {
 function toRow(record: BlockNumberRecord): BlockNumberRow {
   return {
     unix_timestamp: record.timestamp.toString(),
-    block_number: Number(record.blockNumber),
+    block_number: record.blockNumber,
   }
 }
 
 function toRecord(row: BlockNumberRow): BlockNumberRecord {
   return {
     timestamp: new UnixTime(+row.unix_timestamp),
-    blockNumber: BigInt(row.block_number),
+    blockNumber: row.block_number,
   }
 }

--- a/packages/backend/src/peripherals/ethereum/EthereumClient.ts
+++ b/packages/backend/src/peripherals/ethereum/EthereumClient.ts
@@ -19,7 +19,7 @@ export class EthereumClient {
 
   async getBlockNumber() {
     const result = await this.provider.getBlockNumber()
-    return BigInt(result) // TODO: probably could be a simple number
+    return result
   }
 
   async getBlock(blockNumber: number) {
@@ -36,8 +36,7 @@ export class EthereumClient {
         value: parameters.value,
         data: parameters.data?.toString(),
       },
-      // TODO: probably could be a simple number
-      typeof blockTag === 'bigint' ? Number(blockTag) : blockTag,
+      blockTag,
     )
     return Bytes.fromHex(bytes)
   }

--- a/packages/backend/src/peripherals/ethereum/MulticallClient.ts
+++ b/packages/backend/src/peripherals/ethereum/MulticallClient.ts
@@ -4,11 +4,11 @@ import { utils } from 'ethers'
 import { EthereumClient } from './EthereumClient'
 
 export const MULTICALL_BATCH_SIZE = 150
-export const MULTICALL_V1_BLOCK = 7929876n
+export const MULTICALL_V1_BLOCK = 7929876
 export const MULTICALL_V1_ADDRESS = EthereumAddress(
   '0xeefBa1e63905eF1D7ACbA5a8513c70307C1cE441',
 )
-export const MULTICALL_V2_BLOCK = 12336033n
+export const MULTICALL_V2_BLOCK = 12336033
 export const MULTICALL_V2_ADDRESS = EthereumAddress(
   '0x5BA1e12693Dc8F9c48aAD8770482f4739bEeD696',
 )
@@ -28,7 +28,7 @@ export class MulticallClient {
 
   async multicallNamed(
     requests: Record<string, MulticallRequest>,
-    blockNumber: bigint,
+    blockNumber: number,
   ): Promise<Record<string, MulticallResponse>> {
     const entries = Object.entries(requests)
     const results = await this.multicall(
@@ -41,7 +41,7 @@ export class MulticallClient {
     return Object.fromEntries(resultEntries)
   }
 
-  async multicall(requests: MulticallRequest[], blockNumber: bigint) {
+  async multicall(requests: MulticallRequest[], blockNumber: number) {
     if (blockNumber < MULTICALL_V1_BLOCK) {
       return this.executeIndividual(requests, blockNumber)
     }
@@ -54,7 +54,7 @@ export class MulticallClient {
 
   private async executeIndividual(
     requests: MulticallRequest[],
-    blockNumber: bigint,
+    blockNumber: number,
   ): Promise<MulticallResponse[]> {
     const results = await Promise.all(
       requests.map((request) =>
@@ -77,7 +77,7 @@ export class MulticallClient {
 
   private async executeBatch(
     requests: MulticallRequest[],
-    blockNumber: bigint,
+    blockNumber: number,
   ): Promise<MulticallResponse[]> {
     if (blockNumber < MULTICALL_V2_BLOCK) {
       const encoded = encodeMulticallV1(requests)

--- a/packages/backend/src/peripherals/ethereum/types.ts
+++ b/packages/backend/src/peripherals/ethereum/types.ts
@@ -1,6 +1,6 @@
 import { Bytes, EthereumAddress } from '@l2beat/types'
 
-export type BlockTag = bigint | 'earliest' | 'latest' | 'pending'
+export type BlockTag = number | 'earliest' | 'latest' | 'pending'
 
 export interface CallParameters {
   from?: EthereumAddress

--- a/packages/backend/src/peripherals/etherscan/EtherscanClient.ts
+++ b/packages/backend/src/peripherals/etherscan/EtherscanClient.ts
@@ -6,7 +6,7 @@ import {
 } from '@l2beat/common'
 import { UnixTime } from '@l2beat/types'
 
-import { stringAsBigInt } from '../../tools/types'
+import { stringAsInt } from '../../tools/types'
 import { parseEtherscanResponse } from './parseEtherscanResponse'
 
 export class EtherscanError extends Error {}
@@ -24,12 +24,12 @@ export class EtherscanClient {
     this.logger = this.logger.for(this)
   }
 
-  async getBlockNumberAtOrBefore(timestamp: UnixTime): Promise<bigint> {
+  async getBlockNumberAtOrBefore(timestamp: UnixTime): Promise<number> {
     const result = await this.call('block', 'getblocknobytime', {
       timestamp: timestamp.toString(),
       closest: 'before',
     })
-    return stringAsBigInt().parse(result)
+    return stringAsInt().parse(result)
   }
 
   async call(module: string, action: string, params: Record<string, string>) {

--- a/packages/backend/src/peripherals/starknet/StarkNetClient.ts
+++ b/packages/backend/src/peripherals/starknet/StarkNetClient.ts
@@ -24,7 +24,7 @@ export class StarkNetClient {
 
   async getBlockNumber() {
     const block = await this.getBlock('latest')
-    return BigInt(block.number)
+    return block.number
   }
 
   async getBlock(blockNumber: number | string) {

--- a/packages/backend/src/tools/types.ts
+++ b/packages/backend/src/tools/types.ts
@@ -7,18 +7,6 @@ export function stringAsInt(fallback?: number) {
   }, z.number().int())
 }
 
-export function stringAsBigInt(fallback?: bigint) {
-  return z.preprocess((v) => {
-    try {
-      const s = z.string().parse(v)
-      if (s === '') return fallback
-      return BigInt(s)
-    } catch {
-      return fallback
-    }
-  }, z.bigint())
-}
-
 function branded<T extends z.ZodTypeAny, B>(
   schema: T,
   Brand: (t: z.TypeOf<T>) => B,

--- a/packages/backend/test/api/controllers/BlocksController.test.ts
+++ b/packages/backend/test/api/controllers/BlocksController.test.ts
@@ -10,8 +10,8 @@ describe(BlocksController.name, () => {
     const blockNumberRepository = mock<BlockNumberRepository>({
       async getAll() {
         return [
-          { blockNumber: 123n, timestamp: new UnixTime(1000) },
-          { blockNumber: 456n, timestamp: new UnixTime(2000) },
+          { blockNumber: 123, timestamp: new UnixTime(1000) },
+          { blockNumber: 456, timestamp: new UnixTime(2000) },
         ]
       },
     })

--- a/packages/backend/test/core/BlockNumberUpdater.test.ts
+++ b/packages/backend/test/core/BlockNumberUpdater.test.ts
@@ -60,7 +60,7 @@ describe(BlockNumberUpdater.name, () => {
     it('returns immediately if the data is available', async () => {
       const timestamp = UnixTime.now()
       const etherscanClient = mock<EtherscanClient>({
-        getBlockNumberAtOrBefore: async () => 1234n,
+        getBlockNumberAtOrBefore: async () => 1234,
       })
       const blockNumberRepository = mock<BlockNumberRepository>({
         add: async () => 0,
@@ -74,13 +74,13 @@ describe(BlockNumberUpdater.name, () => {
 
       await blockNumberUpdater.update(timestamp)
       const result = await blockNumberUpdater.getBlockNumberWhenReady(timestamp)
-      expect(result).toEqual(1234n)
+      expect(result).toEqual(1234)
     })
 
     it('waits until data is available, then returns', async () => {
       const timestamp = UnixTime.now()
       const etherscanClient = mock<EtherscanClient>({
-        getBlockNumberAtOrBefore: async () => 1234n,
+        getBlockNumberAtOrBefore: async () => 1234,
       })
       const blockNumberRepository = mock<BlockNumberRepository>({
         add: async () => 0,
@@ -116,7 +116,7 @@ describe(BlockNumberUpdater.name, () => {
       const to = from.add(2, 'hours')
 
       const etherscanClient = mock<EtherscanClient>({
-        getBlockNumberAtOrBefore: async () => 1234n,
+        getBlockNumberAtOrBefore: async () => 1234,
       })
       const blockNumberRepository = mock<BlockNumberRepository>({
         add: async () => 0,
@@ -137,15 +137,15 @@ describe(BlockNumberUpdater.name, () => {
       expect(result).toEqual([
         {
           timestamp: from,
-          blockNumber: 1234n,
+          blockNumber: 1234,
         },
         {
           timestamp: from.add(1, 'hours'),
-          blockNumber: 1234n,
+          blockNumber: 1234,
         },
         {
           timestamp: from.add(2, 'hours'),
-          blockNumber: 1234n,
+          blockNumber: 1234,
         },
       ])
     })
@@ -155,7 +155,7 @@ describe(BlockNumberUpdater.name, () => {
       const to = from.add(2, 'hours')
 
       const etherscanClient = mock<EtherscanClient>({
-        getBlockNumberAtOrBefore: async () => 1234n,
+        getBlockNumberAtOrBefore: async () => 1234,
       })
       const blockNumberRepository = mock<BlockNumberRepository>({
         add: async () => 0,

--- a/packages/backend/test/core/balances/BalanceUpdater.test.ts
+++ b/packages/backend/test/core/balances/BalanceUpdater.test.ts
@@ -203,7 +203,7 @@ describe(BalanceUpdater.name, () => {
         ],
       })
       const blockNumberUpdater = mock<BlockNumberUpdater>({
-        getBlockNumberWhenReady: async () => 1234n,
+        getBlockNumberWhenReady: async () => 1234,
       })
       const balanceUpdater = new BalanceUpdater(
         multicallClient,

--- a/packages/backend/test/core/events/findCorrespondingBlocks.test.ts
+++ b/packages/backend/test/core/events/findCorrespondingBlocks.test.ts
@@ -12,10 +12,10 @@ describe(findCorrespondingBlocks.name, () => {
       { blockNumber: 15 },
     ]
     const blocks = [
-      { timestamp: new UnixTime(0), blockNumber: 0n },
-      { timestamp: new UnixTime(5), blockNumber: 5n },
-      { timestamp: new UnixTime(10), blockNumber: 10n },
-      { timestamp: new UnixTime(15), blockNumber: 15n },
+      { timestamp: new UnixTime(0), blockNumber: 0 },
+      { timestamp: new UnixTime(5), blockNumber: 5 },
+      { timestamp: new UnixTime(10), blockNumber: 10 },
+      { timestamp: new UnixTime(15), blockNumber: 15 },
     ]
 
     const res = findCorrespondingBlocks(blocks, logs)
@@ -36,29 +36,29 @@ describe(findCorrespondingBlocks.name, () => {
       { blockNumber: 6 },
     ]
     const blocks = [
-      { timestamp: new UnixTime(15), blockNumber: 15n },
-      { timestamp: new UnixTime(0), blockNumber: 0n },
-      { timestamp: new UnixTime(10), blockNumber: 10n },
-      { timestamp: new UnixTime(5), blockNumber: 5n },
+      { timestamp: new UnixTime(15), blockNumber: 15 },
+      { timestamp: new UnixTime(0), blockNumber: 0 },
+      { timestamp: new UnixTime(10), blockNumber: 10 },
+      { timestamp: new UnixTime(5), blockNumber: 5 },
     ]
 
     const res = findCorrespondingBlocks(blocks, logs)
 
     expect(res).toEqual([
       {
-        block: { timestamp: new UnixTime(0), blockNumber: 0n },
+        block: { timestamp: new UnixTime(0), blockNumber: 0 },
         value: { blockNumber: 4 },
       },
       {
-        block: { timestamp: new UnixTime(5), blockNumber: 5n },
+        block: { timestamp: new UnixTime(5), blockNumber: 5 },
         value: { blockNumber: 5 },
       },
       {
-        block: { timestamp: new UnixTime(5), blockNumber: 5n },
+        block: { timestamp: new UnixTime(5), blockNumber: 5 },
         value: { blockNumber: 6 },
       },
       {
-        block: { timestamp: new UnixTime(15), blockNumber: 15n },
+        block: { timestamp: new UnixTime(15), blockNumber: 15 },
         value: { blockNumber: 15 },
       },
     ])
@@ -66,7 +66,7 @@ describe(findCorrespondingBlocks.name, () => {
 
   it('works with only one block', () => {
     const logs = [{ blockNumber: 1 }, { blockNumber: 2 }]
-    const blocks = [{ timestamp: new UnixTime(0), blockNumber: 0n }]
+    const blocks = [{ timestamp: new UnixTime(0), blockNumber: 0 }]
 
     const res = findCorrespondingBlocks(blocks, logs)
 
@@ -78,7 +78,7 @@ describe(findCorrespondingBlocks.name, () => {
 
   it('throws without a matching block', () => {
     const logs = [{ blockNumber: 4 }]
-    const blocks = [{ timestamp: new UnixTime(6), blockNumber: 6n }]
+    const blocks = [{ timestamp: new UnixTime(6), blockNumber: 6 }]
 
     expect(() => findCorrespondingBlocks(blocks, logs)).toThrow()
   })
@@ -86,8 +86,8 @@ describe(findCorrespondingBlocks.name, () => {
   it('throws without any matching blocks', () => {
     const logs = [{ blockNumber: 4 }]
     const blocks = [
-      { timestamp: new UnixTime(6), blockNumber: 6n },
-      { timestamp: new UnixTime(12), blockNumber: 12n },
+      { timestamp: new UnixTime(6), blockNumber: 6 },
+      { timestamp: new UnixTime(12), blockNumber: 12 },
     ]
 
     expect(() => findCorrespondingBlocks(blocks, logs)).toThrow()

--- a/packages/backend/test/core/transaction-count/RpcTransactionUpdater.test.ts
+++ b/packages/backend/test/core/transaction-count/RpcTransactionUpdater.test.ts
@@ -15,7 +15,7 @@ describe(RpcTransactionUpdater.name, () => {
     it('skips known blocks', async () => {
       const ethereumClient = mock<EthereumClient>({
         getBlock: async () => fakeBlock(),
-        getBlockNumber: async () => 5n,
+        getBlockNumber: async () => 5,
       })
       const blockCountTransactionRepository =
         mock<BlockTransactionCountRepository>({
@@ -68,7 +68,7 @@ describe(RpcTransactionUpdater.name, () => {
               transactions: ['t0', 't1', 't2'],
             }),
           ),
-        getBlockNumber: async () => 5n,
+        getBlockNumber: async () => 5,
       })
       const blockCountTransactionRepository =
         mock<BlockTransactionCountRepository>({

--- a/packages/backend/test/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/test/peripherals/database/BlockNumberRepository.test.ts
@@ -14,8 +14,8 @@ describe(BlockNumberRepository.name, () => {
   })
 
   it('can add new records', async () => {
-    const itemA = { blockNumber: 1234n, timestamp: new UnixTime(5678) }
-    const itemB = { blockNumber: 7777n, timestamp: new UnixTime(222222) }
+    const itemA = { blockNumber: 1234, timestamp: new UnixTime(5678) }
+    const itemB = { blockNumber: 7777, timestamp: new UnixTime(222222) }
 
     await repository.add(itemA)
     await repository.add(itemB)
@@ -27,8 +27,8 @@ describe(BlockNumberRepository.name, () => {
   })
 
   it('can find by timestamp', async () => {
-    const itemA = { blockNumber: 1234n, timestamp: new UnixTime(5678) }
-    const itemB = { blockNumber: 7777n, timestamp: new UnixTime(222222) }
+    const itemA = { blockNumber: 1234, timestamp: new UnixTime(5678) }
+    const itemB = { blockNumber: 7777, timestamp: new UnixTime(222222) }
 
     await repository.add(itemA)
     await repository.add(itemB)
@@ -38,7 +38,7 @@ describe(BlockNumberRepository.name, () => {
   })
 
   it('can delete all records', async () => {
-    await repository.add({ blockNumber: 1n, timestamp: new UnixTime(1) })
+    await repository.add({ blockNumber: 1, timestamp: new UnixTime(1) })
     await repository.deleteAll()
 
     const results = await repository.getAll()

--- a/packages/backend/test/peripherals/ethereum/MulticallClient.test.ts
+++ b/packages/backend/test/peripherals/ethereum/MulticallClient.test.ts
@@ -37,7 +37,7 @@ describe(MulticallClient.name, () => {
     })
 
     const multicallClient = new MulticallClient(ethereumClient)
-    const blockTag = MULTICALL_V1_BLOCK - 1n
+    const blockTag = MULTICALL_V1_BLOCK - 1
 
     const result = await multicallClient.multicall(
       [
@@ -75,7 +75,7 @@ describe(MulticallClient.name, () => {
     })
 
     const multicallClient = new MulticallClient(ethereumClient)
-    const blockTag = MULTICALL_V2_BLOCK - 1n
+    const blockTag = MULTICALL_V2_BLOCK - 1
 
     const result = await multicallClient.multicall(
       [
@@ -122,7 +122,7 @@ describe(MulticallClient.name, () => {
     })
 
     const multicallClient = new MulticallClient(ethereumClient)
-    const blockTag = MULTICALL_V2_BLOCK + 1n
+    const blockTag = MULTICALL_V2_BLOCK + 1
 
     const result = await multicallClient.multicall(
       [
@@ -168,7 +168,7 @@ describe(MulticallClient.name, () => {
     })
 
     const multicallClient = new MulticallClient(ethereumClient)
-    const blockTag = MULTICALL_V2_BLOCK + 1n
+    const blockTag = MULTICALL_V2_BLOCK + 1
 
     const result = await multicallClient.multicall(
       new Array(MULTICALL_BATCH_SIZE * 2 + 1).fill(0).map(() => ({
@@ -196,7 +196,7 @@ describe(MulticallClient.name, () => {
     })
 
     const multicallClient = new MulticallClient(ethereumClient)
-    const blockTag = MULTICALL_V2_BLOCK + 1n
+    const blockTag = MULTICALL_V2_BLOCK + 1
 
     const result = await multicallClient.multicallNamed(
       {

--- a/packages/backend/test/peripherals/etherscan/EtherscanClient.test.ts
+++ b/packages/backend/test/peripherals/etherscan/EtherscanClient.test.ts
@@ -110,7 +110,7 @@ describe(EtherscanClient.name, () => {
       const result = await etherscanClient.getBlockNumberAtOrBefore(
         new UnixTime(1578638524),
       )
-      expect(result).toEqual(9251482n)
+      expect(result).toEqual(9251482)
     })
   })
 })

--- a/packages/backend/test/tools/types.test.ts
+++ b/packages/backend/test/tools/types.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'earljs'
 
-import { stringAsBigInt, stringAsInt } from '../../src/tools/types'
+import { stringAsInt } from '../../src/tools/types'
 
 describe(stringAsInt.name, () => {
   describe('parses correct input', () => {
@@ -16,29 +16,6 @@ describe(stringAsInt.name, () => {
 
   describe('parses incorrect input', () => {
     const parser = stringAsInt()
-    const inputs = ['foo', '123foo', '', '1.2']
-
-    inputs.forEach((input) => {
-      it(`${input}`, () =>
-        expect(parser.safeParse(input).success).toEqual(false))
-    })
-  })
-})
-
-describe(stringAsBigInt.name, () => {
-  describe('parses correct input', () => {
-    const parser = stringAsBigInt(10n)
-    const inputs = [undefined, null, '1']
-
-    inputs.forEach((input) => {
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      it(`${input}`, () =>
-        expect(parser.safeParse(input).success).toEqual(true))
-    })
-  })
-
-  describe('parses incorrect input', () => {
-    const parser = stringAsBigInt()
     const inputs = ['foo', '123foo', '', '1.2']
 
     inputs.forEach((input) => {


### PR DESCRIPTION
We don't need a blockNumber to be a big int and it is unnecessary to switch back and forth from number to a bigint