### PR TITLE
Add api metrics middleware

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -44,6 +44,7 @@ export class Application {
       new ApiServer(
         config.api.port,
         logger,
+        metrics,
         modules.flatMap((x) => x?.routers ?? []),
         handleServerError,
       )

--- a/packages/backend/src/api/ApiServer.ts
+++ b/packages/backend/src/api/ApiServer.ts
@@ -4,7 +4,9 @@ import Koa, { Context } from 'koa'
 import conditional from 'koa-conditional-get'
 import etag from 'koa-etag'
 
-import { createApiLogger } from './ApiLogger'
+import { Metrics } from '../Metrics'
+import { createApiLogger } from './middleware/logger'
+import { createApiMetrics } from './middleware/metrics'
 
 export class ApiServer {
   private readonly app: Koa
@@ -12,12 +14,14 @@ export class ApiServer {
   constructor(
     private readonly port: number,
     private readonly logger: Logger,
+    metrics: Metrics,
     routers: Router[],
     handleServerError?: (error: Error, ctx: Context) => void,
   ) {
     this.logger = this.logger.for(this)
     this.app = new Koa()
 
+    this.app.use(createApiMetrics(metrics))
     this.app.use(createApiLogger(this.logger))
     this.app.use(conditional())
     this.app.use(etag())

--- a/packages/backend/src/api/middleware/logger.ts
+++ b/packages/backend/src/api/middleware/logger.ts
@@ -1,8 +1,8 @@
 import { Logger } from '@l2beat/common'
-import { Context, Next } from 'koa'
+import { Context, Middleware, Next } from 'koa'
 
-export function createApiLogger(logger: Logger) {
-  return async function (ctx: Context, next: Next) {
+export function createApiLogger(logger: Logger): Middleware {
+  return async function (ctx: Context, next: Next): Promise<void> {
     const key = Symbol.for('request-received.startTime')
     // eslint-disable-next-line
     const start: number = ctx[key as any]?.getTime?.() ?? Date.now()

--- a/packages/backend/src/api/middleware/metrics.ts
+++ b/packages/backend/src/api/middleware/metrics.ts
@@ -24,10 +24,12 @@ export function createApiMetrics(metrics: Metrics): Middleware {
 
       const timeMs = Date.now() - start
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const path = (ctx._matchedRoute as string | undefined) ?? ctx.path
+
       apiHistogam
         .labels({
-          // TODO: normalizePath
-          path: ctx.path,
+          path,
           method: ctx.method,
           status_code: ctx.status,
         })

--- a/packages/backend/src/api/middleware/metrics.ts
+++ b/packages/backend/src/api/middleware/metrics.ts
@@ -5,9 +5,9 @@ import { Metrics } from '../../Metrics'
 export function createApiMetrics(metrics: Metrics): Middleware {
   const labels = ['path', 'method', 'status_code']
   const apiHistogam = metrics.createHistogram({
-    name: 'api_request_duration_seconds_sum',
+    name: 'api_request_duration_seconds',
     help:
-      'duration histogram of  api http responses labeled with: ' +
+      'duration histogram of api http responses labeled with: ' +
       labels.join(', '),
     labelNames: labels,
   })
@@ -27,6 +27,7 @@ export function createApiMetrics(metrics: Metrics): Middleware {
 
       const timeMs = Date.now() - start
 
+      // ctx._matchedRoute will include parameter range like /user/:id
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const path = (ctx._matchedRoute as string | undefined) ?? ctx.path
 

--- a/packages/backend/src/api/middleware/metrics.ts
+++ b/packages/backend/src/api/middleware/metrics.ts
@@ -3,10 +3,13 @@ import { Context, Middleware, Next } from 'koa'
 import { Metrics } from '../../Metrics'
 
 export function createApiMetrics(metrics: Metrics): Middleware {
+  const labels = ['path', 'method', 'status_code']
   const apiHistogam = metrics.createHistogram({
     name: 'api_request_duration_seconds_sum',
-    help: 'help',
-    labelNames: ['path', 'method', 'status_code'],
+    help:
+      'duration histogram of  api http responses labeled with: ' +
+      labels.join(', '),
+    labelNames: labels,
   })
 
   return async function (ctx: Context, next: Next): Promise<void> {

--- a/packages/backend/src/api/middleware/metrics.ts
+++ b/packages/backend/src/api/middleware/metrics.ts
@@ -1,0 +1,40 @@
+import { Context, Middleware, Next } from 'koa'
+
+import { Metrics } from '../../Metrics'
+
+export function createApiMetrics(metrics: Metrics): Middleware {
+  const apiHistogam = metrics.createHistogram({
+    name: 'api_request_duration_seconds_sum',
+    help: 'help',
+    labelNames: ['path', 'method', 'status_code'],
+  })
+
+  return async function (ctx: Context, next: Next): Promise<void> {
+    const key = Symbol.for('request-received.startTime')
+    // eslint-disable-next-line
+    const start: number = ctx[key as any]?.getTime?.() ?? Date.now()
+
+    await next()
+
+    const { res } = ctx
+
+    const done = () => {
+      res.removeListener('finish', done)
+      res.removeListener('close', done)
+
+      const timeMs = Date.now() - start
+
+      apiHistogam
+        .labels({
+          // TODO: normalizePath
+          path: ctx.path,
+          method: ctx.method,
+          status_code: ctx.status,
+        })
+        .observe(timeMs / 1000)
+    }
+
+    res.once('finish', done)
+    res.once('close', done)
+  }
+}

--- a/packages/backend/src/api/routers/MetricsRouter.test.ts
+++ b/packages/backend/src/api/routers/MetricsRouter.test.ts
@@ -2,13 +2,17 @@ import { mock } from '@l2beat/common'
 
 import { Config } from '../../config'
 import { Metrics } from '../../Metrics'
-import { createTestApiServer } from '../../test/testApiServer'
+import {
+  createMockHistogram,
+  createTestApiServer,
+} from '../../test/testApiServer'
 import { createMetricsRouter } from './MetricsRouter'
 
 describe(createMetricsRouter.name, () => {
   describe('can be configured', () => {
     const metrics = mock<Metrics>({
       getMetrics: async () => 'metrics',
+      createHistogram: createMockHistogram,
     })
 
     it('to require auth', async () => {
@@ -19,7 +23,7 @@ describe(createMetricsRouter.name, () => {
         },
       })
       const router = createMetricsRouter(config, metrics)
-      const server = createTestApiServer([router])
+      const server = createTestApiServer([router], metrics)
 
       await server.get('/metrics').expect(401)
       await server.get('/metrics').auth('user', 'pass').expect(200)
@@ -30,7 +34,7 @@ describe(createMetricsRouter.name, () => {
         metricsAuth: false,
       })
       const router = createMetricsRouter(config, metrics)
-      const server = createTestApiServer([router])
+      const server = createTestApiServer([router], metrics)
 
       await server.get('/metrics').expect(200)
     })

--- a/packages/backend/src/test/testApiServer.ts
+++ b/packages/backend/src/test/testApiServer.ts
@@ -23,6 +23,6 @@ export function createTestApiServer(routers: Router[], metrics?: Metrics) {
 
 export function createMockHistogram() {
   return mock<Histogram>({
-    observe: () => {},
+    labels: () => mock<Histogram>({ observe: () => {} }),
   })
 }

--- a/packages/backend/src/test/testApiServer.ts
+++ b/packages/backend/src/test/testApiServer.ts
@@ -1,10 +1,28 @@
 import Router from '@koa/router'
-import { Logger } from '@l2beat/common'
+import { Logger, mock } from '@l2beat/common'
+import { Histogram } from 'prom-client'
 import { agent } from 'supertest'
 
 import { ApiServer } from '../../src/api/ApiServer'
+import { Metrics } from '../Metrics'
 
-export function createTestApiServer(routers: Router[]) {
-  const callback = new ApiServer(0, Logger.SILENT, routers).getNodeCallback()
+export function createTestApiServer(routers: Router[], metrics?: Metrics) {
+  if (!metrics) {
+    metrics = mock<Metrics>({
+      createHistogram: createMockHistogram,
+    })
+  }
+  const callback = new ApiServer(
+    0,
+    Logger.SILENT,
+    metrics,
+    routers,
+  ).getNodeCallback()
   return agent(callback)
+}
+
+export function createMockHistogram() {
+  return mock<Histogram>({
+    observe: () => {},
+  })
 }


### PR DESCRIPTION
Resolves L2B-566

During the review please mind the code repetitions between `createApiLogger` and `createApiMetrics`. Alternatively, we can use a approach analogical to the following: 
```
// logger

app.use(async (ctx, next) => {
  await next();
  const rt = ctx.response.get('X-Response-Time');
  console.log(`${ctx.method} ${ctx.url} - ${rt}`);
});

// x-response-time

app.use(async (ctx, next) => {
  const start = Date.now();
  await next();
  const ms = Date.now() - start;
  ctx.set('X-Response-Time', `${ms}ms`);
});
```
This would give us less accurate timings but would be more readable and we would have the same exact time logged and saved as a metric. 