### PR TITLE
Use single activity endpoint

### DIFF
--- a/packages/backend/src/api/routers/ActivityRouter.ts
+++ b/packages/backend/src/api/routers/ActivityRouter.ts
@@ -5,7 +5,7 @@ import { ActivityController } from '../controllers/activity/ActivityController'
 export function createActivityRouter(activityController: ActivityController) {
   const router = new Router()
 
-  router.get(['/api/activity', '/api/activity/v2'], async (ctx) => {
+  router.get('/api/activity', async (ctx) => {
     const data = await activityController.getActivity()
     ctx.body = data
   })

--- a/packages/frontend/src/build/fetchActivityApi.ts
+++ b/packages/frontend/src/build/fetchActivityApi.ts
@@ -6,8 +6,7 @@ export async function fetchActivityApi(
   apiUrl: string,
   http: JsonHttpClient,
 ): Promise<ActivityApiResponse> {
-  const url = apiUrl + '/api/activity/v2'
-
+  const url = apiUrl + '/api/activity'
   const json = await http.fetchJson(url)
   return ActivityApiResponse.parse(json)
 }

--- a/packages/frontend/src/build/fetchTvlApi.ts
+++ b/packages/frontend/src/build/fetchTvlApi.ts
@@ -7,8 +7,6 @@ export async function fetchTvlApi(
   http: JsonHttpClient,
 ): Promise<TvlApiResponse> {
   const url = apiUrl + '/api/tvl'
-
   const json = await http.fetchJson(url)
-
   return TvlApiResponse.parse(json)
 }


### PR DESCRIPTION
No need to maintain two endpoints anymore - let's keep it simple.

Resolves L2B-473