### PR TITLE
Change chart's default timescale

### DIFF
--- a/packages/frontend/src/components/chart/RangeControls.tsx
+++ b/packages/frontend/src/components/chart/RangeControls.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import { RadioGroup } from './RadioGroup'
 
 export function RangeControls({
-  days,
   type,
 }: {
   days: number
@@ -16,14 +15,13 @@ export function RangeControls({
       options={[
         {
           value: '7D',
-          checked: days === 7,
           className: type === 'activity' ? '!hidden' : undefined,
         },
-        { value: '30D', checked: days === 30 },
+        { value: '30D' },
         { value: '90D', className: '!hidden sm:!block' },
         { value: '180D', className: '!hidden sm:!block' },
         { value: '1Y' },
-        { value: 'MAX' },
+        { value: 'MAX', checked: true },
       ]}
     />
   )

--- a/packages/frontend/src/components/chart/configure/update/view/getAppropriateEntries.ts
+++ b/packages/frontend/src/components/chart/configure/update/view/getAppropriateEntries.ts
@@ -1,16 +1,19 @@
-export function getAppropriateEntries<T>(
+import { AggregateTvlResponse, TokenTvlResponse } from '../../state/State'
+
+export function getAppropriateEntries(
   days: number,
-  response: {
-    hourly: { data: T[] }
-    sixHourly: { data: T[] }
-    daily: { data: T[] }
-  },
+  response: AggregateTvlResponse | TokenTvlResponse,
 ) {
   if (days <= 7) {
     return response.hourly.data.slice(-24 * days)
   } else if (days <= 90) {
     return response.sixHourly.data.slice(-4 * days)
   } else {
-    return response.daily.data.slice(-days)
+    const firstNonZero = response.daily.data.findIndex((p) => p[1] > 0)
+    if (firstNonZero === -1) {
+      // TODO: filter out tokens for which this is the case on the backend
+      return response.daily.data.slice(-days)
+    }
+    return response.daily.data.slice(firstNonZero).slice(-days)
   }
 }


### PR DESCRIPTION
This PR changes the timescale toggle on chart to be chacked on MAX by default. Additionally the data coming from API is trimmed from the "first n" of zeroes, because right now API returns array with entries as old as oldest project, but in most cases there are just zeros in 50% of elements because the project was not deployed.

![image](https://user-images.githubusercontent.com/72789647/207364151-b5b4c0ba-6789-4145-8564-c6099836f542.png)

Resolves L2B-550