### PR TITLE
Update Arbitrum upgradeability risk factor

### DIFF
--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -98,7 +98,12 @@ export const arbitrum: Layer2 = {
       sentiment: 'warning',
     },
     dataAvailability: RISK_VIEW.DATA_ON_CHAIN,
-    upgradeability: RISK_VIEW.UPGRADABLE_YES,
+    upgradeability: {
+      value: '13d or no delay',
+      description:
+        'There is a 13 days delay unless it is overriden by the 9/12 Security Council multisig.',
+      sentiment: 'warning',
+    },
     sequencerFailure: RISK_VIEW.SEQUENCER_TRANSACT_L1,
     validatorFailure: {
       value: 'Propose blocks',

--- a/packages/config/src/layer2s/nova.ts
+++ b/packages/config/src/layer2s/nova.ts
@@ -82,7 +82,12 @@ export const nova: Layer2 = {
       sentiment: 'warning',
     },
     dataAvailability: RISK_VIEW.DATA_EXTERNAL_DAC,
-    upgradeability: RISK_VIEW.UPGRADABLE_YES,
+    upgradeability: {
+      value: '13d or no delay',
+      description:
+        'There is a 13 days delay unless it is overriden by the 9/12 Security Council multisig.',
+      sentiment: 'warning',
+    },
     sequencerFailure: RISK_VIEW.SEQUENCER_TRANSACT_L1,
     validatorFailure: {
       value: 'Propose blocks',


### PR DESCRIPTION
Arbitrum One and Arbitrum Nova are now both owned by the Arbitrum DAO, which has a 13 day delay on upgrades going through after approval. However, there is a 9/12 security council multisig that can make instant upgrades, as noted here.