### PR TITLE
Move category field to display in project config

### DIFF
--- a/packages/config/src/bridges/acrossV2.ts
+++ b/packages/config/src/bridges/acrossV2.ts
@@ -14,6 +14,7 @@ export const acrossV2: Bridge = {
   display: {
     name: 'Across V2',
     slug: 'acrossv2',
+    category: 'Liquidity Network',
     links: {
       websites: ['https://across.to/'],
       apps: ['https://across.to/'],
@@ -64,7 +65,6 @@ export const acrossV2: Bridge = {
     destinationToken: RISK_VIEW.CANONICAL,
   },
   technology: {
-    category: 'Liquidity Network',
     destination: ['Optimism', 'Polygon', 'Boba', 'Arbitrum'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/allbridge.ts
+++ b/packages/config/src/bridges/allbridge.ts
@@ -16,6 +16,7 @@ export const allbridge: Bridge = {
     For its stableconin liquidity network it is using either own AMB or Wormhole to pass messages. Allbridge bridge is a token bridge implemented\
     as a separate contract. Both bridges contains a number of core, unverified smart contracts and it is owned by an EOA\
     account that can drain all funds.',
+    category: 'Hybrid',
     links: {
       websites: ['https://app.allbridge.io/'],
       apps: ['https://core.allbridge.io/'],
@@ -62,7 +63,6 @@ export const allbridge: Bridge = {
   },
   technology: {
     canonical: false,
-    category: 'Hybrid',
     destination: [
       'Aurora',
       'Avalanche',

--- a/packages/config/src/bridges/amarok.ts
+++ b/packages/config/src/bridges/amarok.ts
@@ -15,6 +15,7 @@ export const amarok: Bridge = {
     description:
       'Connext is a multilayered system that aggregates various native AMBs in an Hub-and-Spoke architecture with Ethereum being the Hub receiving\
     messages from other domains. It implements a liquidity network on top of its Hub-and-Spoke architecture.',
+    category: 'Liquidity Network',
     links: {
       apps: ['https://bridge.connext.network/', 'https://connextscan.io/'],
       websites: ['https://blog.connext.network/'],
@@ -55,7 +56,6 @@ export const amarok: Bridge = {
   },
   technology: {
     canonical: false,
-    category: 'Liquidity Network',
     destination: ['Gnosis', 'Optimism', 'Arbitrum', 'Polygon', 'BSC'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/aptos.ts
+++ b/packages/config/src/bridges/aptos.ts
@@ -26,6 +26,7 @@ export const aptos: Bridge = {
     },
     description:
       'Aptos Bridge is built on top of LayerZero protocol and is a token bridge for transferring assets from Ethereum to Aptos. It leverages an oracle and relayer for cross-chain security for the protocol.',
+    category: 'Token Bridge',
   },
   riskView: {
     validatedBy: {
@@ -44,7 +45,6 @@ export const aptos: Bridge = {
   },
   technology: {
     destination: ['Aptos'],
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/avalanche.ts
+++ b/packages/config/src/bridges/avalanche.ts
@@ -11,6 +11,7 @@ export const avalanche: Bridge = {
     slug: 'avalanche',
     description:
       'Avalanche Bridge is an externally validated bridge. It uses a set of Wardens using secure SGX Enclave to sign transfers. On Ethereum side it uses periodically rotated EOA address for an Escrow. In the announcement, 3 out of 4 Warden signatures are required, however the exact number is impossible to verify for an external observer.',
+    category: 'Token Bridge',
     links: {
       websites: ['https://www.avax.network/'],
       explorers: ['https://subnets.avax.network/'],
@@ -92,7 +93,6 @@ export const avalanche: Bridge = {
   technology: {
     destination: ['Avalanche'],
     canonical: true,
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/cBridge.ts
+++ b/packages/config/src/bridges/cBridge.ts
@@ -17,6 +17,7 @@ export const cBridge: Bridge = {
       'Celer cBridge offers cross-chain token bridging in two modes: Token Bridge and Liquidity Network. It also offers AMB facility - ability to pass arbitrary\
       messages across chains. It leverages the "State Guardian Network" aka SGN to perform cross-chain communication.\
       For Liquidity Network, liquidity providers need to rely on SGN to remove their funds from the network.',
+    category: 'Hybrid',
     links: {
       websites: ['https://www.celer.network/'],
       apps: ['https://cbridge.celer.network/'],
@@ -78,7 +79,6 @@ export const cBridge: Bridge = {
       'Metis',
       'Boba Network',
     ],
-    category: 'Hybrid',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/connext.ts
+++ b/packages/config/src/bridges/connext.ts
@@ -14,6 +14,7 @@ export const connext: Bridge = {
   display: {
     name: 'Connext (Legacy)',
     slug: 'connext-legacy',
+    category: 'Liquidity Network',
     links: {
       websites: [
         'https://bridge.connext.network/',
@@ -41,7 +42,6 @@ export const connext: Bridge = {
     ],
   },
   technology: {
-    category: 'Liquidity Network',
     destination: [
       'Avalanche',
       'BNB Chain',

--- a/packages/config/src/bridges/debridge.ts
+++ b/packages/config/src/bridges/debridge.ts
@@ -13,6 +13,7 @@ export const debridge: Bridge = {
   display: {
     name: 'deBridge',
     slug: 'debridge',
+    category: 'Token Bridge',
     links: {
       websites: ['https://debridge.finance'],
       documentation: ['https://docs.debridge.finance'],
@@ -51,7 +52,6 @@ export const debridge: Bridge = {
   },
   technology: {
     destination: ['Arbitrum', 'Avalanche', 'BNB Chain', 'Polygon'],
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/gravity.ts
+++ b/packages/config/src/bridges/gravity.ts
@@ -12,6 +12,7 @@ export const gravity: Bridge = {
   display: {
     name: 'Gravity',
     slug: 'gravity',
+    category: 'Token Bridge',
     links: {
       websites: ['https://www.gravitybridge.net/'],
       explorers: [
@@ -60,7 +61,6 @@ export const gravity: Bridge = {
   technology: {
     destination: ['Cosmos'],
     canonical: false,
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/harmony.ts
+++ b/packages/config/src/bridges/harmony.ts
@@ -9,6 +9,7 @@ export const harmony: Bridge = {
     name: 'Harmony',
     slug: 'harmony',
     description: 'Externally Validated Token Bridge secured by a multisig.',
+    category: 'Token Bridge',
     links: {
       websites: ['https://bridge.harmony.one/erc20'],
     },
@@ -46,7 +47,6 @@ export const harmony: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Harmony'],
   },
   riskView: {

--- a/packages/config/src/bridges/hop.ts
+++ b/packages/config/src/bridges/hop.ts
@@ -12,6 +12,7 @@ export const hop: Bridge = {
   display: {
     name: 'Hop',
     slug: 'hop',
+    category: 'Liquidity Network',
     links: {
       websites: ['https://hop.exchange/'],
       repositories: ['https://github.com/hop-protocol'],
@@ -63,7 +64,6 @@ export const hop: Bridge = {
     ],
   },
   technology: {
-    category: 'Liquidity Network',
     destination: ['Polygon', 'Gnosis', 'Optimism', 'Arbitrum'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/hyphen.ts
+++ b/packages/config/src/bridges/hyphen.ts
@@ -13,6 +13,7 @@ export const hyphen: Bridge = {
   display: {
     name: 'Hyphen',
     slug: 'hyphen',
+    category: 'Liquidity Network',
     links: {
       websites: ['https://hyphen.biconomy.io/'],
       documentation: [
@@ -41,7 +42,6 @@ export const hyphen: Bridge = {
     ],
   },
   technology: {
-    category: 'Liquidity Network',
     destination: [
       'Polygon',
       'Avalanche',

--- a/packages/config/src/bridges/lzOmnichain.ts
+++ b/packages/config/src/bridges/lzOmnichain.ts
@@ -16,6 +16,7 @@ export const lzOmnichain: Bridge = {
     slug: 'omnichain',
     warning:
       'The security parameters of each individual token must be individually assessed, and can be changed by the developers. Omnichain tokens are are in the early stages of development, use at your own risk.',
+    category: 'Token Bridge',
     links: {
       websites: ['https://layerzero.network/'],
       repositories: [
@@ -48,7 +49,6 @@ export const lzOmnichain: Bridge = {
   },
   technology: {
     destination: ['Various'],
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/multichain.ts
+++ b/packages/config/src/bridges/multichain.ts
@@ -17,6 +17,7 @@ export const multichain: Bridge = {
       As a result there is more tokens minted (e.g. DAI on Fantom) than there are tokens directly backing them in escrow.',
     description:
       'Multichain is an externally validated bridge. It uses a network of nodes running SMPC (Secure Multi Party Computation) protocol. It supports dozens of blockchains and thousands of tokens with both Token Bridge and Liquidity Network.',
+    category: 'Hybrid',
     links: {
       websites: ['https://multichain.xyz/'],
       repositories: ['https://github.com/anyswap'],
@@ -35,7 +36,6 @@ export const multichain: Bridge = {
     })),
   },
   technology: {
-    category: 'Hybrid',
     destination: config.destinations,
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/near.ts
+++ b/packages/config/src/bridges/near.ts
@@ -19,6 +19,7 @@ export const near: Bridge = {
     },
     description:
       'Rainbow bridge is a light client based bridge between NEAR/AURORA and Ethereum that allows for asset and data movement between these chains. For better gas efficiency from NEAR to Ethereum, it leverages optimistic validation, which adds some trust assumption and latency.',
+    category: 'Token Bridge',
   },
   config: {
     associatedTokens: ['AURORA'],
@@ -69,7 +70,6 @@ export const near: Bridge = {
   },
   technology: {
     canonical: true,
-    category: 'Token Bridge',
     destination: ['Near', 'Aurora'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/nomad.ts
+++ b/packages/config/src/bridges/nomad.ts
@@ -13,6 +13,7 @@ export const nomad: Bridge = {
     slug: 'nomad',
     warning:
       'The Nomad token bridge contract has recently been exploited and currently is not operational.',
+    category: 'Token Bridge',
     links: {
       websites: ['https://app.nomad.xyz/', 'https://docs.nomad.xyz/'],
       repositories: ['https://github.com/nomad-xyz/monorepo'],
@@ -44,7 +45,6 @@ export const nomad: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Avalanche', 'Evmos', 'Milkomedia C1', 'Moonbeam'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/omni.ts
+++ b/packages/config/src/bridges/omni.ts
@@ -10,6 +10,7 @@ export const omni: Bridge = {
   display: {
     name: 'Omni Bridge',
     slug: 'omni',
+    category: 'Token Bridge',
     links: {
       websites: ['https://omni.gnosischain.com/'],
       apps: ['https://omni.gnosischain.com/'],
@@ -65,7 +66,6 @@ export const omni: Bridge = {
     },
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Gnosis Chain'],
     canonical: true,
     principleOfOperation: {

--- a/packages/config/src/bridges/opticsV1.ts
+++ b/packages/config/src/bridges/opticsV1.ts
@@ -10,6 +10,7 @@ export const opticsV1: Bridge = {
   display: {
     name: 'Optics V1',
     slug: 'opticsv1',
+    category: 'Token Bridge',
     links: {
       websites: ['https://old.optics.app/'],
       repositories: ['https://github.com/celo-org/optics-monorepo'],
@@ -40,7 +41,6 @@ export const opticsV1: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Celo', 'Polygon'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/opticsV2.ts
+++ b/packages/config/src/bridges/opticsV2.ts
@@ -10,6 +10,7 @@ export const opticsV2: Bridge = {
   display: {
     name: 'Optics V2',
     slug: 'opticsv2',
+    category: 'Token Bridge',
     links: {
       websites: ['https://optics.app/'],
       repositories: ['https://github.com/celo-org/optics-monorepo'],
@@ -38,7 +39,6 @@ export const opticsV2: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Celo', 'Polygon'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/bridges/orbit.ts
+++ b/packages/config/src/bridges/orbit.ts
@@ -13,6 +13,7 @@ export const orbit: Bridge = {
   display: {
     name: 'Orbit Bridge',
     slug: 'orbit',
+    category: 'Token Bridge',
     links: {
       websites: [
         'https://bridge.orbitchain.io/',
@@ -74,7 +75,6 @@ export const orbit: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     //TODO: Originally for KLAYTN, Orbit Bridge now supports multiple chains and has Liquidity Network
     destination: [
       'Orbit',

--- a/packages/config/src/bridges/orbiter.ts
+++ b/packages/config/src/bridges/orbiter.ts
@@ -9,6 +9,7 @@ export const orbiter: Bridge = {
   display: {
     name: 'Orbiter',
     slug: 'orbiter',
+    category: 'Liquidity Network',
     links: {
       websites: ['https://orbiter.finance/'],
       documentation: ['https://docs.orbiter.finance/'],
@@ -52,7 +53,6 @@ export const orbiter: Bridge = {
     ],
   },
   technology: {
-    category: 'Liquidity Network',
     destination: [
       'zkSync',
       'Polygon',

--- a/packages/config/src/bridges/pNetwork.ts
+++ b/packages/config/src/bridges/pNetwork.ts
@@ -16,6 +16,7 @@ export const pNetwork: Bridge = {
     warning:
       'TVL of the bridge does not take into the account pTokens minted on Ethereum. These are wrapped tokens that should be backed 1:1 with their native counterparts on\
     other chains, for example pBTC being backed by BTC on  Bitcoin or pFTM backed by FTM on Fantom.',
+    category: 'Token Bridge',
     links: {
       websites: ['https://p.network/'],
       apps: ['https://dapp.ptokens.io/'],
@@ -83,7 +84,6 @@ export const pNetwork: Bridge = {
       'Phoenix',
     ],
     canonical: false,
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/polygonplasma.ts
+++ b/packages/config/src/bridges/polygonplasma.ts
@@ -14,6 +14,7 @@ export const polygonplasma: Bridge = {
     links: polygonpos.display.links,
     description:
       'Polygon Plasma is the official bridge provided by the Polygon team to bridge MATIC tokens from Ethereum to Polygon chain. Originally it was also used to bridge DAI, but now Polygon PoS bridge is recommended. Tokens are bridged to the same Polygon sidechain as if Polygon PoS bridge was used, the only difference is a required 7-day withdrawal delay. This delay was originally designed to allow users to challenge the withdrawal, however this functionality is not deployed.',
+    category: 'Token Bridge',
   },
   config: {
     associatedTokens: ['MATIC'],
@@ -43,7 +44,6 @@ export const polygonplasma: Bridge = {
   technology: {
     destination: ['Polygon'],
     canonical: true,
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/polygonpos.ts
+++ b/packages/config/src/bridges/polygonpos.ts
@@ -30,6 +30,7 @@ export const polygonpos: Bridge = {
     },
     description:
       'Polygon PoS it the official bridge provided by the Polygon team to bridge assets from Ethereum to Polygon chain. The bridge is validated by Polygon validators and allows for asset as well as data movement between Polygon and Ethereum.',
+    category: 'Token Bridge',
   },
   config: {
     escrows: [
@@ -87,7 +88,6 @@ export const polygonpos: Bridge = {
   technology: {
     destination: ['Polygon'],
     canonical: true,
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/polynetwork.ts
+++ b/packages/config/src/bridges/polynetwork.ts
@@ -31,6 +31,7 @@ export const polynetwork: Bridge = {
     },
     description:
       'Poly Bridge allows users to transfer assets between different blockchains using Lock-Mint swap. It uses a PolyNetwork chain to verify and coordinate message passing between Relayers on supported chains. Each chain has a set of Relayers, while PolyNetwork chain has a set of Keepers that sign cross-chain messages. Chains integrated with Poly Bridge need to support light client verification, since validation of cross-chain messages includes verifying block headers and transactions via Merkle proofs. Some of the smart contracts used by the bridge infrastructure are not verified on Etherscan.',
+    category: 'Token Bridge',
   },
   riskView: {
     validatedBy: {
@@ -83,7 +84,6 @@ export const polynetwork: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Various'], // Careful, on UI, the destination options change based on selected asset
     // e.g. ETH supports only some niche chains, while FEI supports e.g. BNB.
     canonical: false,

--- a/packages/config/src/bridges/portal.ts
+++ b/packages/config/src/bridges/portal.ts
@@ -32,6 +32,7 @@ export const portal: Bridge = {
       'Portal Token Bridge is built on top of Wormhole, which is a message passing protocol that leverages specialized network \
       of nodes called Guardians to perform cross-chain communication. It is governed by the same set of Guardians that run the underlying Wormhole\
       protocols.',
+    category: 'Token Bridge',
   },
   config: {
     escrows: [
@@ -90,7 +91,6 @@ export const portal: Bridge = {
       'Polygon',
     ],
     canonical: true,
-    category: 'Token Bridge',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/pulseChain.ts
+++ b/packages/config/src/bridges/pulseChain.ts
@@ -25,6 +25,8 @@ export const pulseChain: Bridge = {
     slug: 'pulsechain',
     description:
       'Bridge used to transfer assets from Ethereum to PulseChain. Transfers are validated by set of trusted Validators.',
+    // not sure about this
+    category: 'Token Bridge',
     links: {
       websites: [
         'https://pulsechain.com/',
@@ -46,8 +48,6 @@ export const pulseChain: Bridge = {
     ],
   },
   technology: {
-    // not sure about this
-    category: 'Token Bridge',
     destination: ['PulseChain'],
     validation: {
       name: 'Validation',

--- a/packages/config/src/bridges/ronin.ts
+++ b/packages/config/src/bridges/ronin.ts
@@ -27,6 +27,7 @@ export const ronin: Bridge = {
     },
     description:
       'Ronin Bridge V2 is the official bridge for the Axie Infinity chain (Ronin chain). It uses external validators to confirm deposits for a typical Token Bridge swap.',
+    category: 'Token Bridge',
   },
   config: {
     associatedTokens: ['AXS'],
@@ -63,7 +64,6 @@ export const ronin: Bridge = {
     },
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Axie Infinity Chain'],
     canonical: true,
     principleOfOperation: {

--- a/packages/config/src/bridges/satellite.ts
+++ b/packages/config/src/bridges/satellite.ts
@@ -9,6 +9,7 @@ export const satellite: Bridge = {
     name: 'Satellite (Axelar)',
     slug: 'satellite',
     description: 'Satellite is a token bridge powered by Axelar network',
+    category: 'Liquidity Network',
     links: {
       websites: ['https://satellite.money/'],
     },
@@ -34,7 +35,6 @@ export const satellite: Bridge = {
   },
   technology: {
     canonical: true,
-    category: 'Liquidity Network',
     destination: ['Various'], // TODO: list the chains
   },
   riskView: {

--- a/packages/config/src/bridges/skaleIMA.ts
+++ b/packages/config/src/bridges/skaleIMA.ts
@@ -32,6 +32,7 @@ export const skaleIMA: Bridge = {
     },
     description:
       'SKALE IMA Bridge is a part of SKALE Network ecosystem. It is a cross-chain BLS threshold bridge that allows users to transfer tokens and arbitrary messages between supported blockchains.',
+    category: 'Token Bridge',
   },
   config: {
     associatedTokens: ['SKL'],
@@ -59,7 +60,6 @@ export const skaleIMA: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Ethereum', 'SKALE'],
     principleOfOperation: {
       name: 'Principle of Operation',

--- a/packages/config/src/bridges/sollet.ts
+++ b/packages/config/src/bridges/sollet.ts
@@ -17,6 +17,7 @@ export const sollet: Bridge = {
       'Sollet Bridge becomes deprecated on Oct 31, 2022. Users are encouraged to use Wormhole instead.',
     description:
       'Externally Validated bridge to Solana that is now being phased out - users are encouraged to use Wormhole instead.',
+    category: 'Token Bridge',
     links: {
       websites: ['https://www.sollet.io/'],
       socialMedia: ['https://projectserum.medium.com/'],
@@ -35,7 +36,6 @@ export const sollet: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Solana'],
     principleOfOperation: {
       name: 'Principle of Operation',

--- a/packages/config/src/bridges/stargate.ts
+++ b/packages/config/src/bridges/stargate.ts
@@ -29,6 +29,7 @@ export const stargate: Bridge = {
     description:
       'StarGate is built on top of LayerZero protocol and is a liquidity network for cross-chain transfer for assets. It leverages an oracle and relayer for cross-chain security for the protocol. \
       Note that StarGate UI also supports omnichain tokens built directly on top of LayerZero protocol, e.g. JOE.',
+    category: 'Liquidity Network',
   },
   riskView: {
     validatedBy: {
@@ -52,7 +53,6 @@ export const stargate: Bridge = {
       'Optimism',
       'Fantom',
     ],
-    category: 'Liquidity Network',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/synapse.ts
+++ b/packages/config/src/bridges/synapse.ts
@@ -28,6 +28,7 @@ export const synapse: Bridge = {
     },
     description:
       'Synapse is a token bridge leveraging a validator between chains and liquidity pools to perform cross-chain and same chain swaps.',
+    category: 'Hybrid',
   },
   config: {
     escrows: [
@@ -61,7 +62,6 @@ export const synapse: Bridge = {
       'Fantom',
       'Metis',
     ],
-    category: 'Hybrid',
     principleOfOperation: {
       name: 'Principle of operation',
       description:

--- a/packages/config/src/bridges/types/Bridge.ts
+++ b/packages/config/src/bridges/types/Bridge.ts
@@ -31,6 +31,7 @@ export interface BridgeDisplay {
   slug: string
   warning?: string
   description?: string
+  category: 'Token Bridge' | 'Liquidity Network' | 'Hybrid'
   links: Partial<ProjectLinks>
 }
 
@@ -47,7 +48,6 @@ export interface BridgeRiskView {
 
 export interface BridgeTechnology {
   canonical?: boolean
-  category: 'Token Bridge' | 'Liquidity Network' | 'Hybrid'
   destination: string[]
   principleOfOperation?: ProjectTechnologyChoice
   validation?: ProjectTechnologyChoice

--- a/packages/config/src/bridges/wormholeV1.ts
+++ b/packages/config/src/bridges/wormholeV1.ts
@@ -13,6 +13,7 @@ export const wormholeV1: Bridge = {
     links: {
       websites: ['https://wormhole.com/'],
     },
+    category: 'Token Bridge',
   },
   config: {
     escrows: [
@@ -34,7 +35,6 @@ export const wormholeV1: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Various'], // TODO: list the chains
     canonical: true,
   },

--- a/packages/config/src/bridges/xdai.ts
+++ b/packages/config/src/bridges/xdai.ts
@@ -9,6 +9,7 @@ export const xdai: Bridge = {
   display: {
     name: 'xDai Bridge',
     slug: 'xdai',
+    category: 'Token Bridge',
     links: {
       websites: ['https://bridge.gnosischain.com/'],
       apps: ['https://bridge.gnosischain.com/'],
@@ -42,7 +43,6 @@ export const xdai: Bridge = {
     ],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Gnosis Chain'],
     principleOfOperation: {
       name: 'Principle of operation',

--- a/packages/config/src/layer2s/apex.ts
+++ b/packages/config/src/layer2s/apex.ts
@@ -50,6 +50,8 @@ export const apex: Layer2 = {
     description:
       'ApeX Pro is a non-custodial trading platform that delivers limitless cross-margined perpetual contracts trading.',
     purpose: 'Exchange',
+    provider: 'StarkEx',
+    category: 'Validium',
     links: {
       websites: ['https://apex.exchange/'],
       apps: ['https://pro.apex.exchange/'],
@@ -102,8 +104,6 @@ export const apex: Layer2 = {
     destinationToken: RISK_VIEW.CANONICAL_USDC,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'Validium',
     stateCorrectness: STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
     newCryptography: NEW_CRYPTOGRAPHY.ZK_STARKS,
     dataAvailability: DATA_AVAILABILITY.STARKEX_OFF_CHAIN,

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -89,6 +89,7 @@ export const arbitrum: Layer2 = {
       validatorAfkTime,
     )} (${validatorAfkBlocks} blocks), the whitelist is dropped and anyone can take over as a new Proposer or Validator.`,
     purpose: 'Universal',
+    category: 'Optimistic Rollup',
     links: {
       websites: ['https://arbitrum.io/', 'https://arbitrum.foundation/'],
       apps: [],
@@ -228,7 +229,6 @@ export const arbitrum: Layer2 = {
     destinationToken: RISK_VIEW.NATIVE_AND_CANONICAL(),
   }),
   technology: {
-    category: 'Optimistic Rollup',
     stateCorrectness: {
       name: 'Fraud proofs ensure state correctness',
       description:

--- a/packages/config/src/layer2s/aztec.ts
+++ b/packages/config/src/layer2s/aztec.ts
@@ -48,6 +48,7 @@ export const aztec: Layer2 = {
     description:
       'Aztec is an open source layer 2 network that aims to bring scalability and privacy to Ethereum. It strives to enable affordable, private crypto payments via zero-knowledge proofs.',
     purpose: 'Private payments',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://aztec.network/'],
       apps: ['https://old.zk.money'],
@@ -168,7 +169,6 @@ export const aztec: Layer2 = {
     },
   }),
   technology: {
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -72,6 +72,7 @@ export const aztecconnect: Layer2 = {
     description:
       'Aztec Connect is an open source layer 2 network that aims to bring scalability and privacy to Ethereum. It strives to enable affordable, private crypto payments via zero-knowledge proofs. Additionally it allows to deposit funds into a variety of DeFi Protocols such as LiDo, Element.Fi, etc.',
     purpose: 'Private DeFi',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://aztec.network/'],
       apps: ['https://zk.money'],
@@ -176,7 +177,6 @@ export const aztecconnect: Layer2 = {
     },
   }),
   technology: {
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/base.ts
+++ b/packages/config/src/layer2s/base.ts
@@ -13,6 +13,8 @@ export const base: Layer2 = {
     description:
       'Base is an Optimistic Rollup that has been developed on the Ethereum network, utilizing OP Stack technology. It is currently in the incubation phase at Coinbase and intends to gradually transition towards a more decentralized model over the coming years. At present, Base is deployed on the Goerli testnet for further testing and optimization.',
     purpose: 'Universal',
+    category: 'Optimistic Rollup',
+    provider: 'Optimism',
     links: {
       websites: ['https://base.org/'],
       apps: ['https://bridge.base.org/'],
@@ -30,10 +32,6 @@ export const base: Layer2 = {
     escrows: [],
   },
   riskView: UPCOMING_RISK_VIEW,
-  technology: {
-    ...TECHNOLOGY.UPCOMING,
-    category: 'Optimistic Rollup',
-    provider: 'Optimism',
-  },
+  technology: TECHNOLOGY.UPCOMING,
   contracts: CONTRACTS.EMPTY,
 }

--- a/packages/config/src/layer2s/bobanetwork.ts
+++ b/packages/config/src/layer2s/bobanetwork.ts
@@ -42,6 +42,8 @@ export const bobanetwork: Layer2 = {
     This facility is using funds from liquidity providers. The second is Hybrid Compute technology that enables Ethereum developers to build dApps that trigger code executed on web-scale infrastructure. \
     Boba Network operates on multiple Layer 1 blockchains.',
     purpose: 'Universal',
+    provider: 'Optimism',
+    category: 'Optimistic Rollup',
     links: {
       websites: ['https://boba.network'],
       apps: [],
@@ -159,8 +161,6 @@ export const bobanetwork: Layer2 = {
     },
   }),
   technology: {
-    provider: 'Optimism',
-    category: 'Optimistic Rollup',
     stateCorrectness: {
       name: 'Fraud proofs are in development',
       description:

--- a/packages/config/src/layer2s/canvasconnect.ts
+++ b/packages/config/src/layer2s/canvasconnect.ts
@@ -50,6 +50,8 @@ export const canvasconnect: Layer2 = {
     description:
       'Canvas Connect is a Layer 2 solution based on StarkEx technology, specifically designed to provide centralized investment and trading services to financial institutions.',
     purpose: 'Privacy, Finance',
+    provider: 'StarkEx',
+    category: 'Validium',
     links: {
       websites: ['https://canvas.co/'],
       apps: [],
@@ -83,8 +85,6 @@ export const canvasconnect: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'Validium',
     stateCorrectness: STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
     newCryptography: NEW_CRYPTOGRAPHY.ZK_STARKS,
     dataAvailability: DATA_AVAILABILITY.STARKEX_OFF_CHAIN,

--- a/packages/config/src/layer2s/cartesiHoneypot.ts
+++ b/packages/config/src/layer2s/cartesiHoneypot.ts
@@ -16,6 +16,7 @@ export const cartesiHoneypot: Layer2 = {
        Honeypot holds real assets with a dual objective: setting a financial benchmark for secure asset management\
        and providing a gamified battlefield for the community to help audit and test Cartesi Rollups.',
     purpose: 'Bug bounty',
+    category: 'Optimistic Rollup',
     links: {
       websites: ['https://cartesi.io/'],
       apps: [],
@@ -33,7 +34,7 @@ export const cartesiHoneypot: Layer2 = {
     escrows: [],
   },
   riskView: UPCOMING_RISK_VIEW,
-  technology: { ...TECHNOLOGY.UPCOMING, category: 'Optimistic Rollup' },
+  technology: TECHNOLOGY.UPCOMING,
   contracts: CONTRACTS.EMPTY,
   milestones: [
     {

--- a/packages/config/src/layer2s/consensys.ts
+++ b/packages/config/src/layer2s/consensys.ts
@@ -13,6 +13,7 @@ export const linea: Layer2 = {
     description:
       'Linea is a zkRollup powered by Consensys zkEVM, designed to scale the Ethereum network. At present, it is undergoing further testing and optimization on the Goerli testnet before deployment.',
     purpose: 'Universal',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://linea.build/'],
       apps: ['https://goerli.linea.build/'],
@@ -30,10 +31,7 @@ export const linea: Layer2 = {
     escrows: [],
   },
   riskView: UPCOMING_RISK_VIEW,
-  technology: {
-    ...TECHNOLOGY.UPCOMING,
-    category: 'ZK Rollup',
-  },
+  technology: TECHNOLOGY.UPCOMING,
   contracts: CONTRACTS.EMPTY,
   milestones: [
     {

--- a/packages/config/src/layer2s/degate.ts
+++ b/packages/config/src/layer2s/degate.ts
@@ -54,6 +54,8 @@ export const degate: Layer2 = {
     description:
       'DeGate is an app-specific ZK rollup that enables a trustless, fast and low-fee decentralized order book exchange, helping users to trade easy and sleep easy. DeGate smart contracts are forked from Loopring V3.',
     purpose: 'Exchange',
+    provider: 'loopring',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://degate.com/'],
       apps: ['https://app.degate.com/'],
@@ -137,8 +139,6 @@ export const degate: Layer2 = {
     },
   }),
   technology: {
-    provider: 'loopring',
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/dydx.ts
+++ b/packages/config/src/layer2s/dydx.ts
@@ -85,6 +85,8 @@ export const dydx: Layer2 = {
     description:
       'dYdX aims to build a powerful and professional exchange for trading crypto assets where users can truly own their trades and, eventually, the exchange itself.',
     purpose: 'Exchange',
+    provider: 'StarkEx',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://dydx.exchange/'],
       apps: [
@@ -179,8 +181,6 @@ export const dydx: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/fuelv1.ts
+++ b/packages/config/src/layer2s/fuelv1.ts
@@ -22,6 +22,7 @@ export const fuelv1: Layer2 = {
     description:
       'Fuel aims to be a complete optimistic rollup with low transaction costs, high speed and high throughput.',
     purpose: 'Payments',
+    category: 'Optimistic Rollup',
     links: {
       websites: ['https://fuel.sh/'],
       apps: [],
@@ -76,7 +77,6 @@ export const fuelv1: Layer2 = {
     },
   }),
   technology: {
-    category: 'Optimistic Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.FRAUD_PROOFS,
       references: [

--- a/packages/config/src/layer2s/gluon.ts
+++ b/packages/config/src/layer2s/gluon.ts
@@ -24,6 +24,7 @@ export const gluon: Layer2 = {
     warning:
       'LeverJ trading platform appears to be in a maintenance mode as the team moved to build NFT trading platform. Social medias associated with the project are silent since mid 2021.',
     purpose: 'Exchange',
+    category: 'Plasma',
     links: {
       websites: ['https://gluon.network/', 'https://leverj.io/'],
       apps: ['https://live.leverj.io/'],
@@ -70,7 +71,6 @@ export const gluon: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    category: 'Plasma',
     stateCorrectness: {
       ...STATE_CORRECTNESS.FRAUD_PROOFS,
       isIncomplete: true,

--- a/packages/config/src/layer2s/hermez.ts
+++ b/packages/config/src/layer2s/hermez.ts
@@ -25,6 +25,7 @@ export const hermez: Layer2 = {
     description:
       'Hermez is an open-source ZK-Rollup that aims to be optimized for secure, low-cost and usable token transfers on the wings of Ethereum.',
     purpose: 'Payments',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://hermez.io/'],
       apps: ['https://wallet.hermez.io/'],
@@ -63,7 +64,6 @@ export const hermez: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/immutablex.ts
+++ b/packages/config/src/layer2s/immutablex.ts
@@ -49,6 +49,8 @@ export const immutablex: Layer2 = {
     description:
       'Immutable X claims to be the first Layer 2 for NFTs on Ethereum. It promises zero gas fees, instant trades and scalability for games, applications, marketplaces, without compromise.',
     purpose: 'NFT, Exchange',
+    provider: 'StarkEx',
+    category: 'Validium',
     links: {
       websites: ['https://www.immutable.com/'],
       apps: ['https://market.x.immutable.com/'],
@@ -105,8 +107,6 @@ export const immutablex: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'Validium',
     stateCorrectness: STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
     newCryptography: NEW_CRYPTOGRAPHY.ZK_STARKS,
     dataAvailability: DATA_AVAILABILITY.STARKEX_OFF_CHAIN,

--- a/packages/config/src/layer2s/kroma.ts
+++ b/packages/config/src/layer2s/kroma.ts
@@ -16,6 +16,8 @@ export const kroma: Layer2 = {
             The goal of Kroma is to eventually transition to a ZK Rollup once the generation of ZK proofs becomes more cost-efficient and faster. \
             Kroma is deployed on the Sepolia testnet for further testing and optimization.',
     purpose: 'Universal',
+    category: 'Optimistic Rollup',
+    provider: 'Optimism',
     links: {
       websites: ['https://kroma.network/'],
       apps: [
@@ -36,10 +38,6 @@ export const kroma: Layer2 = {
     escrows: [],
   },
   riskView: UPCOMING_RISK_VIEW,
-  technology: {
-    ...TECHNOLOGY.UPCOMING,
-    category: 'Optimistic Rollup',
-    provider: 'Optimism',
-  },
+  technology: TECHNOLOGY.UPCOMING,
   contracts: CONTRACTS.EMPTY,
 }

--- a/packages/config/src/layer2s/layer2finance.ts
+++ b/packages/config/src/layer2s/layer2finance.ts
@@ -21,6 +21,7 @@ export const layer2finance: Layer2 = {
     description:
       'Layer2.Finance aims to democratize access to DeFi protocols for everyone. Users can aggregate their DeFi usage and save on Ethereum fees.',
     purpose: 'DeFi aggregation',
+    category: 'Optimistic Rollup',
     links: {
       websites: ['https://layer2.finance/'],
       apps: ['https://app.l2.finance/'],
@@ -58,7 +59,6 @@ export const layer2finance: Layer2 = {
     stage: 'UnderReview',
   },
   technology: {
-    category: 'Optimistic Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.FRAUD_PROOFS,
       description:

--- a/packages/config/src/layer2s/layer2financezk.ts
+++ b/packages/config/src/layer2s/layer2financezk.ts
@@ -29,6 +29,8 @@ export const layer2financezk: Layer2 = {
     description:
       'Celer’s Layer2.finance in ZK Proofs Mode Built with StarkEx from StarkWare.',
     purpose: 'DeFi protocols',
+    provider: 'StarkEx',
+    category: 'Validium',
     links: {
       websites: ['https://layer2.finance/'],
       apps: [],
@@ -79,8 +81,6 @@ export const layer2financezk: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'Validium',
     stateCorrectness: STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
     newCryptography: NEW_CRYPTOGRAPHY.ZK_STARKS,
     dataAvailability: DATA_AVAILABILITY.STARKEX_OFF_CHAIN,

--- a/packages/config/src/layer2s/loopring.ts
+++ b/packages/config/src/layer2s/loopring.ts
@@ -43,6 +43,8 @@ export const loopring: Layer2 = {
     description:
       "Loopring's zkRollup L2 solution aims to offer the same security guarantees as Ethereum mainnet, with a big scalability boost: throughput increased by 1000x, and cost reduced to just 0.1% of L1.",
     purpose: 'Tokens, NFTs, AMM',
+    provider: 'loopring',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://loopring.org'],
       apps: ['https://exchange.loopring.io/'],
@@ -154,8 +156,6 @@ export const loopring: Layer2 = {
     },
   }),
   technology: {
-    provider: 'loopring',
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/mantle.ts
+++ b/packages/config/src/layer2s/mantle.ts
@@ -13,6 +13,7 @@ export const mantle: Layer2 = {
     description:
       'Mantle is an EVM compatible zkRollup that has been designed for use on the Ethereum network. At present, it is undergoing further testing and optimization on the Goerli testnet before deployment.',
     purpose: 'Universal',
+    category: 'Optimistic Chain',
     links: {
       websites: ['https://www.mantle.xyz/'],
       apps: ['https://bridge.testnet.mantle.xyz'],
@@ -31,6 +32,6 @@ export const mantle: Layer2 = {
     escrows: [],
   },
   riskView: UPCOMING_RISK_VIEW,
-  technology: { ...TECHNOLOGY.UPCOMING, category: 'Optimistic Chain' },
+  technology: TECHNOLOGY.UPCOMING,
   contracts: CONTRACTS.EMPTY,
 }

--- a/packages/config/src/layer2s/metis.ts
+++ b/packages/config/src/layer2s/metis.ts
@@ -30,6 +30,8 @@ export const metis: Layer2 = {
       uses "optimistic data availability" scheme in which transaction data is kept off-chain in MEMO while Validators can \
       request tx data from Sequencer via L1 challenge mechanism if it does not make it available for validation off-chain.',
     purpose: 'Universal',
+    provider: 'Optimism',
+    category: 'Optimistic Chain',
     links: {
       websites: ['https://www.metis.io'],
       apps: [],
@@ -86,8 +88,6 @@ export const metis: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'Optimism',
-    category: 'Optimistic Chain',
     stateCorrectness: {
       name: 'No automatic on-chain fraud proof system',
       description:

--- a/packages/config/src/layer2s/myria.ts
+++ b/packages/config/src/layer2s/myria.ts
@@ -50,6 +50,8 @@ export const myria: Layer2 = {
     description:
       'Myria is an expansive blockchain gaming ecosystem, comprised of a blockchain gaming hub and Myriaverse metaverse, underpinned by a full suite of Myria infrastructure. Myria will also offer B2B services to enable third-party studios and developers to onboard onto the Myria chain.',
     purpose: 'NFT, Exchange',
+    provider: 'StarkEx',
+    category: 'Validium',
     links: {
       websites: ['https://myria.com/'],
       apps: ['https://market.x.immutable.com/'],
@@ -104,8 +106,6 @@ export const myria: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'Validium',
     stateCorrectness: STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
     newCryptography: NEW_CRYPTOGRAPHY.ZK_STARKS,
     dataAvailability: DATA_AVAILABILITY.STARKEX_OFF_CHAIN,

--- a/packages/config/src/layer2s/nova.ts
+++ b/packages/config/src/layer2s/nova.ts
@@ -46,6 +46,7 @@ export const nova: Layer2 = {
     description:
       'Arbitrum Nova is an AnyTrust chain that aims for ultra low transaction fees. Nova differs from Arbitrum One by not posting transaction data on chain, but to Data Availability Committee.',
     purpose: 'Universal',
+    category: 'Optimistic Chain',
     links: {
       websites: [
         'https://nova.arbitrum.io/',
@@ -119,7 +120,6 @@ export const nova: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    category: 'Optimistic Chain',
     stateCorrectness: {
       name: 'Fraud proofs ensure state correctness',
       description:

--- a/packages/config/src/layer2s/omgnetwork.ts
+++ b/packages/config/src/layer2s/omgnetwork.ts
@@ -24,6 +24,7 @@ export const omgnetwork: Layer2 = {
     description:
       'OMG Network claims to be the leading value transfer network for ETH and ERC20 tokens. Using the OMG Network, individuals and businesses can transact on a financial infrastructure that is claimed to be several times faster, 1/3rd the cost, and as secure as the Ethereum Network — while retaining full autonomy over their funds and keys. The Network scales by centralizing transaction processing and remains safe by decentralizing security.',
     purpose: 'Payments',
+    category: 'Plasma',
     links: {
       websites: ['https://omg.network'],
       apps: [],
@@ -68,7 +69,6 @@ export const omgnetwork: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    category: 'Plasma',
     stateCorrectness: {
       ...STATE_CORRECTNESS.EXIT_FRAUD_PROOFS,
       isIncomplete: true,

--- a/packages/config/src/layer2s/optimism.ts
+++ b/packages/config/src/layer2s/optimism.ts
@@ -43,6 +43,8 @@ export const optimism: Layer2 = {
     With the Nov 2021 upgrade to OVM 2.0 old fraud proof system has been disabled while the \
     new fraud-proof system is being built (https://github.com/ethereum-optimism/cannon).',
     purpose: 'Universal',
+    provider: 'Optimism',
+    category: 'Optimistic Rollup',
     links: {
       websites: ['https://optimism.io/'],
       apps: [],
@@ -188,8 +190,6 @@ export const optimism: Layer2 = {
     },
   }),
   technology: {
-    provider: 'Optimism',
-    category: 'Optimistic Rollup',
     stateCorrectness: {
       name: 'Fraud proofs are in development',
       description:

--- a/packages/config/src/layer2s/polygonzkevm.ts
+++ b/packages/config/src/layer2s/polygonzkevm.ts
@@ -71,6 +71,7 @@ export const polygonzkevm: Layer2 = {
     description:
       'Polygon zkEVM is aiming to become a decentralized Ethereum Layer 2 scalability solution that uses cryptographic zero-knowledge proofs to offer validity and finality of off-chain transactions. Polygon zkEVM wants to be equivalent with the Ethereum Virtual Machine.',
     purpose: 'Universal',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://polygon.technology/polygon-zkevm'],
       apps: ['https://bridge.zkevm-rpc.com'],
@@ -242,7 +243,6 @@ export const polygonzkevm: Layer2 = {
         ],
       },
     ],
-    category: 'ZK Rollup',
   },
   permissions: [
     ...discovery.getMultisigPermission(

--- a/packages/config/src/layer2s/rhinofi.ts
+++ b/packages/config/src/layer2s/rhinofi.ts
@@ -48,6 +48,8 @@ export const rhinofi: Layer2 = {
     description:
       'rhino.fi (formerly DeversiFi) claims to be the easiest way to access DeFi opportunities on Ethereum: invest, trade, and send tokens without paying gas fees.',
     purpose: 'Exchange',
+    provider: 'StarkEx',
+    category: 'Validium',
     links: {
       websites: ['https://rhino.fi/'],
       apps: ['https://app.rhino.fi/'],
@@ -112,8 +114,6 @@ export const rhinofi: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'Validium',
     stateCorrectness: STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
     newCryptography: NEW_CRYPTOGRAPHY.ZK_STARKS,
     dataAvailability: DATA_AVAILABILITY.STARKEX_OFF_CHAIN,

--- a/packages/config/src/layer2s/scroll.ts
+++ b/packages/config/src/layer2s/scroll.ts
@@ -13,6 +13,7 @@ export const scroll: Layer2 = {
     description:
       'Scroll is an EVM compatible zkRollup that has been designed for use on the Ethereum network. At present, it is undergoing further testing and optimization on the Goerli testnet before deployment.',
     purpose: 'Universal',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://scroll.io'],
       apps: ['https://scroll.io/alpha/bridge', 'https://uniswap-v3.scroll.io'],
@@ -41,6 +42,6 @@ export const scroll: Layer2 = {
     escrows: [],
   },
   riskView: UPCOMING_RISK_VIEW,
-  technology: { ...TECHNOLOGY.UPCOMING, category: 'ZK Rollup' },
+  technology: TECHNOLOGY.UPCOMING,
   contracts: CONTRACTS.EMPTY,
 }

--- a/packages/config/src/layer2s/sorare.ts
+++ b/packages/config/src/layer2s/sorare.ts
@@ -48,6 +48,8 @@ export const sorare: Layer2 = {
     description:
       'Sorare is a global fantasy football game where you can play with officially licensed digital cards and earn prizes every week.',
     purpose: 'NFT, Exchange',
+    provider: 'StarkEx',
+    category: 'Validium',
     links: {
       websites: ['https://sorare.com/'],
       apps: [],
@@ -104,8 +106,6 @@ export const sorare: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'StarkEx',
-    category: 'Validium',
     stateCorrectness: STATE_CORRECTNESS.STARKEX_VALIDITY_PROOFS,
     newCryptography: NEW_CRYPTOGRAPHY.ZK_STARKS,
     dataAvailability: DATA_AVAILABILITY.STARKEX_OFF_CHAIN,

--- a/packages/config/src/layer2s/starknet.ts
+++ b/packages/config/src/layer2s/starknet.ts
@@ -73,6 +73,7 @@ export const starknet: Layer2 = {
       is available and contracts are fully composable. It is currently launched \
       with a single Sequencer.',
     purpose: 'Universal',
+    category: 'ZK Rollup',
     links: {
       apps: [],
       websites: [
@@ -207,7 +208,6 @@ export const starknet: Layer2 = {
     },
   }),
   technology: {
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/taiko.ts
+++ b/packages/config/src/layer2s/taiko.ts
@@ -13,6 +13,7 @@ export const taiko: Layer2 = {
     description:
       'Taiko is a decentralized, Ethereum-equivalent ZK Rollup that has been developed on the Ethereum network. At present, Taiko is deployed on the Sepolia testnet for further testing and optimization.',
     purpose: 'Universal',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://taiko.xyz'],
       apps: ['https://bridge.test.taiko.xyz'],
@@ -33,6 +34,6 @@ export const taiko: Layer2 = {
     escrows: [],
   },
   riskView: UPCOMING_RISK_VIEW,
-  technology: { ...TECHNOLOGY.UPCOMING, category: 'ZK Rollup' },
+  technology: TECHNOLOGY.UPCOMING,
   contracts: CONTRACTS.EMPTY,
 }

--- a/packages/config/src/layer2s/types/Layer2.ts
+++ b/packages/config/src/layer2s/types/Layer2.ts
@@ -61,6 +61,10 @@ export interface Layer2Display {
   description: string
   /** A short (<20 characters) description of the use case */
   purpose: string
+  /** Name of the category the layer2 belongs to */
+  category: Layer2Category
+  /** Technology provider */
+  provider?: 'StarkEx' | 'Optimism' | 'zkSync' | 'loopring'
   /** List of links */
   links: ProjectLinks
   /** Where does the activity data come from? */
@@ -77,3 +81,11 @@ export interface Layer2Config {
   /** API parameters used to get transaction count */
   transactionApi?: Layer2TransactionApi
 }
+
+export type Layer2Category =
+  | 'Optimistic Rollup'
+  | 'Optimistic Chain'
+  | 'Plasma'
+  | 'State Pools'
+  | 'Validium'
+  | 'ZK Rollup'

--- a/packages/config/src/layer2s/types/Layer2Technology.ts
+++ b/packages/config/src/layer2s/types/Layer2Technology.ts
@@ -1,10 +1,6 @@
 import { ProjectTechnologyChoice } from '../../common/ProjectTechnologyChoice'
 
 export interface Layer2Technology {
-  /** Technology provider */
-  provider?: 'StarkEx' | 'Optimism' | 'zkSync' | 'loopring'
-  /** Name of the category the layer2 belongs to */
-  category: Layer2Category
   /** What state correctness mechanism is used in the layer2 */
   stateCorrectness: ProjectTechnologyChoice
   /** What is the new cryptography used in the layer2 */
@@ -26,11 +22,3 @@ export interface Layer2Technology {
   /** How can the Layer2 be upgraded? */
   upgradeMechanism?: ProjectTechnologyChoice
 }
-
-export type Layer2Category =
-  | 'Optimistic Rollup'
-  | 'Optimistic Chain'
-  | 'Plasma'
-  | 'State Pools'
-  | 'Validium'
-  | 'ZK Rollup'

--- a/packages/config/src/layer2s/zkspace.ts
+++ b/packages/config/src/layer2s/zkspace.ts
@@ -32,6 +32,8 @@ export const zkspace: Layer2 = {
     description:
       'The ZKSpace platform consists of three main parts: a Layer 2 AMM DEX utilizing ZK-Rollups technology ZKSwap v3, a payment service called ZKSquare, and an NFT marketplace called ZKSea.',
     purpose: 'Tokens, NFTs, AMM',
+    provider: 'zkSync',
+    category: zkswap.display.category,
     links: {
       websites: ['https://zks.org/'],
       apps: ['https://zks.app'],
@@ -139,8 +141,6 @@ export const zkspace: Layer2 = {
     },
   }),
   technology: {
-    provider: 'zkSync',
-    category: zkswap.technology.category,
     stateCorrectness: zkswap.technology.stateCorrectness,
     newCryptography: {
       ...NEW_CRYPTOGRAPHY.ZK_SNARKS,

--- a/packages/config/src/layer2s/zkswap.ts
+++ b/packages/config/src/layer2s/zkswap.ts
@@ -28,6 +28,8 @@ export const zkswap: Layer2 = {
     description:
       'ZKSwap is a fork of ZkSync with added AMM functionality. Based on ZK-Rollup technology, ZKSwap aims to execute the full functionality of Uniswap on Layer 2, while ensuring the core value of decentralized exchange. ZKSwap aims to increase the TPS by multiple orders of magnitude compared to Uniswap, and make transaction processing hardly consume any gas fees.',
     purpose: 'Payments, AMM',
+    provider: 'zkSync',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://zks.org/'],
       apps: ['https://zks.app'],
@@ -64,8 +66,6 @@ export const zkswap: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'zkSync',
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/zkswap2.ts
+++ b/packages/config/src/layer2s/zkswap2.ts
@@ -24,7 +24,8 @@ export const zkswap2: Layer2 = {
     description:
       'ZKSwap is a fork of ZkSync with added AMM functionality. Based on ZK-Rollup technology, ZKSwap aims to execute the full functionality of Uniswap on Layer 2, while ensuring the core value of decentralized exchange. ZKSwap aims to increase the TPS by multiple orders of magnitude compared to Uniswap, and make transaction processing hardly consume any gas fees.',
     purpose: 'Payments, AMM',
-
+    provider: 'zkSync',
+    category: zkswap.display.category,
     links: {
       websites: ['https://zks.org/'],
       apps: ['https://zks.app'],
@@ -60,8 +61,6 @@ export const zkswap2: Layer2 = {
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
   }),
   technology: {
-    provider: 'zkSync',
-    category: zkswap.technology.category,
     stateCorrectness: zkswap.technology.stateCorrectness,
     newCryptography: {
       ...NEW_CRYPTOGRAPHY.ZK_SNARKS,

--- a/packages/config/src/layer2s/zksyncera.ts
+++ b/packages/config/src/layer2s/zksyncera.ts
@@ -44,6 +44,8 @@ export const zksyncera: Layer2 = {
       'zkSync Era is a general-purpose zk-rollup platform from Matter Labs aiming at implementing nearly full EVM compatibility in its zk-friendly custom virtual machine.\
       It implements standard Web3 API and it preserves key EVM features such as smart contract composability while introducing some new concept such as native account abstraction.',
     purpose: 'Universal',
+    provider: 'zkSync',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://zksync.io/', 'https://ecosystem.zksync.io/'],
       apps: ['https://bridge.zksync.io/', 'https://portal.zksync.io/'],
@@ -212,8 +214,6 @@ export const zksyncera: Layer2 = {
     },
   }),
   technology: {
-    provider: 'zkSync',
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/zksynclite.ts
+++ b/packages/config/src/layer2s/zksynclite.ts
@@ -53,6 +53,8 @@ export const zksynclite: Layer2 = {
     description:
       'zkSync Lite (formerly zkSync) is a user-centric zk rollup platform from Matter Labs. It is a scaling solution for Ethereum, already live on Ethereum mainnet. It supports payments, token swaps and NFT minting.',
     purpose: 'Payments, Tokens',
+    provider: 'zkSync',
+    category: 'ZK Rollup',
     links: {
       websites: ['https://zksync.io/'],
       apps: ['https://lite.zksync.io/'],
@@ -171,8 +173,6 @@ export const zksynclite: Layer2 = {
     },
   }),
   technology: {
-    provider: 'zkSync',
-    category: 'ZK Rollup',
     stateCorrectness: {
       ...STATE_CORRECTNESS.VALIDITY_PROOFS,
       references: [

--- a/packages/config/src/layer2s/zora.ts
+++ b/packages/config/src/layer2s/zora.ts
@@ -41,6 +41,8 @@ export const zora: Layer2 = {
     description:
       'The Zora Network is a fast, cost-efficient, and scalable Layer 2 built to help bring media onchain, powered by the OP Stack.',
     purpose: 'Universal, NFTs',
+    provider: 'Optimism',
+    category: 'Optimistic Rollup',
     links: {
       websites: ['https://zora.energy/', 'https://zora.co/'],
       apps: [],
@@ -153,8 +155,6 @@ export const zora: Layer2 = {
     },
   }),
   technology: {
-    provider: 'Optimism',
-    category: 'Optimistic Rollup',
     stateCorrectness: {
       name: 'Fraud proofs are in development',
       description:

--- a/packages/config/src/test/stubs/bridge1WithDups.ts
+++ b/packages/config/src/test/stubs/bridge1WithDups.ts
@@ -8,13 +8,13 @@ export const bridge1WithDups: Bridge = {
   display: {
     name: 'Bridge1',
     slug: 'bridge1',
+    category: 'Token Bridge',
     links: {},
   },
   config: {
     escrows: [],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Dest chain'],
   },
   contracts: {

--- a/packages/config/src/test/stubs/bridge2WithDups.ts
+++ b/packages/config/src/test/stubs/bridge2WithDups.ts
@@ -8,13 +8,13 @@ export const bridge2WithDups: Bridge = {
   display: {
     name: 'Bridge2',
     slug: 'bridge2',
+    category: 'Token Bridge',
     links: {},
   },
   config: {
     escrows: [],
   },
   technology: {
-    category: 'Token Bridge',
     destination: ['Dest Chain'],
   },
   contracts: {

--- a/packages/config/src/test/stubs/layer2aWithDups.ts
+++ b/packages/config/src/test/stubs/layer2aWithDups.ts
@@ -16,6 +16,8 @@ export const layer2aWithDups: Layer2 = {
     slug: 'layer2a',
     description: '',
     purpose: 'Universal',
+    provider: 'Optimism',
+    category: 'Optimistic Rollup',
     links: {
       websites: [],
       apps: [],
@@ -42,8 +44,6 @@ export const layer2aWithDups: Layer2 = {
     sourceUpgradeability: RISK_VIEW.UPGRADABLE_YES,
   },
   technology: {
-    provider: 'Optimism',
-    category: 'Optimistic Rollup',
     stateCorrectness: {
       name: 'Fraud proofs are in development',
       description:

--- a/packages/frontend/src/components/table/TechnologyCell.tsx
+++ b/packages/frontend/src/components/table/TechnologyCell.tsx
@@ -6,7 +6,7 @@ import { LoopringIcon, OptimismIcon, StarkWareIcon, ZkSyncIcon } from '../icons'
 
 export interface TechnologyCellProps {
   children: string
-  provider?: Layer2['technology']['provider']
+  provider?: Layer2['display']['provider']
 }
 
 export function TechnologyCell({ provider, children }: TechnologyCellProps) {

--- a/packages/frontend/src/pages/bridges-projects/props/getProjectHeader.ts
+++ b/packages/frontend/src/pages/bridges-projects/props/getProjectHeader.ts
@@ -21,7 +21,7 @@ export function getProjectHeader(
     tvlWeeklyChange,
     destination: getDestination(project.technology.destination),
     validatedBy: project.riskView?.validatedBy,
-    type: project.technology.category,
+    type: project.display.category,
     isArchived: project.isArchived,
     isUpcoming: project.isUpcoming,
     links: getLinks(project.display.links),

--- a/packages/frontend/src/pages/bridges-risk/getProps.ts
+++ b/packages/frontend/src/pages/bridges-risk/getProps.ts
@@ -32,7 +32,7 @@ export function getProps(
             warning: project.display.warning,
             isArchived: project.isArchived,
             isVerified: verificationStatus.projects[project.id.toString()],
-            category: project.technology.category,
+            category: project.display.category,
             destination: getDestination(
               project.type === 'bridge'
                 ? project.technology.destination

--- a/packages/frontend/src/pages/bridges-tvl/props/getBridgesTvlView.ts
+++ b/packages/frontend/src/pages/bridges-tvl/props/getBridgesTvlView.ts
@@ -61,6 +61,6 @@ function getBridgesTvlViewEntry(
       ? formatPercent(stats.tvl / combinedTvl)
       : undefined,
     validatedBy: project.riskView?.validatedBy,
-    category: project.technology.category,
+    category: project.display.category,
   }
 }

--- a/packages/frontend/src/pages/scaling-activity/props/getActivityView.ts
+++ b/packages/frontend/src/pages/scaling-activity/props/getActivityView.ts
@@ -38,7 +38,7 @@ export function getActivityViewEntry(
   return {
     name: project.display.name,
     slug: project.display.slug,
-    provider: project.technology.provider,
+    provider: project.display.provider,
     warning: project.display.warning,
     isVerified,
     dataSource: project.display.activityDataSource,

--- a/packages/frontend/src/pages/scaling-activity/view/ActivityView.tsx
+++ b/packages/frontend/src/pages/scaling-activity/view/ActivityView.tsx
@@ -24,7 +24,7 @@ export interface ActivityViewProps {
 export interface ActivityViewEntry {
   name: string
   slug: string
-  provider?: Layer2['technology']['provider']
+  provider?: Layer2['display']['provider']
   warning?: string
   isVerified?: boolean
   isUpcoming?: boolean

--- a/packages/frontend/src/pages/scaling-projects/props/getProjectDetails.ts
+++ b/packages/frontend/src/pages/scaling-projects/props/getProjectDetails.ts
@@ -85,7 +85,7 @@ export function getProjectDetails(
           stage: project.stage,
           name: project.display.name,
           icon: `/icons/${project.display.slug}.png`,
-          type: project.technology.category,
+          type: project.display.category,
           id: 'stage',
           title: 'Rollup stage',
         },

--- a/packages/frontend/src/pages/scaling-projects/props/getProjectHeader.ts
+++ b/packages/frontend/src/pages/scaling-projects/props/getProjectHeader.ts
@@ -48,7 +48,7 @@ export function getProjectHeader(
         ? formatLargeNumber(transactionMonthlyCount)
         : undefined,
     purpose: project.display.purpose,
-    technology: project.technology.category,
+    technology: project.display.category,
     tvlBreakdown,
     links: getLinks(project.display.links),
     stagesEnabled: config.features.stages,

--- a/packages/frontend/src/pages/scaling-risk/props/getRiskView.ts
+++ b/packages/frontend/src/pages/scaling-risk/props/getRiskView.ts
@@ -24,7 +24,7 @@ export function getRiskViewEntry(
   return {
     name: project.display.name,
     slug: project.display.slug,
-    provider: project.technology.provider,
+    provider: project.display.provider,
     warning: project.display.warning,
     isArchived: project.isArchived,
     isVerified,

--- a/packages/frontend/src/pages/scaling-risk/view/types.ts
+++ b/packages/frontend/src/pages/scaling-risk/view/types.ts
@@ -3,7 +3,7 @@ import { Layer2, ProjectRiskViewEntry } from '@l2beat/config'
 export interface ScalingRiskViewEntry {
   name: string
   slug: string
-  provider?: Layer2['technology']['provider']
+  provider?: Layer2['display']['provider']
   warning?: string
   isArchived?: boolean
   isVerified?: boolean

--- a/packages/frontend/src/pages/scaling-tvl/props/getScalingTvlView.ts
+++ b/packages/frontend/src/pages/scaling-tvl/props/getScalingTvlView.ts
@@ -51,7 +51,7 @@ function getScalingTvlViewEntry(
   return {
     name: project.display.name,
     slug: project.display.slug,
-    provider: project.technology.provider,
+    provider: project.display.provider,
     riskValues: getRiskValues(project.riskView),
     warning: project.display.warning,
     isVerified,
@@ -63,7 +63,7 @@ function getScalingTvlViewEntry(
     sevenDayChange: stats ? stats.sevenDayChange : undefined,
     marketShare: stats ? formatPercent(stats.tvl / aggregateTvl) : undefined,
     purpose: project.display.purpose,
-    technology: project.technology.category,
+    technology: project.display.category,
     stage: project.stage,
   }
 }

--- a/packages/frontend/src/pages/scaling-tvl/types.ts
+++ b/packages/frontend/src/pages/scaling-tvl/types.ts
@@ -7,7 +7,7 @@ export interface ScalingTvlViewEntry {
   name: string
   slug: string
   riskValues: RiskValues
-  provider?: Layer2['technology']['provider']
+  provider?: Layer2['display']['provider']
   warning?: string
   isArchived?: boolean
   isVerified?: boolean


### PR DESCRIPTION
The idea behind this change is that rn the technology field in config is mostly used to define the technology section. By moving the category field we leave only the technology section in there, which gives it kinda logical structure. Also, after the category field is determined, it will not change easily. This change will make it easier to implement the `UnderReview` config option.