### PR TITLE
Add multiple channel support to DiscordClient

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -63,6 +63,8 @@ environment variables. One variable per line `KEY=value`.
 - `TVL_SYNC_ENABLED` (default `true`) - When set to `true` tvl sync is enabled
 - `DISCOVERY_BLOCK_NUMBER` (Optional) - Override the block number used during local discovery
 - `WATCHMODE_ENABLED` (Optional) - Enable update monitor's watch mode
+- `DISCORD_CHANNEL_IDS` - space separated list of channel ids the message will be sent to, e.g. "123 456 789" becomes [123, 456, 789]
+- `DISCORD_TOKEN` - Bot account authentication token, for more details go to `DiscordClient.ts`
 
 #### .env boilerplate:
 
@@ -85,6 +87,8 @@ STARKEX_API_KEY=
 #TVL_SYNC_ENABLED=
 #DISCOVERY_BLOCK_NUMBER=
 #WATCHMODE_ENABLED=
+#DISCORD_CHANNEL_IDS=
+#DISCORD_TOKEN=
 ```
 
 ## Scripts

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -95,7 +95,7 @@ export interface DiscoveryWatcherConfig {
   readonly discord:
     | {
         readonly token: string
-        readonly channelId: string
+        readonly channelIds: string[]
       }
     | false
 }

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -108,7 +108,7 @@ export function getLocalConfig(cli: CliParameters): Config {
       etherscanApiKey: getEnv('ETHERSCAN_API_KEY'),
       discord: discordEnabled && {
         token: getEnv('DISCORD_TOKEN'),
-        channelId: getEnv('DISCORD_CHANNEL_ID'),
+        channelIds: getEnv('DISCORD_CHANNEL_ID').split(' '),
       },
     },
   }

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -28,7 +28,7 @@ export function getLocalConfig(cli: CliParameters): Config {
   const discoveryWatcherEnabled =
     cli.mode === 'server' && getEnv.boolean('WATCHMODE_ENABLED', false)
   const discordEnabled =
-    !!process.env.DISCORD_TOKEN && !!process.env.DISCORD_CHANNEL_ID
+    !!process.env.DISCORD_TOKEN && !!process.env.DISCORD_CHANNEL_IDS
   const invertEnabled = cli.mode === 'invert'
 
   return {
@@ -108,9 +108,7 @@ export function getLocalConfig(cli: CliParameters): Config {
       etherscanApiKey: getEnv('ETHERSCAN_API_KEY'),
       discord: discordEnabled && {
         token: getEnv('DISCORD_TOKEN'),
-        channelIds: getEnv('DISCORD_CHANNEL_ID')
-          .split(' ')
-          .filter((x) => x.length > 0),
+        channelIds: getEnv.array('DISCORD_CHANNEL_IDS'),
       },
     },
   }

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -108,7 +108,9 @@ export function getLocalConfig(cli: CliParameters): Config {
       etherscanApiKey: getEnv('ETHERSCAN_API_KEY'),
       discord: discordEnabled && {
         token: getEnv('DISCORD_TOKEN'),
-        channelIds: getEnv('DISCORD_CHANNEL_ID').split(' '),
+        channelIds: getEnv('DISCORD_CHANNEL_ID')
+          .split(' ')
+          .filter((x) => x.length > 0),
       },
     },
   }

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -92,7 +92,9 @@ export function getProductionConfig(cli: CliParameters): Config {
       etherscanApiKey: getEnv('ETHERSCAN_API_KEY'),
       discord: discordEnabled && {
         token: getEnv('DISCORD_TOKEN'),
-        channelIds: getEnv('DISCORD_CHANNEL_ID').split(' '),
+        channelIds: getEnv('DISCORD_CHANNEL_ID')
+          .split(' ')
+          .filter((x) => x.length > 0),
       },
     },
   }

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -14,7 +14,7 @@ export function getProductionConfig(cli: CliParameters): Config {
 
   const discoveryWatcherEnabled = getEnv.boolean('WATCHMODE_ENABLED', false)
   const discordEnabled =
-    !!process.env.DISCORD_TOKEN && !!process.env.DISCORD_CHANNEL_ID
+    !!process.env.DISCORD_TOKEN && !!process.env.DISCORD_CHANNEL_IDS
 
   return {
     name: 'Backend/Production',
@@ -92,9 +92,7 @@ export function getProductionConfig(cli: CliParameters): Config {
       etherscanApiKey: getEnv('ETHERSCAN_API_KEY'),
       discord: discordEnabled && {
         token: getEnv('DISCORD_TOKEN'),
-        channelIds: getEnv('DISCORD_CHANNEL_ID')
-          .split(' ')
-          .filter((x) => x.length > 0),
+        channelIds: getEnv.array('DISCORD_CHANNEL_IDS'),
       },
     },
   }

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -92,7 +92,7 @@ export function getProductionConfig(cli: CliParameters): Config {
       etherscanApiKey: getEnv('ETHERSCAN_API_KEY'),
       discord: discordEnabled && {
         token: getEnv('DISCORD_TOKEN'),
-        channelId: getEnv('DISCORD_CHANNEL_ID'),
+        channelIds: getEnv('DISCORD_CHANNEL_ID').split(' '),
       },
     },
   }

--- a/packages/backend/src/config/getEnv.test.ts
+++ b/packages/backend/src/config/getEnv.test.ts
@@ -67,4 +67,18 @@ describe(getEnv.name, () => {
       expect(() => getEnv.boolean('TEST_B')).toThrow()
     })
   })
+
+  describe(getEnv.array.name, () => {
+    it('returns environment variable as array', () => {
+      process.env.TEST_ARRAY = 'A B C'
+      const result = getEnv.array('TEST_ARRAY')
+      expect(result).toEqual(['A', 'B', 'C'])
+    })
+
+    it('handles additional spaces', () => {
+      process.env.TEST_ARRAY = 'A    B    C'
+      const result = getEnv.array('TEST_ARRAY')
+      expect(result).toEqual(['A', 'B', 'C'])
+    })
+  })
 })

--- a/packages/backend/src/config/getEnv.ts
+++ b/packages/backend/src/config/getEnv.ts
@@ -58,3 +58,11 @@ getEnv.boolean = function getBooleanFromEnv(
   }
   throw new Error(`Missing environment variable ${name}!`)
 }
+
+getEnv.array = function array(name: string): string[] {
+  const value = process.env[name]
+  if (value !== undefined) {
+    return value.split(' ').filter((x) => x.length > 0)
+  }
+  throw new Error(`Missing environment variable ${name}!`)
+}

--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -62,7 +62,7 @@ describe(DiscoveryWatcher.name, () => {
 
   beforeEach(() => {
     discordClient = mock<DiscordClient>({
-      sendMessage: async () => {},
+      sendMessage: async () => [],
     })
     discoveryEngine = mock<DiscoveryEngine>({
       run: async () => DISCOVERY_RESULT,

--- a/packages/backend/src/modules/discoveryWatcher/DiscoveryWatcherModule.ts
+++ b/packages/backend/src/modules/discoveryWatcher/DiscoveryWatcherModule.ts
@@ -36,7 +36,7 @@ export function createDiscoveryWatcherModule(
     ? new DiscordClient(
         http,
         config.discoveryWatcher.discord.token,
-        config.discoveryWatcher.discord.channelId,
+        config.discoveryWatcher.discord.channelIds,
       )
     : undefined
 

--- a/packages/backend/src/peripherals/discord/DiscordClient.ts
+++ b/packages/backend/src/peripherals/discord/DiscordClient.ts
@@ -20,22 +20,19 @@ export class DiscordClient {
       throw new Error(`Discord error: Message size exceeded (2000 characters)`)
     }
 
-    const result = []
-    for (const channelId of this.channelIds) {
-      const endpoint = `/channels/${channelId}/messages`
-      const body = {
-        content: message,
-      }
+    return await Promise.all(
+      this.channelIds.map((channelId) => {
+        const endpoint = `/channels/${channelId}/messages`
+        const body = {
+          content: message,
+        }
 
-      result.push(
-        await this.query(endpoint, {
+        return this.query(endpoint, {
           method: 'POST',
           body: JSON.stringify(body),
-        }),
-      )
-    }
-
-    return result
+        })
+      }),
+    )
   }
 
   async query(endpoint: string, options?: RequestInit) {

--- a/packages/backend/src/peripherals/discord/DiscordClient.ts
+++ b/packages/backend/src/peripherals/discord/DiscordClient.ts
@@ -12,7 +12,7 @@ export class DiscordClient {
   constructor(
     private readonly httpClient: HttpClient,
     private readonly discordToken: string,
-    private readonly channelId: string,
+    private readonly channelIds: string[],
   ) {}
 
   async sendMessage(message: string) {
@@ -20,15 +20,22 @@ export class DiscordClient {
       throw new Error(`Discord error: Message size exceeded (2000 characters)`)
     }
 
-    const endpoint = `/channels/${this.channelId}/messages`
-    const body = {
-      content: message,
+    const result = []
+    for (const channelId of this.channelIds) {
+      const endpoint = `/channels/${channelId}/messages`
+      const body = {
+        content: message,
+      }
+
+      result.push(
+        await this.query(endpoint, {
+          method: 'POST',
+          body: JSON.stringify(body),
+        }),
+      )
     }
 
-    return this.query(endpoint, {
-      method: 'POST',
-      body: JSON.stringify(body),
-    })
+    return result
   }
 
   async query(endpoint: string, options?: RequestInit) {


### PR DESCRIPTION
This PR aims to introduce functionality enabling sending message to multiple discord channels. This code changes the way we get env variable, initialize DiscordClient object, and sendMessage logic

Resolves L2B-834