### PR TITLE
remove "new" badges

### DIFF
--- a/packages/frontend/src/components/navbar/Navbar.tsx
+++ b/packages/frontend/src/components/navbar/Navbar.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import { Config } from '../../build/config'
-import { NewItemBadge } from '../badge/NewItemBadge'
 import { MenuOpenIcon } from '../icons'
 import { Logo } from '../Logo'
 import { OutLink } from '../OutLink'
@@ -79,7 +78,6 @@ export function Navbar(props: NavbarProps) {
                 href="/bridges/tvl"
               >
                 Bridges
-                <NewItemBadge className="ml-2" />
               </PageLink>
             </li>
           </ul>

--- a/packages/frontend/src/components/navbar/SidebarMenu.tsx
+++ b/packages/frontend/src/components/navbar/SidebarMenu.tsx
@@ -1,7 +1,6 @@
 import cx from 'classnames'
 import React from 'react'
 
-import { NewItemBadge } from '../badge/NewItemBadge'
 import { ActivityIcon, RiskIcon, TvlIcon } from '../icons'
 import { MenuCloseIcon } from '../icons/symbols/MenuCloseIcon'
 import { Logo } from '../Logo'
@@ -62,7 +61,6 @@ export function SidebarMenu(props: SidebarMenuProps) {
                   <li className="flex items-center gap-2 font-medium">
                     <ActivityIcon className="h-auto w-4" />
                     <a href="/scaling/activity">Activity</a>
-                    <NewItemBadge />
                   </li>
                 )}
               </ul>
@@ -74,18 +72,15 @@ export function SidebarMenu(props: SidebarMenuProps) {
                 <span className="text-sm font-bold uppercase tracking-wider text-pink-900 dark:text-pink-200">
                   <a href="/bridges/tvl">Bridges</a>
                 </span>
-                <NewItemBadge />
               </div>
               <ul className="ml-4 flex flex-col gap-4">
                 <li className="flex items-center gap-2 font-medium">
                   <TvlIcon className="h-auto w-4" />
                   <a href="/bridges/tvl">Total Value Locked</a>
-                  <NewItemBadge />
                 </li>
                 <li className="flex items-center gap-2 font-medium">
                   <RiskIcon className="h-auto w-4" />
                   <a href="/bridges/risk">Risks</a>
-                  <NewItemBadge />
                 </li>
               </ul>
             </li>

--- a/packages/frontend/src/components/navigation-tabs/BridgesNavigationTabs.tsx
+++ b/packages/frontend/src/components/navigation-tabs/BridgesNavigationTabs.tsx
@@ -17,7 +17,6 @@ export function BridgesNavigationTabs(props: BridgesNavigationTabsProps) {
           icon: <TvlIcon />,
           link: '/bridges/tvl',
           selected: props.selected === 'tvl',
-          new: true,
         },
         {
           icon: <RiskIcon />,
@@ -25,7 +24,6 @@ export function BridgesNavigationTabs(props: BridgesNavigationTabsProps) {
           shortTitle: 'Risks',
           link: '/bridges/risk',
           selected: props.selected === 'risk',
-          new: true,
         },
       ]}
     />

--- a/packages/frontend/src/components/navigation-tabs/ScalingNavigationTabs.tsx
+++ b/packages/frontend/src/components/navigation-tabs/ScalingNavigationTabs.tsx
@@ -32,7 +32,6 @@ export function ScalingNavigationTabs(props: ScalingNavigationTabsProps) {
       icon: <ActivityIcon />,
       link: '/scaling/activity',
       selected: props.selected === 'activity',
-      new: true,
     })
   }
   return <NavigationTabs pages={pages} />


### PR DESCRIPTION
Resolves L2B-1322

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27a6a0d</samp>

Removed `NewItemBadge` components and `new` properties from the navigation UI components. This simplifies the UI and avoids confusion for users who might expect new features or updates.
​
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 27a6a0d</samp>

> _Sing, O Muse, of the code review that simplified the UI_
> _Of the scaling and the bridges tabs, where `new` was bid adieu_
> _Like the sun-god who removes his rays from the darkening sky_
> _So the `NewItemBadge` component from the navbar was made to fly_

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27a6a0d</samp>

* Remove `NewItemBadge` component from `Navbar.tsx` and `SidebarMenu.tsx` as it is no longer needed to indicate new features in the navigation menu ([link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-9b19d235f121b4a685d68e6236409faf243a5ba573c856935cb41039b29f3e00L4), [link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-9b19d235f121b4a685d68e6236409faf243a5ba573c856935cb41039b29f3e00L82), [link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-32d36536690e132febe91dd238788570dc43b7814a5db4660a59e78de5ae9b1aL4), [link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-32d36536690e132febe91dd238788570dc43b7814a5db4660a59e78de5ae9b1aL65), [link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-32d36536690e132febe91dd238788570dc43b7814a5db4660a59e78de5ae9b1aL77), [link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-32d36536690e132febe91dd238788570dc43b7814a5db4660a59e78de5ae9b1aL83-R83))
* Remove `new` property from tab objects in `BridgesNavigationTabs.tsx` and `ScalingNavigationTabs.tsx` as it is no longer needed to indicate new features in the navigation tabs ([link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-af504716deb0fa082c1e8dc08efc30d953f0f59ad76c0b2df0bf257476b42109L20), [link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-af504716deb0fa082c1e8dc08efc30d953f0f59ad76c0b2df0bf257476b42109L28), [link](https://github.com/l2beat/l2beat/pull/1402/files?diff=unified&w=0#diff-648cd518b11b9eec4ec7171a726eaa637a3c2e67a65e623384bc79dc9052b796L35))