### PR TITLE
Change default chart range to 1Y

### DIFF
--- a/packages/frontend/src/components/chart/RangeControls.tsx
+++ b/packages/frontend/src/components/chart/RangeControls.tsx
@@ -21,7 +21,7 @@ export function RangeControls({
         { value: '90D', className: '!hidden sm:!block' },
         { value: '180D', className: '!hidden sm:!block' },
         { value: '1Y' },
-        { value: 'MAX', checked: true },
+        { value: 'MAX' },
       ]}
     />
   )

--- a/packages/frontend/src/components/chart/RangeControls.tsx
+++ b/packages/frontend/src/components/chart/RangeControls.tsx
@@ -20,7 +20,7 @@ export function RangeControls({
         { value: '30D' },
         { value: '90D', className: '!hidden sm:!block' },
         { value: '180D', className: '!hidden sm:!block' },
-        { value: '1Y' },
+        { value: '1Y', checked: true },
         { value: 'MAX' },
       ]}
     />

--- a/packages/frontend/src/components/chart/configure/index.ts
+++ b/packages/frontend/src/components/chart/configure/index.ts
@@ -3,6 +3,7 @@ import { toDays } from './controls/toDays'
 import { handleEffect } from './effects/handleEffect'
 import { ChartElements, getChartElements } from './elements'
 import { InitMessage, Message } from './messages'
+import { isMobile } from './render/isMobile'
 import { render } from './render/render'
 import { EMPTY_STATE } from './state/empty'
 import { Milestones, State } from './state/State'
@@ -44,8 +45,10 @@ function configureChart(chart: HTMLElement) {
 function getInitMessage(elements: ChartElements): InitMessage {
   const initialView = elements.chart.dataset.type === 'tvl' ? 'tvl' : 'activity'
 
+  const initialRange = isMobile() ? '30D' : '180D'
+
   const daysValue =
-    elements.controls.days.find((x) => x.checked)?.value ?? '30D'
+    elements.controls.days.find((x) => x.checked)?.value ?? initialRange
   const days = toDays(daysValue)
 
   const showEthereum = !!elements.controls.showEthereum?.checked

--- a/packages/frontend/src/components/chart/configure/index.ts
+++ b/packages/frontend/src/components/chart/configure/index.ts
@@ -3,7 +3,6 @@ import { toDays } from './controls/toDays'
 import { handleEffect } from './effects/handleEffect'
 import { ChartElements, getChartElements } from './elements'
 import { InitMessage, Message } from './messages'
-import { isMobile } from './render/isMobile'
 import { render } from './render/render'
 import { EMPTY_STATE } from './state/empty'
 import { Milestones, State } from './state/State'
@@ -45,10 +44,7 @@ function configureChart(chart: HTMLElement) {
 function getInitMessage(elements: ChartElements): InitMessage {
   const initialView = elements.chart.dataset.type === 'tvl' ? 'tvl' : 'activity'
 
-  const initialRange = isMobile() ? '30D' : '180D'
-
-  const daysValue =
-    elements.controls.days.find((x) => x.checked)?.value ?? initialRange
+  const daysValue = elements.controls.days.find((x) => x.checked)?.value ?? '1Y'
   const days = toDays(daysValue)
 
   const showEthereum = !!elements.controls.showEthereum?.checked

--- a/packages/frontend/src/components/chart/configure/render/isMobile.ts
+++ b/packages/frontend/src/components/chart/configure/render/isMobile.ts
@@ -1,0 +1,3 @@
+export function isMobile() {
+  return window.innerWidth < 750
+}

--- a/packages/frontend/src/components/chart/configure/render/renderHover.ts
+++ b/packages/frontend/src/components/chart/configure/render/renderHover.ts
@@ -2,6 +2,7 @@ import { formatTps } from '../../../../utils/formatTps'
 import { ChartElements } from '../elements'
 import { State } from '../state/State'
 import { formatCurrencyExactValue } from '../update/view/format'
+import { isMobile } from './isMobile'
 
 export function renderHover(
   elements: ChartElements,
@@ -93,7 +94,7 @@ export function renderHover(
       if (point.milestone.description) {
         rows.push(renderDescriptionRow(point.milestone.description))
       }
-      if (window.innerWidth < 750) {
+      if (isMobile()) {
         rows.push(
           `<div class="text-link"><a href="${point.milestone.link}" target="blank">Learn more</a></div>`,
         )

--- a/packages/frontend/src/components/chart/configure/render/renderMilestones.ts
+++ b/packages/frontend/src/components/chart/configure/render/renderMilestones.ts
@@ -1,4 +1,5 @@
 import { State } from '../state/State'
+import { isMobile } from './isMobile'
 
 export function renderMilestones(state: State, milestones: HTMLElement) {
   const points = state.view.chart?.points
@@ -18,11 +19,10 @@ export function renderMilestones(state: State, milestones: HTMLElement) {
 }
 
 function getMilestoneHtml(x: number, url: string) {
-  const isMobile = window.innerWidth < 750
   return `
   <div class="absolute z-40 select-none scale-75  md:scale-100" 
         style="left: ${x + offset}px; top: ${offset}px">
-    ${isMobile ? '' : `<a href="${url}" target="_blank">`}
+    ${isMobile() ? '' : `<a href="${url}" target="_blank">`}
       <svg
         width="${iconHeight}"
         height="${iconHeight}"
@@ -41,7 +41,7 @@ function getMilestoneHtml(x: number, url: string) {
           stroke-width="2"
         /> 
       <svg>
-    ${isMobile ? '' : '</a>'}
+    ${isMobile() ? '' : '</a>'}
   </div>`
 }
 

--- a/packages/frontend/src/scripts/configureTooltips.ts
+++ b/packages/frontend/src/scripts/configureTooltips.ts
@@ -1,3 +1,4 @@
+import { isMobile } from '../components/chart/configure/render/isMobile'
 import { makeQuery } from './query'
 
 export function configureTooltips() {
@@ -17,7 +18,7 @@ export function configureTooltips() {
   let visible = false
 
   function show(element: HTMLElement, title: string) {
-    if (element.dataset.tooltipBig && window.innerWidth < 750) return
+    if (element.dataset.tooltipBig && isMobile()) return
     visible = true
     activeElement = element
     tooltip.classList.toggle('max-w-[300px]', !element.dataset.tooltipBig)


### PR DESCRIPTION
The initial idea was 180D on desktop and 90D on mobile. After trying that, it was a bit to empty IMO. I think that 1Y gives a good balance between amount of detail and being not too clattered

Resolves L2B-1475