### PR TITLE
Remove `starkexApiDelayHours`

### DIFF
--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -77,7 +77,6 @@ export interface ActivityConfig {
 
 export interface ActivityV2Config {
   readonly starkexApiKey: string
-  readonly starkexApiDelayHours: number
   readonly starkexCallsPerMinute: number
   readonly allowedProjectIds?: string[]
   readonly projects: Record<string, Layer2TransactionApiV2 | undefined>

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -94,7 +94,6 @@ export function getLocalConfig(cli: CliParameters): Config {
     },
     activityV2: activityV2Enabled && {
       starkexApiKey: getEnv('STARKEX_API_KEY'),
-      starkexApiDelayHours: getEnv.integer('STARKEX_API_DELAY_HOURS', 12),
       starkexCallsPerMinute: getEnv.integer('STARKEX_CALLS_PER_MINUTE', 600),
       projects: {
         ethereum: {

--- a/packages/backend/src/config/config.staging.ts
+++ b/packages/backend/src/config/config.staging.ts
@@ -15,7 +15,6 @@ export function getStagingConfig(cli: CliParameters): Config {
     name: 'Backend/Staging',
     activityV2: {
       starkexApiKey: getEnv('STARKEX_API_KEY'),
-      starkexApiDelayHours: getEnv.integer('STARKEX_API_DELAY_HOURS', 12),
       starkexCallsPerMinute: getEnv.integer('STARKEX_CALLS_PER_MINUTE', 600),
       projects: {
         ethereum: {

--- a/packages/backend/src/core/activity/processors/StarkexProcessor.ts
+++ b/packages/backend/src/core/activity/processors/StarkexProcessor.ts
@@ -13,7 +13,6 @@ import { getBatchSizeFromCallsPerMinute } from './getBatchSizeFromCallsPerMinute
 
 export interface StarkexProcessorOptions extends StarkexTransactionApiV2 {
   singleStarkexCPM: number
-  starkexApiDelayHours: number
 }
 
 export function createStarkexProcessor(
@@ -54,8 +53,7 @@ export function createStarkexProcessor(
       batchSize,
       startFrom: startDay,
       // eslint-disable-next-line @typescript-eslint/require-await
-      getLatest: async () =>
-        getStarkexLastDay(clock.getLastHour(), options.starkexApiDelayHours),
+      getLatest: async () => getStarkexLastDay(clock.getLastHour()),
       processRange,
     },
   )
@@ -75,10 +73,7 @@ export function createStarkexProcessor(
 
   return processor
 }
-function getStarkexLastDay(timestamp: UnixTime, hoursDelay: number) {
-  return timestamp
-    .add(-hoursDelay, 'hours')
-    .toStartOf('day')
-    .add(-1, 'days')
-    .toDays()
+
+function getStarkexLastDay(timestamp: UnixTime) {
+  return timestamp.toStartOf('day').add(-1, 'days').toDays()
 }

--- a/packages/backend/src/modules/activityV2/createSequenceProcessors.ts
+++ b/packages/backend/src/modules/activityV2/createSequenceProcessors.ts
@@ -31,7 +31,6 @@ export function createSequenceProcessors(
     activityV2: {
       starkexApiKey,
       starkexCallsPerMinute,
-      starkexApiDelayHours,
       projects: activityV2ConfigProjects,
       allowedProjectIds,
     },
@@ -88,7 +87,6 @@ export function createSequenceProcessors(
             clock,
             {
               ...transactionApiV2,
-              starkexApiDelayHours,
               singleStarkexCPM,
             },
           )


### PR DESCRIPTION
Not used anymore for refreshing view, but was affecting last starkex day we fetch, so it needs to be gone.