### PR TITLE
Show gitcoin beta round banner

### DIFF
--- a/packages/frontend/src/build/config/common.ts
+++ b/packages/frontend/src/build/config/common.ts
@@ -2,6 +2,8 @@ import { bridges, layer2s, milestonesLayer2s, tokenList } from '@l2beat/config'
 
 import { Config } from './Config'
 
+const GITCOIN_BETA_ROUND_END = new Date('2023-05-09T23:59:59Z')
+
 export const common: Omit<Config, 'backend'> = {
   links: {
     twitter: 'https://twitter.com/l2beat',
@@ -13,7 +15,7 @@ export const common: Omit<Config, 'backend'> = {
     forum: 'https://gov.l2beat.com/',
   },
   features: {
-    banner: false,
+    banner: new Date() <= GITCOIN_BETA_ROUND_END,
     gitcoinOption: false,
     hiring: true,
     activity: true,

--- a/packages/frontend/src/components/navbar/Banner.tsx
+++ b/packages/frontend/src/components/navbar/Banner.tsx
@@ -1,17 +1,14 @@
 import React from 'react'
 
-import { ArrowRightIcon } from '../icons'
-
 export function Banner() {
   return (
     <a
-      className="flex items-center justify-center bg-blue-800 px-4 py-1.5 text-center text-xs font-medium text-white"
-      href="https://www.tally.xyz/profile/l2beatcom.eth?governanceId=eip155:42161:0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9"
+      className="block bg-pink-900 px-4 py-1.5 text-center text-xs font-medium text-white"
+      href="https://explorer.gitcoin.co/#/round/1/0xdf22a2c8f6ba9376ff17ee13e6154b784ee92094/0xdf22a2c8f6ba9376ff17ee13e6154b784ee92094-29"
       target="_blank"
     >
-      We're striving to become an Arbitrum DAO delegate.{' '}
-      <span className="ml-2 underline">Checkout our application!</span>
-      <ArrowRightIcon className="ml-0.5 h-3 w-3 fill-white" />
+      L2BEAT is now participating in the Gitcoin Beta Round!
+      <span className="ml-2 underline">Check it out!</span>
     </a>
   )
 }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e44413e</samp>

Added a banner feature flag and updated the banner content to promote the Gitcoin Beta Round on the frontend. The feature flag is based on a constant for the end date of the grant matching program in `common.ts`, and the banner component in `Banner.tsx` displays the new message and link.
