### PR TITLE
Handle flattened solidity sources

### DIFF
--- a/packages/backend/src/core/discovery/utils/saveDiscoveryResult.ts
+++ b/packages/backend/src/core/discovery/utils/saveDiscoveryResult.ts
@@ -23,8 +23,9 @@ export async function saveDiscoveryResult(
   for (const result of results) {
     for (const [i, source] of result.meta.sources.entries()) {
       for (const [file, content] of Object.entries(source.files)) {
-        const name = getSourceName(i, result.meta.sources.length)
-        const path = `${root}/.code/${result.name}${name}/${file}`
+        const codebase = getSourceName(i, result.meta.sources.length)
+        const { name } = getCustomName(result.name, result.address, config)
+        const path = `${root}/.code/${name}${codebase}/${file}`
         await mkdirp(dirname(path))
         await writeFile(path, content)
       }
@@ -102,7 +103,7 @@ export function prepareDiscoveryFile(
   }
 }
 
-function getCustomName(
+export function getCustomName(
   derivedName: string,
   address: EthereumAddress,
   config: DiscoveryConfig,


### PR DESCRIPTION
You can test this yourself on loopring.

Basically the output changes from:
```
.code/ExchangeV3/implementation
  meta.txt
  ExchangeV3.sol
```
to:
```
.code/ExchangeV3/implementation
  core/ ...
  lib/ ...
  thirdparty/ ...
  meta.txt
  flattenedsol
```

  