### PR TITLE
Remove contracts verification check

### DIFF
--- a/packages/frontend/gulpfile.js
+++ b/packages/frontend/gulpfile.js
@@ -68,19 +68,6 @@ function generateMetaImages() {
   return exec('node -r esbuild-register src/build/buildMetaImages.ts')
 }
 
-async function updateVerifiedContracts() {
-  if (
-    process.env.DEPLOYMENT_ENV !== 'production' &&
-    process.env.DEPLOYMENT_ENV !== 'staging'
-  ) {
-    return
-  }
-  const cwd = process.cwd()
-  process.chdir('../config')
-  await exec('yarn check-verified-contracts')
-  process.chdir(cwd)
-}
-
 function serve() {
   const app = express()
   app.use(express.static('build'))
@@ -106,7 +93,6 @@ function serve() {
 
 const build = gulp.series(
   clean,
-  updateVerifiedContracts,
   gulp.parallel(buildScripts, buildSass, buildStyles, buildContent, copyStatic),
   generateMetaImages,
 )


### PR DESCRIPTION
From time to time our frontend build fails because of Etherscan timeout
<img width="1044" alt="image" src="https://github.com/l2beat/l2beat/assets/72789647/892a27c6-08d4-43b2-a4cb-eb405a6b9d5a">

We tried fixing it by lowering the workers number (via env on Vercel) to `1` but it did not help.

For now I am removing it altogether, for now we will do it by hand, I have created a task to discuss what we should do with it in the future

https://linear.app/l2beat/issue/L2B-1981/rethink-verified-contracts-check