### PR TITLE
Add sanity check to discord bot

### DIFF
--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -337,7 +337,11 @@ describe(DiscoveryWatcher.name, () => {
 
       const discoveryWatcherRepository = mockObject<DiscoveryWatcherRepository>(
         {
-          findLatest: async () => undefined,
+          findLatest: async () => ({
+            ...mockRecord,
+            discovery: DISCOVERY_RESULT,
+            configHash: mockConfig(PROJECT_A).hash,
+          }),
           addOrUpdate: async () => '',
         },
       )
@@ -346,8 +350,8 @@ describe(DiscoveryWatcher.name, () => {
         run: mockFn(),
       })
 
-      discoveryEngine.run.resolvesToOnce(DISCOVERY_RESULT)
       discoveryEngine.run.resolvesToOnce({ ...DISCOVERY_RESULT, contracts: [] })
+      discoveryEngine.run.resolvesToOnce({ ...DISCOVERY_RESULT })
 
       const discoveryWatcher = new DiscoveryWatcher(
         provider,

--- a/packages/backend/src/core/DiscoveryWatcher.test.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.test.ts
@@ -6,7 +6,7 @@ import {
   ProjectParameters,
   UnixTime,
 } from '@l2beat/shared'
-import { expect, mockObject } from 'earl'
+import { expect, mockFn, mockObject } from 'earl'
 import { providers } from 'ethers'
 
 import {
@@ -105,15 +105,15 @@ describe(DiscoveryWatcher.name, () => {
       expect(provider.getBlockNumber).toHaveBeenCalledTimes(1)
       // reads all the configs
       expect(configReader.readAllConfigs).toHaveBeenCalledTimes(1)
-      // runs discovery for every project
-      expect(discoveryEngine.run).toHaveBeenCalledTimes(2)
+      // runs discovery for every project + sanity check
+      expect(discoveryEngine.run).toHaveBeenCalledTimes(2 * 2)
       expect(discoveryEngine.run).toHaveBeenNthCalledWith(
         1,
         mockConfig(PROJECT_A),
         BLOCK_NUMBER,
       )
       expect(discoveryEngine.run).toHaveBeenNthCalledWith(
-        2,
+        3,
         mockConfig(PROJECT_B),
         BLOCK_NUMBER,
       )
@@ -186,6 +186,8 @@ describe(DiscoveryWatcher.name, () => {
       expect(discoveryWatcherRepository.findLatest).toHaveBeenOnlyCalledWith(
         PROJECT_A,
       )
+      // runs discovery
+      expect(discoveryEngine.run).toHaveBeenCalledTimes(1)
       // does not send a notification
       expect(discordClient.sendMessage).toHaveBeenCalledTimes(0)
     })
@@ -225,15 +227,15 @@ describe(DiscoveryWatcher.name, () => {
       expect(provider.getBlockNumber).toHaveBeenCalledTimes(1)
       // reads all the configs
       expect(configReader.readAllConfigs).toHaveBeenCalledTimes(1)
-      // runs discovery for every project
-      expect(discoveryEngine.run).toHaveBeenCalledTimes(2)
+      // runs discovery for every project + sanity check
+      expect(discoveryEngine.run).toHaveBeenCalledTimes(2 * 2)
       expect(discoveryEngine.run).toHaveBeenNthCalledWith(
         1,
         mockConfig(PROJECT_A),
         BLOCK_NUMBER,
       )
       expect(discoveryEngine.run).toHaveBeenNthCalledWith(
-        2,
+        3,
         mockConfig(PROJECT_B),
         BLOCK_NUMBER,
       )
@@ -325,6 +327,48 @@ describe(DiscoveryWatcher.name, () => {
       expect(discoveryWatcherRepository.addOrUpdate).toHaveBeenCalledTimes(0)
       // does not send a notification
       expect(discordClient.sendMessage).toHaveBeenCalledTimes(0)
+    })
+
+    it('does not send notification if sanity check failed', async () => {
+      const configReader = mockObject<ConfigReader>({
+        readAllConfigs: async () => [mockConfig(PROJECT_A)],
+        readDiscovery: async () => ({ ...mockProject, contracts: [] }),
+      })
+
+      const discoveryWatcherRepository = mockObject<DiscoveryWatcherRepository>(
+        {
+          findLatest: async () => undefined,
+          addOrUpdate: async () => '',
+        },
+      )
+
+      const discoveryEngine = mockObject<DiscoveryEngine>({
+        run: mockFn(),
+      })
+
+      discoveryEngine.run.resolvesToOnce(DISCOVERY_RESULT)
+      discoveryEngine.run.resolvesToOnce({ ...DISCOVERY_RESULT, contracts: [] })
+
+      const discoveryWatcher = new DiscoveryWatcher(
+        provider,
+        discoveryEngine,
+        discordClient,
+        configReader,
+        discoveryWatcherRepository,
+        mockObject<Clock>(),
+        Logger.SILENT,
+      )
+
+      await discoveryWatcher.update(new UnixTime(0))
+
+      // send notification about the error of 3rd party API
+      expect(discordClient.sendMessage).toHaveBeenCalledTimes(1)
+
+      expect(discordClient.sendMessage).toHaveBeenNthCalledWith(
+        1,
+        `⚠️ [${PROJECT_A}]: 3rd party API returns non-integral data`,
+        'INTERNAL',
+      )
     })
 
     it('handles error', async () => {

--- a/packages/backend/src/core/DiscoveryWatcher.ts
+++ b/packages/backend/src/core/DiscoveryWatcher.ts
@@ -1,5 +1,6 @@
 import { Hash256, Logger, ProjectParameters, UnixTime } from '@l2beat/shared'
 import { providers } from 'ethers'
+import { isEqual } from 'lodash'
 import { Gauge, Histogram } from 'prom-client'
 
 import { DiscoveryWatcherRepository } from '../peripherals/database/discovery/DiscoveryWatcherRepository'
@@ -106,6 +107,8 @@ export class DiscoveryWatcher {
     )
 
     if (diff.changes.length > 0) {
+      await this.sanityCheck(discovery, projectConfig, blockNumber)
+
       const dependents = await findDependents(
         projectConfig.name,
         this.configReader,
@@ -211,6 +214,28 @@ export class DiscoveryWatcher {
         () => this.logger.info('Notification to Discord has been sent'),
         (e) => this.logger.error(e),
       )
+    }
+  }
+
+  // 3rd party APIs are unstable, so we do a sanity check before sending
+  // notifications, which makes the same request again and compares the
+  // results.
+  async sanityCheck(
+    discovery: ProjectParameters,
+    projectConfig: DiscoveryConfig,
+    blockNumber: number,
+  ) {
+    const secondDiscovery = await this.discoveryEngine.run(
+      projectConfig,
+      blockNumber,
+    )
+
+    if (!isEqual(discovery, secondDiscovery)) {
+      await this.notify(
+        [`⚠️ [${projectConfig.name}]: 3rd party API returns non-integral data`],
+        'INTERNAL',
+      )
+      throw new Error('Sanity check failed')
     }
   }
 


### PR DESCRIPTION
Sometimes Alchemy reverts without a reason, when it should not, or the Etherscan does not return the source code when it should. This PR aims to add a sanity check to prevent such malfunctions to influence our bot stability.

When a bot detects the chane, it re-runs the discovery to see whether the result is the same, if not then there obviously was an 3rd party API error and should notify this one to our internal discord.

Resolves L2B-1353