### PR TITLE
Remove ibBTC

### DIFF
--- a/packages/config/src/tokens/tokenList.json
+++ b/packages/config/src/tokens/tokenList.json
@@ -981,16 +981,6 @@
       "category": "other"
     },
     {
-      "id": "ibbtc-interest-bearing-btc",
-      "name": "Interest-Bearing BTC",
-      "coingeckoId": "interest-bearing-bitcoin",
-      "address": "0xc4E15973E6fF2A35cC804c2CF9D2a1b817a8b40F",
-      "symbol": "ibBTC",
-      "decimals": 18,
-      "sinceTimestamp": 1619789623,
-      "category": "other"
-    },
-    {
       "id": "keep-keep-token",
       "name": "KEEP Token",
       "coingeckoId": "keep-network",


### PR DESCRIPTION
ibBTC has been removed from coingecko
<img width="1298" alt="Screenshot 2023-03-23 at 17 31 43" src="https://user-images.githubusercontent.com/38423054/227271804-f6e78f2c-5a3d-4a9a-8fc0-270886e92cbd.png">
