### PR TITLE
Show the list header and move it down for under review

### DIFF
--- a/packages/frontend/src/components/project/navigation/DesktopProjectNavigation.tsx
+++ b/packages/frontend/src/components/project/navigation/DesktopProjectNavigation.tsx
@@ -23,7 +23,7 @@ export function DesktopProjectNavigation({
   sections,
 }: ProjectNavigationProps) {
   const translateClassName = project.showProjectUnderReview
-    ? '-translate-y-[180px]'
+    ? '-translate-y-[40px]'
     : '-translate-y-16'
   return (
     <div
@@ -34,7 +34,7 @@ export function DesktopProjectNavigation({
       <div
         id={DESKTOP_PROJECT_NAVIGATION_IDS.listHeader}
         className={cx(
-          'opacity-0 transition-all duration-300',
+          'opacity-100 transition-all duration-300',
           translateClassName,
         )}
       >


### PR DESCRIPTION
After #1627 stages tooltip for under review did not work, this is caused by the summary header being too high up and covering up the Tooltip trigger

@michalsidzej please have a look if you intended to hide the summary header