### PR TITLE
Speed up activity max timestamp queries

### DIFF
--- a/packages/backend/src/peripherals/database/activity-v2/BlockTransactionCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity-v2/BlockTransactionCountRepository.ts
@@ -43,9 +43,9 @@ export class BlockTransactionCountRepository extends BaseRepository {
     const knex = await this.knex()
     const row = await knex('activity_v2.block')
       .where('project_id', projectId.toString())
-      .max('unix_timestamp')
+      .orderBy('block_number', 'desc')
       .first()
-    return row ? UnixTime.fromDate(row.max) : undefined
+    return row ? UnixTime.fromDate(row.unix_timestamp) : undefined
   }
 }
 

--- a/packages/backend/src/peripherals/database/activity-v2/ZksyncTransactionRepository.ts
+++ b/packages/backend/src/peripherals/database/activity-v2/ZksyncTransactionRepository.ts
@@ -36,8 +36,11 @@ export class ZksyncTransactionRepository extends BaseRepository {
 
   async getLastTimestamp(): Promise<UnixTime | undefined> {
     const knex = await this.knex()
-    const row = await knex('activity_v2.zksync').max('unix_timestamp').first()
-    return row ? UnixTime.fromDate(row.max) : undefined
+    const row = await knex('activity_v2.zksync')
+      .orderBy('block_number', 'desc')
+      .orderBy('block_index', 'desc')
+      .first()
+    return row ? UnixTime.fromDate(row.unix_timestamp) : undefined
   }
 }
 


### PR DESCRIPTION
Prior to this PR these queries were way slower, especially `block` table query was taking ~1.5min.