### PR TITLE
Add TwitterClient

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^18.1.0",
     "rollbar": "^2.25.2",
     "source-map-support": "^0.5.21",
+    "twitter-api-v2": "^1.12.10",
     "zod": "^3.17.3"
   },
   "devDependencies": {

--- a/packages/backend/src/peripherals/twitter/TwitterApiWrapper.ts
+++ b/packages/backend/src/peripherals/twitter/TwitterApiWrapper.ts
@@ -1,0 +1,36 @@
+/*
+To tweet you need to:
+- have Twitter Developer Account
+- create Project on your Developer Account
+- have an account (Bot) from which you want to tweet
+- give access to the Project from your Bot account
+
+The process is described here:
+https://developer.twitter.com/en/docs/tutorials/how-to-create-a-twitter-bot-with-twitter-api-v2
+*/
+
+import { TweetV2PostTweetResult, TwitterApi } from 'twitter-api-v2'
+
+// OAuth 1.0a
+export interface TwitterAuth {
+  // Consumer Key
+  appKey: string
+  // Consumer Secret
+  appSecret: string
+  // Access Token
+  accessToken: string
+  // Token Secret
+  accessSecret: string
+}
+
+export class TwitterApiWrapper {
+  private readonly twitterApi: TwitterApi
+
+  constructor(params: TwitterAuth) {
+    this.twitterApi = new TwitterApi(params)
+  }
+
+  async tweet(message: string): Promise<TweetV2PostTweetResult> {
+    return this.twitterApi.v2.tweet(message)
+  }
+}

--- a/packages/backend/src/peripherals/twitter/TwitterClient.test.ts
+++ b/packages/backend/src/peripherals/twitter/TwitterClient.test.ts
@@ -1,0 +1,20 @@
+import { mock } from '@l2beat/common'
+import { expect, mockFn } from 'earljs'
+
+import { TwitterApiWrapper } from './TwitterApiWrapper'
+import { TwitterClient } from './TwitterClient'
+
+describe(TwitterClient.name, () => {
+  describe(TwitterClient.prototype.tweet.name, () => {
+    it('uses wrapper for tweet', async () => {
+      const twitterApiWrapper = mock<TwitterApiWrapper>({
+        tweet: mockFn().returns({}),
+      })
+
+      const twitterClient = new TwitterClient(twitterApiWrapper)
+      await twitterClient.tweet('test')
+
+      expect(twitterApiWrapper.tweet).toHaveBeenCalledExactlyWith([['test']])
+    })
+  })
+})

--- a/packages/backend/src/peripherals/twitter/TwitterClient.ts
+++ b/packages/backend/src/peripherals/twitter/TwitterClient.ts
@@ -1,0 +1,11 @@
+import { TweetV2PostTweetResult } from 'twitter-api-v2'
+
+import { TwitterApiWrapper } from './TwitterApiWrapper'
+
+export class TwitterClient {
+  constructor(private readonly twitterApi: TwitterApiWrapper) {}
+
+  async tweet(message: string): Promise<TweetV2PostTweetResult> {
+    return this.twitterApi.tweet(message)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13452,6 +13452,11 @@ tty-browserify@0.0.0:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
   integrity sha512-JVa5ijo+j/sOoHGjw0sxw734b1LhBkQ3bvUGNdxnVXDCX81Yx7TFgnZygxrIIWn23hbfTaMYLwRmAxFyDuFmIw==
 
+twitter-api-v2@^1.12.10:
+  version "1.12.10"
+  resolved "https://registry.yarnpkg.com/twitter-api-v2/-/twitter-api-v2-1.12.10.tgz#355d20d5af97a83b75694ff15396f7099a296d11"
+  integrity sha512-gLo4u3EZM8zt2CRZ5uJaWpGVoH1/xR0veF74E3K7WCQXUONoZVc0pbg6dGfoPBOmEXhS4QHGcgAMj1TRU+OSXA==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"


### PR DESCRIPTION
This PR aims to add TwitterClient able to create tweets from authorized account. 

I decided to solve communication with Twitter API using [twitter-api-v2](https://www.npmjs.com/package/twitter-api-v2?activeTab=explore) package, which handles OAuth 1.0a authentication out of the box. This API does not add any external dependencies, what it does is: it takes your message, constructs request, generate OAuth header and send request using node's `http`. Using this library introduces security risks, we are trusting the library maintainer to not extract our API keys via malicious code upgrade. But without it I would have to spend X amount of time to construct HTTP request myself and test it well. Provided this is an experimental feature, spending too much time on it is not a desired outcome.

I have done some research to do this more 'low-level' either via constructing Authentication header in code, or using the library for OAuth 1.0, but both cases would have produced harder to maintain code IMO.


Resolves L2B-557