### PR TITLE
Speedup zksyncera activity sync

### DIFF
--- a/packages/config/src/layer2s/zksyncera.ts
+++ b/packages/config/src/layer2s/zksyncera.ts
@@ -69,6 +69,7 @@ export const zksyncera: Layer2 = {
       type: 'rpc',
       startBlock: 1,
       url: 'https://mainnet.era.zksync.io',
+      callsPerMinute: 1500,
       excludeFromActivityApi: true, // excluding until it's synced
     },
   },


### PR DESCRIPTION
The node handles 3k calls/minute (tested locally). Setting it to 1.5k/min (25/s) to speed up the sync. After we're on track we should probably go for like 200/min