### PR TITLE
Prepare backend activity production config

### DIFF
--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -37,6 +37,32 @@ export function getProductionConfig(): Config {
     freshStart: false,
     tvlReportSync: true,
     eventsSync: false,
-    transactionCountSync: false,
+    transactionCountSync: {
+      starkexApiKey: getEnv('STARKEX_API_KEY'),
+      starkexApiDelayHours: 5,
+      zkSyncWorkQueueWorkers: 100,
+      starkexWorkQueueWorkers: 10,
+      starkexCallsPerMinute: 200,
+      loopringWorkQueueWorkers: 10,
+      loopringCallsPerMinute: 200,
+      rpc: {
+        workQueueLimit: 200_000,
+        workQueueWorkers: getEnv.integer('ACTIVITY_RPC_WORKERS'),
+        projects: {
+          ethereum: {
+            callsPerMinute: getEnv.integer('ACTIVITY_ETHEREUM_CALLS'),
+            url: getEnv('ACTIVITY_ETHEREUM_URL'),
+          },
+          optimism: {
+            callsPerMinute: getEnv.integer('ACTIVITY_OPTIMISM_CALLS'),
+            url: getEnv('ACTIVITY_OPTIMISM_URL'),
+          },
+          arbitrum: {
+            callsPerMinute: getEnv.integer('ACTIVITY_ARBITRUM_CALLS'),
+            url: getEnv('ACTIVITY_ARBITRUM_URL'),
+          },
+        },
+      },
+    },
   }
 }

--- a/packages/backend/src/config/config.staging.ts
+++ b/packages/backend/src/config/config.staging.ts
@@ -2,7 +2,6 @@ import { Knex } from 'knex'
 
 import { Config } from './Config'
 import { getProductionConfig } from './config.production'
-import { getEnv } from './getEnv'
 
 export function getStagingConfig(): Config {
   const name = 'Backend/Staging'
@@ -16,32 +15,5 @@ export function getStagingConfig(): Config {
       application_name: name,
     },
     tvlReportSync: true,
-    transactionCountSync: {
-      starkexApiKey: getEnv('STARKEX_API_KEY'),
-      starkexApiDelayHours: 5,
-      zkSyncWorkQueueWorkers: 100,
-      starkexWorkQueueWorkers: 1,
-      starkexCallsPerMinute: 400,
-      loopringWorkQueueWorkers: 1,
-      loopringCallsPerMinute: 400,
-      rpc: {
-        workQueueLimit: 200_000,
-        workQueueWorkers: getEnv.integer('ACTIVITY_RPC_WORKERS'),
-        projects: {
-          ethereum: {
-            callsPerMinute: getEnv.integer('ACTIVITY_ETHEREUM_CALLS'),
-            url: getEnv('ACTIVITY_ETHEREUM_URL'),
-          },
-          optimism: {
-            callsPerMinute: getEnv.integer('ACTIVITY_OPTIMISM_CALLS'),
-            url: getEnv('ACTIVITY_OPTIMISM_URL'),
-          },
-          arbitrum: {
-            callsPerMinute: getEnv.integer('ACTIVITY_ARBITRUM_CALLS'),
-            url: getEnv('ACTIVITY_ARBITRUM_URL'),
-          },
-        },
-      },
-    },
   }
 }


### PR DESCRIPTION
Environment variables have been copied over from staging api. Performance values have been cut in half to enable both staging and production to run using the same keys. This is feasible since we're already fully synced and are only catching up on the tip.

Resolves L2B-291