### PR TITLE
yarn start hotfix

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "yarn lint --fix",
     "lint": "eslint --ext .ts,.tsx --max-warnings 0 src",
     "start:dev": "node -r esbuild-register src server",
-    "start": "node -r source-map-support/register build/src/index.js server",
+    "start": "node -r source-map-support/register build/index.js server",
     "discover": "node -r esbuild-register src discover",
     "test": "mocha",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
Fixes build on staging. Because of the removal of files from /scripts folder, the `index.js` file is now located in `/build` folder directly