### PR TITLE
Correcting the link to the zkSync Era github repo

### DIFF
--- a/packages/config/src/layer2s/zksyncera.ts
+++ b/packages/config/src/layer2s/zksyncera.ts
@@ -32,7 +32,7 @@ export const zksyncera: Layer2 = {
       apps: ['https://portal.zksync.io/'],
       documentation: ['https://era.zksync.io/docs/'],
       explorers: ['https://explorer.zksync.io/'],
-      repositories: ['https://github.com/matter-labs/zksync'],
+      repositories: ['https://github.com/matter-labs/zksync-era'],
       socialMedia: [
         'https://blog.matter-labs.io/',
         'https://join.zksync.dev/',


### PR DESCRIPTION
Currently, the Github link for zkSync Era points to the zkSync Lite codebase - this PR fixes that. 