### PR TITLE
Bunch of random fixes

### DIFF
--- a/packages/backend/scripts/start_db.sh
+++ b/packages/backend/scripts/start_db.sh
@@ -7,15 +7,24 @@ name=l2beat_postgres
 if [ ! "$(docker ps -q -f name=${name})" ]; then
     if [ "$(docker ps -aq -f status=exited -f name=${name})" ]; then
         echo "${name} container exists. Restarting..."
-        docker start l2beat_postgres >/dev/null
+        docker start ${name} >/dev/null
+
+        sleep 5
+        if [ "$(docker ps -aq -f status=exited -f name=${name})" ]; then
+            echo "Couldn't restart ${name}"
+            docker logs ${name} --since 10s
+            exit 1
+        else 
+            echo "Restarted successfully"
+        fi
     else
         echo "${name} container doesn't exist. Creating it and setting up databases."
-        docker run -d --name=l2beat_postgres -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:14
+        docker run -d --name=${name} -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:14
         
         echo "Waiting for db container..."
         sleep 5
-        docker exec -it l2beat_postgres psql -U postgres -c 'CREATE DATABASE l2beat_local'
-        docker exec -it l2beat_postgres psql -U postgres -c 'CREATE DATABASE l2beat_test'
+        docker exec -it ${name} psql -U postgres -c 'CREATE DATABASE l2beat_local'
+        docker exec -it ${name} psql -U postgres -c 'CREATE DATABASE l2beat_test'
     fi
 else
     echo "${name} container already running."

--- a/packages/backend/src/core/SequenceProcessor.test.ts
+++ b/packages/backend/src/core/SequenceProcessor.test.ts
@@ -77,9 +77,9 @@ describe(SequenceProcessor.name, () => {
       expect(sequenceProcessor.hasProcessedAll()).toEqual(true)
       expect(getLatestMock).toHaveBeenCalledExactlyWith([[0], [5]])
       expect(processRangeMock).toHaveBeenCalledExactlyWith([
-        [0, 1, expect.anything()],
-        [2, 3, expect.anything()],
-        [4, 5, expect.anything()],
+        [0, 1, expect.anything(), expect.a(Logger)],
+        [2, 3, expect.anything(), expect.a(Logger)],
+        [4, 5, expect.anything(), expect.a(Logger)],
       ])
       expect(await repository.getById(PROCESSOR_ID)).toEqual({
         id: PROCESSOR_ID,
@@ -105,7 +105,7 @@ describe(SequenceProcessor.name, () => {
 
       expect(sequenceProcessor.hasProcessedAll()).toEqual(true)
       expect(processRangeMock).toHaveBeenCalledExactlyWith([
-        [4, 5, expect.anything()],
+        [4, 5, expect.anything(), expect.a(Logger)],
       ])
       expect(await repository.getById(PROCESSOR_ID)).toEqual({
         id: PROCESSOR_ID,
@@ -131,7 +131,7 @@ describe(SequenceProcessor.name, () => {
 
       expect(sequenceProcessor.hasProcessedAll()).toEqual(true)
       expect(processRangeMock).toHaveBeenCalledExactlyWith([
-        [4, 4, expect.anything()],
+        [4, 4, expect.anything(), expect.a(Logger)],
       ])
       expect(await repository.getById(PROCESSOR_ID)).toEqual({
         id: PROCESSOR_ID,
@@ -158,9 +158,9 @@ describe(SequenceProcessor.name, () => {
       expect(sequenceProcessor.hasProcessedAll()).toEqual(true)
       expect(getLatestMock).toHaveBeenCalledExactlyWith([[0], [2]])
       expect(processRangeMock).toHaveBeenCalledExactlyWith([
-        [0, 0, expect.anything()],
-        [1, 1, expect.anything()],
-        [2, 2, expect.anything()],
+        [0, 0, expect.anything(), expect.a(Logger)],
+        [1, 1, expect.anything(), expect.a(Logger)],
+        [2, 2, expect.anything(), expect.a(Logger)],
       ])
       expect(await repository.getById(PROCESSOR_ID)).toEqual({
         id: PROCESSOR_ID,
@@ -187,7 +187,7 @@ describe(SequenceProcessor.name, () => {
       expect(sequenceProcessor.hasProcessedAll()).toEqual(true)
       expect(getLatestMock).toHaveBeenCalledExactlyWith([[0], [2]])
       expect(processRangeMock).toHaveBeenCalledExactlyWith([
-        [0, 2, expect.anything()],
+        [0, 2, expect.anything(), expect.a(Logger)],
       ])
       expect(await repository.getById(PROCESSOR_ID)).toEqual({
         id: PROCESSOR_ID,
@@ -319,10 +319,10 @@ describe(SequenceProcessor.name, () => {
         ...new Array(getLatestMock.calls.length - 2).fill([7]),
       ])
       expect(processRangeMock).toHaveBeenCalledExactlyWith([
-        [0, 1, expect.anything()],
-        [2, 3, expect.anything()],
-        [4, 5, expect.anything()],
-        [6, 7, expect.anything()],
+        [0, 1, expect.anything(), expect.a(Logger)],
+        [2, 3, expect.anything(), expect.a(Logger)],
+        [4, 5, expect.anything(), expect.a(Logger)],
+        [6, 7, expect.anything(), expect.a(Logger)],
       ])
       expect(await repository.getById(PROCESSOR_ID)).toEqual({
         id: PROCESSOR_ID,
@@ -367,9 +367,9 @@ describe(SequenceProcessor.name, () => {
         expect.arrayWith([0], [1], [2]),
       )
       expect(processRangeMock).toHaveBeenCalledExactlyWith([
-        [0, 0, expect.anything()],
-        [1, 1, expect.anything()],
-        [2, 2, expect.anything()],
+        [0, 0, expect.anything(), expect.a(Logger)],
+        [1, 1, expect.anything(), expect.a(Logger)],
+        [2, 2, expect.anything(), expect.a(Logger)],
       ])
       expect(await repository.getById(PROCESSOR_ID)).toEqual({
         id: PROCESSOR_ID,

--- a/packages/backend/src/core/SequenceProcessor.ts
+++ b/packages/backend/src/core/SequenceProcessor.ts
@@ -20,6 +20,7 @@ export interface SequenceProcessorOpts {
     from: number,
     to: number,
     trx: Knex.Transaction,
+    logger: Logger, // logger with properly set name
   ) => Promise<void>
   scheduleIntervalMs?: number
 }
@@ -161,7 +162,7 @@ export class SequenceProcessor extends EventEmitter {
     try {
       this.eventTracker.record('range started')
       await this.repository.runInTransaction(async (trx) => {
-        await this.opts.processRange(from, to, trx)
+        await this.opts.processRange(from, to, trx, this.logger)
         await this.setState({ lastProcessed: to, latest }, trx)
       })
       this.eventTracker.record('range succeeded')

--- a/packages/backend/src/core/activity/counters/AztecConnectCounter.ts
+++ b/packages/backend/src/core/activity/counters/AztecConnectCounter.ts
@@ -34,7 +34,7 @@ export function createAztecConnectCounter(
         const block = await client.getLatestBlock()
         return block.number
       },
-      processRange: async (from, to, trx) => {
+      processRange: async (from, to, trx, logger) => {
         const queries = range(from, to + 1).map((blockNumber) => async () => {
           const block = await client.getBlock(blockNumber)
 

--- a/packages/backend/src/core/activity/counters/AztecCounter.ts
+++ b/packages/backend/src/core/activity/counters/AztecCounter.ts
@@ -34,7 +34,7 @@ export function createAztecCounter(
         const block = await client.getLatestBlock()
         return block.number
       },
-      processRange: async (from, to, trx) => {
+      processRange: async (from, to, trx, logger) => {
         const queries = range(from, to + 1).map((blockNumber) => async () => {
           const block = await client.getBlock(blockNumber)
 

--- a/packages/backend/src/core/activity/counters/LoopringCounter.ts
+++ b/packages/backend/src/core/activity/counters/LoopringCounter.ts
@@ -31,7 +31,7 @@ export function createLoopringCounter(
       batchSize,
       startFrom: 1,
       getLatest: client.getFinalizedBlockNumber.bind(client),
-      processRange: async (from, to, trx) => {
+      processRange: async (from, to, trx, logger) => {
         const queries = range(from, to + 1).map((blockNumber) => async () => {
           const block = await client.getBlock(blockNumber)
 

--- a/packages/backend/src/core/activity/counters/RpcCounter.ts
+++ b/packages/backend/src/core/activity/counters/RpcCounter.ts
@@ -45,7 +45,7 @@ export function createRpcCounter(
       startFrom: transactionApi.startBlock ?? 0,
       getLatest: (previousLatest) =>
         client.getBlockNumberAtOrBefore(clock.getLastHour(), previousLatest),
-      processRange: async (from, to, trx) => {
+      processRange: async (from, to, trx, logger) => {
         const queries = range(from, to + 1).map((blockNumber) => async () => {
           const block = await client.getBlock(blockNumber)
           const timestamp = new UnixTime(block.timestamp)

--- a/packages/backend/src/core/activity/counters/StarkexCounter.ts
+++ b/packages/backend/src/core/activity/counters/StarkexCounter.ts
@@ -34,6 +34,7 @@ export function createStarkexCounter(
     {
       batchSize,
       startFrom: startDay,
+      uncertaintyBuffer: options.resyncLastDays, // starkex APIs are not stable and can change from the past. With this we make sure to scrape them again
       getLatest: () => getStarkexLastDay(clock.getLastHour()),
       processRange: async (from, to, trx, logger) => {
         const queries = range(from, to + 1).map((day) => async () => {
@@ -49,7 +50,6 @@ export function createStarkexCounter(
         const counts = await promiseAllPlus(queries, logger)
         await starkexRepository.addOrUpdateMany(counts, trx)
       },
-      uncertaintyBuffer: options.resyncLastDays,
     },
   )
 

--- a/packages/backend/src/core/activity/counters/StarkexCounter.ts
+++ b/packages/backend/src/core/activity/counters/StarkexCounter.ts
@@ -1,7 +1,6 @@
 import { Logger, promiseAllPlus } from '@l2beat/common'
 import { StarkexTransactionApi } from '@l2beat/config'
 import { ProjectId, UnixTime } from '@l2beat/types'
-import { Knex } from 'knex'
 import { range } from 'lodash'
 
 import { StarkexTransactionCountRepository } from '../../../peripherals/database/activity/StarkexCountRepository'

--- a/packages/backend/src/core/activity/counters/StarknetCounter.ts
+++ b/packages/backend/src/core/activity/counters/StarknetCounter.ts
@@ -41,7 +41,7 @@ export function createStarknetCounter(
         )
         return blockNumber
       },
-      processRange: async (from, to, trx) => {
+      processRange: async (from, to, trx, logger) => {
         const queries = range(from, to + 1).map((blockNumber) => async () => {
           const block = await client.getBlock(blockNumber)
 

--- a/packages/backend/src/core/activity/counters/ZksyncCounter.ts
+++ b/packages/backend/src/core/activity/counters/ZksyncCounter.ts
@@ -33,7 +33,7 @@ export function createZksyncCounter(
       batchSize,
       startFrom: 1,
       getLatest: client.getLatestBlock.bind(client),
-      processRange: async (from, to, trx) => {
+      processRange: async (from, to, trx, logger) => {
         const queries = range(from, to + 1).map((blockNumber) => async () => {
           const transactions = await client.getTransactionsInBlock(blockNumber)
 

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -143,6 +143,14 @@ describe(PriceRepository.name, () => {
         ]),
       )
     })
+
+    it('works with empty database', async () => {
+      await repository.deleteAll()
+
+      const result = await repository.calcDataBoundaries()
+
+      expect(result).toEqual(new Map())
+    })
   })
 
   describe(PriceRepository.prototype.getLatestByTokenBetween.name, () => {
@@ -167,6 +175,17 @@ describe(PriceRepository.name, () => {
       )
 
       expect(result).toEqual(new Map([[AssetId.ETH, START.add(-1, 'days')]]))
+    })
+
+    it('works with empty database', async () => {
+      await repository.deleteAll()
+
+      const result = await repository.getLatestByTokenBetween(
+        START.add(-1, 'days'),
+        START.add(-1, 'hours'),
+      )
+
+      expect(result).toEqual(new Map())
     })
   })
 })

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.test.ts
@@ -66,4 +66,9 @@ describe(ReportStatusRepository.name, () => {
     const result = await repository.findLatestTimestamp()
     expect(result).toEqual(TIME_ONE)
   })
+
+  it('finds latest timestamp when database is empty', async () => {
+    const result = await repository.findLatestTimestamp()
+    expect(result).toEqual(undefined)
+  })
 })

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.ts
@@ -3,6 +3,7 @@ import { Hash256, UnixTime } from '@l2beat/types'
 
 import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
+import { OptionalDict } from './shared/types'
 
 export interface ReportStatusRecord {
   configHash: Hash256
@@ -75,10 +76,14 @@ export class ReportStatusRepository extends BaseRepository {
 
   async findLatestTimestamp(): Promise<UnixTime | undefined> {
     const knex = await this.knex()
-    const row = await knex('report_status').max('unix_timestamp').first()
-    if (!row) {
+    // note: we need to provide better types manually here
+    const row = (await knex('report_status').max('unix_timestamp').first()) as
+      | OptionalDict<Date>
+      | undefined
+    if (!row || row.max === null) {
       return undefined
     }
+
     return UnixTime.fromDate(row.max)
   }
 }

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.ts
@@ -3,7 +3,7 @@ import { Hash256, UnixTime } from '@l2beat/types'
 
 import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
-import { OptionalDict } from './shared/types'
+import { NullableDict } from './shared/types'
 
 export interface ReportStatusRecord {
   configHash: Hash256
@@ -78,7 +78,7 @@ export class ReportStatusRepository extends BaseRepository {
     const knex = await this.knex()
     // note: we need to provide better types manually here
     const row = (await knex('report_status').max('unix_timestamp').first()) as
-      | OptionalDict<Date>
+      | NullableDict<Date>
       | undefined
     if (!row || row.max === null) {
       return undefined

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.test.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.test.ts
@@ -1,0 +1,29 @@
+import { Logger } from '@l2beat/common'
+import { ProjectId } from '@l2beat/types'
+import { expect } from 'earljs'
+import { setupDatabaseTestSuite } from '../../../test/database'
+import { StarkexTransactionCountRepository } from './StarkexCountRepository'
+
+describe(StarkexTransactionCountRepository.name, () => {
+  const { database } = setupDatabaseTestSuite()
+  const repository = new StarkexTransactionCountRepository(
+    database,
+    Logger.SILENT,
+  )
+
+  beforeEach(async () => {
+    await repository.deleteAll()
+  })
+
+  describe(
+    StarkexTransactionCountRepository.prototype.getLastTimestampByProjectId
+      .name,
+    () => {
+      it('works with empty database', async () => {
+        expect(
+          await repository.getLastTimestampByProjectId(ProjectId.STARKNET),
+        ).toEqual(undefined)
+      })
+    },
+  )
+})

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.test.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.test.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@l2beat/common'
 import { ProjectId } from '@l2beat/types'
 import { expect } from 'earljs'
+
 import { setupDatabaseTestSuite } from '../../../test/database'
 import { StarkexTransactionCountRepository } from './StarkexCountRepository'
 

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.test.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.test.ts
@@ -3,6 +3,7 @@ import { ProjectId } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../../test/database'
+import { createMockMetrics } from '../../../test/mocks/Metrics'
 import { StarkexTransactionCountRepository } from './StarkexCountRepository'
 
 describe(StarkexTransactionCountRepository.name, () => {
@@ -10,6 +11,7 @@ describe(StarkexTransactionCountRepository.name, () => {
   const repository = new StarkexTransactionCountRepository(
     database,
     Logger.SILENT,
+    createMockMetrics(),
   )
 
   beforeEach(async () => {

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
@@ -47,7 +47,7 @@ export class StarkexTransactionCountRepository extends BaseRepository {
       .where('project_id', projectId.toString())
       .max('unix_timestamp')
       .first()
-    return row ? UnixTime.fromDate(row.max) : undefined
+    return row && row.max ? UnixTime.fromDate(row.max) : undefined
   }
 }
 

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
@@ -47,7 +47,8 @@ export class StarkexTransactionCountRepository extends BaseRepository {
       .where('project_id', projectId.toString())
       .max('unix_timestamp')
       .first()
-    return row && row.max ? UnixTime.fromDate(row.max) : undefined
+
+    return row?.max ? UnixTime.fromDate(row.max) : undefined
   }
 }
 

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
@@ -5,7 +5,7 @@ import { StarkexTransactionCountRow } from 'knex/types/tables'
 
 import { BaseRepository } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
-import { OptionalDict } from '../shared/types'
+import { NullableDict } from '../shared/types'
 
 export interface StarkexTransactionCountRecord {
   timestamp: UnixTime
@@ -48,7 +48,7 @@ export class StarkexTransactionCountRepository extends BaseRepository {
     const row = (await knex('activity.starkex')
       .where('project_id', projectId.toString())
       .max('unix_timestamp')
-      .first()) as OptionalDict<Date> | undefined
+      .first()) as NullableDict<Date> | undefined
 
     if (!row || row.max === null) {
       return undefined

--- a/packages/backend/src/peripherals/database/shared/types.ts
+++ b/packages/backend/src/peripherals/database/shared/types.ts
@@ -97,4 +97,4 @@ declare module 'knex/types/tables' {
 
 // Some aggregations return not empty row with null values. Use this type to explicitly type them.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type OptionalDict<T = any> = Record<string, T | null>
+export type NullableDict<T = any> = Record<string, T | null>

--- a/packages/backend/src/peripherals/database/shared/types.ts
+++ b/packages/backend/src/peripherals/database/shared/types.ts
@@ -94,3 +94,7 @@ declare module 'knex/types/tables' {
     'activity.daily_count_view': DailyTransactionCountRow
   }
 }
+
+// Some aggregations return not empty row with null values. Use this type to explicitly type them.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type OptionalDict<T = any> = Record<string, T | null>

--- a/packages/common/src/tools/Logger.ts
+++ b/packages/common/src/tools/Logger.ts
@@ -122,7 +122,7 @@ export class Logger {
   }
 }
 
-export function getErrorMessage(error: unknown) {
+export function getErrorMessage(error: unknown): string {
   if (typeof error === 'string') {
     return error
   } else if (error instanceof Error) {
@@ -131,6 +131,14 @@ export function getErrorMessage(error: unknown) {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     return `${error}`
   }
+}
+
+export function getErrorStackTrace(error: unknown): string | null {
+  if (!(error instanceof Error)) {
+    return null
+  }
+
+  return error.stack || null
 }
 
 function combine(

--- a/packages/common/src/tools/Logger.ts
+++ b/packages/common/src/tools/Logger.ts
@@ -138,7 +138,7 @@ export function getErrorStackTrace(error: unknown): string | null {
     return null
   }
 
-  return error.stack || null
+  return error.stack ?? null
 }
 
 function combine(

--- a/packages/common/src/tools/queue/TaskQueue.ts
+++ b/packages/common/src/tools/queue/TaskQueue.ts
@@ -3,7 +3,7 @@ import assert from 'assert'
 import { setTimeout as wait } from 'timers/promises'
 
 import { EventTracker } from '../EventTracker'
-import { getErrorMessage, Logger } from '../Logger'
+import { getErrorMessage, getErrorStackTrace, Logger } from '../Logger'
 import { Retries } from './Retries'
 import { Job, ShouldRetry, TaskQueueOpts } from './types'
 
@@ -144,6 +144,7 @@ export class TaskQueue<T> {
       this.logger.warn('Error during task execution', {
         job: JSON.stringify(job),
         error: getErrorMessage(error),
+        stack: getErrorStackTrace(error),
       })
       this.handleFailure(job, error)
     } finally {


### PR DESCRIPTION
Mostly stuff that I noticed while running backend locally:
* fixed logger names for the activity
* untangled StarkexCounter code by introducing `uncertaintyBuffer` directly to SequenceProcessor
* Fix bug in StarkexCountRepository
* Improved start_db.sh script