### PR TITLE
Update `syncEnabled` for staging and production

### DIFF
--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -16,7 +16,7 @@ export function getProductionConfig(cli: CliParameters): Config {
   return {
     name: 'Backend/Production',
     projects: layer2s.map(layer2ToProject).concat(bridges.map(bridgeToProject)),
-    syncEnabled: true,
+    syncEnabled: false,
     logger: {
       logLevel: getEnv.integer('LOG_LEVEL', LogLevel.INFO),
       format: 'json',

--- a/packages/backend/src/config/config.staging.ts
+++ b/packages/backend/src/config/config.staging.ts
@@ -13,7 +13,7 @@ export function getStagingConfig(cli: CliParameters): Config {
   return {
     ...productionConfig,
     name: 'Backend/Staging',
-    syncEnabled: false,
+    syncEnabled: true,
     activityV2: {
       starkexApiKey: getEnv('STARKEX_API_KEY'),
       starkexApiDelayHours: getEnv.integer('STARKEX_API_DELAY_HOURS', 12),


### PR DESCRIPTION
Postgres was updated to v14 on staging, so we can re-enable syncing there. We will update production now, so we need to disable syncing there.