### PR TITLE
Add detailed TVL endpoint

### DIFF
--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
@@ -1,0 +1,130 @@
+import { tokenList } from '@l2beat/config'
+import { Logger } from '@l2beat/shared'
+import {
+  AssetId,
+  ChainId,
+  EthereumAddress,
+  ProjectId,
+  UnixTime,
+  ValueType,
+} from '@l2beat/shared-pure'
+import { expect, mockObject } from 'earl'
+
+import { ReportProject } from '../../../core/reports/ReportProject'
+import { AggregatedReportRepository } from '../../../peripherals/database/AggregatedReportRepository'
+import { AggregatedReportStatusRepository } from '../../../peripherals/database/AggregatedReportStatusRepository'
+import { ReportRepository } from '../../../peripherals/database/ReportRepository'
+import { ReportStatusRepository } from '../../../peripherals/database/ReportStatusRepository'
+import { DetailedTvlController } from './DetailedTvlController'
+
+const START = UnixTime.fromDate(new Date('2022-05-31'))
+const MINIMUM_TIMESTAMP = START.add(-1, 'hours')
+const USDC = tokenList.find((x) => x.symbol === 'USDC')!
+
+const ARBITRUM: ReportProject = {
+  projectId: ProjectId('arbitrum'),
+  type: 'layer2',
+  escrows: [
+    {
+      address: EthereumAddress.random(),
+      sinceTimestamp: new UnixTime(0),
+      tokens: [USDC],
+    },
+  ],
+}
+
+describe(DetailedTvlController.name, () => {
+  describe(
+    DetailedTvlController.prototype.getDetailedTvlApiResponse.name,
+    () => {
+      it('selects minimum viable timestamp for the aggregation', async () => {
+        const baseReport = {
+          timestamp: MINIMUM_TIMESTAMP,
+          usdValue: 1234_56n,
+          ethValue: 1_111111n,
+          amount: 111_1111n * 10n ** (6n - 4n),
+          asset: AssetId.USDC,
+          chainId: ChainId.ETHEREUM,
+          projectId: ARBITRUM.projectId,
+          type: ValueType.CBV,
+        }
+
+        const baseAggregatedReport = [
+          {
+            timestamp: MINIMUM_TIMESTAMP,
+            usdValue: 1234_56n,
+            ethValue: 1_111111n,
+            valueType: ValueType.CBV,
+            projectId: ARBITRUM.projectId,
+          },
+          {
+            timestamp: MINIMUM_TIMESTAMP,
+            usdValue: 1234_56n,
+            ethValue: 1_111111n,
+            valueType: ValueType.CBV,
+            projectId: ProjectId.ALL,
+          },
+          {
+            timestamp: MINIMUM_TIMESTAMP,
+            usdValue: 1234_56n,
+            ethValue: 1_111111n,
+            valueType: ValueType.CBV,
+            projectId: ProjectId.BRIDGES,
+          },
+          {
+            timestamp: MINIMUM_TIMESTAMP,
+            usdValue: 1234_56n,
+            ethValue: 1_111111n,
+            valueType: ValueType.CBV,
+            projectId: ProjectId.LAYER2S,
+          },
+        ]
+
+        const reportStatusRepository = mockObject<ReportStatusRepository>({
+          findAnyLatestTimestamp: async () => START,
+        })
+        const aggregatedReportStatusRepository =
+          mockObject<AggregatedReportStatusRepository>({
+            findLatestTimestamp: async () => MINIMUM_TIMESTAMP,
+          })
+
+        const reportRepository = mockObject<ReportRepository>({
+          getByTimestamp: async () => [baseReport],
+        })
+
+        const aggregatedReportRepository =
+          mockObject<AggregatedReportRepository>({
+            getDailyWithAnyType: async () => baseAggregatedReport,
+            getHourlyWithAnyType: async () => baseAggregatedReport,
+            getSixHourlyWithAnyType: async () => baseAggregatedReport,
+          })
+        const controller = new DetailedTvlController(
+          reportStatusRepository,
+          aggregatedReportRepository,
+          reportRepository,
+          aggregatedReportStatusRepository,
+          [ARBITRUM],
+          Logger.SILENT,
+        )
+
+        await controller.getDetailedTvlApiResponse()
+
+        expect(reportRepository.getByTimestamp).toHaveBeenCalledWith(
+          MINIMUM_TIMESTAMP,
+        )
+
+        expect(
+          aggregatedReportRepository.getDailyWithAnyType,
+        ).toHaveBeenCalledTimes(1)
+
+        expect(
+          aggregatedReportRepository.getHourlyWithAnyType,
+        ).toHaveBeenCalledWith(MINIMUM_TIMESTAMP.add(-7, 'days'))
+
+        expect(
+          aggregatedReportRepository.getSixHourlyWithAnyType,
+        ).toHaveBeenCalledWith(MINIMUM_TIMESTAMP.add(-90, 'days'))
+      })
+    },
+  )
+})

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
@@ -81,7 +81,14 @@ describe(DetailedTvlController.name, () => {
         ]
 
         const reportStatusRepository = mockObject<ReportStatusRepository>({
-          findAnyLatestTimestamp: async () => START,
+          findLatestTimestampOfType: async (type) =>
+            type === ValueType.CBV
+              ? START
+              : type === ValueType.EBV
+              ? START.add(-15, 'minutes')
+              : type === ValueType.NMV
+              ? START.add(-30, 'minutes')
+              : undefined,
         })
         const aggregatedReportStatusRepository =
           mockObject<AggregatedReportStatusRepository>({

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -18,8 +18,8 @@ export class DetailedTvlController {
   constructor(
     private readonly reportStatusRepository: ReportStatusRepository,
     private readonly aggregatedReportRepository: AggregatedReportRepository,
-    private readonly aggregatedReportStatusRepository: AggregatedReportStatusRepository,
     private readonly reportRepository: ReportRepository,
+    private readonly aggregatedReportStatusRepository: AggregatedReportStatusRepository,
     private readonly projects: ReportProject[],
     private readonly logger: Logger,
   ) {

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -1,0 +1,94 @@
+import { Logger } from '@l2beat/shared'
+import { DetailedTvlApiResponse, UnixTime } from '@l2beat/shared-pure'
+
+import { ReportProject } from '../../../core/reports/ReportProject'
+import { AggregatedReportRepository } from '../../../peripherals/database/AggregatedReportRepository'
+import { AggregatedReportStatusRepository } from '../../../peripherals/database/AggregatedReportStatusRepository'
+import { ReportRepository } from '../../../peripherals/database/ReportRepository'
+import { ReportStatusRepository } from '../../../peripherals/database/ReportStatusRepository'
+import { getHourlyMinTimestamp } from '../utils/getHourlyMinTimestamp'
+import { getSixHourlyMinTimestamp } from '../utils/getSixHourlyMinTimestamp'
+import {
+  groupByProjectIdAndAsset,
+  groupByProjectIdAndTimestamp,
+} from './detailedTvl'
+import { generateDetailedTvlApiResponse } from './generateDetailedTvlApiResponse'
+
+export class DetailedTvlController {
+  constructor(
+    private readonly reportStatusRepository: ReportStatusRepository,
+    private readonly aggregatedReportRepository: AggregatedReportRepository,
+    private readonly aggregatedReportStatusRepository: AggregatedReportStatusRepository,
+    private readonly reportRepository: ReportRepository,
+    private readonly projects: ReportProject[],
+    private readonly logger: Logger,
+  ) {
+    this.logger = this.logger.for(this)
+  }
+
+  async getDetailedTvlApiResponse(): Promise<
+    DetailedTvlApiResponse | undefined
+  > {
+    const [latestReportUpdateTime, latestAggregateReportUpdateTime] =
+      await Promise.all([
+        this.reportStatusRepository.findAnyLatestTimestamp(),
+        this.aggregatedReportStatusRepository.findLatestTimestamp(),
+      ])
+
+    if (!latestReportUpdateTime || !latestAggregateReportUpdateTime) {
+      return
+    }
+
+    const minimumTimestamp = new UnixTime(
+      Math.min(
+        Number(latestReportUpdateTime),
+        Number(latestAggregateReportUpdateTime),
+      ),
+    )
+
+    const [hourlyReports, sixHourlyReports, dailyReports, latestReports] =
+      await Promise.all([
+        this.aggregatedReportRepository.getHourlyWithAnyType(
+          getHourlyMinTimestamp(minimumTimestamp),
+        ),
+
+        this.aggregatedReportRepository.getSixHourlyWithAnyType(
+          getSixHourlyMinTimestamp(minimumTimestamp),
+        ),
+
+        this.aggregatedReportRepository.getDailyWithAnyType(),
+
+        this.reportRepository.getByTimestamp(minimumTimestamp),
+      ])
+
+    /**
+     * ProjectID => Timestamp => [Report, Report, Report, Report]
+     * Ideally 4 reports per project per timestamp corresponding to 4 Value Types
+     */
+    const groupedHourlyReports = groupByProjectIdAndTimestamp(hourlyReports)
+
+    const groupedSixHourlyReportsTree =
+      groupByProjectIdAndTimestamp(sixHourlyReports)
+
+    const groupedDailyReports = groupByProjectIdAndTimestamp(dailyReports)
+
+    /**
+     * ProjectID => Asset => Report[]
+     * Ideally 1 report. Some chains like Arbitrum may have multiple reports per asset differentiated by Value Type
+     * That isl 1 report for USDC of value type CBV and 1 report for USDC of value type EBV
+     * Reduce (dedupe) occurs later in the call chain
+     * @see getProjectTokensCharts
+     */
+    const groupedLatestReports = groupByProjectIdAndAsset(latestReports)
+
+    const tvlApiResponse = generateDetailedTvlApiResponse(
+      groupedHourlyReports,
+      groupedSixHourlyReportsTree,
+      groupedDailyReports,
+      groupedLatestReports,
+      this.projects.map((x) => x.projectId),
+    )
+
+    return tvlApiResponse
+  }
+}

--- a/packages/backend/src/api/controllers/tvl/TvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/TvlController.ts
@@ -76,6 +76,7 @@ export class TvlController {
         this.aggregatedReportRepository.getDaily(ValueType.TVL),
         this.reportRepository.getByTimestamp(timestamp),
       ])
+
     const tvlApiResponse = generateTvlApiResponse(
       hourlyReports,
       sixHourlyReports,

--- a/packages/backend/src/api/controllers/tvl/charts.test.ts
+++ b/packages/backend/src/api/controllers/tvl/charts.test.ts
@@ -1,7 +1,7 @@
 import { UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 
-import { addMissingTimestamps } from './charts'
+import { addDetailedMissingTimestamps, addMissingTimestamps } from './charts'
 
 const now = UnixTime.now().toStartOf('day')
 
@@ -29,6 +29,35 @@ describe(addMissingTimestamps.name, () => {
         [now.add(3 * hours, 'hours'), 2, 2],
         [now.add(4 * hours, 'hours'), 2, 2],
         [now.add(5 * hours, 'hours'), 5, 5],
+      ])
+    })
+  })
+})
+
+describe(addDetailedMissingTimestamps.name, () => {
+  it('returns empty for empty input', () => {
+    expect(addDetailedMissingTimestamps([], 1)).toEqual([])
+  })
+
+  const cases = [1, 6, 24]
+  cases.forEach((hours) => {
+    it(`adds missing ${hours}h timestamps`, () => {
+      expect(
+        addDetailedMissingTimestamps(
+          [
+            [now, 1, 1, 1, 1, 1, 1, 1, 1],
+            [now.add(2 * hours, 'hours'), 2, 2, 2, 2, 2, 2, 2, 2],
+            [now.add(5 * hours, 'hours'), 5, 5, 5, 5, 5, 5, 5, 5],
+          ],
+          hours,
+        ),
+      ).toEqual([
+        [now, 1, 1, 1, 1, 1, 1, 1, 1],
+        [now.add(1 * hours, 'hours'), 1, 1, 1, 1, 1, 1, 1, 1],
+        [now.add(2 * hours, 'hours'), 2, 2, 2, 2, 2, 2, 2, 2],
+        [now.add(3 * hours, 'hours'), 2, 2, 2, 2, 2, 2, 2, 2],
+        [now.add(4 * hours, 'hours'), 2, 2, 2, 2, 2, 2, 2, 2],
+        [now.add(5 * hours, 'hours'), 5, 5, 5, 5, 5, 5, 5, 5],
       ])
     })
   })

--- a/packages/backend/src/api/controllers/tvl/charts.ts
+++ b/packages/backend/src/api/controllers/tvl/charts.ts
@@ -1,6 +1,22 @@
-import { TvlApiChartPoint, UnixTime } from '@l2beat/shared-pure'
+import {
+  DetailedTvlApiChartPoint,
+  TvlApiChartPoint,
+  UnixTime,
+} from '@l2beat/shared-pure'
 
 import { asNumber } from './asNumber'
+
+interface BalanceInTime {
+  timestamp: UnixTime
+  usdTvl: bigint
+  ethTvl: bigint
+  usdEbv: bigint
+  ethEbv: bigint
+  usdCbv: bigint
+  ethCbv: bigint
+  usdNmv: bigint
+  ethNmv: bigint
+}
 
 export function addMissingTimestamps(
   points: TvlApiChartPoint[],
@@ -29,6 +45,40 @@ export function addMissingTimestamps(
   return allPoints
 }
 
+export function addDetailedMissingTimestamps(
+  points: DetailedTvlApiChartPoint[],
+  hours: number,
+): DetailedTvlApiChartPoint[] {
+  if (points.length === 0) return []
+  const [min] = points[0]
+  const [max] = points[points.length - 1]
+  const timestampValues = new Map(
+    points.map(([t, ...values]) => [t.toString(), values]),
+  )
+  const allPoints: DetailedTvlApiChartPoint[] = []
+  for (
+    let timestamp = min;
+    timestamp.lte(max);
+    timestamp = timestamp.add(hours, 'hours')
+  ) {
+    const existing = timestampValues.get(timestamp.toString())
+    const previous = allPoints[allPoints.length - 1]
+
+    allPoints.push([
+      timestamp,
+      existing?.[0] ?? previous[1],
+      existing?.[1] ?? previous[2],
+      existing?.[2] ?? previous[3],
+      existing?.[3] ?? previous[4],
+      existing?.[4] ?? previous[5],
+      existing?.[5] ?? previous[6],
+      existing?.[6] ?? previous[7],
+      existing?.[7] ?? previous[8],
+    ])
+  }
+  return allPoints
+}
+
 export function getChartPoints(
   balances: { usd: bigint; asset: bigint; timestamp: UnixTime }[],
   hours: number,
@@ -41,4 +91,59 @@ export function getChartPoints(
     return usdFirst ? [b.timestamp, usd, asset] : [b.timestamp, asset, usd]
   })
   return addMissingTimestamps(existing, hours)
+}
+
+export function covertBalancesToChartPoints(
+  balancesInTime: BalanceInTime[],
+  resolutionInHours: number,
+  decimals: number,
+  usdFirst = false,
+): DetailedTvlApiChartPoint[] {
+  const USD_DECIMALS = 2
+
+  const existingBalanceChartPoints: DetailedTvlApiChartPoint[] =
+    balancesInTime.map((bit) => {
+      const [usdTvl, usdCbv, usdEbv, usdNmv] = [
+        bit.usdTvl,
+        bit.usdCbv,
+        bit.usdEbv,
+        bit.usdNmv,
+      ].map((usdBalance) => asNumber(usdBalance, USD_DECIMALS))
+
+      const [assetTvl, assetCbv, assetEbv, assetNmv] = [
+        bit.usdTvl,
+        bit.usdCbv,
+        bit.usdEbv,
+        bit.usdNmv,
+      ].map((usdBalance) => asNumber(usdBalance, decimals))
+
+      return usdFirst
+        ? [
+            bit.timestamp,
+            usdTvl,
+            usdCbv,
+            usdEbv,
+            usdNmv,
+            assetTvl,
+            assetCbv,
+            assetEbv,
+            assetNmv,
+          ]
+        : [
+            bit.timestamp,
+            assetTvl,
+            assetCbv,
+            assetEbv,
+            assetNmv,
+            usdTvl,
+            usdCbv,
+            usdEbv,
+            usdNmv,
+          ]
+    })
+
+  return addDetailedMissingTimestamps(
+    existingBalanceChartPoints,
+    resolutionInHours,
+  )
 }

--- a/packages/backend/src/api/controllers/tvl/charts.ts
+++ b/packages/backend/src/api/controllers/tvl/charts.ts
@@ -6,7 +6,7 @@ import {
 
 import { asNumber } from './asNumber'
 
-interface BalanceInTime {
+interface DetailedBalanceInTime {
   timestamp: UnixTime
   usdTvl: bigint
   ethTvl: bigint
@@ -94,7 +94,7 @@ export function getChartPoints(
 }
 
 export function covertBalancesToChartPoints(
-  balancesInTime: BalanceInTime[],
+  balancesInTime: DetailedBalanceInTime[],
   resolutionInHours: number,
   decimals: number,
   usdFirst = false,

--- a/packages/backend/src/api/controllers/tvl/charts.ts
+++ b/packages/backend/src/api/controllers/tvl/charts.ts
@@ -110,12 +110,12 @@ export function covertBalancesToChartPoints(
         bit.usdNmv,
       ].map((usdBalance) => asNumber(usdBalance, USD_DECIMALS))
 
-      const [assetTvl, assetCbv, assetEbv, assetNmv] = [
-        bit.usdTvl,
-        bit.usdCbv,
-        bit.usdEbv,
-        bit.usdNmv,
-      ].map((usdBalance) => asNumber(usdBalance, decimals))
+      const [ethTvl, ethCbv, ethEbv, ethNmv] = [
+        bit.ethTvl,
+        bit.ethCbv,
+        bit.ethEbv,
+        bit.ethNmv,
+      ].map((ethBalance) => asNumber(ethBalance, decimals))
 
       return usdFirst
         ? [
@@ -124,17 +124,17 @@ export function covertBalancesToChartPoints(
             usdCbv,
             usdEbv,
             usdNmv,
-            assetTvl,
-            assetCbv,
-            assetEbv,
-            assetNmv,
+            ethTvl,
+            ethCbv,
+            ethEbv,
+            ethNmv,
           ]
         : [
             bit.timestamp,
-            assetTvl,
-            assetCbv,
-            assetEbv,
-            assetNmv,
+            ethTvl,
+            ethCbv,
+            ethEbv,
+            ethNmv,
             usdTvl,
             usdCbv,
             usdEbv,

--- a/packages/backend/src/api/controllers/tvl/detailedTvl.test.ts
+++ b/packages/backend/src/api/controllers/tvl/detailedTvl.test.ts
@@ -1,0 +1,387 @@
+import {
+  AssetId,
+  ChainId,
+  ProjectId,
+  UnixTime,
+  ValueType,
+} from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { describe } from 'mocha'
+
+import { AggregatedReportRecord } from '../../../peripherals/database/AggregatedReportRepository'
+import { ReportRecord } from '../../../peripherals/database/ReportRepository'
+import {
+  getProjectTokensCharts,
+  groupByProjectIdAndAsset,
+  groupByProjectIdAndTimestamp,
+} from './detailedTvl'
+
+describe('detailedTvl', () => {
+  describe(groupByProjectIdAndTimestamp.name, () => {
+    it('groups reports by project id and timestamp', () => {
+      const firstUnixTimestamp = UnixTime.now()
+      const secondUnixTimestamp = UnixTime.now().add(-1, 'hours')
+
+      const mockReports: AggregatedReportRecord[] = [
+        {
+          timestamp: firstUnixTimestamp,
+          usdValue: 1n,
+          ethValue: 1n,
+          valueType: ValueType.CBV,
+          projectId: ProjectId.ARBITRUM,
+        },
+        {
+          timestamp: firstUnixTimestamp,
+          usdValue: 2n,
+          ethValue: 2n,
+          valueType: ValueType.EBV,
+          projectId: ProjectId.ARBITRUM,
+        },
+        {
+          timestamp: secondUnixTimestamp,
+          usdValue: 3n,
+          ethValue: 3n,
+          valueType: ValueType.TVL,
+          projectId: ProjectId.ARBITRUM,
+        },
+        {
+          timestamp: firstUnixTimestamp,
+          usdValue: 1n,
+          ethValue: 1n,
+          valueType: ValueType.CBV,
+          projectId: ProjectId.ETHEREUM,
+        },
+        {
+          timestamp: firstUnixTimestamp,
+          usdValue: 2n,
+          ethValue: 2n,
+          valueType: ValueType.EBV,
+          projectId: ProjectId.ETHEREUM,
+        },
+        {
+          timestamp: secondUnixTimestamp,
+          usdValue: 3n,
+          ethValue: 3n,
+          valueType: ValueType.TVL,
+          projectId: ProjectId.ETHEREUM,
+        },
+      ]
+
+      const result = groupByProjectIdAndTimestamp(mockReports)
+
+      expect(result).toEqual({
+        [ProjectId.ARBITRUM.toString()]: {
+          [firstUnixTimestamp.toString()]: [
+            {
+              timestamp: firstUnixTimestamp,
+              usdValue: 1n,
+              ethValue: 1n,
+              valueType: ValueType.CBV,
+              projectId: ProjectId.ARBITRUM,
+            },
+            {
+              timestamp: firstUnixTimestamp,
+              usdValue: 2n,
+              ethValue: 2n,
+              valueType: ValueType.EBV,
+              projectId: ProjectId.ARBITRUM,
+            },
+          ],
+          [secondUnixTimestamp.toString()]: [
+            {
+              timestamp: secondUnixTimestamp,
+              usdValue: 3n,
+              ethValue: 3n,
+              valueType: ValueType.TVL,
+              projectId: ProjectId.ARBITRUM,
+            },
+          ],
+        },
+        [ProjectId.ETHEREUM.toString()]: {
+          [firstUnixTimestamp.toString()]: [
+            {
+              timestamp: firstUnixTimestamp,
+              usdValue: 1n,
+              ethValue: 1n,
+              valueType: ValueType.CBV,
+              projectId: ProjectId.ETHEREUM,
+            },
+            {
+              timestamp: firstUnixTimestamp,
+              usdValue: 2n,
+              ethValue: 2n,
+              valueType: ValueType.EBV,
+              projectId: ProjectId.ETHEREUM,
+            },
+          ],
+          [secondUnixTimestamp.toString()]: [
+            {
+              timestamp: secondUnixTimestamp,
+              usdValue: 3n,
+              ethValue: 3n,
+              valueType: ValueType.TVL,
+              projectId: ProjectId.ETHEREUM,
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe(groupByProjectIdAndAsset.name, () => {
+    it('groups reports by project id and asset', () => {
+      const timestamp = UnixTime.now()
+      const mockReports: ReportRecord[] = [
+        {
+          timestamp,
+          type: ValueType.CBV,
+          chainId: ChainId.ARBITRUM,
+          projectId: ProjectId.ARBITRUM,
+          amount: 1n,
+          usdValue: 1n,
+          ethValue: 1n,
+          asset: AssetId.USDC,
+        },
+        {
+          timestamp,
+          type: ValueType.NMV,
+          chainId: ChainId.ARBITRUM,
+          projectId: ProjectId.ARBITRUM,
+          amount: 2n,
+          usdValue: 2n,
+          ethValue: 2n,
+          asset: AssetId.USDC,
+        },
+        {
+          timestamp,
+          type: ValueType.EBV,
+          chainId: ChainId.ARBITRUM,
+          projectId: ProjectId.ARBITRUM,
+          amount: 3n,
+          usdValue: 3n,
+          ethValue: 3n,
+          asset: AssetId.ETH,
+        },
+        {
+          timestamp,
+          type: ValueType.EBV,
+          chainId: ChainId.ETHEREUM,
+          projectId: ProjectId.ETHEREUM,
+          amount: 1n,
+          usdValue: 1n,
+          ethValue: 1n,
+          asset: AssetId.USDC,
+        },
+        {
+          timestamp,
+          type: ValueType.CBV,
+          chainId: ChainId.ETHEREUM,
+          projectId: ProjectId.ETHEREUM,
+          amount: 2n,
+          usdValue: 2n,
+          ethValue: 2n,
+          asset: AssetId.USDC,
+        },
+        {
+          timestamp,
+          type: ValueType.NMV,
+          chainId: ChainId.ETHEREUM,
+          projectId: ProjectId.ETHEREUM,
+          amount: 3n,
+          usdValue: 3n,
+          ethValue: 3n,
+          asset: AssetId.ETH,
+        },
+      ]
+
+      const result = groupByProjectIdAndAsset(mockReports)
+
+      expect(result).toEqual({
+        [ProjectId.ARBITRUM.toString()]: {
+          [AssetId.USDC.toString()]: [
+            {
+              timestamp,
+              type: ValueType.CBV,
+              chainId: ChainId.ARBITRUM,
+              projectId: ProjectId.ARBITRUM,
+              amount: 1n,
+              usdValue: 1n,
+              ethValue: 1n,
+              asset: AssetId.USDC,
+            },
+            {
+              timestamp,
+              type: ValueType.NMV,
+              chainId: ChainId.ARBITRUM,
+              projectId: ProjectId.ARBITRUM,
+              amount: 2n,
+              usdValue: 2n,
+              ethValue: 2n,
+              asset: AssetId.USDC,
+            },
+          ],
+          [AssetId.ETH.toString()]: [
+            {
+              timestamp,
+              type: ValueType.EBV,
+              chainId: ChainId.ARBITRUM,
+              projectId: ProjectId.ARBITRUM,
+              amount: 3n,
+              usdValue: 3n,
+              ethValue: 3n,
+              asset: AssetId.ETH,
+            },
+          ],
+        },
+        [ProjectId.ETHEREUM.toString()]: {
+          [AssetId.USDC.toString()]: [
+            {
+              timestamp,
+              type: ValueType.EBV,
+              chainId: ChainId.ETHEREUM,
+              projectId: ProjectId.ETHEREUM,
+              amount: 1n,
+              usdValue: 1n,
+              ethValue: 1n,
+              asset: AssetId.USDC,
+            },
+            {
+              timestamp,
+              type: ValueType.CBV,
+              chainId: ChainId.ETHEREUM,
+              projectId: ProjectId.ETHEREUM,
+              amount: 2n,
+              usdValue: 2n,
+              ethValue: 2n,
+              asset: AssetId.USDC,
+            },
+          ],
+          [AssetId.ETH.toString()]: [
+            {
+              timestamp,
+              type: ValueType.NMV,
+              chainId: ChainId.ETHEREUM,
+              projectId: ProjectId.ETHEREUM,
+              amount: 3n,
+              usdValue: 3n,
+              ethValue: 3n,
+              asset: AssetId.ETH,
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe(getProjectTokensCharts.name, () => {
+    const timestamp = UnixTime.now()
+
+    const mockReports: ReportRecord[] = [
+      {
+        timestamp,
+        type: ValueType.CBV,
+        chainId: ChainId.ARBITRUM,
+        projectId: ProjectId.ARBITRUM,
+        amount: 1n,
+        usdValue: 1n,
+        ethValue: 1n,
+        asset: AssetId.USDC,
+      },
+      {
+        timestamp,
+        type: ValueType.NMV,
+        chainId: ChainId.ARBITRUM,
+        projectId: ProjectId.ARBITRUM,
+        amount: 2n,
+        usdValue: 2n,
+        ethValue: 2n,
+        asset: AssetId.USDC,
+      },
+      {
+        timestamp,
+        type: ValueType.EBV,
+        chainId: ChainId.ARBITRUM,
+        projectId: ProjectId.ARBITRUM,
+        amount: 3n,
+        usdValue: 3n,
+        ethValue: 3n,
+        asset: AssetId.ETH,
+      },
+      {
+        timestamp,
+        type: ValueType.EBV,
+        chainId: ChainId.ETHEREUM,
+        projectId: ProjectId.ETHEREUM,
+        amount: 10n,
+        usdValue: 10n,
+        ethValue: 10n,
+        asset: AssetId.USDC,
+      },
+      {
+        timestamp,
+        type: ValueType.CBV,
+        chainId: ChainId.ETHEREUM,
+        projectId: ProjectId.ETHEREUM,
+        amount: 20n,
+        usdValue: 20n,
+        ethValue: 20n,
+        asset: AssetId.USDC,
+      },
+      {
+        timestamp,
+        type: ValueType.NMV,
+        chainId: ChainId.ETHEREUM,
+        projectId: ProjectId.ETHEREUM,
+        amount: 30n,
+        usdValue: 30n,
+        ethValue: 30n,
+        asset: AssetId.ETH,
+      },
+    ]
+    it('deduplicates assets and reduces overall value', () => {
+      const groupedReports = groupByProjectIdAndAsset(mockReports)
+
+      const arbitrumResult = getProjectTokensCharts(
+        groupedReports,
+        ProjectId.ARBITRUM,
+      )
+
+      const ethereumResult = getProjectTokensCharts(
+        groupedReports,
+        ProjectId.ETHEREUM,
+      )
+
+      expect(arbitrumResult).toEqual([
+        {
+          assetId: AssetId.USDC,
+          tvl: 0.03, // 1n + 2n
+        },
+        {
+          assetId: AssetId.ETH,
+          tvl: 0.03, // 3n
+        },
+      ])
+
+      expect(ethereumResult).toEqual([
+        {
+          assetId: AssetId.USDC,
+          tvl: 0.3, // 10n + 20n
+        },
+        {
+          assetId: AssetId.ETH,
+          tvl: 0.3, // 30n
+        },
+      ])
+    })
+    it('return empty array if no project assets were found', () => {
+      const groupedReports = groupByProjectIdAndAsset(mockReports)
+
+      const optimismResult = getProjectTokensCharts(
+        groupedReports,
+        ProjectId.OPTIMISM,
+      )
+
+      expect(optimismResult).toEqual([])
+    })
+  })
+})

--- a/packages/backend/src/api/controllers/tvl/detailedTvl.ts
+++ b/packages/backend/src/api/controllers/tvl/detailedTvl.ts
@@ -58,15 +58,19 @@ export function getProjectTokensCharts(
     return []
   }
 
-  const tokens = []
+  const tokens = Object.entries(assetValuesPerProject).map(
+    ([asset, reports]) => {
+      const tokenUsdTvl = reports.reduce(
+        (acc, report) => acc + report.usdValue,
+        0n,
+      )
 
-  for (const [asset, reports] of Object.entries(assetValuesPerProject)) {
-    const tvl = reports.reduce((acc, report) => acc + report.usdValue, 0n)
-    tokens.push({
-      assetId: AssetId(asset),
-      tvl: asNumber(tvl, 2),
-    })
-  }
+      return {
+        assetId: AssetId(asset),
+        tvl: asNumber(tokenUsdTvl, 2),
+      }
+    },
+  )
 
   return tokens
 }

--- a/packages/backend/src/api/controllers/tvl/detailedTvl.ts
+++ b/packages/backend/src/api/controllers/tvl/detailedTvl.ts
@@ -1,0 +1,72 @@
+import { AssetId, ProjectId } from '@l2beat/shared-pure'
+import { groupBy, mapValues } from 'lodash'
+
+import { AggregatedReportRecord } from '../../../peripherals/database/AggregatedReportRepository'
+import { ReportRecord } from '../../../peripherals/database/ReportRepository'
+import { asNumber } from './asNumber'
+
+export type ReportsPerProjectIdAndTimestamp = ReturnType<
+  typeof groupByProjectIdAndTimestamp
+>
+
+export type ReportsPerProjectIdAndAsset = ReturnType<
+  typeof groupByProjectIdAndAsset
+>
+
+export function groupByProjectIdAndTimestamp(
+  reports: AggregatedReportRecord[],
+) {
+  return nestedGroupBy(
+    reports,
+    (report) => report.projectId,
+    (report) => report.timestamp,
+  )
+}
+
+export function groupByProjectIdAndAsset(reports: ReportRecord[]) {
+  return nestedGroupBy(
+    reports,
+    (report) => report.projectId,
+    (report) => report.asset,
+  )
+}
+
+type ObjectValues<T> = T[keyof T]
+type GroupingFunction<T> = (item: T) => ObjectValues<T>
+
+export function nestedGroupBy<T extends ReportRecord | AggregatedReportRecord>(
+  items: T[],
+  firstLevel: GroupingFunction<T>,
+  secondLevel: GroupingFunction<T>,
+) {
+  return mapValues(
+    mapValues(groupBy(items, firstLevel), (firstGroupingResult) =>
+      groupBy(firstGroupingResult, secondLevel),
+    ),
+  )
+}
+
+export function getProjectTokensCharts(
+  reports: ReportsPerProjectIdAndAsset,
+  projectId: ProjectId,
+): { assetId: AssetId; tvl: number }[] {
+  const assetValuesPerProject = reports[projectId.toString()]
+
+  // Project may be missing reports
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!assetValuesPerProject) {
+    return []
+  }
+
+  const tokens = []
+
+  for (const [asset, reports] of Object.entries(assetValuesPerProject)) {
+    const tvl = reports.reduce((acc, report) => acc + report.usdValue, 0n)
+    tokens.push({
+      assetId: AssetId(asset),
+      tvl: asNumber(tvl, 2),
+    })
+  }
+
+  return tokens
+}

--- a/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.test.ts
+++ b/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.test.ts
@@ -18,6 +18,7 @@ import {
   groupByProjectIdAndTimestamp,
 } from './detailedTvl'
 import {
+  extractValueTypeSet,
   generateDetailedTvlApiResponse,
   getProjectChartData,
 } from './generateDetailedTvlApiResponse'
@@ -201,4 +202,61 @@ describe(generateDetailedTvlApiResponse.name, () => {
     }
     return result
   }
+})
+
+describe(extractValueTypeSet.name, () => {
+  it('fills in missing values', () => {
+    const timestamp = UnixTime.now()
+    const usdValue = 1_000n
+    const ethValue = 1_000_000n
+
+    const filledUsdValue = 0n
+    const filledEthValue = 0n
+
+    // NMV missing
+    const mockReports: AggregatedReportRecord[] = [
+      {
+        timestamp,
+        projectId: ProjectId.ARBITRUM,
+        usdValue,
+        ethValue,
+        valueType: ValueType.TVL,
+      },
+      {
+        timestamp,
+        projectId: ProjectId.ARBITRUM,
+        usdValue,
+        ethValue,
+        valueType: ValueType.CBV,
+      },
+      {
+        timestamp,
+        projectId: ProjectId.ARBITRUM,
+        usdValue,
+        ethValue,
+        valueType: ValueType.EBV,
+      },
+    ]
+
+    const result = extractValueTypeSet(mockReports)
+
+    expect(result).toEqual({
+      ebvReport: {
+        usdValue,
+        ethValue,
+      },
+      cbvReport: {
+        usdValue,
+        ethValue,
+      },
+      tvlReport: {
+        usdValue,
+        ethValue,
+      },
+      nmvReport: {
+        usdValue: filledUsdValue,
+        ethValue: filledEthValue,
+      },
+    })
+  })
 })

--- a/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.test.ts
+++ b/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.test.ts
@@ -1,0 +1,204 @@
+import {
+  AssetId,
+  ChainId,
+  DetailedTvlApiChart,
+  DetailedTvlApiCharts,
+  ProjectId,
+  UnixTime,
+  ValueType,
+} from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { writeFileSync } from 'fs'
+
+import { AggregatedReportRecord } from '../../../peripherals/database/AggregatedReportRepository'
+import { ReportRecord } from '../../../peripherals/database/ReportRepository'
+import {
+  getProjectTokensCharts,
+  groupByProjectIdAndAsset,
+  groupByProjectIdAndTimestamp,
+} from './detailedTvl'
+import {
+  generateDetailedTvlApiResponse,
+  getProjectChartData,
+} from './generateDetailedTvlApiResponse'
+
+describe(generateDetailedTvlApiResponse.name, () => {
+  it('returns the correct groupings', () => {
+    const reports = fakeReports([
+      ProjectId('arbitrum'),
+      ProjectId('optimism'),
+      ProjectId('avalanche'),
+      ProjectId.ALL,
+      ProjectId.BRIDGES,
+      ProjectId.LAYER2S,
+    ])
+    const result = generateDetailedTvlApiResponse(
+      reports.hourly,
+      reports.sixHourly,
+      reports.daily,
+      reports.latest,
+      [ProjectId('arbitrum'), ProjectId('optimism'), ProjectId('avalanche')],
+    )
+
+    const expected = {
+      layers2s: charts(reports, ProjectId.LAYER2S),
+      bridges: charts(reports, ProjectId.BRIDGES),
+      combined: charts(reports, ProjectId.ALL),
+      projects: {
+        arbitrum: {
+          charts: charts(reports, ProjectId('arbitrum')),
+          tokens: tokens(reports, ProjectId('arbitrum')),
+        },
+        optimism: {
+          charts: charts(reports, ProjectId('optimism')),
+          tokens: tokens(reports, ProjectId('optimism')),
+        },
+        avalanche: {
+          charts: charts(reports, ProjectId('avalanche')),
+          tokens: tokens(reports, ProjectId('avalanche')),
+        },
+      },
+    }
+
+    writeFileSync('result.json', JSON.stringify(result, null, 2))
+    writeFileSync('expected.json', JSON.stringify(expected, null, 2))
+
+    expect(result).toEqual(expected)
+  })
+
+  function charts(
+    reports: ReturnType<typeof fakeReports>,
+    projectId: ProjectId,
+  ): DetailedTvlApiCharts {
+    const types: DetailedTvlApiChart['types'] = [
+      'timestamp',
+      'valueUsd',
+      'cbvUsd',
+      'ebvUsd',
+      'nmvUsd',
+      'valueEth',
+      'cbvEth',
+      'ebvEth',
+      'nmvEth',
+    ]
+
+    return {
+      hourly: {
+        types,
+        data: getProjectChartData(reports.hourly, projectId, 1),
+      },
+      sixHourly: {
+        types,
+        data: getProjectChartData(reports.sixHourly, projectId, 6),
+      },
+      daily: {
+        types,
+        data: getProjectChartData(reports.daily, projectId, 24),
+      },
+    }
+  }
+
+  function tokens(
+    reports: ReturnType<typeof fakeReports>,
+    projectId: ProjectId,
+  ) {
+    return getProjectTokensCharts(reports.latest, projectId)
+  }
+
+  function fakeReports(projectIds: ProjectId[]) {
+    const now = UnixTime.now().toStartOf('day')
+
+    return {
+      hourly: groupByProjectIdAndTimestamp(
+        fakeTimePeriodReports(now, 1, 1, projectIds),
+      ),
+      sixHourly: groupByProjectIdAndTimestamp(
+        fakeTimePeriodReports(now, 6, 1, projectIds),
+      ),
+      daily: groupByProjectIdAndTimestamp(
+        fakeTimePeriodReports(now, 24, 1, projectIds),
+      ),
+      latest: groupByProjectIdAndAsset(fakeLatestReports(now, projectIds)),
+    }
+  }
+
+  function fakeTimePeriodReports(
+    now: UnixTime,
+    offsetHours: number,
+    count: number,
+    projectIds: ProjectId[],
+  ) {
+    const result: AggregatedReportRecord[] = []
+
+    for (let i = 0; i < count; i++) {
+      const timestamp = now.add(-i * offsetHours, 'hours')
+      for (const projectId of projectIds) {
+        const usdEbv = BigInt(Math.floor(Math.random() * 20_000 + 5_000))
+        const usdCbv = BigInt(Math.floor(Math.random() * 20_000 + 5_000))
+        const usdNmv = BigInt(Math.floor(Math.random() * 20_000 + 5_000))
+
+        const usdTvl = usdEbv + usdCbv + usdNmv
+
+        const ethEbv = usdEbv * 1000n
+        const ethCbv = usdCbv * 1000n
+        const ethNmv = usdNmv * 1000n
+
+        const ethTvl = ethEbv + ethCbv + ethNmv
+
+        result.push({
+          timestamp,
+          projectId,
+          usdValue: usdEbv,
+          ethValue: ethEbv,
+          valueType: ValueType.EBV,
+        })
+
+        result.push({
+          timestamp,
+          projectId,
+          usdValue: usdCbv,
+          ethValue: ethCbv,
+          valueType: ValueType.CBV,
+        })
+
+        result.push({
+          timestamp,
+          projectId,
+          usdValue: usdNmv,
+          ethValue: ethNmv,
+          valueType: ValueType.NMV,
+        })
+
+        result.push({
+          timestamp,
+          projectId,
+          usdValue: usdTvl,
+          ethValue: ethTvl,
+          valueType: ValueType.TVL,
+        })
+      }
+    }
+    return result
+  }
+
+  function fakeLatestReports(now: UnixTime, projectIds: ProjectId[]) {
+    const assets = [AssetId.ETH, AssetId.DAI]
+    const result: ReportRecord[] = []
+    for (const projectId of projectIds) {
+      for (const assetId of assets) {
+        const balanceUsd = BigInt(Math.floor(Math.random() * 20_000 + 5_000))
+        result.push({
+          asset: assetId,
+          chainId: ChainId.ARBITRUM, // ignored - not grouped
+          type: ValueType.CBV,
+          amount: 0n, // ignored
+          ethValue: 0n, // ignored
+          usdValue: balanceUsd,
+          projectId,
+          timestamp: now,
+        })
+      }
+    }
+    return result
+  }
+})

--- a/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.ts
+++ b/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.ts
@@ -88,7 +88,7 @@ function getProjectCharts(
   }
 }
 
-function getProjectChartData(
+export function getProjectChartData(
   reportTree: ReportsPerProjectIdAndTimestamp,
   projectId: ProjectId,
   resolutionInHours: number,
@@ -117,7 +117,7 @@ function getProjectChartData(
   return covertBalancesToChartPoints(balancesInTime, resolutionInHours, 6, true)
 }
 
-function extractValueTypeSet(reports: AggregatedReportRecord[]) {
+export function extractValueTypeSet(reports: AggregatedReportRecord[]) {
   const typesToSeek = [
     ValueType.TVL,
     ValueType.CBV,

--- a/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.ts
+++ b/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.ts
@@ -95,6 +95,12 @@ export function getProjectChartData(
 ): DetailedTvlApiChartPoint[] {
   const projectReportsByTimestamp = reportTree[projectId.toString()]
 
+  // Project may be missing reports
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (!projectReportsByTimestamp) {
+    return []
+  }
+
   const balancesInTime = Object.entries(projectReportsByTimestamp).map(
     ([timestamp, valueReports]) => {
       const { tvlReport, cbvReport, ebvReport, nmvReport } =

--- a/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.ts
+++ b/packages/backend/src/api/controllers/tvl/generateDetailedTvlApiResponse.ts
@@ -1,0 +1,156 @@
+import {
+  DetailedTvlApiChart,
+  DetailedTvlApiChartPoint,
+  DetailedTvlApiCharts,
+  DetailedTvlApiResponse,
+  ProjectId,
+  UnixTime,
+  ValueType,
+} from '@l2beat/shared-pure'
+
+import { AggregatedReportRecord } from '../../../peripherals/database/AggregatedReportRepository'
+import { covertBalancesToChartPoints } from './charts'
+import {
+  getProjectTokensCharts,
+  ReportsPerProjectIdAndAsset,
+  ReportsPerProjectIdAndTimestamp,
+} from './detailedTvl'
+
+const DETAILED_LABELS: DetailedTvlApiChart['types'] = [
+  'timestamp',
+  'valueUsd',
+  'cbvUsd',
+  'ebvUsd',
+  'nmvUsd',
+  'valueEth',
+  'cbvEth',
+  'ebvEth',
+  'nmvEth',
+]
+
+export function generateDetailedTvlApiResponse(
+  hourlyReports: ReportsPerProjectIdAndTimestamp,
+  sixHourlyReports: ReportsPerProjectIdAndTimestamp,
+  dailyReports: ReportsPerProjectIdAndTimestamp,
+  latestReports: ReportsPerProjectIdAndAsset,
+  projectIds: ProjectId[],
+): DetailedTvlApiResponse {
+  const reports = {
+    hourly: hourlyReports,
+    sixHourly: sixHourlyReports,
+    daily: dailyReports,
+  }
+
+  const layers2s = getProjectCharts(reports, ProjectId.LAYER2S)
+  const bridges = getProjectCharts(reports, ProjectId.BRIDGES)
+  const combined = getProjectCharts(reports, ProjectId.ALL)
+
+  const projects = projectIds.reduce<DetailedTvlApiResponse['projects']>(
+    (acc, projectId) => {
+      acc[projectId.toString()] = {
+        charts: getProjectCharts(reports, projectId),
+        tokens: getProjectTokensCharts(latestReports, projectId),
+      }
+      return acc
+    },
+    {},
+  )
+
+  return {
+    layers2s,
+    bridges,
+    combined,
+    projects,
+  }
+}
+
+function getProjectCharts(
+  reports: {
+    hourly: ReportsPerProjectIdAndTimestamp
+    sixHourly: ReportsPerProjectIdAndTimestamp
+    daily: ReportsPerProjectIdAndTimestamp
+  },
+  projectId: ProjectId,
+): DetailedTvlApiCharts {
+  return {
+    hourly: {
+      types: DETAILED_LABELS,
+      data: getProjectChartData(reports.hourly, projectId, 1),
+    },
+    sixHourly: {
+      types: DETAILED_LABELS,
+      data: getProjectChartData(reports.sixHourly, projectId, 6),
+    },
+    daily: {
+      types: DETAILED_LABELS,
+      data: getProjectChartData(reports.daily, projectId, 24),
+    },
+  }
+}
+
+function getProjectChartData(
+  reportTree: ReportsPerProjectIdAndTimestamp,
+  projectId: ProjectId,
+  resolutionInHours: number,
+): DetailedTvlApiChartPoint[] {
+  const projectReportsByTimestamp = reportTree[projectId.toString()]
+
+  const balancesInTime = Object.entries(projectReportsByTimestamp).map(
+    ([timestamp, valueReports]) => {
+      const { tvlReport, cbvReport, ebvReport, nmvReport } =
+        extractValueTypeSet(valueReports)
+
+      return {
+        timestamp: new UnixTime(Number(timestamp)),
+        usdTvl: tvlReport.usdValue,
+        ethTvl: tvlReport.ethValue,
+        usdCbv: cbvReport.usdValue,
+        ethCbv: cbvReport.ethValue,
+        usdEbv: ebvReport.usdValue,
+        ethEbv: ebvReport.ethValue,
+        usdNmv: nmvReport.usdValue,
+        ethNmv: nmvReport.ethValue,
+      }
+    },
+  )
+
+  return covertBalancesToChartPoints(balancesInTime, resolutionInHours, 6, true)
+}
+
+function extractValueTypeSet(reports: AggregatedReportRecord[]) {
+  const typesToSeek = [
+    ValueType.TVL,
+    ValueType.CBV,
+    ValueType.EBV,
+    ValueType.NMV,
+  ]
+
+  const defaultValue = {
+    usdValue: 0n,
+    ethValue: 0n,
+  }
+
+  const fillMissingReportValues = getReportValuesOr(defaultValue)
+
+  const [tvlReport, cbvReport, ebvReport, nmvReport] = typesToSeek
+    .map((requestedValueType) =>
+      reports.find(({ valueType }) => valueType === requestedValueType),
+    )
+    .map(fillMissingReportValues)
+
+  return {
+    tvlReport,
+    cbvReport,
+    ebvReport,
+    nmvReport,
+  }
+}
+
+function getReportValuesOr(fallback: { usdValue: bigint; ethValue: bigint }) {
+  return function (report?: AggregatedReportRecord) {
+    return {
+      usdValue: report?.usdValue ?? fallback.usdValue,
+      ethValue: report?.ethValue ?? fallback.ethValue,
+    }
+  }
+}

--- a/packages/backend/src/api/routers/TvlRouter.ts
+++ b/packages/backend/src/api/routers/TvlRouter.ts
@@ -2,10 +2,17 @@ import Router from '@koa/router'
 import { AssetId, branded, ProjectId } from '@l2beat/shared-pure'
 import { z } from 'zod'
 
+import { DetailedTvlController } from '../controllers/tvl/DetailedTvlController'
 import { TvlController } from '../controllers/tvl/TvlController'
 import { withTypedContext } from './types'
 
-export function createTvlRouter(tvlController: TvlController) {
+export function createTvlRouter(
+  tvlController: TvlController,
+  detailedTvlController: DetailedTvlController,
+  features: {
+    detailedTvlEnabled: boolean
+  },
+) {
   const router = new Router()
 
   router.get('/api/tvl', async (ctx) => {
@@ -14,6 +21,7 @@ export function createTvlRouter(tvlController: TvlController) {
       ctx.status = 404
       return
     }
+
     ctx.body = data
   })
 
@@ -40,6 +48,19 @@ export function createTvlRouter(tvlController: TvlController) {
       },
     ),
   )
+
+  if (features.detailedTvlEnabled) {
+    router.get('/api/detailed-tvl', async (ctx) => {
+      const data = await detailedTvlController.getDetailedTvlApiResponse()
+
+      if (!data) {
+        ctx.status = 404
+        return
+      }
+
+      ctx.body = data
+    })
+  }
 
   return router
 }

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -53,6 +53,7 @@ export interface ClockConfig {
 
 export interface TvlConfig {
   readonly enabled: boolean
+  readonly detailedTvlEnabled: boolean
   readonly coingeckoApiKey: string | undefined
   readonly ethereum: EthereumTvlConfig | false
   readonly arbitrum: ArbitrumTvlConfig | false

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -11,6 +11,7 @@ export function getLocalConfig(): Config {
   dotenv()
 
   const tvlEnabled = getEnv.boolean('TVL_ENABLED', true)
+  const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', true)
   const ethereumTvlEnabled = getEnv.boolean('ETHEREUM_TVL_ENABLED', true)
   const arbitrumTvlEnabled = getEnv.boolean('ARBITRUM_TVL_ENABLED', false)
   const activityEnabled = getEnv.boolean('ACTIVITY_ENABLED', false)
@@ -52,6 +53,7 @@ export function getLocalConfig(): Config {
 
     tvl: {
       enabled: tvlEnabled,
+      detailedTvlEnabled: detailedTvlEnabled,
       coingeckoApiKey: process.env.COINGECKO_API_KEY, // this is optional
       ethereum: ethereumTvlEnabled && {
         alchemyApiKey: getEnv('ETHEREUM_ALCHEMY_API_KEY'),

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -8,6 +8,7 @@ import { getGitCommitHash } from './getGitCommitHash'
 
 export function getProductionConfig(): Config {
   const arbitrumTvlEnabled = getEnv.boolean('ARBITRUM_TVL_ENABLED', false)
+  const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', false)
 
   const updateMonitorEnabled = getEnv.boolean('WATCHMODE_ENABLED', false)
   const discordEnabled =
@@ -57,6 +58,7 @@ export function getProductionConfig(): Config {
       pass: getEnv('METRICS_AUTH_PASS'),
     },
     tvl: {
+      detailedTvlEnabled,
       enabled: true,
       coingeckoApiKey: getEnv('COINGECKO_API_KEY'),
       ethereum: {

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -97,8 +97,8 @@ export function createTvlModule(
   const detailedTvlController = new DetailedTvlController(
     db.reportStatusRepository,
     db.aggregatedReportRepository,
-    db.aggregatedReportStatusRepository,
     db.reportRepository,
+    db.aggregatedReportStatusRepository,
     config.projects,
     logger,
   )

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -2,6 +2,7 @@ import { CoingeckoClient, HttpClient, Logger } from '@l2beat/shared'
 
 import { BlocksController } from '../../api/controllers/BlocksController'
 import { DydxController } from '../../api/controllers/DydxController'
+import { DetailedTvlController } from '../../api/controllers/tvl/DetailedTvlController'
 import { TvlController } from '../../api/controllers/tvl/TvlController'
 import { createBlocksRouter } from '../../api/routers/BlocksRouter'
 import { createDydxRouter } from '../../api/routers/DydxRouter'
@@ -93,10 +94,21 @@ export function createTvlModule(
     config.tvl.arbitrum ? true : false,
   )
 
+  const detailedTvlController = new DetailedTvlController(
+    db.reportStatusRepository,
+    db.aggregatedReportRepository,
+    db.aggregatedReportStatusRepository,
+    db.reportRepository,
+    config.projects,
+    logger,
+  )
+
   const dydxController = new DydxController(db.aggregatedReportRepository)
 
   const blocksRouter = createBlocksRouter(blocksController)
-  const tvlRouter = createTvlRouter(tvlController)
+  const tvlRouter = createTvlRouter(tvlController, detailedTvlController, {
+    detailedTvlEnabled: config.tvl.detailedTvlEnabled,
+  })
   const dydxRouter = createDydxRouter(dydxController)
 
   // #endregion

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
@@ -28,6 +28,14 @@ export class AggregatedReportRepository extends BaseRepository {
     return rows.map(toRecord)
   }
 
+  async getDailyWithAnyType(): Promise<AggregatedReportRecord[]> {
+    const knex = await this.knex()
+    const rows = await knex('aggregated_reports')
+      .whereRaw(`EXTRACT(hour FROM unix_timestamp) = 0`)
+      .orderBy('unix_timestamp')
+    return rows.map(toRecord)
+  }
+
   async getSixHourly(
     from: UnixTime,
     valueType: ValueType,
@@ -41,6 +49,17 @@ export class AggregatedReportRepository extends BaseRepository {
     return rows.map(toRecord)
   }
 
+  async getSixHourlyWithAnyType(
+    from: UnixTime,
+  ): Promise<AggregatedReportRecord[]> {
+    const knex = await this.knex()
+    const rows = await knex('aggregated_reports')
+      .where('unix_timestamp', '>=', from.toDate())
+      .andWhereRaw(`EXTRACT(hour FROM unix_timestamp) % 6 = 0`)
+      .orderBy('unix_timestamp')
+    return rows.map(toRecord)
+  }
+
   async getHourly(
     from: UnixTime,
     valueType: ValueType,
@@ -49,6 +68,16 @@ export class AggregatedReportRepository extends BaseRepository {
     const rows = await knex('aggregated_reports')
       .where('unix_timestamp', '>=', from.toDate())
       .andWhere({ value_type: valueType.toString() })
+      .orderBy('unix_timestamp')
+    return rows.map(toRecord)
+  }
+
+  async getHourlyWithAnyType(
+    from: UnixTime,
+  ): Promise<AggregatedReportRecord[]> {
+    const knex = await this.knex()
+    const rows = await knex('aggregated_reports')
+      .where('unix_timestamp', '>=', from.toDate())
       .orderBy('unix_timestamp')
     return rows.map(toRecord)
   }

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.ts
@@ -103,4 +103,16 @@ export class ReportStatusRepository extends BaseRepository {
 
     return UnixTime.fromDate(row.max)
   }
+
+  async findAnyLatestTimestamp(): Promise<UnixTime | undefined> {
+    const knex = await this.knex()
+    const row = (await knex('reports_status').max('unix_timestamp').first()) as
+      | NullableDict<Date>
+      | undefined
+    if (!row || row.max === null) {
+      return
+    }
+
+    return UnixTime.fromDate(row.max)
+  }
 }

--- a/packages/backend/src/peripherals/database/ReportStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportStatusRepository.ts
@@ -104,11 +104,16 @@ export class ReportStatusRepository extends BaseRepository {
     return UnixTime.fromDate(row.max)
   }
 
-  async findAnyLatestTimestamp(): Promise<UnixTime | undefined> {
+  async findLatestTimestampOfType(
+    assetType: ValueType,
+  ): Promise<UnixTime | undefined> {
     const knex = await this.knex()
-    const row = (await knex('reports_status').max('unix_timestamp').first()) as
-      | NullableDict<Date>
-      | undefined
+    const row = (await knex('reports_status')
+      .where({
+        asset_type: assetType.toString(),
+      })
+      .max('unix_timestamp')
+      .first()) as NullableDict<Date> | undefined
     if (!row || row.max === null) {
       return
     }


### PR DESCRIPTION
Resolves L2B-2005

## What's changed
- Added new endpoint for stacked charts.
- Response charts data now should include TVL values, along the per Value Type composition of the TVL
- Instead of chart old TVL-in-time now we include TVL-breakdown-in-time - that is:
```ts
const chartDataPoint = [timestamp, usdTvl, ethTvl]

// now's converted to:

const detailedDataPoint = [
  timestamp
  valueUsd,
  cbvUsd,
  ebvUsd,
  nmvUsd,
  valueEth,
  cbvEth,
  ebvEth,
  nmvEth,
]
```
