### PR TITLE
Update contracts and permissions section

### DIFF
--- a/packages/frontend/src/components/project/ContractEntry.tsx
+++ b/packages/frontend/src/components/project/ContractEntry.tsx
@@ -24,11 +24,13 @@ export interface TechnologyContractLinks {
 export interface ContractEntryProps {
   contract: TechnologyContract
   verificationStatus: VerificationStatus
+  className?: string
 }
 
 export function ContractEntry({
   contract,
   verificationStatus,
+  className,
 }: ContractEntryProps) {
   const areLinksUnverified = contract.links
     .filter((c) => !c.isAdmin)
@@ -52,7 +54,7 @@ export function ContractEntry({
 
   return (
     <Callout
-      className={cx(color === 'red' ? 'p-4' : 'px-4')}
+      className={cx(color === 'red' ? 'p-4' : 'px-4', className)}
       color={color}
       icon={icon}
       body={

--- a/packages/frontend/src/components/project/ContractsSection.tsx
+++ b/packages/frontend/src/components/project/ContractsSection.tsx
@@ -39,12 +39,13 @@ export function ContractsSection(props: ContractsSectionProps) {
       <h3 className="font-bold md:text-md">
         The system consists of the following smart contracts:
       </h3>
-      <div className="flex flex-wrap gap-4 my-4">
+      <div className="mt-4 mb-4">
         {props.contracts.map((contract, i) => (
           <React.Fragment key={i}>
             <ContractEntry
               contract={contract}
               verificationStatus={props.verificationStatus}
+              className="mt-4 mb-4"
             />
           </React.Fragment>
         ))}

--- a/packages/frontend/src/components/project/PermissionsSection.tsx
+++ b/packages/frontend/src/components/project/PermissionsSection.tsx
@@ -18,12 +18,13 @@ export function PermissionsSection({
       <h3 className="mt-4 font-bold md:text-md">
         The system uses the following set of permissioned addresses:
       </h3>
-      <div className="flex flex-wrap gap-4 my-4">
+      <div className="mt-4 mb-4">
         {permissions.map((permission, i) => (
           <ContractEntry
             key={i}
             contract={permission}
             verificationStatus={verificationStatus}
+            className="mt-4 mb-4"
           />
         ))}
       </div>

--- a/packages/frontend/src/components/project/TechnologyIncomplete.tsx
+++ b/packages/frontend/src/components/project/TechnologyIncomplete.tsx
@@ -38,7 +38,7 @@ export function TechnologyIncompleteShort() {
   return (
     <div
       className={cx(
-        'mt-2 py-1 px-2 text-xs md:text-base rounded-lg',
+        'mt-2 mb-2 py-1 px-2 text-xs md:text-base rounded-lg',
         'bg-blue-450 bg-opacity-20 text-blue-700 dark:text-blue-300',
       )}
     >


### PR DESCRIPTION
This PR aims to remove `display:flex` from ContractsSection and PermissionsSection, so the wrapping  like this (see below)  will not take place

![image](https://user-images.githubusercontent.com/72789647/201919640-eaadbc1e-296f-4bf1-b95f-bbcd32a26635.png)
