### PR TITLE
Use projectId instead of slug when checking if project has activity

### DIFF
--- a/packages/frontend/src/utils/project/getChart.ts
+++ b/packages/frontend/src/utils/project/getChart.ts
@@ -16,7 +16,7 @@ export function getChart(
     tokens: getTokens(project.id, tvlApiResponse),
     hasActivity:
       config?.features.activity &&
-      !!activityApiResponse?.projects[project.display.slug],
+      !!activityApiResponse?.projects[project.id.toString()],
   }
 }
 


### PR DESCRIPTION
Fixing rhino.fi not showing activity toggle