### PR TITLE
Fix starknet not being returned by activity api

### DIFF
--- a/packages/backend/src/modules/activityV2/createSequenceProcessors.ts
+++ b/packages/backend/src/modules/activityV2/createSequenceProcessors.ts
@@ -1,5 +1,5 @@
 import { assert, HttpClient, Logger } from '@l2beat/common'
-import { Layer2TransactionApi } from '@l2beat/config'
+import { Layer2TransactionApiV2 } from '@l2beat/config'
 import { ProjectId } from '@l2beat/types'
 
 import { Config } from '../../config'
@@ -60,7 +60,7 @@ export function createSequenceProcessors(
   const ethereum = activityProjects.ethereum
   assert(ethereum?.type === 'rpc', 'Ethereum transactionApi config missing')
   const layer1Projects: [
-    { projectId: ProjectId; transactionApi: Layer2TransactionApi },
+    { projectId: ProjectId; transactionApi: Layer2TransactionApiV2 },
   ] = [
     {
       projectId: ProjectId.ETHEREUM,
@@ -144,17 +144,18 @@ export function createSequenceProcessors(
 
 const hasTransactionApi = (
   p: Project,
-): p is Project & { transactionApi: Layer2TransactionApi } => !!p.transactionApi
+): p is Project & { transactionApi: Layer2TransactionApiV2 } =>
+  !!p.transactionApi
 
 function mergeWithConfig(
-  activityProjects: Record<string, Layer2TransactionApi | undefined>,
+  activityProjects: Record<string, Layer2TransactionApiV2 | undefined>,
 ) {
   return ({
     projectId,
     transactionApi,
   }: {
     projectId: ProjectId
-    transactionApi: Layer2TransactionApi
+    transactionApi: Layer2TransactionApiV2
   }) => ({
     projectId,
     transactionApi: {

--- a/packages/config/src/layer2s/starknet.ts
+++ b/packages/config/src/layer2s/starknet.ts
@@ -100,7 +100,7 @@ export const starknet: Layer2 = {
       },
     ],
     transactionApi: {
-      type: 'starknet',
+      type: 'rpc',
       callsPerMinute: 60 * 5,
       url: 'https://alpha-mainnet.starknet.io',
     },

--- a/packages/config/src/layer2s/types/Layer2TransactionApi.ts
+++ b/packages/config/src/layer2s/types/Layer2TransactionApi.ts
@@ -10,25 +10,10 @@ export interface RpcTransactionApi {
   startBlock?: number
 }
 
-export interface StarknetTransactionApi {
-  type: 'starknet'
-  url: string
-  callsPerMinute?: number
-}
-
 export interface AztecTransactionApi {
   type: 'aztec'
   url: string
   callsPerMinute?: number
-}
-export interface ZksyncTransactionApi {
-  type: 'zksync'
-  callsPerMinute: number
-}
-
-export interface LoopringTransactionApi {
-  type: 'loopring'
-  callsPerMinute: number
 }
 
 export type StarkexProduct =
@@ -37,6 +22,7 @@ export type StarkexProduct =
   | 'immutable'
   | 'myria'
   | 'deversifi'
+
 export interface StarkexTransactionApi {
   type: 'starkex'
   product: StarkexProduct
@@ -47,7 +33,4 @@ export type Layer2TransactionApi = { excludeFromActivityApi?: boolean } & (
   | RpcTransactionApi
   | StarkexTransactionApi
   | AztecTransactionApi
-  | StarknetTransactionApi
-  | ZksyncTransactionApi
-  | LoopringTransactionApi
 )


### PR DESCRIPTION
**What happened?**
Staging frontend is unable to build, because staging api is not returning starknet activity data. The reason for that was a mistake in `config` package, specifically in `starknet.ts` - `transactionApi.type` was set to `starknet`, which made `createRpcTransactionUpdaters.ts` skip Starknet when creating an updater for it. If an updater is not created it does not get to activity api, which results in lack of this projects' data in the api response.

**Why wasn't this error picked up in the CI pipeline?**
`Layer2TransactionApi` type in `config` package was mistakenly updated when activity v2 was introduced - it included other types, such as `starknet`, which are used only in activity v2. This made the whole program compile without errors.

**How does it gets solved?**
Changes in `Layer2TransactionApi` are reverted and `type` for Starknet is brought back as `rpc`. On top of that wrong `Layer2TransactionApi` type has been updated to `Layer2TransactionApiV2` in `createSequenceProcessors.ts` in order to avoid future errors.

Resolves L2B-413