### PR TITLE
Update ProjectDetail page

### DIFF
--- a/packages/frontend/src/styles/components/_ProjectDetails.scss
+++ b/packages/frontend/src/styles/components/_ProjectDetails.scss
@@ -6,7 +6,7 @@
   column-gap: 16px;
   row-gap: 3rem;
 
-  @media (min-width: 1200px) {
+  @media (min-width: 1024px) {
     grid-template-columns: 1fr 400px;
     grid-template-areas: 'content side';
   }

--- a/packages/frontend/src/styles/components/_ProjectDetails.scss
+++ b/packages/frontend/src/styles/components/_ProjectDetails.scss
@@ -6,7 +6,7 @@
   column-gap: 16px;
   row-gap: 3rem;
 
-  @media (min-width: 750px) {
+  @media (min-width: 1200px) {
     grid-template-columns: 1fr 400px;
     grid-template-areas: 'content side';
   }


### PR DESCRIPTION
Problem: currently when viewing on a window larger than mobile breakpoint, but not wide enough to fit both columns, the project details page is hard to read
<img width="960" alt="image" src="https://user-images.githubusercontent.com/72789647/219346761-b4f40798-d4b4-4c35-92c4-66c7cf4598f7.png">

This PR aims to change the breakpoint, so the column split happens only from window larger than 1200px
<img width="955" alt="image" src="https://user-images.githubusercontent.com/72789647/219346851-a4c314bc-2cfa-4302-a85e-8fc0302a6bd4.png">
