### PR TITLE
Add ArrayHandler

### DIFF
--- a/packages/backend/src/core/discovery/handlers/getHandlers.test.ts
+++ b/packages/backend/src/core/discovery/handlers/getHandlers.test.ts
@@ -3,7 +3,6 @@ import { expect } from 'earljs'
 import { getHandlers } from './getHandlers'
 import { LimitedArrayHandler } from './system/LimitedArrayHandler'
 import { SimpleMethodHandler } from './system/SimpleMethodHandler'
-import { ArrayHandler } from './user/ArrayHandler'
 import { StorageHandler } from './user/StorageHandler'
 
 describe(getHandlers.name, () => {
@@ -92,11 +91,11 @@ describe(getHandlers.name, () => {
     const handlers = getHandlers([], {
       fields: {
         foo: { type: 'storage', slot: 1 },
-        bar: { type: 'array' },
+        bar: { type: 'storage', slot: 2 },
       },
     })
     expect(handlers).toEqual([
-      new ArrayHandler('bar', { type: 'array' }),
+      new StorageHandler('bar', { type: 'storage', slot: 2 }),
       new StorageHandler('foo', { type: 'storage', slot: 1 }),
     ])
   })
@@ -110,12 +109,12 @@ describe(getHandlers.name, () => {
       {
         fields: {
           foo: { type: 'storage', slot: 1 },
-          bar: { type: 'array' },
+          bar: { type: 'storage', slot: 2 },
         },
       },
     )
     expect(handlers).toEqual([
-      new ArrayHandler('bar', { type: 'array' }),
+      new StorageHandler('bar', { type: 'storage', slot: 2 }),
       new SimpleMethodHandler('function baz() view returns (address)'),
       new StorageHandler('foo', { type: 'storage', slot: 1 }),
     ])

--- a/packages/backend/src/core/discovery/handlers/getHandlers.ts
+++ b/packages/backend/src/core/discovery/handlers/getHandlers.ts
@@ -8,7 +8,7 @@ export function getHandlers(
 ) {
   const systemHandlers = getSystemHandlers(abi, overrides)
   const userHandlers = Object.entries(overrides?.fields ?? {}).map(
-    ([field, definition]) => getUserHandler(field, definition),
+    ([field, definition]) => getUserHandler(field, definition, abi),
   )
 
   const handlers = userHandlers

--- a/packages/backend/src/core/discovery/handlers/getUserHandler.ts
+++ b/packages/backend/src/core/discovery/handlers/getUserHandler.ts
@@ -6,11 +6,12 @@ import { UserHandlerDefinition } from './UserHandlerDefinition'
 export function getUserHandler(
   field: string,
   definition: UserHandlerDefinition,
+  abi: string[],
 ): Handler {
   switch (definition.type) {
     case 'storage':
       return new StorageHandler(field, definition)
     case 'array':
-      return new ArrayHandler(field, definition)
+      return new ArrayHandler(field, definition, abi)
   }
 }

--- a/packages/backend/src/core/discovery/handlers/user/ArrayHandler.test.ts
+++ b/packages/backend/src/core/discovery/handlers/user/ArrayHandler.test.ts
@@ -1,0 +1,272 @@
+import { mock } from '@l2beat/common'
+import { Bytes, EthereumAddress } from '@l2beat/types'
+import { expect } from 'earljs'
+
+import { DiscoveryProvider } from '../../provider/DiscoveryProvider'
+import { ArrayHandler } from './ArrayHandler'
+
+describe(ArrayHandler.name, () => {
+  describe('dependencies', () => {
+    it('detects no dependencies for a simple definition', () => {
+      const handler = new ArrayHandler(
+        'someName',
+        {
+          type: 'array',
+          method: 'function foo(uint i) view returns (uint)',
+          length: 1,
+        },
+        [],
+      )
+
+      expect(handler.dependencies).toEqual([])
+    })
+
+    it('detects dependency from the length field', () => {
+      const handler = new ArrayHandler(
+        'someName',
+        {
+          type: 'array',
+          method: 'function foo(uint i) view returns (uint)',
+          length: '{{ foo }}',
+        },
+        [],
+      )
+
+      expect(handler.dependencies).toEqual(['foo'])
+    })
+  })
+
+  describe('getMethod', () => {
+    it('returns the passed method properly formatted', () => {
+      const handler = new ArrayHandler(
+        'someName',
+        {
+          type: 'array',
+          method: 'function foo(uint i) view returns (uint)',
+        },
+        [],
+      )
+
+      expect(handler.getMethod()).toEqual(
+        'function foo(uint256 i) view returns (uint256)',
+      )
+    })
+
+    it('rejects a non-array method abi', () => {
+      expect(
+        () =>
+          new ArrayHandler(
+            'someName',
+            {
+              type: 'array',
+              method: 'function foo() view returns (uint)',
+            },
+            [],
+          ),
+      ).toThrow('Invalid method abi')
+    })
+
+    it('finds the method by field name', () => {
+      const handler = new ArrayHandler('someName', { type: 'array' }, [
+        'function foo(uint256 i) view returns (uint256)',
+        'function someName(uint256 i) view returns (uint256)',
+        'function someName(uint256 a, uint256 b) view returns (uint256)',
+        'function someName() view returns (uint256)',
+      ])
+
+      expect(handler.getMethod()).toEqual(
+        'function someName(uint256 i) view returns (uint256)',
+      )
+    })
+
+    it('throws if it cannot find the method by field name', () => {
+      expect(
+        () =>
+          new ArrayHandler('someName', { type: 'array' }, [
+            'function foo(uint256 i) view returns (uint256)',
+            'function someName(uint256 a, uint256 b) view returns (uint256)',
+            'function someName() view returns (uint256)',
+          ]),
+      ).toThrow('Cannot find an array method for someName')
+    })
+
+    it('finds the method by method name', () => {
+      const handler = new ArrayHandler(
+        'someName',
+        { type: 'array', method: 'bar' },
+        [
+          'function foo(uint256 i) view returns (uint256)',
+          'function someName(uint256 i) view returns (uint256)',
+          'function someName(uint256 a, uint256 b) view returns (uint256)',
+          'function someName() view returns (uint256)',
+          'function bar(uint256 i) view returns (uint256)',
+          'function bar(uint256 a, uint256 b) view returns (uint256)',
+          'function bar() view returns (uint256)',
+        ],
+      )
+
+      expect(handler.getMethod()).toEqual(
+        'function bar(uint256 i) view returns (uint256)',
+      )
+    })
+
+    it('throws if it cannot find the method by method name', () => {
+      expect(
+        () =>
+          new ArrayHandler('someName', { type: 'array', method: 'bar' }, [
+            'function foo(uint256 i) view returns (uint256)',
+            'function someName(uint256 i) view returns (uint256)',
+            'function someName(uint256 a, uint256 b) view returns (uint256)',
+            'function someName() view returns (uint256)',
+            'function bar(uint256 a, uint256 b) view returns (uint256)',
+            'function bar() view returns (uint256)',
+          ]),
+      ).toThrow('Cannot find an array method for bar')
+    })
+  })
+
+  describe('execute', () => {
+    const method = 'function owners(uint256 index) view returns (address)'
+    const signature = '0x025e7c27'
+    const address = EthereumAddress.random()
+    const owners = [
+      EthereumAddress.random(),
+      EthereumAddress.random(),
+      EthereumAddress.random(),
+    ]
+
+    it('calls the method "length" times', async () => {
+      const provider = mock<DiscoveryProvider>({
+        async call(passedAddress, data) {
+          expect(passedAddress).toEqual(address)
+
+          const index = data.get(35)
+
+          expect(data).toEqual(
+            Bytes.fromHex(signature + index.toString().padStart(64, '0')),
+          )
+
+          return Bytes.fromHex('00'.repeat(12)).concat(
+            Bytes.fromHex(owners[index].toString()),
+          )
+        },
+      })
+
+      const handler = new ArrayHandler(
+        'owners',
+        { type: 'array', method, length: 3 },
+        [],
+      )
+      expect(handler.field).toEqual('owners')
+
+      const result = await handler.execute(provider, address, {})
+      expect<unknown>(result).toEqual({
+        field: 'owners',
+        value: owners,
+      })
+    })
+
+    it('resolves the "length" field', async () => {
+      const provider = mock<DiscoveryProvider>({
+        async call(passedAddress, data) {
+          expect(passedAddress).toEqual(address)
+          const index = data.get(35)
+          return Bytes.fromHex('00'.repeat(12)).concat(
+            Bytes.fromHex(owners[index].toString()),
+          )
+        },
+      })
+
+      const handler = new ArrayHandler(
+        'owners',
+        { type: 'array', method, length: '{{ foo }}' },
+        [],
+      )
+      expect(handler.field).toEqual('owners')
+
+      const result = await handler.execute(provider, address, {
+        foo: { field: 'foo', value: 3 },
+      })
+      expect<unknown>(result).toEqual({
+        field: 'owners',
+        value: owners,
+      })
+    })
+
+    it('handles errors when length is present', async () => {
+      const provider = mock<DiscoveryProvider>({
+        async call(passedAddress, data) {
+          expect(passedAddress).toEqual(address)
+          const index = data.get(35)
+          if (index === 1) {
+            throw new Error('revert')
+          }
+          return Bytes.fromHex('00'.repeat(12)).concat(
+            Bytes.fromHex(owners[index].toString()),
+          )
+        },
+      })
+
+      const handler = new ArrayHandler(
+        'owners',
+        { type: 'array', method, length: 3 },
+        [],
+      )
+      expect(handler.field).toEqual('owners')
+
+      const result = await handler.execute(provider, address, {})
+      expect<unknown>(result).toEqual({
+        field: 'owners',
+        error: 'Execution reverted',
+      })
+    })
+
+    it('calls the method until revert without length', async () => {
+      const provider = mock<DiscoveryProvider>({
+        async call(passedAddress, data) {
+          expect(passedAddress).toEqual(address)
+          const index = data.get(35)
+          if (index >= 3) {
+            throw new Error('revert')
+          }
+          return Bytes.fromHex('00'.repeat(12)).concat(
+            Bytes.fromHex(owners[index].toString()),
+          )
+        },
+      })
+
+      const handler = new ArrayHandler('owners', { type: 'array', method }, [])
+      expect(handler.field).toEqual('owners')
+
+      const result = await handler.execute(provider, address, {})
+      expect<unknown>(result).toEqual({
+        field: 'owners',
+        value: owners,
+      })
+    })
+
+    it('handles non-revert errors without length', async () => {
+      const provider = mock<DiscoveryProvider>({
+        async call(passedAddress, data) {
+          expect(passedAddress).toEqual(address)
+          const index = data.get(35)
+          if (index === 1) {
+            throw new Error('oops')
+          }
+          return Bytes.fromHex('00'.repeat(12)).concat(
+            Bytes.fromHex(owners[index].toString()),
+          )
+        },
+      })
+
+      const handler = new ArrayHandler('owners', { type: 'array', method }, [])
+      expect(handler.field).toEqual('owners')
+
+      const result = await handler.execute(provider, address, {})
+      expect<unknown>(result).toEqual({
+        field: 'owners',
+        error: 'oops',
+      })
+    })
+  })
+})

--- a/packages/backend/src/core/discovery/handlers/user/ArrayHandler.test.ts
+++ b/packages/backend/src/core/discovery/handlers/user/ArrayHandler.test.ts
@@ -157,8 +157,6 @@ describe(ArrayHandler.name, () => {
         { type: 'array', method, length: 3 },
         [],
       )
-      expect(handler.field).toEqual('owners')
-
       const result = await handler.execute(provider, address, {})
       expect<unknown>(result).toEqual({
         field: 'owners',
@@ -182,8 +180,6 @@ describe(ArrayHandler.name, () => {
         { type: 'array', method, length: '{{ foo }}' },
         [],
       )
-      expect(handler.field).toEqual('owners')
-
       const result = await handler.execute(provider, address, {
         foo: { field: 'foo', value: 3 },
       })
@@ -212,8 +208,6 @@ describe(ArrayHandler.name, () => {
         { type: 'array', method, length: 3 },
         [],
       )
-      expect(handler.field).toEqual('owners')
-
       const result = await handler.execute(provider, address, {})
       expect<unknown>(result).toEqual({
         field: 'owners',
@@ -236,8 +230,6 @@ describe(ArrayHandler.name, () => {
       })
 
       const handler = new ArrayHandler('owners', { type: 'array', method }, [])
-      expect(handler.field).toEqual('owners')
-
       const result = await handler.execute(provider, address, {})
       expect<unknown>(result).toEqual({
         field: 'owners',
@@ -260,12 +252,46 @@ describe(ArrayHandler.name, () => {
       })
 
       const handler = new ArrayHandler('owners', { type: 'array', method }, [])
-      expect(handler.field).toEqual('owners')
-
       const result = await handler.execute(provider, address, {})
       expect<unknown>(result).toEqual({
         field: 'owners',
         error: 'oops',
+      })
+    })
+
+    it('has a builtin limit of 100', async () => {
+      const provider = mock<DiscoveryProvider>({
+        async call() {
+          return Bytes.fromHex('0'.repeat(64))
+        },
+      })
+
+      const handler = new ArrayHandler('owners', { type: 'array', method }, [])
+      const result = await handler.execute(provider, address, {})
+      expect<unknown>(result).toEqual({
+        field: 'owners',
+        error: 'Too many values. Provide a higher maxLength value',
+        value: new Array(100).fill('0x' + '0'.repeat(40)),
+      })
+    })
+
+    it('can have a different maxLength', async () => {
+      const provider = mock<DiscoveryProvider>({
+        async call() {
+          return Bytes.fromHex('0'.repeat(64))
+        },
+      })
+
+      const handler = new ArrayHandler(
+        'owners',
+        { type: 'array', method, maxLength: 15 },
+        [],
+      )
+      const result = await handler.execute(provider, address, {})
+      expect<unknown>(result).toEqual({
+        field: 'owners',
+        error: 'Too many values. Provide a higher maxLength value',
+        value: new Array(15).fill('0x' + '0'.repeat(40)),
       })
     })
   })

--- a/packages/backend/src/core/discovery/handlers/utils/valueToBigInt.ts
+++ b/packages/backend/src/core/discovery/handlers/utils/valueToBigInt.ts
@@ -1,0 +1,17 @@
+import { Bytes } from '@l2beat/types'
+
+import { ContractValue } from '../../types'
+
+export function valueToBigInt(value: bigint | Bytes | ContractValue) {
+  if (Array.isArray(value)) {
+    throw new Error('Cannot convert value to bigint')
+  }
+  if (value instanceof Bytes) {
+    return BigInt(value.toString())
+  }
+  try {
+    return BigInt(value)
+  } catch (e) {
+    throw new Error('Cannot convert value to bigint')
+  }
+}

--- a/packages/backend/src/core/discovery/handlers/utils/valueToNumber.ts
+++ b/packages/backend/src/core/discovery/handlers/utils/valueToNumber.ts
@@ -1,0 +1,12 @@
+import { Bytes } from '@l2beat/types'
+
+import { ContractValue } from '../../types'
+import { valueToBigInt } from './valueToBigInt'
+
+export function valueToNumber(value: bigint | Bytes | ContractValue) {
+  const bigint = valueToBigInt(value)
+  if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
+    throw new Error('Cannot convert value to number')
+  }
+  return Number(bigint)
+}


### PR DESCRIPTION
Resolves L2B-516, L2B-358

This new array handler is quite smart, here are some examples:
```jsonc
{
  "one": {
    // simplest mode, finds the method one(uint) from abi and calls it
    // until it reverts
    "type": "array"
  },
  "two": {
    // specifies a different method foo(uint) from abi
    "type": "array",
    "method": "foo"
  },
  "three": {
    // specifies a specific abi that doesn't have to exist on the contract
    "type": "array",
    "method": "function bar(uint256 i) view returns (uint256)"
  },
  "four": {
    // specifies a specific abi that doesn't have to exist on the contract
    "type": "array",
    "method": "function bar(uint256 i) view returns (uint256)"
  },
  "five": {
    // specifies a maximum length
    "type": "array",
    "length": 1
  },
  "six": {
    // specifies a maximum length as a reference
    "type": "array",
    "length": "{{ foo }}"
  },
  "seven": {
    // everything, everywhere all at once
    "type": "array",
    "method": "function bar(uint256 i) view returns (uint256)",
    "length": "{{ foo }}"
  }
}
```