### PR TITLE
Retry strategy improvements

### DIFF
--- a/packages/backend/src/core/discovery/DiscoveryRunner.ts
+++ b/packages/backend/src/core/discovery/DiscoveryRunner.ts
@@ -18,6 +18,9 @@ export interface DiscoveryRunnerOptions {
   retryDelayMs?: number
 }
 
+const MAX_RETRIES = 6
+const RETRY_DELAY_MS = 10_000
+
 export class DiscoveryRunner {
   constructor(
     private readonly discoveryProvider: DiscoveryProvider,
@@ -46,8 +49,8 @@ export class DiscoveryRunner {
     const discovery = await this.discoverWithRetry(
       config,
       blockNumber,
-      options.maxRetries,
-      options.retryDelayMs,
+      MAX_RETRIES,
+      RETRY_DELAY_MS,
     )
 
     if (options.runSanityCheck) {
@@ -80,8 +83,8 @@ export class DiscoveryRunner {
   async discoverWithRetry(
     config: DiscoveryConfig,
     blockNumber: number,
-    maxRetries = 2,
-    delayMs = 1000,
+    maxRetries: number,
+    delayMs: number,
   ): Promise<DiscoveryOutput> {
     let discovery: DiscoveryOutput | undefined = undefined
     let err: Error | undefined = undefined
@@ -94,6 +97,11 @@ export class DiscoveryRunner {
         err = isError(err) ? (error as Error) : new Error(JSON.stringify(error))
       }
 
+      console.log(
+        `DiscoveryRunner: Retrying ${config.name} (chain: ${ChainId.getName(
+          config.chainId,
+        )}) | attempt:${i}`,
+      )
       await new Promise((resolve) => setTimeout(resolve, delayMs))
     }
 

--- a/packages/backend/src/core/queue/TaskQueue.ts
+++ b/packages/backend/src/core/queue/TaskQueue.ts
@@ -1,10 +1,10 @@
 import { EventTracker, Logger } from '@l2beat/shared'
 import {
+  Retries,
+  ShouldRetry,
   getErrorMessage,
   getErrorStackTrace,
   json,
-  Retries,
-  ShouldRetry,
   wrapAndMeasure,
 } from '@l2beat/shared-pure'
 import assert from 'assert'
@@ -12,8 +12,8 @@ import { Histogram } from 'prom-client'
 import { setTimeout as wait } from 'timers/promises'
 
 const DEFAULT_RETRY = Retries.exponentialBackOff({
-  stepMs: 100,
-  maxDistanceMs: 3_000,
+  stepMs: 1000,
+  maxDistanceMs: 60_000,
   maxAttempts: 10,
 })
 
@@ -93,11 +93,13 @@ export class TaskQueue<T> {
   }
 
   addToFront(task: T) {
+    this.halted = false
     this.queue.unshift({ task, attempts: 0, executeAt: Date.now() })
     setTimeout(() => this.execute())
   }
 
   addToBack(task: T) {
+    this.halted = false
     this.queue.push({ task, attempts: 0, executeAt: Date.now() })
     setTimeout(() => this.execute())
   }

--- a/packages/backend/src/core/queue/promiseAllPlus.ts
+++ b/packages/backend/src/core/queue/promiseAllPlus.ts
@@ -42,8 +42,8 @@ export async function promiseAllPlus<T>(
     // this is quite ugly but we do exponential retries and finally propagate error
     shouldRetry: (job, error) => {
       const shouldRetry = Retries.exponentialBackOff({
-        stepMs: 100,
-        maxDistanceMs: 3_000,
+        stepMs: 1000,
+        maxDistanceMs: 60_000,
         maxAttempts: maxAttempts,
       })(job)
 


### PR DESCRIPTION
- change the TaskQueue retry params
- unhalt the queue when new task is added
- change DiscoveryRunner retry params 