### PR TITLE
Change milestones date type

### DIFF
--- a/packages/config/src/common/Milestone.ts
+++ b/packages/config/src/common/Milestone.ts
@@ -1,6 +1,6 @@
 export interface Milestone {
   name: string
   link: string
-  date: Date
+  date: string
   description?: string
 }

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -473,27 +473,27 @@ export const arbitrum: Layer2 = {
     {
       name: 'Nitro Upgrade',
       link: 'https://medium.com/offchainlabs/arbitrum-nitro-one-small-step-for-l2-one-giant-leap-for-ethereum-bc9108047450',
-      date: new Date('2022-08-31'),
+      date: '2022-08-31T00:00:00Z',
       description:
         'Upgrade is live, introducing new architecture, increased throughput and lower fees.',
     },
     {
       name: 'Odyssey paused',
       link: 'https://twitter.com/arbitrum/status/1542159109511847937',
-      date: new Date('2022-06-29'),
+      date: '2022-06-29T00:00:00Z',
       description:
         'Due of the heavy load being put on the chain, Odyssey program got paused.',
     },
     {
       name: 'Odyssey started',
       link: 'https://twitter.com/arbitrum/status/1539292126105706496',
-      date: new Date('2022-06-21'),
+      date: '2022-06-21T00:00:00Z',
       description: 'Incentives program to onboard new users has started.',
     },
     {
       ...MILESTONES.MAINNET_OPEN,
       link: 'https://twitter.com/arbitrum/status/1432817424752128008',
-      date: new Date('2021-08-31'),
+      date: '2021-08-3T00:00:00Z1',
     },
   ],
 }

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -493,7 +493,7 @@ export const arbitrum: Layer2 = {
     {
       ...MILESTONES.MAINNET_OPEN,
       link: 'https://twitter.com/arbitrum/status/1432817424752128008',
-      date: '2021-08-3T00:00:00Z1',
+      date: '2021-08-31T00:00:00Z',
     },
   ],
 }

--- a/packages/config/src/layer2s/aztec.ts
+++ b/packages/config/src/layer2s/aztec.ts
@@ -190,7 +190,7 @@ export const aztec: Layer2 = {
   milestones: [
     {
       name: 'Aztec 2.0',
-      date: new Date('2021-03-15'),
+      date: '2021-03-15T00:00:00Z',
       link: 'https://medium.com/aztec-protocol/launching-aztec-2-0-rollup-ac7db8012f4b',
       description:
         'Private Rollup is live on mainnet, allowing user to access DeFi.',

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -202,7 +202,7 @@ export const aztecconnect: Layer2 = {
   milestones: [
     {
       name: 'Mainnet Launch',
-      date: new Date('2022-07-07'),
+      date: '2022-07-07T00:00:00Z',
       link: 'https://medium.com/aztec-protocol/aztec-network-launches-first-ever-private-defi-solution-for-ethereum-e5ec7624d430',
       description:
         'Aztec Connect is live on mainnet, enabling private DeFi on Ethereum.',

--- a/packages/config/src/layer2s/bobanetwork.ts
+++ b/packages/config/src/layer2s/bobanetwork.ts
@@ -333,7 +333,7 @@ export const bobanetwork: Layer2 = {
   milestones: [
     {
       name: 'Mainnet launch',
-      date: new Date('2021-09-20'),
+      date: '2021-09-20T00:00:00Z',
       link: 'https://www.enya.ai/press/public-mainnet',
       description:
         'Layer 2 Optimistic Rollup based on the Optimism codebase is live on Ethereum.',

--- a/packages/config/src/layer2s/dydx.ts
+++ b/packages/config/src/layer2s/dydx.ts
@@ -186,21 +186,21 @@ export const dydx: Layer2 = {
     {
       name: 'Public launch',
       link: 'https://dydx.exchange/blog/public',
-      date: new Date('2021-04-06'),
+      date: '2021-04-06T00:00:00Z',
       description:
         'Layer 2 cross-margined Perpetuals are now live in production for all traders.',
     },
     {
       name: 'dYdX Foundation',
       link: 'https://dydx.exchange/blog/introducing-dydx-foundation',
-      date: new Date('2021-08-03'),
+      date: '2021-08-03T00:00:00Z',
       description:
         'Independent foundation, headquartered in Zug, Switzerland, was created to participate in propelling the Protocol into the future.',
     },
     {
       name: 'dYdX v4 announcement',
       link: 'https://dydx.exchange/blog/dydx-chain',
-      date: new Date('2022-06-22'),
+      date: '2022-06-22T00:00:00Z',
       description:
         'dYdX V4 will be developed as a standalone blockchain based on the Cosmos SDK and Tendermint Proof-of-stake consensus protocol.',
     },

--- a/packages/config/src/layer2s/metis.ts
+++ b/packages/config/src/layer2s/metis.ts
@@ -339,14 +339,14 @@ export const metis: Layer2 = {
     {
       name: 'Mainnet launch',
       link: 'https://metisdao.medium.com/metis-to-launch-andromeda-honoring-our-commitment-to-decentralization-fa2d03394398',
-      date: new Date('2021-11-19'),
+      date: '2021-11-19T00:00:00Z',
       description:
         'Public launch of Metis Layer 2 Andromeda, based on the Optimism codebase.',
     },
     {
       name: 'Data availability change',
       link: 'https://metisdao.medium.com/decentralized-storage-goes-live-da876dc6eb70',
-      date: new Date('2022-04-12'),
+      date: '2022-04-12T00:00:00Z',
       description:
         'Update results in the system no longer posting data on-chain, instead data is kept off-chain by a committee.',
     },

--- a/packages/config/src/layer2s/myria.ts
+++ b/packages/config/src/layer2s/myria.ts
@@ -158,7 +158,7 @@ export const myria: Layer2 = {
   milestones: [
     {
       name: 'Mainnet Launch',
-      date: new Date(),
+      date: '2022-08-26T00:00:00Z',
       link: 'https://medium.com/myria-official/myrias-layer-2-launch-has-arrived-6a3c3da9561f',
       description:
         'Layer 2 scaling solution powered by Starware is live on Ethereum.',

--- a/packages/config/src/layer2s/nova.ts
+++ b/packages/config/src/layer2s/nova.ts
@@ -317,7 +317,7 @@ export const nova: Layer2 = {
   milestones: [
     {
       ...MILESTONES.MAINNET_OPEN,
-      date: new Date('2022-08-09'),
+      date: '2022-08-09T00:00:00Z',
       link: 'https://medium.com/offchainlabs/its-time-for-a-new-dawn-nova-is-open-to-the-public-a081df1e4ad2',
     },
   ],

--- a/packages/config/src/layer2s/optimism.ts
+++ b/packages/config/src/layer2s/optimism.ts
@@ -341,12 +341,12 @@ export const optimism: Layer2 = {
     {
       ...MILESTONES.MAINNET_OPEN,
       link: 'https://medium.com/ethereum-optimism/all-gas-no-brakes-8b0f32afd466',
-      date: new Date('2021-12-16'),
+      date: '2021-12-16T00:00:00Z',
     },
     {
       name: 'Token airdrop',
       link: 'https://optimism.mirror.xyz/qvd0WfuLKnePm1Gxb9dpGchPf5uDz5NSMEFdgirDS4c',
-      date: new Date('2022-05-31'),
+      date: '2022-05-31T00:00:00Z',
       description: 'The first round of OP token airdrop.',
     },
   ],

--- a/packages/config/src/layer2s/rhinofi.ts
+++ b/packages/config/src/layer2s/rhinofi.ts
@@ -188,7 +188,7 @@ export const rhinofi: Layer2 = {
   milestones: [
     {
       name: 'Rebranding',
-      date: new Date('2022-07-13'),
+      date: '2022-07-13T00:00:00Z',
       link: 'https://rhino.fi/blog/introducing-rhino-fi-the-first-frictionless-gateway-to-multi-chain-defi/',
       description:
         'DeversiFi becomes rhino.fi: multi-chain platform gathering DeFi opportunities in one place.',

--- a/packages/config/src/layer2s/sorare.ts
+++ b/packages/config/src/layer2s/sorare.ts
@@ -145,7 +145,7 @@ export const sorare: Layer2 = {
   milestones: [
     {
       name: 'Mainnet launch',
-      date: new Date('2021-07-26'),
+      date: '2021-07-26T00:00:00Z',
       link: 'https://medium.com/sorare/were-live-on-our-scaling-solution-starkware-62438abee9a8',
       description:
         'Layer 2 scaling solution powered by Starkware, is live on Ethereum.',

--- a/packages/config/src/layer2s/starknet.ts
+++ b/packages/config/src/layer2s/starknet.ts
@@ -279,14 +279,14 @@ export const starknet: Layer2 = {
     {
       name: 'StarkNet Alpha',
       link: 'https://medium.com/starkware/starknet-alpha-now-on-mainnet-4cf35efd1669',
-      date: new Date('2021-11-29'),
+      date: '2021-11-29T00:00:00Z',
       description:
         'Rollup is live on mainnet, enabling general computation smart contracts using zkRollup technology.',
     },
     {
       name: 'StarkGate Alpha',
       link: 'https://medium.com/starkware/starkgate-alpha-35d01d21e3af',
-      date: new Date('2022-05-09'),
+      date: '2022-05-09T00:00:00Z',
       description:
         'Bridge is live on mainnet, serving as gateway between Ethereum and StarkNet.',
     },

--- a/packages/config/src/layer2s/zksync.ts
+++ b/packages/config/src/layer2s/zksync.ts
@@ -346,14 +346,14 @@ export const zksync: Layer2 = {
     {
       name: 'zkSync 1.0 launch',
       link: 'https://blog.matter-labs.io/zksync-is-live-bringing-trustless-scalable-payments-to-ethereum-9c634b3e6823',
-      date: new Date('2020-06-18'),
+      date: '2020-06-18T00:00:00Z',
       description:
         'zkSync is live, bringing trustless, scalable payments to Ethereum using zkRollup technology.',
     },
     {
       name: 'zkEVM alpha',
       link: 'https://blog.matter-labs.io/baby-alpha-has-arrived-5b10798bc623',
-      date: new Date('2022-10-28'),
+      date: '2022-10-28T00:00:00Z',
       description:
         'Deployment of the system to mainnet, for the testing purposes.',
     },

--- a/packages/config/test/layer2s.test.ts
+++ b/packages/config/test/layer2s.test.ts
@@ -1,3 +1,4 @@
+import { UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { ProjectTechnologyChoice } from '../src/common'
@@ -83,18 +84,35 @@ describe('layer2s', () => {
   })
 
   describe('milestones', () => {
-    for (const project of layer2s) {
-      if (project.milestones === undefined) {
-        continue
-      }
-      for (const milestone of project.milestones) {
-        if (milestone.description === undefined) {
+    describe('description', () => {
+      for (const project of layer2s) {
+        if (project.milestones === undefined) {
           continue
         }
-        it(`Milestone: ${milestone.name} (${project.display.name}) description ends with a dot`, () => {
-          expect(milestone.description?.endsWith('.')).toEqual(true)
-        })
+        for (const milestone of project.milestones) {
+          if (milestone.description === undefined) {
+            continue
+          }
+          it(`Milestone: ${milestone.name} (${project.display.name}) description ends with a dot`, () => {
+            expect(milestone.description?.endsWith('.')).toEqual(true)
+          })
+        }
       }
-    }
+    })
+
+    describe('date', () => {
+      for (const project of layer2s) {
+        if (project.milestones === undefined) {
+          continue
+        }
+        for (const milestone of project.milestones) {
+          it(`Milestone: ${milestone.name} (${project.display.name}) date is full day`, () => {
+            expect(
+              UnixTime.fromDate(new Date(milestone.date)).isFull('day'),
+            ).toEqual(true)
+          })
+        }
+      }
+    })
   })
 })

--- a/packages/frontend/src/components/project/Milestones.stories.tsx
+++ b/packages/frontend/src/components/project/Milestones.stories.tsx
@@ -21,19 +21,19 @@ Milestone.args = {
     {
       name: 'Creation of Arbitrum One',
       link: 'https://l2beat.com',
-      date: new Date('2019-11-14'),
+      date: '2019-11-14T00:00:00Z',
     },
     {
       name: 'Arbitrum Odyssey begins',
       link: 'https://l2beat.com',
-      date: new Date('2022-06-25'),
+      date: '2022-06-25T00:00:00Z',
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed iaculis dui eu odio aliquam, in sodales dolor lacinia. Aliquam pharetra malesuada urna turpis.',
     },
     {
       name: 'Nitro upgrade is activated',
       link: 'https://l2beat.com',
-      date: new Date('2022-08-31'),
+      date: '2022-08-31T00:00:00Z',
       description:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed iaculis dui eu odio aliquam, in sodales dolor lacinia. Aliquam pharetra malesuada urna turpis.',
     },

--- a/packages/frontend/src/components/project/Milestones.tsx
+++ b/packages/frontend/src/components/project/Milestones.tsx
@@ -74,7 +74,8 @@ export function Milestones({ milestones, className }: MilestonesProps) {
   )
 }
 
-function formatDate(date: Date): string {
+function formatDate(dateString: string): string {
+  const date = new Date(dateString)
   const year = date.getFullYear()
   const month = date.toLocaleDateString('en', {
     month: 'short',

--- a/packages/frontend/src/components/project/Milestones.tsx
+++ b/packages/frontend/src/components/project/Milestones.tsx
@@ -35,7 +35,7 @@ export function Milestones({ milestones, className }: MilestonesProps) {
         </div>
         <div className="ml-10 mt-6">
           {milestones
-            .sort((a, b) => Number(b.date) - Number(a.date))
+            .sort((a, b) => Number(new Date(b.date)) - Number(new Date(a.date)))
             .map((milestone, i) => (
               <div key={i} className="pb-7">
                 <MilestoneIcon className="absolute left-1.5 fill-green-200 stroke-green-400 dark:fill-green-800 dark:stroke-green-500" />

--- a/packages/frontend/src/components/project/Milestones.tsx
+++ b/packages/frontend/src/components/project/Milestones.tsx
@@ -35,7 +35,9 @@ export function Milestones({ milestones, className }: MilestonesProps) {
         </div>
         <div className="ml-10 mt-6">
           {milestones
-            .sort((a, b) => Number(new Date(b.date)) - Number(new Date(a.date)))
+            .sort(
+              (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+            )
             .map((milestone, i) => (
               <div key={i} className="pb-7">
                 <MilestoneIcon className="absolute left-1.5 fill-green-200 stroke-green-400 dark:fill-green-800 dark:stroke-green-500" />


### PR DESCRIPTION
This PR aims to change type of field `date` inside `Milestone` from JS `Date` to `string` with a specified timezone. This one is needed because without it the execution is environment dependent, is not deterministic from the code, on one machine it can be UTC but on the other it can be 2h offset etc.
Additionally I added test to check whether the date is full day, because we do not want to support hourly granularity as for now.

Resolves L2B-498 