### PR TITLE
Derive escrow section

### DIFF
--- a/packages/backend/discovery/arbitrum/config.jsonc
+++ b/packages/backend/discovery/arbitrum/config.jsonc
@@ -100,7 +100,6 @@
         "counterpartGateway",
         "inbox",
         "l1Dai",
-        "l1Escrow",
         "l1Router",
         "l2Counterpart",
         "l2Dai"

--- a/packages/backend/discovery/arbitrum/discovered.json
+++ b/packages/backend/discovery/arbitrum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "arbitrum",
-  "blockNumber": 16974514,
-  "configHash": "0x28fd1db10cc2fd03059615aed65004e4499da21e6eee0d161a513ff7bcc0f7df",
+  "blockNumber": 16975477,
+  "configHash": "0x1ebb27d99695ec5773aaf1d96c56b010801bc8864c5170a4704ef06270266ff9",
   "contracts": [
     {
       "name": "RollupProxy",
@@ -21,12 +21,12 @@
         "confirmPeriodBlocks": 45818,
         "currentRequiredStake": "1000000000000000000",
         "extraChallengeTimeBlocks": 200,
-        "firstUnresolvedNode": 4196,
+        "firstUnresolvedNode": 4200,
         "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
         "isERC20Enabled": false,
         "lastStakeBlock": 15447818,
-        "latestConfirmed": 4195,
-        "latestNodeCreated": 4350,
+        "latestConfirmed": 4199,
+        "latestNodeCreated": 4353,
         "loserStakeEscrow": "0x5b11BDC6eF32cE261A39f58122E301D59FC05677",
         "minimumAssertionPeriod": 75,
         "outbox": "0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840",
@@ -93,7 +93,7 @@
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
       "values": {
-        "batchCount": 132455,
+        "batchCount": 132700,
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
         "DATA_AUTHENTICATED_FLAG": "0x40",
         "HEADER_LENGTH": 40,
@@ -106,7 +106,7 @@
         ],
         "rollup": "0x5eF0D09d1E6204141B4d37530808eD19f60FBa35",
         "setIsBatchPosterCount": 3,
-        "totalDelayedMessagesRead": 733054
+        "totalDelayedMessagesRead": 733588
       },
       "derivedName": "SequencerInbox"
     },
@@ -386,11 +386,11 @@
           "0x667e23ABd27E623c11d4CC00ca3EC4d0bD63337a",
           "0x760723CD2e632826c38Fef8CD438A4CC7E7E1A40"
         ],
-        "delayedMessageCount": 733077,
+        "delayedMessageCount": 733621,
         "rollup": "0x5eF0D09d1E6204141B4d37530808eD19f60FBa35",
         "sequencerInbox": "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
-        "sequencerMessageCount": 132455,
-        "sequencerReportedSubMessageCount": 54691303
+        "sequencerMessageCount": 132700,
+        "sequencerReportedSubMessageCount": 54738769
       },
       "derivedName": "Bridge"
     },
@@ -562,6 +562,14 @@
         "l2Dai": "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"
       },
       "derivedName": "L1DaiGateway"
+    },
+    {
+      "name": "L1Escrow",
+      "address": "0xA10c7CE4b876998858b1a9E12b10092229539400",
+      "code": "https://etherscan.deth.net/address/0xA10c7CE4b876998858b1a9E12b10092229539400",
+      "upgradeability": {
+        "type": "immutable"
+      }
     }
   ],
   "eoas": [
@@ -1248,6 +1256,16 @@
       "function zombieAddress(uint256 zombieNum) view returns (address)",
       "function zombieCount() view returns (uint256)",
       "function zombieLatestStakedNode(uint256 zombieNum) view returns (uint64)"
+    ],
+    "0xA10c7CE4b876998858b1a9E12b10092229539400": [
+      "constructor()",
+      "event Approve(address indexed token, address indexed spender, uint256 value)",
+      "event Deny(address indexed usr)",
+      "event Rely(address indexed usr)",
+      "function approve(address token, address spender, uint256 value)",
+      "function deny(address usr)",
+      "function rely(address usr)",
+      "function wards(address) view returns (uint256)"
     ],
     "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC": [
       "constructor(address _logic, address admin_, bytes _data) payable",

--- a/packages/config/src/common/ProjectEscrow.ts
+++ b/packages/config/src/common/ProjectEscrow.ts
@@ -1,5 +1,7 @@
 import { EthereumAddress, UnixTime } from '@l2beat/shared'
 
+import { ProjectUpgradeability } from './ProjectContracts'
+
 export interface ProjectEscrow {
   /** Address of the escrow. Use etherscan to verify its correctness. */
   address: EthereumAddress
@@ -7,4 +9,21 @@ export interface ProjectEscrow {
   sinceTimestamp: UnixTime
   /** List of token tickers (e.g. ETH, DAI) to track. Use '*' for all tokens */
   tokens: string[] | '*'
+
+  /** Temporary flag meaning that escrow config was migrated to new format */
+  newVersion?: true
+  name?: string
+  description?: string
+  /** Hiding an escrow when it's not used anymore but we need to keep it to calculate past TVL correctly */
+  hidden?: true
+  /** Details about upgradeability */
+  upgradeability?: ProjectUpgradeability
+}
+
+export interface ProjectEscrowFromDiscovery {
+  newVersion: true
+  address: EthereumAddress
+  name: string
+  description?: string
+  upgradeability?: ProjectUpgradeability
 }

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -76,7 +76,7 @@ export class ProjectDiscovery {
     let contract: ContractParameters
     if (path) {
       const address = this.getAddressFromValue(identifier, path)
-      contract = this.getContractByAddress(address)
+      contract = this.getContractByAddress(address.toString())
     } else {
       contract = this.getContract(identifier)
     }

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -10,7 +10,11 @@ import fs from 'fs'
 import { isArray, isString } from 'lodash'
 import path from 'path'
 
-import { ProjectPermission, ProjectPermissionedAccount } from '../common'
+import {
+  ProjectEscrowFromDiscovery,
+  ProjectPermission,
+  ProjectPermissionedAccount,
+} from '../common'
 import {
   ProjectContract,
   ProjectContractSingleAddress,
@@ -57,6 +61,28 @@ export class ProjectDiscovery {
   ): ProjectContract {
     const contract = this.getContract(identifier)
     return {
+      name: contract.name,
+      address: contract.address,
+      upgradeability: contract.upgradeability,
+      description,
+    }
+  }
+
+  getEscrowDetails(
+    identifier: string,
+    description?: string,
+    path?: string,
+  ): ProjectEscrowFromDiscovery {
+    let contract: ContractParameters
+    if (path) {
+      const address = this.getAddressFromValue(identifier, path)
+      contract = this.getContractByAddress(address)
+    } else {
+      contract = this.getContract(identifier)
+    }
+
+    return {
+      newVersion: true,
       name: contract.name,
       address: contract.address,
       upgradeability: contract.upgradeability,

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -58,7 +58,7 @@ export const arbitrum: Layer2 = {
     associatedTokens: ['ARB'],
     escrows: [
       {
-        address: discovery.getContract('ArbitrumOneBridge').address,
+        ...discovery.getEscrowDetails('ArbitrumOneBridge'),
         sinceTimestamp: new UnixTime(1661450734),
         tokens: ['ETH'],
       },
@@ -68,19 +68,21 @@ export const arbitrum: Layer2 = {
         address: HARDCODED.ARBITRUM.OLD_BRIDGE,
         sinceTimestamp: new UnixTime(1622243344),
         tokens: ['ETH'],
+        hidden: true,
+        newVersion: true,
       },
       {
-        address: discovery.getContract('L1CustomGateway').address,
+        ...discovery.getEscrowDetails('L1CustomGateway'),
         sinceTimestamp: new UnixTime(1623867835),
         tokens: '*',
       },
       {
-        address: discovery.getContract('L1ERC20Gateway').address,
+        ...discovery.getEscrowDetails('L1ERC20Gateway'),
         sinceTimestamp: new UnixTime(1623784100),
         tokens: '*',
       },
       {
-        address: discovery.getAddressFromValue('L1DaiGateway', 'l1Escrow'),
+        ...discovery.getEscrowDetails('L1DaiGateway', undefined, 'l1Escrow'),
         sinceTimestamp: new UnixTime(1632133470),
         tokens: ['DAI'],
       },

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -287,10 +287,6 @@ export const arbitrum: Layer2 = {
         'L1GatewayRouter',
         'Router managing token <--> gateway mapping.',
       ),
-      discovery.getMainContractDetails(
-        'L1CustomGateway',
-        'Main entry point for users depositing ERC20 tokens that require minting custom token on L2.',
-      ),
     ],
     risks: [CONTRACTS.UPGRADE_NO_DELAY_RISK],
   },

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -63,6 +63,27 @@ export const arbitrum: Layer2 = {
         tokens: ['ETH'],
       },
       {
+        ...discovery.getEscrowDetails('L1CustomGateway'),
+        sinceTimestamp: new UnixTime(1623867835),
+        tokens: '*',
+        description:
+          'Main entry point for users depositing ERC20 tokens that require minting custom token on L2.',
+      },
+      {
+        ...discovery.getEscrowDetails('L1ERC20Gateway'),
+        sinceTimestamp: new UnixTime(1623784100),
+        tokens: '*',
+        description:
+          'Main entry point for users depositing ERC20 tokens. Upon depositing, on L2 a generic, "wrapped" token will be minted.',
+      },
+      {
+        ...discovery.getEscrowDetails('L1DaiGateway', undefined, 'l1Escrow'),
+        sinceTimestamp: new UnixTime(1632133470),
+        tokens: ['DAI'],
+        description:
+          'DAI Vault for custom DAI Gateway. Fully controlled by MakerDAO governance.',
+      },
+      {
         // This bridge is inactive, but we keep it
         // in case we have to gather historic data
         address: HARDCODED.ARBITRUM.OLD_BRIDGE,
@@ -70,21 +91,6 @@ export const arbitrum: Layer2 = {
         tokens: ['ETH'],
         hidden: true,
         newVersion: true,
-      },
-      {
-        ...discovery.getEscrowDetails('L1CustomGateway'),
-        sinceTimestamp: new UnixTime(1623867835),
-        tokens: '*',
-      },
-      {
-        ...discovery.getEscrowDetails('L1ERC20Gateway'),
-        sinceTimestamp: new UnixTime(1623784100),
-        tokens: '*',
-      },
-      {
-        ...discovery.getEscrowDetails('L1DaiGateway', undefined, 'l1Escrow'),
-        sinceTimestamp: new UnixTime(1632133470),
-        tokens: ['DAI'],
       },
     ],
     transactionApi: {
@@ -282,22 +288,9 @@ export const arbitrum: Layer2 = {
         'Router managing token <--> gateway mapping.',
       ),
       discovery.getMainContractDetails(
-        'L1ERC20Gateway',
-        'Main entry point for users depositing ERC20 tokens. Upon depositing, on L2 a generic, "wrapped" token will be minted.',
-      ),
-      discovery.getMainContractDetails(
         'L1CustomGateway',
         'Main entry point for users depositing ERC20 tokens that require minting custom token on L2.',
       ),
-      discovery.getMainContractDetails(
-        'L1DaiGateway',
-        'Custom DAI Gateway, main entry point for users depositing DAI to L2 where "canonical" L2 DAI token managed by MakerDAO will be minted. Managed by MakerDAO.',
-      ),
-      {
-        name: 'L1DaiEscrow',
-        address: discovery.getAddressFromValue('L1DaiGateway', 'l1Escrow'),
-        description: 'DAI Vault for custom DAI Gateway managed by MakerDAO.',
-      },
     ],
     risks: [CONTRACTS.UPGRADE_NO_DELAY_RISK],
   },

--- a/packages/frontend/src/components/project/ContractsSection.tsx
+++ b/packages/frontend/src/components/project/ContractsSection.tsx
@@ -51,20 +51,25 @@ export function ContractsSection(props: ContractsSectionProps) {
           </React.Fragment>
         ))}
       </div>
-      <h3 className="md:text-md font-bold">
-        The system uses following escrows:
-      </h3>
-      <div className="mt-4 mb-4">
-        {props.escrows.map((contract, i) => (
-          <React.Fragment key={i}>
-            <ContractEntry
-              contract={contract}
-              verificationStatus={props.verificationStatus}
-              className="mt-4 mb-4"
-            />
-          </React.Fragment>
-        ))}
-      </div>
+      {/* @todo: this "if" can be dropped when all escrows will migrate to new form */}
+      {props.escrows.length > 0 && (
+        <>
+          <h3 className="md:text-md font-bold">
+            The system uses following escrows:
+          </h3>
+          <div className="mt-4 mb-4">
+            {props.escrows.map((contract, i) => (
+              <React.Fragment key={i}>
+                <ContractEntry
+                  contract={contract}
+                  verificationStatus={props.verificationStatus}
+                  className="mt-4 mb-4"
+                />
+              </React.Fragment>
+            ))}
+          </div>
+        </>
+      )}
       {props.risks.length > 0 && (
         <>
           <p className="text-gray-850 dark:text-gray-400">

--- a/packages/frontend/src/components/project/ContractsSection.tsx
+++ b/packages/frontend/src/components/project/ContractsSection.tsx
@@ -9,6 +9,7 @@ import { TechnologyIncompleteShort } from './TechnologyIncomplete'
 
 export interface ContractsSectionProps {
   contracts: TechnologyContract[]
+  escrows: TechnologyContract[]
   risks: TechnologyRisk[]
   references: TechnologyReference[]
   architectureImage?: string
@@ -41,6 +42,20 @@ export function ContractsSection(props: ContractsSectionProps) {
       </h3>
       <div className="mt-4 mb-4">
         {props.contracts.map((contract, i) => (
+          <React.Fragment key={i}>
+            <ContractEntry
+              contract={contract}
+              verificationStatus={props.verificationStatus}
+              className="mt-4 mb-4"
+            />
+          </React.Fragment>
+        ))}
+      </div>
+      <h3 className="md:text-md font-bold">
+        The system uses following escrows:
+      </h3>
+      <div className="mt-4 mb-4">
+        {props.escrows.map((contract, i) => (
           <React.Fragment key={i}>
             <ContractEntry
               contract={contract}


### PR DESCRIPTION
1. New escrow format introduced, with fields like upgradability. 
2. Derive escrows from discovery.
3. Drop duplicated entries from smart contract section UNLESS given escrow has another usecase (like `ArbitrumOneBridge`)