### PR TITLE
Truncate Discord message

### DIFF
--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -10,7 +10,7 @@ import { DiscoveryLogger } from './discovery/DiscoveryLogger'
 import { prepareDiscoveryFile } from './discovery/saveDiscoveryResult'
 import { ContractParameters, ContractValue } from './discovery/types'
 import { diffDiscovery } from './discovery/utils/diffDiscovery'
-import { diffToMessage } from './discovery/utils/diffToMessage'
+import { diffToMessages } from './discovery/utils/diffToMessages'
 import { DiscoveryWatcher } from './DiscoveryWatcher'
 
 const CONTRACT_NAME = 'contract'
@@ -66,7 +66,7 @@ describe(DiscoveryWatcher.name, () => {
 
       const name = 'project'
       await discoveryWatcher.compareWithCommitted(name, [DISCOVERED], {})
-      const expectedMessage = diffToMessage(
+      const expectedMessage = diffToMessages(
         name,
         diffDiscovery(
           [COMMITTED],

--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -65,11 +65,7 @@ describe(DiscoveryWatcher.name, () => {
       )
 
       const name = 'project'
-
       await discoveryWatcher.compareWithCommitted(name, [DISCOVERED], {})
-
-      expect(configReader.readDiscovery).toHaveBeenCalledExactlyWith([[name]])
-
       const expectedMessage = diffToMessage(
         name,
         diffDiscovery(
@@ -78,6 +74,9 @@ describe(DiscoveryWatcher.name, () => {
           {},
         ),
       )
+
+      expect(configReader.readDiscovery).toHaveBeenCalledExactlyWith([[name]])
+
       expect(discordClient.sendMessage).toHaveBeenCalledExactlyWith([
         [expectedMessage[0]],
       ])

--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -1,0 +1,85 @@
+import { Logger, MainnetEtherscanClient, mock } from '@l2beat/common'
+import { EthereumAddress } from '@l2beat/types'
+import { expect, mockFn } from 'earljs'
+import { providers } from 'ethers'
+
+import { DiscordClient } from '../peripherals/discord/DiscordClient'
+import { Clock } from './Clock'
+import { ConfigReader } from './discovery/ConfigReader'
+import { DiscoveryLogger } from './discovery/DiscoveryLogger'
+import { prepareDiscoveryFile } from './discovery/saveDiscoveryResult'
+import { ContractParameters, ContractValue } from './discovery/types'
+import { diffDiscovery } from './discovery/utils/diffDiscovery'
+import { diffToMessage } from './discovery/utils/diffToMessage'
+import { DiscoveryWatcher } from './DiscoveryWatcher'
+
+const CONTRACT_NAME = 'contract'
+const ADDRESS = EthereumAddress.random()
+
+const mockContract = (
+  values: Record<string, ContractValue>,
+): ContractParameters => {
+  return {
+    name: CONTRACT_NAME,
+    address: ADDRESS,
+    upgradeability: {
+      type: 'immutable',
+    },
+    values,
+  }
+}
+
+const COMMITTED = mockContract({ a: true, b: true })
+const DISCOVERED = {
+  ...mockContract({ a: true, b: false }),
+  meta: {
+    isEOA: false,
+    verified: true,
+    implementationVerified: true,
+    abi: [],
+    abis: {},
+  },
+}
+
+describe(DiscoveryWatcher.name, () => {
+  const discordClient = mock<DiscordClient>({
+    sendMessage: mockFn().resolvesTo({}),
+  })
+  const configReader = mock<ConfigReader>({
+    readDiscovery: mockFn().resolvesTo({
+      contracts: [COMMITTED],
+    }),
+  })
+
+  describe(DiscoveryWatcher.prototype.compareWithCommitted.name, () => {
+    it('works', async () => {
+      const discoveryWatcher = new DiscoveryWatcher(
+        mock<providers.AlchemyProvider>({}),
+        mock<MainnetEtherscanClient>({}),
+        discordClient,
+        configReader,
+        mock<Clock>({}),
+        Logger.SILENT,
+        DiscoveryLogger.SILENT,
+      )
+
+      const name = 'project'
+
+      await discoveryWatcher.compareWithCommitted(name, [DISCOVERED], {})
+
+      expect(configReader.readDiscovery).toHaveBeenCalledExactlyWith([[name]])
+
+      const expectedMessage = diffToMessage(
+        name,
+        diffDiscovery(
+          [COMMITTED],
+          [prepareDiscoveryFile([DISCOVERED]).contracts[0]],
+          {},
+        ),
+      )
+      expect(discordClient.sendMessage).toHaveBeenCalledExactlyWith([
+        [expectedMessage[0]],
+      ])
+    })
+  })
+})

--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -42,17 +42,18 @@ const DISCOVERED = {
 }
 
 describe(DiscoveryWatcher.name, () => {
-  const discordClient = mock<DiscordClient>({
-    sendMessage: mockFn().resolvesTo({}),
-  })
-  const configReader = mock<ConfigReader>({
-    readDiscovery: mockFn().resolvesTo({
-      contracts: [COMMITTED],
-    }),
-  })
-
   describe(DiscoveryWatcher.prototype.compareWithCommitted.name, () => {
     it('works', async () => {
+      const discordClient = mock<DiscordClient>({
+        sendMessage: mockFn().resolvesTo({}),
+      })
+
+      const configReader = mock<ConfigReader>({
+        readDiscovery: mockFn().resolvesTo({
+          contracts: [COMMITTED],
+        }),
+      })
+
       const discoveryWatcher = new DiscoveryWatcher(
         mock<providers.AlchemyProvider>({}),
         mock<MainnetEtherscanClient>({}),
@@ -79,6 +80,40 @@ describe(DiscoveryWatcher.name, () => {
       )
       expect(discordClient.sendMessage).toHaveBeenCalledExactlyWith([
         [expectedMessage[0]],
+      ])
+    })
+  })
+
+  describe(DiscoveryWatcher.prototype.notify.name, () => {
+    const discordClient = mock<DiscordClient>({
+      sendMessage: mockFn().resolvesTo({}),
+    })
+
+    const configReader = mock<ConfigReader>({
+      readDiscovery: mockFn().resolvesTo({
+        contracts: [COMMITTED],
+      }),
+    })
+
+    const discoveryWatcher = new DiscoveryWatcher(
+      mock<providers.AlchemyProvider>({}),
+      mock<MainnetEtherscanClient>({}),
+      discordClient,
+      configReader,
+      mock<Clock>({}),
+      Logger.SILENT,
+      DiscoveryLogger.SILENT,
+    )
+
+    it('sends discord messages', async () => {
+      const messages = ['a', 'b', 'c']
+
+      await discoveryWatcher.notify(messages)
+
+      expect(discordClient.sendMessage).toHaveBeenCalledExactlyWith([
+        ['a'],
+        ['b'],
+        ['c'],
       ])
     })
   })

--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -7,7 +7,7 @@ import { DiscordClient } from '../peripherals/discord/DiscordClient'
 import { Clock } from './Clock'
 import { ConfigReader } from './discovery/ConfigReader'
 import { DiscoveryLogger } from './discovery/DiscoveryLogger'
-import { prepareDiscoveryFile } from './discovery/saveDiscoveryResult'
+import { parseDiscoveryOutput } from './discovery/saveDiscoveryResult'
 import { ContractParameters, ContractValue } from './discovery/types'
 import { diffDiscovery } from './discovery/utils/diffDiscovery'
 import { diffToMessages } from './discovery/utils/diffToMessages'
@@ -70,7 +70,7 @@ describe(DiscoveryWatcher.name, () => {
         name,
         diffDiscovery(
           [COMMITTED],
-          [prepareDiscoveryFile([DISCOVERED]).contracts[0]],
+          [parseDiscoveryOutput([DISCOVERED]).contracts[0]],
           {},
         ),
       )

--- a/packages/backend/src/core/DiscoveryWatcher.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.ts
@@ -94,8 +94,10 @@ export class DiscoveryWatcher {
     )
 
     if (diff.length > 0) {
-      const message = diffToMessage(name, diff)
-      await this.notify(message)
+      const messages = diffToMessage(name, diff)
+      for (const message of messages) {
+        await this.notify(message)
+      }
     }
   }
 

--- a/packages/backend/src/core/DiscoveryWatcher.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.ts
@@ -71,11 +71,6 @@ export class DiscoveryWatcher {
         this.logger.error(error)
       }
     }
-
-    await this.notify(
-      `Run discovery for all projects | block_number = ${blockNumber}`,
-    )
-
     this.logger.info('Update finished', { blockNumber })
   }
 
@@ -95,13 +90,11 @@ export class DiscoveryWatcher {
 
     if (diff.length > 0) {
       const messages = diffToMessage(name, diff)
-      for (const message of messages) {
-        await this.notify(message)
-      }
+      await this.notify(messages)
     }
   }
 
-  async notify(message: string) {
+  async notify(messages: string[]) {
     if (!this.discordClient) {
       // TODO: maybe only once? rethink
       this.logger.info(
@@ -110,9 +103,11 @@ export class DiscoveryWatcher {
       return
     }
 
-    await this.discordClient.sendMessage(message).then(
-      () => this.logger.info('Notification to Discord has been sent'),
-      (e) => this.logger.error(e),
-    )
+    for (const message of messages) {
+      await this.discordClient.sendMessage(message).then(
+        () => this.logger.info('Notification to Discord has been sent'),
+        (e) => this.logger.error(e),
+      )
+    }
   }
 }

--- a/packages/backend/src/core/DiscoveryWatcher.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.ts
@@ -11,7 +11,7 @@ import { DiscoveryLogger } from './discovery/DiscoveryLogger'
 import { DiscoveryProvider } from './discovery/provider/DiscoveryProvider'
 import { prepareDiscoveryFile } from './discovery/saveDiscoveryResult'
 import { diffDiscovery } from './discovery/utils/diffDiscovery'
-import { diffToMessage } from './discovery/utils/diffToMessage'
+import { diffToMessages } from './discovery/utils/diffToMessages'
 
 export class DiscoveryWatcher {
   private readonly taskQueue: TaskQueue<void>
@@ -90,7 +90,7 @@ export class DiscoveryWatcher {
     )
 
     if (diff.length > 0) {
-      const messages = diffToMessage(name, diff)
+      const messages = diffToMessages(name, diff)
       await this.notify(messages)
     }
   }

--- a/packages/backend/src/core/DiscoveryWatcher.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.ts
@@ -39,6 +39,7 @@ export class DiscoveryWatcher {
     })
   }
 
+  //TODO: test (it will probably require changing discover to object)
   async update() {
     // TODO: get block number based on clock time
     const blockNumber = await this.provider.getBlockNumber()

--- a/packages/backend/src/core/discovery/saveDiscoveryResult.ts
+++ b/packages/backend/src/core/discovery/saveDiscoveryResult.ts
@@ -23,7 +23,7 @@ export function parseDiscoveryOutput(
   return JSON.parse(JSON.stringify(prepared)) as ProjectParameters
 }
 
-function prepareDiscoveryFile(
+export function prepareDiscoveryFile(
   results: AnalyzedData[],
   name = 'undefined',
   blockNumber = -1,

--- a/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
@@ -89,14 +89,14 @@ describe(diffToMessage.name, () => {
 describe(wrapCodeBlock.name, () => {
   it('wraps messages correctly', () => {
     const name = 'project'
-    const messages = ['a','b','c']
+    const messages = ['a', 'b', 'c']
 
     const expected = [
       `Detected changes for ${name}\n\n\`\`\`diff\n`,
       'a\n',
       'b\n',
       'c',
-      '\n```'
+      '\n```',
     ]
 
     const result = wrapCodeBlock(name, messages)

--- a/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
@@ -60,7 +60,7 @@ describe(diffToMessage.name, () => {
     }
     const differences: DiscoveryDiff[] = []
 
-    while(differences.length < 27) {
+    while (differences.length < 27) {
       differences.push(diff)
     }
 
@@ -69,7 +69,7 @@ describe(diffToMessage.name, () => {
     const firstPart = [
       `Detected changes for system\n\n`,
       '```diff\n',
-      differences.slice(0,26).map(diffToString).join('\n'),
+      differences.slice(0, 26).map(diffToString).join('\n'),
       '\n```',
     ]
 

--- a/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
@@ -2,7 +2,12 @@ import { EthereumAddress } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { DiscoveryDiff } from './diffDiscovery'
-import { diffToMessage, diffToString, wrapCodeBlock } from './diffToMessage'
+import {
+  diffToMessage,
+  diffToString,
+  wrapBoldAndItalic,
+  wrapDiffCodeBlock,
+} from './diffToMessage'
 
 const ADDRESS = EthereumAddress('0x94cA7e313287a0C4c35AD4c243D1B2f3f6557D01')
 
@@ -36,15 +41,13 @@ describe(diffToMessage.name, () => {
     const result = diffToMessage(name, diff)
 
     const expected = [
-      `Detected changes for ${name}\n\n`,
-      '```diff',
+      `***${name}*** | detected changes\`\`\`diff`,
       '\n',
       diffToString(diff[0]),
       '\n',
       diffToString(diff[1]),
       '\n',
       diffToString(diff[2]),
-      '\n',
       '```',
     ]
 
@@ -67,41 +70,42 @@ describe(diffToMessage.name, () => {
     const result = diffToMessage(name, differences)
 
     const firstPart = [
-      `Detected changes for system\n\n`,
-      '```diff\n',
+      `***${name}*** | detected changes\`\`\`diff\n`,
       differences.slice(0, 26).map(diffToString).join('\n'),
-      '\n```',
+      '```',
     ]
 
     const secondPart = [
-      `Detected changes for system\n\n`,
-      '```diff\n',
+      `***${name}*** | detected changes\`\`\`diff\n`,
       differences.slice(26).map(diffToString).join('\n'),
-      '\n```',
+      '```',
     ]
 
     expect(result).toEqual([firstPart.join(''), secondPart.join('')])
-    expect(firstPart.join('').length).toEqual(1990)
-    expect(secondPart.join('').length).toEqual(115)
+    expect(firstPart.join('').length).toEqual(1991)
+    expect(secondPart.join('').length).toEqual(116)
   })
 })
 
-describe(wrapCodeBlock.name, () => {
-  it('wraps messages correctly', () => {
-    const name = 'project'
+describe(wrapDiffCodeBlock.name, () => {
+  it('wraps content correctly', () => {
     const messages = ['a', 'b', 'c']
 
-    const expected = [
-      `Detected changes for ${name}\n\n\`\`\`diff\n`,
-      'a\n',
-      'b\n',
-      'c',
-      '\n```',
-    ]
+    const expected = ['```diff\n', 'a\n', 'b\n', 'c', '```']
 
-    const result = wrapCodeBlock(name, messages)
+    const result = wrapDiffCodeBlock(messages)
 
     expect(result).toEqual(expected.join(''))
+  })
+})
+
+describe(wrapBoldAndItalic.name, () => {
+  it('wraps content correctly', () => {
+    const content = 'projectName'
+
+    const result = wrapBoldAndItalic(content)
+
+    expect(result).toEqual(`***${content}***`)
   })
 })
 

--- a/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
@@ -6,7 +6,7 @@ import {
   diffToMessage,
   diffToString,
   wrapBoldAndItalic,
-  wrapDiffCodeBlock,
+  wrapMessagesInDiffCodeBlock,
 } from './diffToMessage'
 
 const ADDRESS = EthereumAddress('0x94cA7e313287a0C4c35AD4c243D1B2f3f6557D01')
@@ -87,13 +87,13 @@ describe(diffToMessage.name, () => {
   })
 })
 
-describe(wrapDiffCodeBlock.name, () => {
+describe(wrapMessagesInDiffCodeBlock.name, () => {
   it('wraps content correctly', () => {
     const messages = ['a', 'b', 'c']
 
     const expected = ['```diff\n', 'a\n', 'b\n', 'c', '```']
 
-    const result = wrapDiffCodeBlock(messages)
+    const result = wrapMessagesInDiffCodeBlock(messages)
 
     expect(result).toEqual(expected.join(''))
   })

--- a/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
@@ -48,7 +48,41 @@ describe(diffToMessage.name, () => {
       '```',
     ]
 
-    expect(result).toEqual(expected.join(''))
+    expect(result).toEqual([expected.join('')])
+  })
+
+  it('truncates message larger than 2000 characters', () => {
+    const name = 'system'
+    const diff: DiscoveryDiff = {
+      name: 'Contract',
+      address: ADDRESS,
+      type: 'deleted',
+    }
+    const differences: DiscoveryDiff[] = []
+
+    while(differences.length < 27) {
+      differences.push(diff)
+    }
+
+    const result = diffToMessage(name, differences)
+
+    const firstPart = [
+      `Detected changes for system\n\n`,
+      '```diff\n',
+      differences.slice(0,26).map(diffToString).join('\n'),
+      '\n```',
+    ]
+
+    const secondPart = [
+      `Detected changes for system\n\n`,
+      '```diff\n',
+      differences.slice(26).map(diffToString).join('\n'),
+      '\n```',
+    ]
+
+    expect(result).toEqual([firstPart.join(''), secondPart.join('')])
+    expect(firstPart.join('').length).toEqual(1990)
+    expect(secondPart.join('').length).toEqual(115)
   })
 })
 

--- a/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.test.ts
@@ -2,7 +2,7 @@ import { EthereumAddress } from '@l2beat/types'
 import { expect } from 'earljs'
 
 import { DiscoveryDiff } from './diffDiscovery'
-import { diffToMessage, diffToString } from './diffToMessage'
+import { diffToMessage, diffToString, wrapCodeBlock } from './diffToMessage'
 
 const ADDRESS = EthereumAddress('0x94cA7e313287a0C4c35AD4c243D1B2f3f6557D01')
 
@@ -83,6 +83,25 @@ describe(diffToMessage.name, () => {
     expect(result).toEqual([firstPart.join(''), secondPart.join('')])
     expect(firstPart.join('').length).toEqual(1990)
     expect(secondPart.join('').length).toEqual(115)
+  })
+})
+
+describe(wrapCodeBlock.name, () => {
+  it('wraps messages correctly', () => {
+    const name = 'project'
+    const messages = ['a','b','c']
+
+    const expected = [
+      `Detected changes for ${name}\n\n\`\`\`diff\n`,
+      'a\n',
+      'b\n',
+      'c',
+      '\n```'
+    ]
+
+    const result = wrapCodeBlock(name, messages)
+
+    expect(result).toEqual(expected.join(''))
   })
 })
 

--- a/packages/backend/src/core/discovery/utils/diffToMessage.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.ts
@@ -7,7 +7,7 @@ export function diffToMessage(name: string, diffs: DiscoveryDiff[]): string[] {
 
   for (const diff of diffs) {
     const currentLength =
-      wrapDiffCodeBlock(messages[index]).length + header.length
+      wrapMessagesInDiffCodeBlock(messages[index]).length + header.length
     const nextDiff = diffToString(diff)
 
     if (currentLength + nextDiff.length >= 2000) {
@@ -18,7 +18,9 @@ export function diffToMessage(name: string, diffs: DiscoveryDiff[]): string[] {
     messages[index].push(nextDiff)
   }
 
-  const result = messages.map((m) => `${header}${wrapDiffCodeBlock(m)}`)
+  const result = messages.map(
+    (m) => `${header}${wrapMessagesInDiffCodeBlock(m)}`,
+  )
   return result
 }
 
@@ -27,7 +29,7 @@ export function wrapBoldAndItalic(content: string) {
   return `${affix}${content}${affix}`
 }
 
-export function wrapDiffCodeBlock(content: string[]) {
+export function wrapMessagesInDiffCodeBlock(content: string[]) {
   const prefix = '```diff\n'
   const postfix = '```'
 

--- a/packages/backend/src/core/discovery/utils/diffToMessage.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.ts
@@ -1,11 +1,27 @@
 import { DiscoveryDiff } from './diffDiscovery'
 
-export function diffToMessage(name: string, diff: DiscoveryDiff[]): string {
-  const message = `Detected changes for ${name}\n\n\`\`\`diff\n${diff
-    .map(diffToString)
-    .join('\n')}`
+export function diffToMessage(name: string, diff: DiscoveryDiff[]): string[] {
+  const beginning = `Detected changes for ${name}\n\n\`\`\`diff\n`
+  const end = '```'
 
-  return message + '\n```'
+  const messages: string[][] = []
+  let index = 0
+  messages[index] = []
+
+  for(const d of diff) {
+    const l = messages[index].join('').length
+    if(beginning.length + l + end.length + diffToString(d).length < 2000) {
+      messages[index].push(`${diffToString(d)}\n`)
+    } else {
+      index += 1
+      messages[index] = []
+      messages[index].push(`${diffToString(d)}\n`)
+    }
+  }
+
+  const result = messages.map(m => `${beginning}${m.join('')}${end}`)
+
+  return result
 }
 
 export function diffToString(diff: DiscoveryDiff): string {

--- a/packages/backend/src/core/discovery/utils/diffToMessage.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.ts
@@ -1,28 +1,31 @@
 import { DiscoveryDiff } from './diffDiscovery'
 
 export function diffToMessage(name: string, diffs: DiscoveryDiff[]): string[] {
-  const prefix = `Detected changes for ${name}\n\n\`\`\`diff\n`
-  const postfix = '```'
-  const overheadLength = prefix.length + postfix.length
-
   const messages: string[][] = [[]]
   let index = 0
 
   for (const diff of diffs) {
-    const currentLength = messages[index].join('').length + overheadLength
+    const currentLength = wrapCodeBlock(name, messages[index]).length
     const nextDiff = diffToString(diff)
 
     if (currentLength + nextDiff.length < 2000) {
-      messages[index].push(`${nextDiff}\n`)
+      messages[index].push(nextDiff)
     } else {
       index += 1
       messages[index] = []
-      messages[index].push(`${nextDiff}\n`)
+      messages[index].push(nextDiff)
     }
   }
 
-  const result = messages.map((m) => `${prefix}${m.join('')}${postfix}`)
+  const result = messages.map((m) => wrapCodeBlock(name, m))
   return result
+}
+
+export function wrapCodeBlock(name: string, messages: string[]) {
+  const prefix = `Detected changes for ${name}\n\n\`\`\`diff\n`
+  const postfix = '\n```'
+
+  return `${prefix}${messages.join('\n')}${postfix}`
 }
 
 export function diffToString(diff: DiscoveryDiff): string {

--- a/packages/backend/src/core/discovery/utils/diffToMessage.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.ts
@@ -1,31 +1,37 @@
 import { DiscoveryDiff } from './diffDiscovery'
 
 export function diffToMessage(name: string, diffs: DiscoveryDiff[]): string[] {
+  const header = `${wrapBoldAndItalic(name)} | detected changes`
   const messages: string[][] = [[]]
   let index = 0
 
   for (const diff of diffs) {
-    const currentLength = wrapCodeBlock(name, messages[index]).length
+    const currentLength =
+      wrapDiffCodeBlock(messages[index]).length + header.length
     const nextDiff = diffToString(diff)
 
-    if (currentLength + nextDiff.length < 2000) {
-      messages[index].push(nextDiff)
-    } else {
+    if (currentLength + nextDiff.length >= 2000) {
       index += 1
       messages[index] = []
-      messages[index].push(nextDiff)
     }
+
+    messages[index].push(nextDiff)
   }
 
-  const result = messages.map((m) => wrapCodeBlock(name, m))
+  const result = messages.map((m) => `${header}${wrapDiffCodeBlock(m)}`)
   return result
 }
 
-export function wrapCodeBlock(name: string, messages: string[]) {
-  const prefix = `Detected changes for ${name}\n\n\`\`\`diff\n`
-  const postfix = '\n```'
+export function wrapBoldAndItalic(content: string) {
+  const affix = '***'
+  return `${affix}${content}${affix}`
+}
 
-  return `${prefix}${messages.join('\n')}${postfix}`
+export function wrapDiffCodeBlock(content: string[]) {
+  const prefix = '```diff\n'
+  const postfix = '```'
+
+  return `${prefix}${content.join('\n')}${postfix}`
 }
 
 export function diffToString(diff: DiscoveryDiff): string {

--- a/packages/backend/src/core/discovery/utils/diffToMessage.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessage.ts
@@ -1,26 +1,27 @@
 import { DiscoveryDiff } from './diffDiscovery'
 
-export function diffToMessage(name: string, diff: DiscoveryDiff[]): string[] {
-  const beginning = `Detected changes for ${name}\n\n\`\`\`diff\n`
-  const end = '```'
+export function diffToMessage(name: string, diffs: DiscoveryDiff[]): string[] {
+  const prefix = `Detected changes for ${name}\n\n\`\`\`diff\n`
+  const postfix = '```'
+  const overheadLength = prefix.length + postfix.length
 
-  const messages: string[][] = []
+  const messages: string[][] = [[]]
   let index = 0
-  messages[index] = []
 
-  for(const d of diff) {
-    const l = messages[index].join('').length
-    if(beginning.length + l + end.length + diffToString(d).length < 2000) {
-      messages[index].push(`${diffToString(d)}\n`)
+  for (const diff of diffs) {
+    const currentLength = messages[index].join('').length + overheadLength
+    const nextDiff = diffToString(diff)
+
+    if (currentLength + nextDiff.length < 2000) {
+      messages[index].push(`${nextDiff}\n`)
     } else {
       index += 1
       messages[index] = []
-      messages[index].push(`${diffToString(d)}\n`)
+      messages[index].push(`${nextDiff}\n`)
     }
   }
 
-  const result = messages.map(m => `${beginning}${m.join('')}${end}`)
-
+  const result = messages.map((m) => `${prefix}${m.join('')}${postfix}`)
   return result
 }
 

--- a/packages/backend/src/core/discovery/utils/diffToMessages.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessages.test.ts
@@ -6,7 +6,7 @@ import {
   diffToMessages,
   diffToString,
   wrapBoldAndItalic,
-  wrapMessagesInDiffCodeBlock,
+  wrapDiffCodeBlock,
 } from './diffToMessages'
 
 const ADDRESS = EthereumAddress('0x94cA7e313287a0C4c35AD4c243D1B2f3f6557D01')
@@ -48,6 +48,7 @@ describe(diffToMessages.name, () => {
       diffToString(diff[1]),
       '\n',
       diffToString(diff[2]),
+      '\n',
       '```',
     ]
 
@@ -72,30 +73,30 @@ describe(diffToMessages.name, () => {
     const firstPart = [
       `***${name}*** | detected changes\`\`\`diff\n`,
       differences.slice(0, 26).map(diffToString).join('\n'),
-      '```',
+      '\n```',
     ]
 
     const secondPart = [
       `***${name}*** | detected changes\`\`\`diff\n`,
       differences.slice(26).map(diffToString).join('\n'),
-      '```',
+      '\n```',
     ]
 
     expect(result).toEqual([firstPart.join(''), secondPart.join('')])
-    expect(firstPart.join('').length).toEqual(1991)
-    expect(secondPart.join('').length).toEqual(116)
+    expect(firstPart.join('').length).toEqual(1992)
+    expect(secondPart.join('').length).toEqual(117)
   })
 })
 
-describe(wrapMessagesInDiffCodeBlock.name, () => {
+describe(wrapDiffCodeBlock.name, () => {
   it('wraps content correctly', () => {
-    const messages = ['a', 'b', 'c']
+    const messages = 'a\nb\nc'
 
-    const expected = ['```diff\n', 'a\n', 'b\n', 'c', '```']
+    const expected = '```diff\na\nb\nc```'
 
-    const result = wrapMessagesInDiffCodeBlock(messages)
+    const result = wrapDiffCodeBlock(messages)
 
-    expect(result).toEqual(expected.join(''))
+    expect(result).toEqual(expected)
   })
 })
 

--- a/packages/backend/src/core/discovery/utils/diffToMessages.test.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessages.test.ts
@@ -3,15 +3,15 @@ import { expect } from 'earljs'
 
 import { DiscoveryDiff } from './diffDiscovery'
 import {
-  diffToMessage,
+  diffToMessages,
   diffToString,
   wrapBoldAndItalic,
   wrapMessagesInDiffCodeBlock,
-} from './diffToMessage'
+} from './diffToMessages'
 
 const ADDRESS = EthereumAddress('0x94cA7e313287a0C4c35AD4c243D1B2f3f6557D01')
 
-describe(diffToMessage.name, () => {
+describe(diffToMessages.name, () => {
   it('correctly formats a message', () => {
     const name = 'system'
     const diff: DiscoveryDiff[] = [
@@ -38,7 +38,7 @@ describe(diffToMessage.name, () => {
       },
     ]
 
-    const result = diffToMessage(name, diff)
+    const result = diffToMessages(name, diff)
 
     const expected = [
       `***${name}*** | detected changes\`\`\`diff`,
@@ -67,7 +67,7 @@ describe(diffToMessage.name, () => {
       differences.push(diff)
     }
 
-    const result = diffToMessage(name, differences)
+    const result = diffToMessages(name, differences)
 
     const firstPart = [
       `***${name}*** | detected changes\`\`\`diff\n`,

--- a/packages/backend/src/core/discovery/utils/diffToMessages.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessages.ts
@@ -1,3 +1,4 @@
+import { MAX_MESSAGE_LENGTH } from '../../../peripherals/discord/DiscordClient'
 import { DiscoveryDiff } from './diffDiscovery'
 
 export function diffToMessages(name: string, diffs: DiscoveryDiff[]): string[] {
@@ -10,7 +11,7 @@ export function diffToMessages(name: string, diffs: DiscoveryDiff[]): string[] {
       wrapDiffCodeBlock(messages[index]).length + header.length
     const nextDiff = diffToString(diff)
 
-    if (currentLength + nextDiff.length >= 2000) {
+    if (currentLength + nextDiff.length >= MAX_MESSAGE_LENGTH) {
       index += 1
       messages.push('')
     }

--- a/packages/backend/src/core/discovery/utils/diffToMessages.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessages.ts
@@ -1,6 +1,6 @@
 import { DiscoveryDiff } from './diffDiscovery'
 
-export function diffToMessage(name: string, diffs: DiscoveryDiff[]): string[] {
+export function diffToMessages(name: string, diffs: DiscoveryDiff[]): string[] {
   const header = `${wrapBoldAndItalic(name)} | detected changes`
   const messages: string[][] = [[]]
   let index = 0

--- a/packages/backend/src/core/discovery/utils/diffToMessages.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessages.ts
@@ -2,25 +2,23 @@ import { DiscoveryDiff } from './diffDiscovery'
 
 export function diffToMessages(name: string, diffs: DiscoveryDiff[]): string[] {
   const header = `${wrapBoldAndItalic(name)} | detected changes`
-  const messages: string[][] = [[]]
+  const messages: string[] = ['']
   let index = 0
 
   for (const diff of diffs) {
     const currentLength =
-      wrapMessagesInDiffCodeBlock(messages[index]).length + header.length
+      wrapDiffCodeBlock(messages[index]).length + header.length
     const nextDiff = diffToString(diff)
 
     if (currentLength + nextDiff.length >= 2000) {
       index += 1
-      messages[index] = []
+      messages.push('')
     }
 
-    messages[index].push(nextDiff)
+    messages[index] += nextDiff + '\n'
   }
 
-  const result = messages.map(
-    (m) => `${header}${wrapMessagesInDiffCodeBlock(m)}`,
-  )
+  const result = messages.map((m) => `${header}${wrapDiffCodeBlock(m)}`)
   return result
 }
 
@@ -29,11 +27,11 @@ export function wrapBoldAndItalic(content: string) {
   return `${affix}${content}${affix}`
 }
 
-export function wrapMessagesInDiffCodeBlock(content: string[]) {
+export function wrapDiffCodeBlock(content: string) {
   const prefix = '```diff\n'
   const postfix = '```'
 
-  return `${prefix}${content.join('\n')}${postfix}`
+  return `${prefix}${content}${postfix}`
 }
 
 export function diffToString(diff: DiscoveryDiff): string {

--- a/packages/backend/src/peripherals/discord/DiscordClient.test.ts
+++ b/packages/backend/src/peripherals/discord/DiscordClient.test.ts
@@ -109,9 +109,11 @@ describe(DiscordClient.name, () => {
     it('throws when message is too long', async () => {
       const httpClient = mock<HttpClient>({})
       const discord = new DiscordClient(httpClient, DISCORD_TOKEN, CHANNEL_ID)
-      
+
       const message = 'a'.repeat(2001)
-      await expect(discord.sendMessage(message)).toBeRejected(`Discord error: Message size exceeded (2000 characters)`)
+      await expect(discord.sendMessage(message)).toBeRejected(
+        `Discord error: Message size exceeded (2000 characters)`,
+      )
     })
   })
 })

--- a/packages/backend/src/peripherals/discord/DiscordClient.test.ts
+++ b/packages/backend/src/peripherals/discord/DiscordClient.test.ts
@@ -105,5 +105,13 @@ describe(DiscordClient.name, () => {
 
       await discord.sendMessage(message)
     })
+
+    it('throws when message is too long', async () => {
+      const httpClient = mock<HttpClient>({})
+      const discord = new DiscordClient(httpClient, DISCORD_TOKEN, CHANNEL_ID)
+      
+      const message = 'a'.repeat(2001)
+      await expect(discord.sendMessage(message)).toBeRejected(`Discord error: Message size exceeded (2000 characters)`)
+    })
   })
 })

--- a/packages/backend/src/peripherals/discord/DiscordClient.ts
+++ b/packages/backend/src/peripherals/discord/DiscordClient.ts
@@ -6,7 +6,7 @@ https://discord.com/developers/docs/getting-started#configuring-a-bot
 import { HttpClient } from '@l2beat/common'
 import { RequestInit } from 'node-fetch'
 
-const MAX_MESSAGE_LENGTH = 2000
+export const MAX_MESSAGE_LENGTH = 2000
 
 export class DiscordClient {
   constructor(

--- a/packages/backend/src/peripherals/discord/DiscordClient.ts
+++ b/packages/backend/src/peripherals/discord/DiscordClient.ts
@@ -6,6 +6,8 @@ https://discord.com/developers/docs/getting-started#configuring-a-bot
 import { HttpClient } from '@l2beat/common'
 import { RequestInit } from 'node-fetch'
 
+const MAX_MESSAGE_LENGTH = 2000
+
 export class DiscordClient {
   constructor(
     private readonly httpClient: HttpClient,
@@ -14,6 +16,10 @@ export class DiscordClient {
   ) {}
 
   async sendMessage(message: string) {
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      throw new Error(`Discord error: Message size exceeded (2000 characters)`)
+    }
+
     const endpoint = `/channels/${this.channelId}/messages`
     const body = {
       content: message,


### PR DESCRIPTION
This PR aims to cut discord message into pieces when it exceedes Discord API`BASE_TYPE_MAX_LENGTH` (2000 characters). Message is semantically cut inside `diffToMessage`, additionally the check inside `DiscordClient` was added.

Resolves L2B-635