### PR TITLE
Add detailed project asset's TVL endpoint

### DIFF
--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
@@ -15,6 +15,7 @@ import { AggregatedReportRepository } from '../../../peripherals/database/Aggreg
 import { AggregatedReportStatusRepository } from '../../../peripherals/database/AggregatedReportStatusRepository'
 import { ReportRepository } from '../../../peripherals/database/ReportRepository'
 import { ReportStatusRepository } from '../../../peripherals/database/ReportStatusRepository'
+import { getProjectAssetChartData } from './charts'
 import { DetailedTvlController } from './DetailedTvlController'
 
 const START = UnixTime.fromDate(new Date('2022-05-31'))
@@ -111,6 +112,7 @@ describe(DetailedTvlController.name, () => {
           reportRepository,
           aggregatedReportStatusRepository,
           [ARBITRUM],
+          [USDC],
           Logger.SILENT,
         )
 
@@ -134,4 +136,170 @@ describe(DetailedTvlController.name, () => {
       })
     },
   )
+
+  /**
+   * TODO: Add test for granular/exact matches of produces chart points
+   */
+  describe(
+    DetailedTvlController.prototype.getDetailedAssetTvlApiResponse.name,
+    () => {
+      it('produces detailed asset`s balances in time for charts', async () => {
+        const projectId = ProjectId('arbitrum')
+        const chainId = ChainId.ARBITRUM
+        const asset = AssetId.USDC
+        const type = ValueType.CBV
+
+        const fakeReports = fakeReportSeries(projectId, chainId, asset, type)
+
+        const reportStatusRepository = mockObject<ReportStatusRepository>({
+          findLatestTimestamp: async () => fakeReports.to,
+        })
+
+        const reportRepository = mockObject<ReportRepository>({
+          getHourlyForDetailed: async () => fakeReports.hourlyReports,
+          getSixHourlyForDetailed: async () => fakeReports.sixHourlyReports,
+          getDailyForDetailed: async () => fakeReports.dailyReports,
+        })
+
+        const controller = new DetailedTvlController(
+          reportStatusRepository,
+          mockObject<AggregatedReportRepository>(),
+          reportRepository,
+          mockObject<AggregatedReportStatusRepository>(),
+          [ARBITRUM],
+          [USDC],
+          Logger.SILENT,
+        )
+
+        const result = await controller.getDetailedAssetTvlApiResponse(
+          projectId,
+          chainId,
+          asset,
+          type,
+        )
+
+        expect(result?.daily).toEqual({
+          types: ['timestamp', USDC.symbol.toLowerCase(), 'usd'],
+          data: getProjectAssetChartData(
+            fakeReports.dailyReports,
+            USDC.decimals,
+            24,
+          ),
+        })
+
+        expect(result?.sixHourly).toEqual({
+          types: ['timestamp', USDC.symbol.toLowerCase(), 'usd'],
+          data: getProjectAssetChartData(
+            fakeReports.sixHourlyReports,
+            USDC.decimals,
+            6,
+          ),
+        })
+
+        expect(result?.hourly).toEqual({
+          types: ['timestamp', USDC.symbol.toLowerCase(), 'usd'],
+          data: getProjectAssetChartData(
+            fakeReports.hourlyReports,
+            USDC.decimals,
+            1,
+          ),
+        })
+
+        expect(reportStatusRepository.findLatestTimestamp).toHaveBeenCalledWith(
+          chainId,
+          type,
+        )
+
+        expect(reportRepository.getHourlyForDetailed).toHaveBeenCalledWith(
+          projectId,
+          chainId,
+          asset,
+          type,
+          fakeReports.to.add(-7, 'days'),
+        )
+
+        expect(reportRepository.getSixHourlyForDetailed).toHaveBeenCalledWith(
+          projectId,
+          chainId,
+          asset,
+          type,
+          fakeReports.to.add(-90, 'days'),
+        )
+
+        expect(reportRepository.getDailyForDetailed).toHaveBeenCalledWith(
+          projectId,
+          chainId,
+          asset,
+          type,
+        )
+      })
+    },
+  )
 })
+
+function fakeAssetReport(
+  projectId: ProjectId,
+  chainId: ChainId,
+  asset: AssetId,
+  type: ValueType,
+  timestamp: UnixTime,
+) {
+  return {
+    timestamp: timestamp,
+    usdValue: 10_000_000n,
+    ethValue: 10_000n,
+    amount: 50_000_000n * 10n ** (6n - 4n),
+    asset,
+    chainId,
+    projectId,
+    type,
+  }
+}
+
+function fakeReportSeries(
+  projectId: ProjectId,
+  chainId: ChainId,
+  asset: AssetId,
+  type: ValueType,
+) {
+  const to = UnixTime.now()
+  const from = to.add(-90, 'days')
+
+  const timeDiff = to.toNumber() - from.toNumber()
+
+  const hoursInDiff = Math.floor(timeDiff / 1000 / 60 / 60)
+  const sixHoursInDiff = Math.floor(hoursInDiff / 6)
+  const daysInDiff = Math.floor(hoursInDiff / 24)
+
+  const hourlyTimestamps = Array.from({ length: hoursInDiff }, (_, i) =>
+    from.add(i, 'hours'),
+  )
+
+  const sixHourlyTimestamps = Array.from({ length: sixHoursInDiff }, (_, i) =>
+    from.add(i * 6, 'hours'),
+  )
+
+  const dailyTimestamps = Array.from({ length: daysInDiff }, (_, i) =>
+    from.add(i, 'days'),
+  )
+
+  const hourlyReports = hourlyTimestamps.map((timestamp) =>
+    fakeAssetReport(projectId, chainId, asset, type, timestamp),
+  )
+
+  const sixHourlyReports = sixHourlyTimestamps.map((timestamp) =>
+    fakeAssetReport(projectId, chainId, asset, type, timestamp),
+  )
+
+  const dailyReports = dailyTimestamps.map((timestamp) =>
+    fakeAssetReport(projectId, chainId, asset, type, timestamp),
+  )
+
+  return {
+    from,
+    to,
+    hourlyReports,
+    sixHourlyReports,
+    dailyReports,
+  }
+}

--- a/packages/backend/src/api/controllers/tvl/TvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/TvlController.ts
@@ -20,7 +20,7 @@ import {
 import { ReportStatusRepository } from '../../../peripherals/database/ReportStatusRepository'
 import { getHourlyMinTimestamp } from '../utils/getHourlyMinTimestamp'
 import { getSixHourlyMinTimestamp } from '../utils/getSixHourlyMinTimestamp'
-import { getChartPoints } from './charts'
+import { getProjectAssetChartData } from './charts'
 import { generateTvlApiResponse } from './generateTvlApiResponse'
 
 export class TvlController {
@@ -87,19 +87,6 @@ export class TvlController {
     return tvlApiResponse
   }
 
-  private getChartData(
-    reports: ReportRecord[],
-    decimals: number,
-    hours: number,
-  ) {
-    const balances = reports.map((r) => ({
-      timestamp: r.timestamp,
-      usd: r.usdValue,
-      asset: r.amount,
-    }))
-    return getChartPoints(balances, hours, decimals)
-  }
-
   async getProjectAssetChart(
     projectId: ProjectId,
     assetId: AssetId,
@@ -161,7 +148,7 @@ export class TvlController {
     return {
       hourly: {
         types,
-        data: this.getChartData(
+        data: getProjectAssetChartData(
           reduceDuplicatedReports(hourlyReports),
           asset.decimals,
           1,
@@ -169,7 +156,7 @@ export class TvlController {
       },
       sixHourly: {
         types,
-        data: this.getChartData(
+        data: getProjectAssetChartData(
           reduceDuplicatedReports(sixHourlyReports),
           asset.decimals,
           6,
@@ -177,7 +164,7 @@ export class TvlController {
       },
       daily: {
         types,
-        data: this.getChartData(
+        data: getProjectAssetChartData(
           reduceDuplicatedReports(dailyReports),
           asset.decimals,
           24,

--- a/packages/backend/src/api/controllers/tvl/charts.ts
+++ b/packages/backend/src/api/controllers/tvl/charts.ts
@@ -4,6 +4,7 @@ import {
   UnixTime,
 } from '@l2beat/shared-pure'
 
+import { ReportRecord } from '../../../peripherals/database/ReportRepository'
 import { asNumber } from './asNumber'
 
 interface DetailedBalanceInTime {
@@ -77,6 +78,20 @@ export function addDetailedMissingTimestamps(
     ])
   }
   return allPoints
+}
+
+export function getProjectAssetChartData(
+  projectAssetReports: ReportRecord[],
+  decimals: number,
+  hours: number,
+) {
+  const balancesInTime = projectAssetReports.map((report) => ({
+    timestamp: report.timestamp,
+    usd: report.usdValue,
+    asset: report.amount,
+  }))
+
+  return getChartPoints(balancesInTime, hours, decimals)
 }
 
 export function getChartPoints(

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -100,6 +100,7 @@ export function createTvlModule(
     db.reportRepository,
     db.aggregatedReportStatusRepository,
     config.projects,
+    config.tokens,
     logger,
   )
 

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -145,6 +145,67 @@ export class ReportRepository extends BaseRepository {
     return rows.map(toRecord)
   }
 
+  // Detailed asset TVL
+  async getHourlyForDetailed(
+    projectId: ProjectId,
+    chainId: ChainId,
+    assetId: AssetId,
+    assetType: ValueType,
+    from: UnixTime,
+  ): Promise<ReportRecord[]> {
+    const knex = await this.knex()
+
+    const rows = await knex('reports')
+      .where('asset_id', assetId.toString())
+      .andWhere('chain_id', chainId.valueOf())
+      .andWhere('project_id', projectId.valueOf())
+      .andWhere('asset_type', assetType.toString())
+      .andWhere('unix_timestamp', '>=', from.toDate())
+      .orderBy('unix_timestamp')
+
+    return rows.map(toRecord)
+  }
+
+  async getSixHourlyForDetailed(
+    projectId: ProjectId,
+    chainId: ChainId,
+    assetId: AssetId,
+    assetType: ValueType,
+    from: UnixTime,
+  ): Promise<ReportRecord[]> {
+    const knex = await this.knex()
+
+    const rows = await knex('reports')
+      .where('asset_id', assetId.toString())
+      .andWhere('project_id', projectId.valueOf())
+      .andWhere('chain_id', chainId.valueOf())
+      .andWhere('asset_type', assetType.toString())
+      .andWhereRaw(`extract(hour from "unix_timestamp") % 6 = 0`)
+      .andWhere('unix_timestamp', '>=', from.toDate())
+      .orderBy('unix_timestamp')
+
+    return rows.map(toRecord)
+  }
+
+  async getDailyForDetailed(
+    projectId: ProjectId,
+    chainId: ChainId,
+    assetId: AssetId,
+    assetType: ValueType,
+  ): Promise<ReportRecord[]> {
+    const knex = await this.knex()
+
+    const rows = await knex('reports')
+      .where('asset_id', assetId.toString())
+      .andWhere('chain_id', chainId.valueOf())
+      .andWhere('project_id', projectId.valueOf())
+      .andWhere('asset_type', assetType.toString())
+      .andWhereRaw(`extract(hour from "unix_timestamp") = 0`)
+      .orderBy('unix_timestamp')
+
+    return rows.map(toRecord)
+  }
+
   private _getByProjectAndAssetQuery(
     knex: Knex,
     projectId: ProjectId,


### PR DESCRIPTION
Resolves L2B-2007

## What's changed
Added new endpoint which enables querying balances in time  (chart data) of very particular assets.

## Sidenotes
- We have to schedule repository cleanups
- We have to plan old endpoints deprecation
- We have to plan utils cleanup since most things are now split between Detailed and Classic TVL things