### PR TITLE
Update optimism.ts

### DIFF
--- a/packages/config/src/layer2s/optimism.ts
+++ b/packages/config/src/layer2s/optimism.ts
@@ -28,7 +28,7 @@ export const optimism: Layer2 = {
       websites: ['https://optimism.io/'],
       apps: [],
       documentation: ['https://community.optimism.io'],
-      explorers: ['https://optimistic.etherscan.io/'],
+      explorers: ['https://explorer.optimism.io'],
       repositories: ['https://github.com/ethereum-optimism/optimism'],
       socialMedia: [
         'https://optimism.mirror.xyz/',


### PR DESCRIPTION
Updates the explorer link for Optimism. We're shifting over to explorer.optimism.io. It's the same explorer in the backend, new URL.