### PR TITLE
Change coingecko rate limit for free account

### DIFF
--- a/packages/shared/src/services/coingecko/CoingeckoClient.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoClient.ts
@@ -22,7 +22,7 @@ export class CoingeckoClient {
     private readonly apiKey: string | undefined,
   ) {
     const rateLimiter = new RateLimiter({
-      callsPerMinute: apiKey ? 450 : 35,
+      callsPerMinute: apiKey ? 450 : 10,
     })
     this.query = rateLimiter.wrap(this.query.bind(this))
   }


### PR DESCRIPTION
The new rate limit for free accounts on coingecko appears to be between 10 and 30. Setting this to 10 to be on the safe lower limit. https://www.coingecko.com/en/api/pricing