### PR TITLE
Fix failing tests

### DIFF
--- a/packages/backend/src/core/SequenceProcessor.test.ts
+++ b/packages/backend/src/core/SequenceProcessor.test.ts
@@ -220,10 +220,6 @@ describe(SequenceProcessor.name, () => {
       await sequenceProcessor.start()
       await waitForErrorReport(time, reportErrorMock)
 
-      await Promise.all([
-        sequenceProcessor.stop(),
-        waitForErrorReport(time, reportErrorMock),
-      ])
       time.uninstall()
 
       expect(reportErrorMock).toHaveBeenCalledWith(
@@ -254,10 +250,6 @@ describe(SequenceProcessor.name, () => {
       await sequenceProcessor.start()
       await waitForErrorReport(time, reportErrorMock)
 
-      await Promise.all([
-        sequenceProcessor.stop(),
-        waitForErrorReport(time, reportErrorMock),
-      ])
       time.uninstall()
 
       expect(reportErrorMock).toHaveBeenCalledWith(
@@ -473,7 +465,7 @@ async function waitForErrorReport(
   let errorReported = false
 
   while (!errorReported) {
-    await time.runToLastAsync()
+    await time.tickAsync(1)
     errorReported = reportErrorMock.calls.length > currentCalls
   }
 }

--- a/packages/backend/src/core/SequenceProcessor.test.ts
+++ b/packages/backend/src/core/SequenceProcessor.test.ts
@@ -215,6 +215,8 @@ describe(SequenceProcessor.name, () => {
         getLatest: getLatestMock,
         processRange: processRangeMock,
         reportError: reportErrorMock,
+        // Because we use fake-timers, we need to disable the refresh interval
+        refreshInterval: Infinity,
       })
 
       await sequenceProcessor.start()
@@ -245,6 +247,8 @@ describe(SequenceProcessor.name, () => {
         getLatest: getLatestMock,
         processRange: processRangeMock,
         reportError: reportErrorMock,
+        // Because we use fake-timers, we need to disable the refresh interval
+        refreshInterval: Infinity,
       })
 
       await sequenceProcessor.start()


### PR DESCRIPTION
I'm not sure if this will actually fix the failing tests, but for sure it will run them as we should run them. In the previous approach, because `time.runToLastAsync()` breaks the event loop, the `SequenceProcessor`'s interval function was running every time on failed job (so also after the last attempt). `time.tickAsync` fixes that.