### PR TITLE
Measure repository methods execution times

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -10,7 +10,6 @@ import { createDiscoveryModule } from './modules/discovery/DiscoveryModule'
 import { createHealthModule } from './modules/health/HealthModule'
 import { createMetricsModule } from './modules/metrics/MetricsModule'
 import { createTvlModule } from './modules/tvl/TvlModule'
-import { RepositoryHistogram } from './peripherals/database/shared/BaseRepository'
 import { Database } from './peripherals/database/shared/Database'
 import { handleServerError, reportError } from './tools/ErrorReporter'
 
@@ -31,31 +30,12 @@ export class Application {
     )
 
     const metrics = new Metrics()
-    const repositoryHistogram: RepositoryHistogram = metrics.createHistogram({
-      name: 'repository_method_duration_seconds',
-      help: 'duration histogram of repository methods',
-      labelNames: ['repository', 'method'],
-    })
 
     const modules: (ApplicationModule | undefined)[] = [
       createHealthModule(config),
       createMetricsModule(config, metrics),
-      createTvlModule(
-        config,
-        logger,
-        http,
-        database,
-        clock,
-        repositoryHistogram,
-      ),
-      createActivityModule(
-        config,
-        logger,
-        http,
-        database,
-        clock,
-        repositoryHistogram,
-      ),
+      createTvlModule(config, logger, http, database, clock, metrics),
+      createActivityModule(config, logger, http, database, clock, metrics),
       createDiscoveryModule(config, logger, http),
     ]
 

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -10,6 +10,7 @@ import { createDiscoveryModule } from './modules/discovery/DiscoveryModule'
 import { createHealthModule } from './modules/health/HealthModule'
 import { createMetricsModule } from './modules/metrics/MetricsModule'
 import { createTvlModule } from './modules/tvl/TvlModule'
+import { RepositoryHistogram } from './peripherals/database/shared/BaseRepository'
 import { Database } from './peripherals/database/shared/Database'
 import { handleServerError, reportError } from './tools/ErrorReporter'
 
@@ -30,12 +31,31 @@ export class Application {
     )
 
     const metrics = new Metrics()
+    const repositoryHistogram: RepositoryHistogram = metrics.createHistogram({
+      name: 'repository_method_duration_seconds',
+      help: 'duration histogram of repository methods',
+      labelNames: ['repository', 'method'],
+    })
 
     const modules: (ApplicationModule | undefined)[] = [
       createHealthModule(config),
       createMetricsModule(config, metrics),
-      createTvlModule(config, logger, http, database, clock),
-      createActivityModule(config, logger, http, database, clock),
+      createTvlModule(
+        config,
+        logger,
+        http,
+        database,
+        clock,
+        repositoryHistogram,
+      ),
+      createActivityModule(
+        config,
+        logger,
+        http,
+        database,
+        clock,
+        repositoryHistogram,
+      ),
       createDiscoveryModule(config, logger, http),
     ]
 

--- a/packages/backend/src/Metrics.ts
+++ b/packages/backend/src/Metrics.ts
@@ -11,8 +11,10 @@ import {
   SummaryConfiguration,
 } from 'prom-client'
 
+export type RepositoryHistogram = Histogram<'repository' | 'method'>
+
 export class Metrics {
-  repositoryHistogram: Histogram
+  readonly repositoryHistogram: RepositoryHistogram
 
   constructor() {
     this.repositoryHistogram = this.createHistogram({

--- a/packages/backend/src/Metrics.ts
+++ b/packages/backend/src/Metrics.ts
@@ -12,6 +12,16 @@ import {
 } from 'prom-client'
 
 export class Metrics {
+  repositoryHistogram: Histogram
+
+  constructor() {
+    this.repositoryHistogram = this.createHistogram({
+      name: 'repository_method_duration_seconds',
+      help: 'duration histogram of repository methods',
+      labelNames: ['repository', 'method'],
+    })
+  }
+
   collectDefaultMetrics(): void {
     collectDefaultMetrics()
   }

--- a/packages/backend/src/api/routers/MetricsRouter.test.ts
+++ b/packages/backend/src/api/routers/MetricsRouter.test.ts
@@ -2,10 +2,8 @@ import { mock } from '@l2beat/common'
 
 import { Config } from '../../config'
 import { Metrics } from '../../Metrics'
-import {
-  createMockHistogram,
-  createTestApiServer,
-} from '../../test/testApiServer'
+import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createTestApiServer } from '../../test/testApiServer'
 import { createMetricsRouter } from './MetricsRouter'
 
 describe(createMetricsRouter.name, () => {

--- a/packages/backend/src/api/routers/MetricsRouter.test.ts
+++ b/packages/backend/src/api/routers/MetricsRouter.test.ts
@@ -2,7 +2,7 @@ import { mock } from '@l2beat/common'
 
 import { Config } from '../../config'
 import { Metrics } from '../../Metrics'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockHistogram } from '../../test/mocks/Metrics'
 import { createTestApiServer } from '../../test/testApiServer'
 import { createMetricsRouter } from './MetricsRouter'
 

--- a/packages/backend/src/core/SequenceProcessor.test.ts
+++ b/packages/backend/src/core/SequenceProcessor.test.ts
@@ -5,7 +5,7 @@ import { once } from 'events'
 
 import { SequenceProcessorRepository } from '../peripherals/database/SequenceProcessorRepository'
 import { setupDatabaseTestSuite } from '../test/database'
-import { createMockHistogram } from '../test/mocks/Histogram'
+import { createMockMetrics } from '../test/mocks/Metrics'
 import {
   ALL_PROCESSED_EVENT,
   SequenceProcessor,
@@ -14,11 +14,11 @@ import {
 
 describe(SequenceProcessor.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
+  const mockMetrics = createMockMetrics()
   const repository = new SequenceProcessorRepository(
     database,
     Logger.SILENT,
-    mockHistogram,
+    mockMetrics,
   )
   const PROCESSOR_ID = 'test'
   let sequenceProcessor: SequenceProcessor

--- a/packages/backend/src/core/SequenceProcessor.test.ts
+++ b/packages/backend/src/core/SequenceProcessor.test.ts
@@ -5,6 +5,7 @@ import { once } from 'events'
 
 import { SequenceProcessorRepository } from '../peripherals/database/SequenceProcessorRepository'
 import { setupDatabaseTestSuite } from '../test/database'
+import { createMockHistogram } from '../test/mocks/Histogram'
 import {
   ALL_PROCESSED_EVENT,
   SequenceProcessor,
@@ -13,7 +14,12 @@ import {
 
 describe(SequenceProcessor.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new SequenceProcessorRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new SequenceProcessorRepository(
+    database,
+    Logger.SILENT,
+    mockHistogram,
+  )
   const PROCESSOR_ID = 'test'
   let sequenceProcessor: SequenceProcessor
 

--- a/packages/backend/src/core/activity/counters/ZksyncCounter.ts
+++ b/packages/backend/src/core/activity/counters/ZksyncCounter.ts
@@ -5,7 +5,6 @@ import { range } from 'lodash'
 
 import { ZksyncTransactionRepository } from '../../../peripherals/database/activity/ZksyncTransactionRepository'
 import { SequenceProcessorRepository } from '../../../peripherals/database/SequenceProcessorRepository'
-import { Database } from '../../../peripherals/database/shared/Database'
 import { ZksyncClient } from '../../../peripherals/zksync'
 import { SequenceProcessor } from '../../SequenceProcessor'
 import { TransactionCounter } from '../TransactionCounter'
@@ -14,7 +13,7 @@ import { getBatchSizeFromCallsPerMinute } from './getBatchSizeFromCallsPerMinute
 export function createZksyncCounter(
   projectId: ProjectId,
   http: HttpClient,
-  database: Database,
+  zksyncRepository: ZksyncTransactionRepository,
   sequenceProcessorRepository: SequenceProcessorRepository,
   logger: Logger,
   transactionApi: ZksyncTransactionApi,
@@ -23,7 +22,6 @@ export function createZksyncCounter(
     transactionApi.callsPerMinute,
   )
   const client = new ZksyncClient(http, logger, transactionApi.callsPerMinute)
-  const zksyncRepository = new ZksyncTransactionRepository(database, logger)
 
   const processor = new SequenceProcessor(
     projectId.toString(),

--- a/packages/backend/src/modules/activity/ActivityModule.ts
+++ b/packages/backend/src/modules/activity/ActivityModule.ts
@@ -11,6 +11,7 @@ import { TransactionCountingMonitor } from '../../core/activity/TransactionCount
 import { Clock } from '../../core/Clock'
 import { Project } from '../../model'
 import { DailyTransactionCountViewRepository } from '../../peripherals/database/activity/DailyTransactionCountViewRepository'
+import { RepositoryHistogram } from '../../peripherals/database/shared/BaseRepository'
 import { Database } from '../../peripherals/database/shared/Database'
 import { ApplicationModule } from '../ApplicationModule'
 import { createTransactionCounters } from './createTransactionCounters'
@@ -21,6 +22,7 @@ export function createActivityModule(
   http: HttpClient,
   database: Database,
   clock: Clock,
+  histogram: RepositoryHistogram,
 ): ApplicationModule | undefined {
   if (!config.activity) {
     return
@@ -29,6 +31,7 @@ export function createActivityModule(
   const dailyCountViewRepository = new DailyTransactionCountViewRepository(
     database,
     logger,
+    histogram,
   )
 
   const counters = createTransactionCounters(
@@ -37,6 +40,7 @@ export function createActivityModule(
     http,
     database,
     clock,
+    histogram,
   )
 
   const viewRefresher = new DailyTransactionCountViewRefresher(

--- a/packages/backend/src/modules/activity/ActivityModule.ts
+++ b/packages/backend/src/modules/activity/ActivityModule.ts
@@ -9,9 +9,9 @@ import { DailyTransactionCountViewRefresher } from '../../core/activity/DailyTra
 import { TransactionCounter } from '../../core/activity/TransactionCounter'
 import { TransactionCountingMonitor } from '../../core/activity/TransactionCountingMonitor'
 import { Clock } from '../../core/Clock'
+import { Metrics } from '../../Metrics'
 import { Project } from '../../model'
 import { DailyTransactionCountViewRepository } from '../../peripherals/database/activity/DailyTransactionCountViewRepository'
-import { RepositoryHistogram } from '../../peripherals/database/shared/BaseRepository'
 import { Database } from '../../peripherals/database/shared/Database'
 import { ApplicationModule } from '../ApplicationModule'
 import { createTransactionCounters } from './createTransactionCounters'
@@ -22,7 +22,7 @@ export function createActivityModule(
   http: HttpClient,
   database: Database,
   clock: Clock,
-  histogram: RepositoryHistogram,
+  metrics: Metrics,
 ): ApplicationModule | undefined {
   if (!config.activity) {
     return
@@ -31,7 +31,7 @@ export function createActivityModule(
   const dailyCountViewRepository = new DailyTransactionCountViewRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
 
   const counters = createTransactionCounters(
@@ -40,7 +40,7 @@ export function createActivityModule(
     http,
     database,
     clock,
-    histogram,
+    metrics,
   )
 
   const viewRefresher = new DailyTransactionCountViewRefresher(

--- a/packages/backend/src/modules/activity/createTransactionCounters.ts
+++ b/packages/backend/src/modules/activity/createTransactionCounters.ts
@@ -12,12 +12,12 @@ import { createStarknetCounter } from '../../core/activity/counters/StarknetCoun
 import { createZksyncCounter } from '../../core/activity/counters/ZksyncCounter'
 import { TransactionCounter } from '../../core/activity/TransactionCounter'
 import { Clock } from '../../core/Clock'
+import { Metrics } from '../../Metrics'
 import { Project } from '../../model'
 import { BlockTransactionCountRepository } from '../../peripherals/database/activity/BlockTransactionCountRepository'
 import { StarkexTransactionCountRepository } from '../../peripherals/database/activity/StarkexCountRepository'
 import { ZksyncTransactionRepository } from '../../peripherals/database/activity/ZksyncTransactionRepository'
 import { SequenceProcessorRepository } from '../../peripherals/database/SequenceProcessorRepository'
-import { RepositoryHistogram } from '../../peripherals/database/shared/BaseRepository'
 import { Database } from '../../peripherals/database/shared/Database'
 import { StarkexClient } from '../../peripherals/starkex'
 
@@ -27,7 +27,7 @@ export function createTransactionCounters(
   http: HttpClient,
   database: Database,
   clock: Clock,
-  histogram: RepositoryHistogram,
+  metrics: Metrics,
 ): TransactionCounter[] {
   assert(config.activity)
   const {
@@ -52,22 +52,22 @@ export function createTransactionCounters(
   const blockRepository = new BlockTransactionCountRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
   const starkexRepository = new StarkexTransactionCountRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
   const sequenceProcessorRepository = new SequenceProcessorRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
   const zksyncRepository = new ZksyncTransactionRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
 
   // ethereum is kept separately in backend config, because it is not a layer 2 project

--- a/packages/backend/src/modules/activity/createTransactionCounters.ts
+++ b/packages/backend/src/modules/activity/createTransactionCounters.ts
@@ -15,7 +15,9 @@ import { Clock } from '../../core/Clock'
 import { Project } from '../../model'
 import { BlockTransactionCountRepository } from '../../peripherals/database/activity/BlockTransactionCountRepository'
 import { StarkexTransactionCountRepository } from '../../peripherals/database/activity/StarkexCountRepository'
+import { ZksyncTransactionRepository } from '../../peripherals/database/activity/ZksyncTransactionRepository'
 import { SequenceProcessorRepository } from '../../peripherals/database/SequenceProcessorRepository'
+import { RepositoryHistogram } from '../../peripherals/database/shared/BaseRepository'
 import { Database } from '../../peripherals/database/shared/Database'
 import { StarkexClient } from '../../peripherals/starkex'
 
@@ -25,6 +27,7 @@ export function createTransactionCounters(
   http: HttpClient,
   database: Database,
   clock: Clock,
+  histogram: RepositoryHistogram,
 ): TransactionCounter[] {
   assert(config.activity)
   const {
@@ -46,14 +49,25 @@ export function createTransactionCounters(
   })
 
   // shared repositories
-  const blockRepository = new BlockTransactionCountRepository(database, logger)
+  const blockRepository = new BlockTransactionCountRepository(
+    database,
+    logger,
+    histogram,
+  )
   const starkexRepository = new StarkexTransactionCountRepository(
     database,
     logger,
+    histogram,
   )
   const sequenceProcessorRepository = new SequenceProcessorRepository(
     database,
     logger,
+    histogram,
+  )
+  const zksyncRepository = new ZksyncTransactionRepository(
+    database,
+    logger,
+    histogram,
   )
 
   // ethereum is kept separately in backend config, because it is not a layer 2 project
@@ -122,7 +136,7 @@ export function createTransactionCounters(
           return createZksyncCounter(
             projectId,
             http,
-            database,
+            zksyncRepository,
             sequenceProcessorRepository,
             logger,
             transactionApi,

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -23,6 +23,7 @@ import { BlockNumberRepository } from '../../peripherals/database/BlockNumberRep
 import { PriceRepository } from '../../peripherals/database/PriceRepository'
 import { ReportRepository } from '../../peripherals/database/ReportRepository'
 import { ReportStatusRepository } from '../../peripherals/database/ReportStatusRepository'
+import { RepositoryHistogram } from '../../peripherals/database/shared/BaseRepository'
 import { Database } from '../../peripherals/database/shared/Database'
 import { EthereumClient } from '../../peripherals/ethereum/EthereumClient'
 import { MulticallClient } from '../../peripherals/ethereum/MulticallClient'
@@ -35,6 +36,7 @@ export function createTvlModule(
   http: HttpClient,
   database: Database,
   clock: Clock,
+  histogram: RepositoryHistogram,
 ): ApplicationModule | undefined {
   if (!config.tvl) {
     return
@@ -42,16 +44,29 @@ export function createTvlModule(
 
   // #region database
 
-  const blockNumberRepository = new BlockNumberRepository(database, logger)
-  const priceRepository = new PriceRepository(database, logger)
-  const balanceRepository = new BalanceRepository(database, logger)
-  const reportRepository = new ReportRepository(database, logger)
+  const blockNumberRepository = new BlockNumberRepository(
+    database,
+    logger,
+    histogram,
+  )
+  const priceRepository = new PriceRepository(database, logger, histogram)
+  const balanceRepository = new BalanceRepository(database, logger, histogram)
+  const reportRepository = new ReportRepository(database, logger, histogram)
   const aggregateReportRepository = new AggregateReportRepository(
     database,
     logger,
+    histogram,
   )
-  const reportStatusRepository = new ReportStatusRepository(database, logger)
-  const balanceStatusRepository = new BalanceStatusRepository(database, logger)
+  const reportStatusRepository = new ReportStatusRepository(
+    database,
+    logger,
+    histogram,
+  )
+  const balanceStatusRepository = new BalanceStatusRepository(
+    database,
+    logger,
+    histogram,
+  )
 
   // #endregion
   // #region peripherals

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -15,6 +15,7 @@ import { BlockNumberUpdater } from '../../core/BlockNumberUpdater'
 import { Clock } from '../../core/Clock'
 import { PriceUpdater } from '../../core/PriceUpdater'
 import { ReportUpdater } from '../../core/reports/ReportUpdater'
+import { Metrics } from '../../Metrics'
 import { CoingeckoQueryService } from '../../peripherals/coingecko/CoingeckoQueryService'
 import { AggregateReportRepository } from '../../peripherals/database/AggregateReportRepository'
 import { BalanceRepository } from '../../peripherals/database/BalanceRepository'
@@ -23,7 +24,6 @@ import { BlockNumberRepository } from '../../peripherals/database/BlockNumberRep
 import { PriceRepository } from '../../peripherals/database/PriceRepository'
 import { ReportRepository } from '../../peripherals/database/ReportRepository'
 import { ReportStatusRepository } from '../../peripherals/database/ReportStatusRepository'
-import { RepositoryHistogram } from '../../peripherals/database/shared/BaseRepository'
 import { Database } from '../../peripherals/database/shared/Database'
 import { EthereumClient } from '../../peripherals/ethereum/EthereumClient'
 import { MulticallClient } from '../../peripherals/ethereum/MulticallClient'
@@ -36,7 +36,7 @@ export function createTvlModule(
   http: HttpClient,
   database: Database,
   clock: Clock,
-  histogram: RepositoryHistogram,
+  metrics: Metrics,
 ): ApplicationModule | undefined {
   if (!config.tvl) {
     return
@@ -47,25 +47,25 @@ export function createTvlModule(
   const blockNumberRepository = new BlockNumberRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
-  const priceRepository = new PriceRepository(database, logger, histogram)
-  const balanceRepository = new BalanceRepository(database, logger, histogram)
-  const reportRepository = new ReportRepository(database, logger, histogram)
+  const priceRepository = new PriceRepository(database, logger, metrics)
+  const balanceRepository = new BalanceRepository(database, logger, metrics)
+  const reportRepository = new ReportRepository(database, logger, metrics)
   const aggregateReportRepository = new AggregateReportRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
   const reportStatusRepository = new ReportStatusRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
   const balanceStatusRepository = new BalanceStatusRepository(
     database,
     logger,
-    histogram,
+    metrics,
   )
 
   // #endregion

--- a/packages/backend/src/peripherals/database/AggregateReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregateReportRepository.test.ts
@@ -3,7 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockMetrics } from '../../test/mocks/Metrics'
 import {
   AggregateReportRecord,
   AggregateReportRepository,
@@ -11,11 +11,11 @@ import {
 
 describe(AggregateReportRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
+  const mockMetrics = createMockMetrics()
   const repository = new AggregateReportRepository(
     database,
     Logger.SILENT,
-    mockHistogram,
+    mockMetrics,
   )
 
   const TIME_0 = UnixTime.now().toStartOf('day')

--- a/packages/backend/src/peripherals/database/AggregateReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregateReportRepository.test.ts
@@ -3,6 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
+import { createMockHistogram } from '../../test/mocks/Histogram'
 import {
   AggregateReportRecord,
   AggregateReportRepository,
@@ -10,7 +11,12 @@ import {
 
 describe(AggregateReportRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new AggregateReportRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new AggregateReportRepository(
+    database,
+    Logger.SILENT,
+    mockHistogram,
+  )
 
   const TIME_0 = UnixTime.now().toStartOf('day')
   const TIME_1 = TIME_0.add(1, 'hours')

--- a/packages/backend/src/peripherals/database/AggregateReportRepository.ts
+++ b/packages/backend/src/peripherals/database/AggregateReportRepository.ts
@@ -2,7 +2,7 @@ import { assert, Logger } from '@l2beat/common'
 import { ProjectId, UnixTime } from '@l2beat/types'
 import { AggregateReportRow } from 'knex/types/tables'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface AggregateReportRecord {
@@ -13,8 +13,12 @@ export interface AggregateReportRecord {
 }
 
 export class AggregateReportRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
     this.getDaily = this.wrapGet(this.getDaily)

--- a/packages/backend/src/peripherals/database/AggregateReportRepository.ts
+++ b/packages/backend/src/peripherals/database/AggregateReportRepository.ts
@@ -2,7 +2,8 @@ import { assert, Logger } from '@l2beat/common'
 import { ProjectId, UnixTime } from '@l2beat/types'
 import { AggregateReportRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface AggregateReportRecord {
@@ -13,12 +14,8 @@ export interface AggregateReportRecord {
 }
 
 export class AggregateReportRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
     this.getDaily = this.wrapGet(this.getDaily)

--- a/packages/backend/src/peripherals/database/BalanceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.test.ts
@@ -3,6 +3,7 @@ import { AssetId, EthereumAddress, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
+import { createMockHistogram } from '../../test/mocks/Histogram'
 import { BalanceRecord, BalanceRepository } from './BalanceRepository'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
@@ -22,7 +23,12 @@ const mockBalance = (
 
 describe(BalanceRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new BalanceRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new BalanceRepository(
+    database,
+    Logger.SILENT,
+    mockHistogram,
+  )
 
   const HOLDER_A = EthereumAddress.random()
   const HOLDER_B = EthereumAddress.random()

--- a/packages/backend/src/peripherals/database/BalanceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.test.ts
@@ -3,7 +3,7 @@ import { AssetId, EthereumAddress, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockMetrics } from '../../test/mocks/Metrics'
 import { BalanceRecord, BalanceRepository } from './BalanceRepository'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
@@ -23,12 +23,8 @@ const mockBalance = (
 
 describe(BalanceRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
-  const repository = new BalanceRepository(
-    database,
-    Logger.SILENT,
-    mockHistogram,
-  )
+  const mockMetrics = createMockMetrics()
+  const repository = new BalanceRepository(database, Logger.SILENT, mockMetrics)
 
   const HOLDER_A = EthereumAddress.random()
   const HOLDER_B = EthereumAddress.random()

--- a/packages/backend/src/peripherals/database/BalanceRepository.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.ts
@@ -2,7 +2,7 @@ import { Logger } from '@l2beat/common'
 import { AssetId, EthereumAddress, UnixTime } from '@l2beat/types'
 import { BalanceRow } from 'knex/types/tables'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface BalanceRecord {
@@ -18,8 +18,12 @@ export interface DataBoundary {
 }
 
 export class BalanceRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/BalanceRepository.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.ts
@@ -2,7 +2,8 @@ import { Logger } from '@l2beat/common'
 import { AssetId, EthereumAddress, UnixTime } from '@l2beat/types'
 import { BalanceRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface BalanceRecord {
@@ -18,12 +19,8 @@ export interface DataBoundary {
 }
 
 export class BalanceRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/BalanceStatusRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceStatusRepository.test.ts
@@ -3,11 +3,17 @@ import { Hash256, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
+import { createMockHistogram } from '../../test/mocks/Histogram'
 import { BalanceStatusRepository } from './BalanceStatusRepository'
 
 describe(BalanceStatusRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new BalanceStatusRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new BalanceStatusRepository(
+    database,
+    Logger.SILENT,
+    mockHistogram,
+  )
 
   beforeEach(async () => {
     await repository.deleteAll()

--- a/packages/backend/src/peripherals/database/BalanceStatusRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceStatusRepository.test.ts
@@ -3,16 +3,16 @@ import { Hash256, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockMetrics } from '../../test/mocks/Metrics'
 import { BalanceStatusRepository } from './BalanceStatusRepository'
 
 describe(BalanceStatusRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
+  const mockMetrics = createMockMetrics()
   const repository = new BalanceStatusRepository(
     database,
     Logger.SILENT,
-    mockHistogram,
+    mockMetrics,
   )
 
   beforeEach(async () => {

--- a/packages/backend/src/peripherals/database/BalanceStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/BalanceStatusRepository.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@l2beat/common'
 import { Hash256, UnixTime } from '@l2beat/types'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface BalanceStatusRecord {
@@ -10,8 +10,12 @@ export interface BalanceStatusRecord {
 }
 
 export class BalanceStatusRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/BalanceStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/BalanceStatusRepository.ts
@@ -1,7 +1,8 @@
 import { Logger } from '@l2beat/common'
 import { Hash256, UnixTime } from '@l2beat/types'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface BalanceStatusRecord {
@@ -10,12 +11,8 @@ export interface BalanceStatusRecord {
 }
 
 export class BalanceStatusRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -3,11 +3,17 @@ import { UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
+import { createMockHistogram } from '../../test/mocks/Histogram'
 import { BlockNumberRepository } from './BlockNumberRepository'
 
 describe(BlockNumberRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new BlockNumberRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new BlockNumberRepository(
+    database,
+    Logger.SILENT,
+    mockHistogram,
+  )
 
   beforeEach(async () => {
     await repository.deleteAll()

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -3,16 +3,16 @@ import { UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockMetrics } from '../../test/mocks/Metrics'
 import { BlockNumberRepository } from './BlockNumberRepository'
 
 describe(BlockNumberRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
+  const mockMetrics = createMockMetrics()
   const repository = new BlockNumberRepository(
     database,
     Logger.SILENT,
-    mockHistogram,
+    mockMetrics,
   )
 
   beforeEach(async () => {

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -2,7 +2,7 @@ import { Logger } from '@l2beat/common'
 import { UnixTime } from '@l2beat/types'
 import { BlockNumberRow } from 'knex/types/tables'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface BlockNumberRecord {
@@ -11,8 +11,12 @@ export interface BlockNumberRecord {
 }
 
 export class BlockNumberRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -2,7 +2,8 @@ import { Logger } from '@l2beat/common'
 import { UnixTime } from '@l2beat/types'
 import { BlockNumberRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface BlockNumberRecord {
@@ -11,12 +12,8 @@ export interface BlockNumberRecord {
 }
 
 export class BlockNumberRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -3,11 +3,13 @@ import { AssetId, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
+import { createMockHistogram } from '../../test/mocks/Histogram'
 import { PriceRecord, PriceRepository } from './PriceRepository'
 
 describe(PriceRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new PriceRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new PriceRepository(database, Logger.SILENT, mockHistogram)
 
   const START = UnixTime.now()
   const DATA = [

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -3,13 +3,13 @@ import { AssetId, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockMetrics } from '../../test/mocks/Metrics'
 import { PriceRecord, PriceRepository } from './PriceRepository'
 
 describe(PriceRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
-  const repository = new PriceRepository(database, Logger.SILENT, mockHistogram)
+  const mockMetrics = createMockMetrics()
+  const repository = new PriceRepository(database, Logger.SILENT, mockMetrics)
 
   const START = UnixTime.now()
   const DATA = [

--- a/packages/backend/src/peripherals/database/PriceRepository.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.ts
@@ -2,7 +2,8 @@ import { Logger } from '@l2beat/common'
 import { AssetId, UnixTime } from '@l2beat/types'
 import { PriceRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface PriceRecord {
@@ -17,12 +18,8 @@ export interface DataBoundary {
 }
 
 export class PriceRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/PriceRepository.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.ts
@@ -2,7 +2,7 @@ import { Logger } from '@l2beat/common'
 import { AssetId, UnixTime } from '@l2beat/types'
 import { PriceRow } from 'knex/types/tables'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface PriceRecord {
@@ -17,8 +17,12 @@ export interface DataBoundary {
 }
 
 export class PriceRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -3,17 +3,13 @@ import { AssetId, ProjectId, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockMetrics } from '../../test/mocks/Metrics'
 import { ReportRecord, ReportRepository } from './ReportRepository'
 
 describe(ReportRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
-  const repository = new ReportRepository(
-    database,
-    Logger.SILENT,
-    mockHistogram,
-  )
+  const mockMetrics = createMockMetrics()
+  const repository = new ReportRepository(database, Logger.SILENT, mockMetrics)
 
   const TIME_0 = UnixTime.now().toStartOf('day')
   const TIME_1 = TIME_0.add(1, 'hours')

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -3,11 +3,17 @@ import { AssetId, ProjectId, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
+import { createMockHistogram } from '../../test/mocks/Histogram'
 import { ReportRecord, ReportRepository } from './ReportRepository'
 
 describe(ReportRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new ReportRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new ReportRepository(
+    database,
+    Logger.SILENT,
+    mockHistogram,
+  )
 
   const TIME_0 = UnixTime.now().toStartOf('day')
   const TIME_1 = TIME_0.add(1, 'hours')

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -3,7 +3,8 @@ import { AssetId, ProjectId, UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { ReportRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface ReportRecord {
@@ -18,12 +19,8 @@ export interface ReportRecord {
 export const SIX_HOURS = UnixTime.HOUR * 6
 
 export class ReportRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -3,7 +3,7 @@ import { AssetId, ProjectId, UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { ReportRow } from 'knex/types/tables'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface ReportRecord {
@@ -18,8 +18,12 @@ export interface ReportRecord {
 export const SIX_HOURS = UnixTime.HOUR * 6
 
 export class ReportRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.test.ts
@@ -3,11 +3,17 @@ import { Hash256, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
+import { createMockHistogram } from '../../test/mocks/Histogram'
 import { ReportStatusRepository } from './ReportStatusRepository'
 
 describe(ReportStatusRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const repository = new ReportStatusRepository(database, Logger.SILENT)
+  const mockHistogram = createMockHistogram()
+  const repository = new ReportStatusRepository(
+    database,
+    Logger.SILENT,
+    mockHistogram,
+  )
 
   beforeEach(async () => {
     await repository.deleteAll()

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.test.ts
@@ -3,16 +3,16 @@ import { Hash256, UnixTime } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { setupDatabaseTestSuite } from '../../test/database'
-import { createMockHistogram } from '../../test/mocks/Histogram'
+import { createMockMetrics } from '../../test/mocks/Metrics'
 import { ReportStatusRepository } from './ReportStatusRepository'
 
 describe(ReportStatusRepository.name, () => {
   const { database } = setupDatabaseTestSuite()
-  const mockHistogram = createMockHistogram()
+  const mockMetrics = createMockMetrics()
   const repository = new ReportStatusRepository(
     database,
     Logger.SILENT,
-    mockHistogram,
+    mockMetrics,
   )
 
   beforeEach(async () => {

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@l2beat/common'
 import { Hash256, UnixTime } from '@l2beat/types'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface ReportStatusRecord {
@@ -10,8 +10,12 @@ export interface ReportStatusRecord {
 }
 
 export class ReportStatusRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.ts
@@ -1,7 +1,8 @@
 import { Logger } from '@l2beat/common'
 import { Hash256, UnixTime } from '@l2beat/types'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface ReportStatusRecord {
@@ -10,12 +11,8 @@ export interface ReportStatusRecord {
 }
 
 export class ReportStatusRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
 

--- a/packages/backend/src/peripherals/database/SequenceProcessorRepository.ts
+++ b/packages/backend/src/peripherals/database/SequenceProcessorRepository.ts
@@ -2,7 +2,8 @@ import { Logger } from '@l2beat/common'
 import { Knex } from 'knex'
 import { SequenceProcessorRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
+import { Metrics } from '../../Metrics'
+import { BaseRepository } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface SequenceProcessorRecord {
@@ -12,12 +13,8 @@ export interface SequenceProcessorRecord {
 }
 
 export class SequenceProcessorRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addOrUpdate = this.wrapAny(this.addOrUpdate)

--- a/packages/backend/src/peripherals/database/SequenceProcessorRepository.ts
+++ b/packages/backend/src/peripherals/database/SequenceProcessorRepository.ts
@@ -2,7 +2,7 @@ import { Logger } from '@l2beat/common'
 import { Knex } from 'knex'
 import { SequenceProcessorRow } from 'knex/types/tables'
 
-import { BaseRepository } from './shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 
 export interface SequenceProcessorRecord {
@@ -12,8 +12,12 @@ export interface SequenceProcessorRecord {
 }
 
 export class SequenceProcessorRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addOrUpdate = this.wrapAny(this.addOrUpdate)

--- a/packages/backend/src/peripherals/database/activity/BlockTransactionCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/BlockTransactionCountRepository.ts
@@ -3,7 +3,8 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { BlockTransactionCountRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
+import { Metrics } from '../../../Metrics'
+import { BaseRepository } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface BlockTransactionCountRecord {
@@ -14,12 +15,8 @@ export interface BlockTransactionCountRecord {
 }
 
 export class BlockTransactionCountRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addMany = this.wrapAny(this.addMany)
     this.deleteAll = this.wrapDelete(this.deleteAll)

--- a/packages/backend/src/peripherals/database/activity/BlockTransactionCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/BlockTransactionCountRepository.ts
@@ -3,7 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { BlockTransactionCountRow } from 'knex/types/tables'
 
-import { BaseRepository } from '../shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface BlockTransactionCountRecord {
@@ -14,8 +14,12 @@ export interface BlockTransactionCountRecord {
 }
 
 export class BlockTransactionCountRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addMany = this.wrapAny(this.addMany)
     this.deleteAll = this.wrapDelete(this.deleteAll)

--- a/packages/backend/src/peripherals/database/activity/DailyTransactionCountViewRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/DailyTransactionCountViewRepository.ts
@@ -2,7 +2,7 @@ import { Logger } from '@l2beat/common'
 import { ProjectId, UnixTime } from '@l2beat/types'
 import { DailyTransactionCountRow } from 'knex/types/tables'
 
-import { BaseRepository } from '../shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface DailyTransactionCountRecord {
@@ -12,8 +12,12 @@ export interface DailyTransactionCountRecord {
 }
 
 export class DailyTransactionCountViewRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
     /* eslint-disable @typescript-eslint/unbound-method */
     this.refresh = this.wrapAny(this.refresh)
     this.getDailyCounts = this.wrapGet(this.getDailyCounts)

--- a/packages/backend/src/peripherals/database/activity/DailyTransactionCountViewRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/DailyTransactionCountViewRepository.ts
@@ -2,7 +2,8 @@ import { Logger } from '@l2beat/common'
 import { ProjectId, UnixTime } from '@l2beat/types'
 import { DailyTransactionCountRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
+import { Metrics } from '../../../Metrics'
+import { BaseRepository } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface DailyTransactionCountRecord {
@@ -12,12 +13,8 @@ export interface DailyTransactionCountRecord {
 }
 
 export class DailyTransactionCountViewRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
     /* eslint-disable @typescript-eslint/unbound-method */
     this.refresh = this.wrapAny(this.refresh)
     this.getDailyCounts = this.wrapGet(this.getDailyCounts)

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
@@ -3,7 +3,7 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { StarkexTransactionCountRow } from 'knex/types/tables'
 
-import { BaseRepository } from '../shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface StarkexTransactionCountRecord {
@@ -13,8 +13,12 @@ export interface StarkexTransactionCountRecord {
 }
 
 export class StarkexTransactionCountRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addOrUpdateMany = this.wrapAny(this.addOrUpdateMany)
     this.deleteAll = this.wrapDelete(this.deleteAll)

--- a/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/StarkexCountRepository.ts
@@ -3,7 +3,8 @@ import { ProjectId, UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { StarkexTransactionCountRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
+import { Metrics } from '../../../Metrics'
+import { BaseRepository } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface StarkexTransactionCountRecord {
@@ -13,12 +14,8 @@ export interface StarkexTransactionCountRecord {
 }
 
 export class StarkexTransactionCountRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addOrUpdateMany = this.wrapAny(this.addOrUpdateMany)
     this.deleteAll = this.wrapDelete(this.deleteAll)

--- a/packages/backend/src/peripherals/database/activity/ZksyncTransactionRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/ZksyncTransactionRepository.ts
@@ -3,7 +3,8 @@ import { UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { ZksyncTransactionRow } from 'knex/types/tables'
 
-import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
+import { Metrics } from '../../../Metrics'
+import { BaseRepository } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface ZksyncTransactionRecord {
@@ -13,12 +14,8 @@ export interface ZksyncTransactionRecord {
 }
 
 export class ZksyncTransactionRepository extends BaseRepository {
-  constructor(
-    database: Database,
-    logger: Logger,
-    histogram: RepositoryHistogram,
-  ) {
-    super(database, logger, histogram)
+  constructor(database: Database, logger: Logger, metrics: Metrics) {
+    super(database, logger, metrics)
 
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addMany = this.wrapAddMany(this.addMany)

--- a/packages/backend/src/peripherals/database/activity/ZksyncTransactionRepository.ts
+++ b/packages/backend/src/peripherals/database/activity/ZksyncTransactionRepository.ts
@@ -3,7 +3,7 @@ import { UnixTime } from '@l2beat/types'
 import { Knex } from 'knex'
 import { ZksyncTransactionRow } from 'knex/types/tables'
 
-import { BaseRepository } from '../shared/BaseRepository'
+import { BaseRepository, RepositoryHistogram } from '../shared/BaseRepository'
 import { Database } from '../shared/Database'
 
 export interface ZksyncTransactionRecord {
@@ -13,8 +13,12 @@ export interface ZksyncTransactionRecord {
 }
 
 export class ZksyncTransactionRepository extends BaseRepository {
-  constructor(database: Database, logger: Logger) {
-    super(database, logger)
+  constructor(
+    database: Database,
+    logger: Logger,
+    histogram: RepositoryHistogram,
+  ) {
+    super(database, logger, histogram)
 
     /* eslint-disable @typescript-eslint/unbound-method */
     this.addMany = this.wrapAddMany(this.addMany)

--- a/packages/backend/src/peripherals/database/shared/BaseRepository.ts
+++ b/packages/backend/src/peripherals/database/shared/BaseRepository.ts
@@ -1,8 +1,7 @@
 import { Logger } from '@l2beat/common'
 import { Knex } from 'knex'
-import { Histogram } from 'prom-client'
 
-import { Metrics } from '../../../Metrics'
+import { Metrics, RepositoryHistogram } from '../../../Metrics'
 import { Database } from './Database'
 
 type AnyMethod<A extends unknown[], R> = (...args: A) => Promise<R>
@@ -22,8 +21,6 @@ type FindMethod<A extends unknown[], T> = (...args: A) => Promise<T | undefined>
 type DeleteMethod<A extends unknown[]> = (...args: A) => Promise<number>
 
 type SaveMethod<T> = (record: T) => Promise<boolean>
-
-type RepositoryHistogram = Histogram<'module' | 'repository' | 'method'>
 
 export class BaseRepository {
   protected histogram: RepositoryHistogram

--- a/packages/backend/src/peripherals/database/shared/BaseRepository.ts
+++ b/packages/backend/src/peripherals/database/shared/BaseRepository.ts
@@ -2,6 +2,7 @@ import { Logger } from '@l2beat/common'
 import { Knex } from 'knex'
 import { Histogram } from 'prom-client'
 
+import { Metrics } from '../../../Metrics'
 import { Database } from './Database'
 
 type AnyMethod<A extends unknown[], R> = (...args: A) => Promise<R>
@@ -22,15 +23,18 @@ type DeleteMethod<A extends unknown[]> = (...args: A) => Promise<number>
 
 type SaveMethod<T> = (record: T) => Promise<boolean>
 
-export type RepositoryHistogram = Histogram<'module' | 'repository' | 'method'>
+type RepositoryHistogram = Histogram<'module' | 'repository' | 'method'>
 
 export class BaseRepository {
+  protected histogram: RepositoryHistogram
+
   constructor(
     protected readonly database: Database,
     protected readonly logger: Logger,
-    protected readonly histogram: RepositoryHistogram,
+    readonly metrics: Metrics,
   ) {
     this.logger = logger.for(this)
+    this.histogram = metrics.repositoryHistogram
   }
 
   protected knex(trx?: Knex.Transaction) {

--- a/packages/backend/src/test/mocks/Histogram.ts
+++ b/packages/backend/src/test/mocks/Histogram.ts
@@ -1,0 +1,8 @@
+import { mock } from '@l2beat/common'
+import { Histogram } from 'prom-client'
+
+export function createMockHistogram() {
+  return mock<Histogram>({
+    labels: () => mock<Histogram>({ observe: () => {} }),
+  })
+}

--- a/packages/backend/src/test/mocks/Metrics.ts
+++ b/packages/backend/src/test/mocks/Metrics.ts
@@ -1,6 +1,14 @@
 import { mock } from '@l2beat/common'
 import { Histogram } from 'prom-client'
 
+import { Metrics } from '../../Metrics'
+
+export function createMockMetrics() {
+  return mock<Metrics>({
+    repositoryHistogram: createMockHistogram(),
+  })
+}
+
 export function createMockHistogram() {
   return mock<Histogram>({
     labels: () => mock<Histogram>({ observe: () => {} }),

--- a/packages/backend/src/test/testApiServer.ts
+++ b/packages/backend/src/test/testApiServer.ts
@@ -1,10 +1,10 @@
 import Router from '@koa/router'
 import { Logger, mock } from '@l2beat/common'
-import { Histogram } from 'prom-client'
 import { agent } from 'supertest'
 
 import { ApiServer } from '../../src/api/ApiServer'
 import { Metrics } from '../Metrics'
+import { createMockHistogram } from './mocks/Histogram'
 
 export function createTestApiServer(routers: Router[], metrics?: Metrics) {
   if (!metrics) {
@@ -19,10 +19,4 @@ export function createTestApiServer(routers: Router[], metrics?: Metrics) {
     routers,
   ).getNodeCallback()
   return agent(callback)
-}
-
-export function createMockHistogram() {
-  return mock<Histogram>({
-    labels: () => mock<Histogram>({ observe: () => {} }),
-  })
 }

--- a/packages/backend/src/test/testApiServer.ts
+++ b/packages/backend/src/test/testApiServer.ts
@@ -4,7 +4,7 @@ import { agent } from 'supertest'
 
 import { ApiServer } from '../../src/api/ApiServer'
 import { Metrics } from '../Metrics'
-import { createMockHistogram } from './mocks/Histogram'
+import { createMockHistogram } from './mocks/Metrics'
 
 export function createTestApiServer(routers: Router[], metrics?: Metrics) {
   if (!metrics) {


### PR DESCRIPTION
Resolves L2B-90

Many files changed, but mostly passing the `histogram` object down the pipe.

Simple (maybe naive?) approach to adding repository methods execution times measurements. We want all the repositories to use the same `Histogram` instance, so we should instantiate it on the top level and pass it to each module (probably could use a function to extract this logic from `Application.ts`. I was thinking about adding this metric to `Metrics` class, but I'm not sure if it should be aware of this kind of logic. Help here is appreciated.

TODO: add test to BaseRepository to check if we get a measurement