### PR TITLE
Fix delay warning

### DIFF
--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -427,7 +427,11 @@ export const arbitrum: Layer2 = {
         ...upgradesGatewaysAdmin,
       }),
     ],
-    risks: [CONTRACTS.UPGRADE_NO_DELAY_RISK],
+    risks: [
+      CONTRACTS.UPGRADE_WITH_DELAY_RISK_WITH_SC(
+        Math.round(totalDelay / 86400).toString(), // delay in days
+      ),
+    ],
   },
   milestones: [
     {

--- a/packages/config/src/layer2s/common/contracts.ts
+++ b/packages/config/src/layer2s/common/contracts.ts
@@ -26,6 +26,14 @@ function UPGRADE_WITH_DELAY_RISK(delay: string): ProjectRisk {
   }
 }
 
+function UPGRADE_WITH_DELAY_RISK_WITH_SC(delay: string): ProjectRisk {
+  return {
+    category: 'Funds can be stolen if',
+    text: `a contract receives a malicious code upgrade. There is a ${delay} days delay on code upgrades unless upgrade is initiated by the \
+    Security Council in which case there is no delay.`,
+  }
+}
+
 function UPGRADE_WITH_DELAY_SECONDS_RISK(delaySeconds: number): ProjectRisk {
   if (delaySeconds < DANGER_DELAY_THRESHOLD_SECONDS) {
     return UPGRADE_NO_DELAY_RISK
@@ -50,5 +58,6 @@ export const CONTRACTS = {
   UPGRADE_NO_DELAY_RISK,
   UPGRADE_WITH_DELAY_RISK,
   UPGRADE_WITH_DELAY_SECONDS_RISK,
+  UPGRADE_WITH_DELAY_RISK_WITH_SC,
   ARBITRUM_OLD_BRIDGE,
 }


### PR DESCRIPTION
Fixes erronous warning at the bottom of smart contracts upgradability from:

<img width="856" alt="image" src="https://github.com/l2beat/l2beat/assets/30408726/f5edfd2e-4365-4148-bad8-7bd06082cd60">

to 

<img width="774" alt="image" src="https://github.com/l2beat/l2beat/assets/30408726/a8af71ec-5098-4dd5-897c-8a93d2bcdeb9">
