### PR TITLE
Fix tooltip z-index sorting

### DIFF
--- a/packages/frontend/src/components/Tooltip.tsx
+++ b/packages/frontend/src/components/Tooltip.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export function Tooltip() {
   return (
-    <div className="Tooltip-Popup fixed top-0 left-0 z-60 hidden max-w-[300px] rounded-md bg-white px-4 py-3 text-left text-sm leading-tight text-gray-700 shadow-[0px_4px_12px_0px_rgba(0,0,0,0.55)] dark:bg-neutral-700 dark:text-white">
+    <div className="Tooltip-Popup fixed top-0 left-0 z-110 hidden max-w-[300px] rounded-md bg-white px-4 py-3 text-left text-sm leading-tight text-gray-700 shadow-[0px_4px_12px_0px_rgba(0,0,0,0.55)] dark:bg-neutral-700 dark:text-white">
       <span />
       <svg
         width="16"

--- a/packages/frontend/tailwind.config.js
+++ b/packages/frontend/tailwind.config.js
@@ -113,8 +113,9 @@ module.exports = {
       30: '30', // Chart hover line
       40: '40', // Milestones, Chart hover line point (squares and circles)
       50: '50', // Chart hover content
-      60: '60', // Tooltip, Hoverable dropdown menu, Chart "Coming soon" disclaimer
+      60: '60', // Hoverable dropdown menu, Chart "Coming soon" disclaimer
       100: '100', // Mobile project navigation
+      110: '110', // Tooltip
       999: '999', // Mobile side menu
     },
     extend: {


### PR DESCRIPTION
Resolves L2B-1697

Sets the z-index for tooltip to be higher than mobile navbar and chart. On some devices it looked weird. To trigger on current production in responsive design use a device like `iPhone SE`.

On current production:
<img src="https://github.com/l2beat/l2beat/assets/33978857/cba390f0-947a-4aef-a9a4-7bb2063ed5ef" width=33% height=33%>

With this commit:
<img src="https://github.com/l2beat/l2beat/assets/33978857/71b0b232-d96b-4bfc-98b3-d9237090ed38" width=33% height=33%>