### PR TITLE
Update rhino and upgrade description

### DIFF
--- a/packages/backend/discovery/deversifi/ethereum/discovered.json
+++ b/packages/backend/discovery/deversifi/ethereum/discovered.json
@@ -1,6 +1,6 @@
 {
   "name": "deversifi",
-  "blockNumber": 17684746,
+  "blockNumber": 17783222,
   "configHash": "0x658d4052c425a9d4155ea4a74d209c7fd39006ff9ed7fff6a54a72a4a6cf69aa",
   "version": 1,
   "contracts": [
@@ -49,7 +49,7 @@
       "upgradeability": {
         "type": "StarkWare diamond",
         "implementation": "0x4EDD62189732e9fF476ABa880b48c29432A7AC9B",
-        "upgradeDelay": 1209600,
+        "upgradeDelay": 259200,
         "isFinal": false,
         "facets": {
           "StarkWare_AllVerifiers_2020_1": "0x62BCA4DB742A99c834e2c24b609656A70EA25379",
@@ -68,8 +68,8 @@
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,
         "FREEZE_GRACE_PERIOD": 604800,
-        "getLastBatchId": 3767,
-        "getOrderRoot": "1103053906209757678866539785852926010657276660011701433574582617410679697088",
+        "getLastBatchId": 3866,
+        "getOrderRoot": "360631126010355824183317493522340741787107541035421187726199382005786982696",
         "getOrderTreeHeight": 63,
         "getRegisteredAvailabilityVerifiers": [
           "0x28780349A33eEE56bb92241bAAB8095449e24306"
@@ -77,8 +77,8 @@
         "getRegisteredVerifiers": [
           "0x6e3AbCE72A3CD5edc05E59283c733Fd4bF8B3baE"
         ],
-        "getSequenceNumber": 3742,
-        "getVaultRoot": "943188244487030137129315096336191652515227928249320423539934938360221262626",
+        "getSequenceNumber": 3841,
+        "getVaultRoot": "2783815725772431273228498382440401428183850263808950613029859549852197178281",
         "getVaultTreeHeight": 31,
         "implementation": "0x4EDD62189732e9fF476ABa880b48c29432A7AC9B",
         "isFrozen": false,
@@ -129,7 +129,7 @@
           "0x0405107a60391Eb51821be373ff978115Ee58488"
         ],
         "getThreshold": 2,
-        "nonce": 3,
+        "nonce": 5,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"

--- a/packages/config/src/layer2s/common/riskView.ts
+++ b/packages/config/src/layer2s/common/riskView.ts
@@ -146,21 +146,39 @@ export function UPGRADABLE_ZKSYNC(
   }
 }
 
-export function UPGRADE_DELAY(delay: string): ProjectRiskViewEntry {
+export function UPGRADE_DELAY(
+  upgradeDelay: number,
+  canExit?: boolean,
+): ProjectRiskViewEntry {
+  const upgradeDelayString = formatSeconds(upgradeDelay)
+  const canReactString =
+    canExit === false
+      ? 'and users have not enough time to react if the permissioned operator is censoring.'
+      : 'but users have some time to react even if the permissioned operator is censoring.'
   return {
-    value: `${delay} delay`,
+    value: `${upgradeDelayString} delay`,
     description:
-      'The code that secures the system can be changed arbitrarily but users have some time to react.',
+      'The code that secures the system can be changed arbitrarily ' +
+      canReactString +
+      '.',
     sentiment: 'warning',
   }
 }
 
-function UPGRADE_DELAY_SECONDS(delay: number): ProjectRiskViewEntry {
-  if (delay < DANGER_DELAY_THRESHOLD_SECONDS) {
+function UPGRADE_DELAY_SECONDS(
+  upgradeDelay: number,
+  exitDelay?: number,
+): ProjectRiskViewEntry {
+  if (upgradeDelay < DANGER_DELAY_THRESHOLD_SECONDS) {
     return UPGRADABLE_YES
   }
-  const delayString = formatSeconds(delay)
-  return UPGRADE_DELAY(delayString)
+  if (
+    exitDelay !== undefined &&
+    upgradeDelay - exitDelay < DANGER_DELAY_THRESHOLD_SECONDS
+  ) {
+    return UPGRADE_DELAY(upgradeDelay, false)
+  }
+  return UPGRADE_DELAY(upgradeDelay, true)
 }
 
 export const UPGRADABLE_NO: ProjectRiskViewEntry = {

--- a/packages/config/src/layer2s/hermez.ts
+++ b/packages/config/src/layer2s/hermez.ts
@@ -55,7 +55,7 @@ export const hermez: Layer2 = {
   riskView: makeBridgeCompatible({
     stateValidation: RISK_VIEW.STATE_ZKP_SN,
     dataAvailability: RISK_VIEW.DATA_ON_CHAIN,
-    upgradeability: RISK_VIEW.UPGRADE_DELAY('7 days'),
+    upgradeability: RISK_VIEW.UPGRADE_DELAY(604800),
     sequencerFailure: RISK_VIEW.SEQUENCER_FORCE_VIA_L1(),
     proposerFailure: RISK_VIEW.PROPOSER_SELF_PROPOSE_ZK,
     // NOTE: I have no clue what token are fees paid in. There are fees but

--- a/packages/config/src/layer2s/rhinofi.ts
+++ b/packages/config/src/layer2s/rhinofi.ts
@@ -107,7 +107,10 @@ export const rhinofi: Layer2 = {
         },
       ],
     },
-    upgradeability: RISK_VIEW.UPGRADE_DELAY_SECONDS(delaySeconds),
+    upgradeability: RISK_VIEW.UPGRADE_DELAY_SECONDS(
+      delaySeconds,
+      freezeGracePeriod,
+    ),
     sequencerFailure: RISK_VIEW.SEQUENCER_FORCE_VIA_L1(freezeGracePeriod),
     proposerFailure: RISK_VIEW.PROPOSER_USE_ESCAPE_HATCH_MP,
     destinationToken: RISK_VIEW.CANONICAL,

--- a/packages/config/src/layer2s/zkspace.ts
+++ b/packages/config/src/layer2s/zkspace.ts
@@ -15,12 +15,13 @@ import { zkswap } from './zkswap'
 
 const discovery = new ProjectDiscovery('zkspace')
 
-const upgradeDelay = formatSeconds(HARDCODED.ZKSPACE.UPGRADE_NOTICE_PERIOD)
+const upgradeDelay = HARDCODED.ZKSPACE.UPGRADE_NOTICE_PERIOD
+const upgradeDelayString = formatSeconds(upgradeDelay)
 const forcedWithdrawalDelay = HARDCODED.ZKSPACE.PRIORITY_EXPIRATION_PERIOD
 
 const upgradeability = {
   upgradableBy: ['zkSpace Admin'],
-  upgradeDelay,
+  upgradeDelayString,
 }
 
 export const zkspace: Layer2 = {
@@ -189,7 +190,7 @@ export const zkspace: Layer2 = {
         'This is the contract that implements the upgrade mechanism for Governance, Verifier and ZkSync. It relies on the ZkSync contract to enforce upgrade delays.',
       ),
     ],
-    risks: [CONTRACTS.UPGRADE_WITH_DELAY_RISK(upgradeDelay)],
+    risks: [CONTRACTS.UPGRADE_WITH_DELAY_RISK(upgradeDelayString)],
   },
   permissions: [
     {

--- a/packages/config/src/layer2s/zkswap.ts
+++ b/packages/config/src/layer2s/zkswap.ts
@@ -59,7 +59,7 @@ export const zkswap: Layer2 = {
   riskView: makeBridgeCompatible({
     stateValidation: RISK_VIEW.STATE_ZKP_SN,
     dataAvailability: RISK_VIEW.DATA_ON_CHAIN,
-    upgradeability: RISK_VIEW.UPGRADE_DELAY('8 days'),
+    upgradeability: RISK_VIEW.UPGRADE_DELAY(691200),
     sequencerFailure: RISK_VIEW.SEQUENCER_FORCE_VIA_L1(),
     proposerFailure: RISK_VIEW.PROPOSER_USE_ESCAPE_HATCH_ZK,
     destinationToken: RISK_VIEW.NATIVE_AND_CANONICAL(),

--- a/packages/config/src/layer2s/zkswap2.ts
+++ b/packages/config/src/layer2s/zkswap2.ts
@@ -54,7 +54,7 @@ export const zkswap2: Layer2 = {
   riskView: makeBridgeCompatible({
     stateValidation: RISK_VIEW.STATE_ZKP_SN,
     dataAvailability: RISK_VIEW.DATA_ON_CHAIN,
-    upgradeability: RISK_VIEW.UPGRADE_DELAY('8 days'),
+    upgradeability: RISK_VIEW.UPGRADE_DELAY(691200),
     sequencerFailure: RISK_VIEW.SEQUENCER_FORCE_VIA_L1(),
     proposerFailure: RISK_VIEW.PROPOSER_USE_ESCAPE_HATCH_ZK,
     destinationToken: RISK_VIEW.NATIVE_AND_CANONICAL(),


### PR DESCRIPTION
rhino have a 7d exit delay but they recently shortened their upgrade delay from 14d to 3d. The upgrade description specifies, every time that there is an upgrade delay, that users have some time to react which is not true anymore in this case. The upgrade description logic is updated to take into account this case. 