### PR TITLE
Enable incremental build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,21 +12,21 @@
     ]
   },
   "scripts": {
+    "build": "wsrun -ecsm build",
     "build:backend": "wsrun -p @l2beat/backend -recsm build",
     "build:frontend": "wsrun -p @l2beat/frontend -recsm build",
-    "build": "wsrun -ecsm build",
     "build:dependencies": "wsrun -p @l2beat/{shared,discovery,config} -recsm build",
-    "ci:check": "yarn clean && yarn build && yarn format && yarn lint && yarn typecheck && yarn test",
     "clean": "wsrun -ecam clean",
     "fix": "yarn lint:fix && yarn format:fix",
-    "format:fix": "wsrun -ecam format:fix",
     "format": "wsrun -ecam format",
-    "heroku-postbuild": "yarn build:backend",
-    "lint:fix": "wsrun -ecam lint:fix",
+    "format:fix": "wsrun -ecam format:fix",
     "lint": "wsrun -ecam lint",
+    "lint:fix": "wsrun -ecam lint:fix",
     "start": "cd packages/backend && yarn start",
     "test": "wsrun -ecam test",
-    "typecheck": "wsrun -ecam typecheck"
+    "typecheck": "wsrun -ecam typecheck",
+    "ci:check": "yarn clean && yarn build && yarn format && yarn lint && yarn typecheck && yarn test",
+    "heroku-postbuild": "yarn build:backend"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "wsrun -ecam test",
     "typecheck": "wsrun -ecam typecheck",
     "ci:check": "yarn clean && yarn build && yarn format && yarn lint && yarn typecheck && yarn test",
-    "heroku-postbuild": "yarn build:backend"
+    "heroku-postbuild": "yarn build:backend",
+    "checkout": "yarn clean && yarn && yarn build"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "wsrun -ecsm build",
     "build:backend": "wsrun -p @l2beat/backend -recsm build",
     "build:frontend": "wsrun -p @l2beat/frontend -recsm build",
-    "build:dependencies": "wsrun -p @l2beat/{shared,discovery,config} -recsm build",
+    "build:dependencies": "wsrun -p @l2beat/{shared-pure,shared,discovery,config} -recsm build",
     "clean": "wsrun -ecam clean",
     "fix": "yarn lint:fix && yarn format:fix",
     "format": "wsrun -ecam format",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,6 +6,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "build:dependencies": "cd ../.. && yarn build:dependencies && cd -",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,6 @@
   "types": "./index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prebuild": "yarn clean",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "build:dependencies": "cd ../.. && yarn build:dependencies && cd -",
+    "build:dependencies": "cd ../.. && yarn build:dependencies",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -6,7 +6,6 @@
   "types": "build/src/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prebuild": "yarn clean",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -9,7 +9,6 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prebuild": "yarn clean",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,6 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "NODE_ENV=production gulp build",
+    "build:dependencies": "cd ../.. && yarn build:dependencies && cd -",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -20,12 +20,11 @@
     "test": "mocha",
     "typecheck": "tsc --noEmit",
     "storybook": "storybook dev -p 6006 --no-open",
-    "storybook:build": "(cd ../.. && wsrun -p @l2beat/{shared,config} -recsm build --module es6) && storybook build",
+    "storybook:build": "(cd ../.. && wsrun -p @l2beat/{shared-pure,config} -recsm build --module es6) && storybook build",
     "storybook:screenshot": "yarn storycap --serverCmd \"npx http-server ./storybook-static -p 9001\" http://localhost:9001 --captureTimeout 50000 --parallel 8"
   },
   "dependencies": {
     "@l2beat/config": "*",
-    "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
     "@types/express": "^4.17.16",
     "@types/fs-extra": "^9.0.13",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,6 @@
   "sideEffects": false,
   "scripts": {
     "build": "NODE_ENV=production gulp build",
-    "prebuild": "yarn clean",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "NODE_ENV=production gulp build",
-    "build:dependencies": "cd ../.. && yarn build:dependencies && cd -",
+    "build:dependencies": "cd ../.. && yarn build:dependencies",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/shared-pure/package.json
+++ b/packages/shared-pure/package.json
@@ -7,7 +7,6 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prebuild": "yarn clean",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,7 +7,6 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "prebuild": "yarn clean",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",
     "format": "prettier --check .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "jsx": "react",
     "declaration": true,
     "declarationMap": true,
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "incremental": true
   }
 }


### PR DESCRIPTION
Resolves L2B-1698

Open question: 

Is it possible to write such a script that will:
1. run from e.g. frontend
2. go to root directory and build all the deps (not with the script where we specify the list of them, but somehow yarn will figure it out)
3. go back to frontend and run

right now we have this `build:frontend` but it builds the dependencies and the frontend itself so we will build the frontend twice when runing it