### PR TITLE
Add pausable in contract details

### DIFF
--- a/packages/config/src/common/ProjectContracts.ts
+++ b/packages/config/src/common/ProjectContracts.ts
@@ -33,6 +33,13 @@ export interface ProjectContractSingleAddress {
   upgradableBy?: string[]
   /** Other considerations worth mentioning about the upgrade process */
   upgradeConsiderations?: string
+  /** Pasuable contract */
+  pausable?: {
+    /** Is it paused? **/
+    paused: boolean
+    /** Who can pause/unpause the contract */
+    pausableBy: string[]
+  }
 }
 
 export function isSingleAddress(

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -62,8 +62,19 @@ export class ProjectDiscovery {
     descriptionOrOptions?: string | Partial<ProjectContractSingleAddress>,
   ): ProjectContractSingleAddress {
     const contract = this.getContract(identifier)
+    const values = contract.values ?? {}
     if (typeof descriptionOrOptions === 'string') {
       descriptionOrOptions = { description: descriptionOrOptions }
+      const paused = values.paused as boolean | undefined
+      if (typeof paused === 'boolean') {
+        const owner = values.owner as string | undefined
+        if (typeof owner === 'string') {
+          descriptionOrOptions.description += ` The contract is pausable.`
+          if (paused) {
+            descriptionOrOptions.description += ` The contract is currently paused.`
+          }
+        }
+      }
     }
     return {
       name: contract.name,

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -62,19 +62,19 @@ export class ProjectDiscovery {
     descriptionOrOptions?: string | Partial<ProjectContractSingleAddress>,
   ): ProjectContractSingleAddress {
     const contract = this.getContract(identifier)
-    const values = contract.values ?? {}
     if (typeof descriptionOrOptions === 'string') {
       descriptionOrOptions = { description: descriptionOrOptions }
-      const paused = values.paused as boolean | undefined
-      if (typeof paused === 'boolean') {
-        const owner = values.owner as string | undefined
-        if (typeof owner === 'string') {
-          descriptionOrOptions.description += ` The contract is pausable.`
-          if (paused) {
-            descriptionOrOptions.description += ` The contract is currently paused.`
-          }
-        }
+    } else if (descriptionOrOptions?.pausable !== undefined) {
+      const descriptions = [
+        descriptionOrOptions.description,
+        `The contract is pausable by ${descriptionOrOptions.pausable.pausableBy.join(
+          ', ',
+        )}.`,
+      ]
+      if (descriptionOrOptions.pausable.paused) {
+        descriptions.push('The contract is currently paused.')
       }
+      descriptionOrOptions.description = descriptions.filter(isString).join(' ')
     }
     return {
       name: contract.name,

--- a/packages/config/src/layer2s/bobanetwork.ts
+++ b/packages/config/src/layer2s/bobanetwork.ts
@@ -230,14 +230,28 @@ export const bobanetwork: Layer2 = {
         'BondManager',
         "The Bond Manager contract will handle deposits in the form of an ERC20 token from bonded Proposers. It will also handle the accounting of gas costs spent by a Verifier during the course of a challenge. In the event of a successful challenge, the faulty Proposer's bond will be slashed, and the Verifier's gas costs will be refunded. Current mock implementation allows only OVM_Proposer to propose new state roots. No slashing is implemented.",
       ),
-      discovery.getContractDetails(
-        'L1CrossDomainMessenger_1',
-        "The L1 Cross Domain Messenger (L1xDM) contract sends messages from L1 to L2, and relays messages from L2 onto L1. In the event that a message sent from L1 to L2 is rejected for exceeding the L2 epoch gas limit, it can be resubmitted via this contract's replay function.",
-      ),
-      discovery.getContractDetails(
-        'L1CrossDomainMessengerFast',
-        'The L1 Cross Domain Messenger (L1xDM) contract that allows permissioned relayer to relay messages from L2 onto L1 immediately without waiting for the end of the fraud proof window. It is used only for L2->L1 communication.',
-      ),
+      discovery.getContractDetails('L1CrossDomainMessenger_1', {
+        description:
+          "The L1 Cross Domain Messenger (L1xDM) contract sends messages from L1 to L2, and relays messages from L2 onto L1. In the event that a message sent from L1 to L2 is rejected for exceeding the L2 epoch gas limit, it can be resubmitted via this contract's replay function.",
+        pausable: {
+          paused: discovery.getContractValue<boolean>(
+            'L1CrossDomainMessenger_1',
+            'paused',
+          ),
+          pausableBy: ['Owner'],
+        },
+      }),
+      discovery.getContractDetails('L1CrossDomainMessengerFast', {
+        description:
+          'The L1 Cross Domain Messenger (L1xDM) contract that allows permissioned relayer to relay messages from L2 onto L1 immediately without waiting for the end of the fraud proof window. It is used only for L2->L1 communication.',
+        pausable: {
+          paused: discovery.getContractValue<boolean>(
+            'L1CrossDomainMessengerFast',
+            'paused',
+          ),
+          pausableBy: ['Owner'],
+        },
+      }),
       discovery.getContractDetails(
         'L1MultiMessageRelayer',
         'Helper contract that allows for relaying a batch of messages using L1CrossDomainMessenger.',
@@ -258,7 +272,13 @@ export const bobanetwork: Layer2 = {
         'L1StandardBridge',
         'Main entry point for users depositing ERC20 tokens and ETH that do not require custom gateway.',
       ),
-      discovery.getContractDetails('L1NFTBridge', 'Standard NFT bridge.'),
+      discovery.getContractDetails('L1NFTBridge', {
+        description: 'Standard NFT bridge.',
+        pausable: {
+          paused: discovery.getContractValue<boolean>('L1NFTBridge', 'paused'),
+          pausableBy: ['Owner'],
+        },
+      }),
     ],
     risks: [CONTRACTS.UPGRADE_NO_DELAY_RISK],
   },

--- a/packages/frontend/src/utils/project/getContractSection.ts
+++ b/packages/frontend/src/utils/project/getContractSection.ts
@@ -240,7 +240,7 @@ function makeTechnologyContract(
     if (tokens && !isEscrow) {
       const tokenText =
         tokens === '*'
-          ? 'This contract can store any token'
+          ? 'This contract can store any token.'
           : `This contract stores the following tokens: ${tokens.join(', ')}.`
       if (!description) {
         description = tokenText


### PR DESCRIPTION
Update: I changed it to a semi-automatic approach as proposed by Piotr 

Old: I tried to add the info that a contract is pausable in the contract details, but I'm not sure this is the best approach. An issue I see is the `paused` name could be used by some contract with some other functionality (idk if checkable) -- also I tried to include the owner but for some contracts there is no name associated and the address looks ugly (e.g. EOAs)