### PR TITLE
fix: clarify whitelisted validator security model

### DIFF
--- a/packages/config/src/layer2s/common/riskView.ts
+++ b/packages/config/src/layer2s/common/riskView.ts
@@ -224,7 +224,7 @@ export const VALIDATOR_NO_MECHANISM: ProjectRiskViewEntry = {
 export const VALIDATOR_WHITELISTED_BLOCKS: ProjectRiskViewEntry = {
   value: 'No mechanism',
   description:
-    'If the whitelisted validator goes down, no activity including withdrawals can happen. Funds will be frozen.',
+    'If the whitelisted validator goes down, withdrawals cannot be processed. Users can still transact on L2.',
   sentiment: 'bad',
 }
 


### PR DESCRIPTION
Updates the string that describes the whitelisted validator security model. Original string was inaccurate because an inactive whitelisted validator would only block withdrawals but would not block transactions on the L2.