### PR TITLE
Skip often eth_chainId calls during activity sync

### DIFF
--- a/packages/backend/src/core/activity/processors/RpcProcessor.ts
+++ b/packages/backend/src/core/activity/processors/RpcProcessor.ts
@@ -24,7 +24,7 @@ export function createRpcProcessor(
   const batchSize = getBatchSizeFromCallsPerMinute(callsPerMinute)
   const url = transactionApi.url
   assert(url, 'Url for rpc client must be defined')
-  const provider = new providers.JsonRpcProvider({
+  const provider = new providers.StaticJsonRpcProvider({
     url,
     timeout,
   })


### PR DESCRIPTION
Resolves L2B-443

https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#StaticJsonRpcProvider