### PR TITLE
Refactor detailed TVL data timings

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -80,7 +80,7 @@ environment variables. One variable per line `KEY=value`.
 
 ##### Multichain discovery CLI
 
-If you want to use multichain discovery cli, make sure you include the `RPC_URL` and `ETHERSCAN_API_KEY` for desired chains. If you want to use one RPC provider, all of them (unless stated in brackets) are supported by https://www.quicknode.com/ and https://www.ankr.com/. Etherscan API key should be created by creating an account on Etherscan instance for every chain separately (check config.discovery.ts for etherscan links).
+If you want to use multichain discovery cli, make sure you include the `RPC_URL` and `ETHERSCAN_API_KEY` for desired chains. If you want to use one RPC provider, all of them (unless stated in brackets) are supported by <https://www.quicknode.com/> and <https://www.ankr.com/>. Etherscan API key should be created by creating an account on Etherscan instance for every chain separately (check config.discovery.ts for etherscan links).
 
 - `DISCOVERY_ARBITRUM_RPC_URL` (Optional)
 - `DISCOVERY_ARBITRUM_ETHERSCAN_API_KEY` (Optional)
@@ -125,7 +125,10 @@ ETHEREUM_ALCHEMY_API_KEY=
 # ARBITRUM_TVL_ENABLED=
 # ARBISCAN_API_KEY=
 # ARBITRUM_PROVIDER_URL=
-
+## Enable/disable detailed-tvl endpoint exposure - defaults to true
+# DETAILED_TVL_ENABLED=
+## Should detailed-tvl endpoint return 404 if data is not synced yet - defaults to false
+# SKIP_UNSYNCED_DETAILED_TVL=
 # UPDATE_MONITOR_RUN_ON_START=
 # ACTIVITY_PROJECTS_EXCLUDED_FROM_API=project-a project-b
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -125,10 +125,10 @@ ETHEREUM_ALCHEMY_API_KEY=
 # ARBITRUM_TVL_ENABLED=
 # ARBISCAN_API_KEY=
 # ARBITRUM_PROVIDER_URL=
-## Enable/disable detailed-tvl endpoint exposure - defaults to true
-# DETAILED_TVL_ENABLED=
-## Should detailed-tvl endpoint return 404 if data is not synced yet - defaults to false
-# SKIP_UNSYNCED_DETAILED_TVL=
+## Enable/disable detailed-tvl endpoint exposure - defaults to false
+# DETAILED_TVL_ENABLED=true
+## Should detailed-tvl endpoint return 404 if data is not synced yet? - defaults to false
+# SKIP_UNSYNCED_DETAILED_TVL=true
 # UPDATE_MONITOR_RUN_ON_START=
 # ACTIVITY_PROJECTS_EXCLUDED_FROM_API=project-a project-b
 

--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -128,7 +128,7 @@ ETHEREUM_ALCHEMY_API_KEY=
 ## Enable/disable detailed-tvl endpoint exposure - defaults to false
 # DETAILED_TVL_ENABLED=true
 ## Should detailed-tvl endpoint return 404 if data is not synced yet? - defaults to false
-# SKIP_UNSYNCED_DETAILED_TVL=true
+# ERROR_ON_UNSYNCED_DETAILED_TVL=true
 # UPDATE_MONITOR_RUN_ON_START=
 # ACTIVITY_PROJECTS_EXCLUDED_FROM_API=project-a project-b
 

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
@@ -128,7 +128,7 @@ describe(DetailedTvlController.name, () => {
           Logger.SILENT,
           latestConfigHash,
           {
-            skipUnsyncedDetailedTvl: false,
+            errorOnUnsyncedDetailedTvl: false,
           },
         )
 
@@ -199,7 +199,7 @@ describe(DetailedTvlController.name, () => {
           Logger.SILENT,
           latestConfigHash,
           {
-            skipUnsyncedDetailedTvl: false,
+            errorOnUnsyncedDetailedTvl: false,
           },
         )
 

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.test.ts
@@ -1,6 +1,7 @@
 import { tokenList } from '@l2beat/config'
 import { Logger } from '@l2beat/shared'
 import {
+  assert,
   AssetId,
   ChainId,
   EthereumAddress,
@@ -126,6 +127,9 @@ describe(DetailedTvlController.name, () => {
           [USDC],
           Logger.SILENT,
           latestConfigHash,
+          {
+            skipUnsyncedDetailedTvl: false,
+          },
         )
 
         await controller.getDetailedTvlApiResponse()
@@ -194,6 +198,9 @@ describe(DetailedTvlController.name, () => {
           [USDC],
           Logger.SILENT,
           latestConfigHash,
+          {
+            skipUnsyncedDetailedTvl: false,
+          },
         )
 
         const result = await controller.getDetailedAssetTvlApiResponse(
@@ -203,7 +210,9 @@ describe(DetailedTvlController.name, () => {
           type,
         )
 
-        expect(result?.daily).toEqual({
+        assert(result.result === 'success')
+
+        expect(result.data.daily).toEqual({
           types: ['timestamp', USDC.symbol.toLowerCase(), 'usd'],
           data: getProjectAssetChartData(
             fakeReports.dailyReports,
@@ -212,7 +221,7 @@ describe(DetailedTvlController.name, () => {
           ),
         })
 
-        expect(result?.sixHourly).toEqual({
+        expect(result.data.sixHourly).toEqual({
           types: ['timestamp', USDC.symbol.toLowerCase(), 'usd'],
           data: getProjectAssetChartData(
             fakeReports.sixHourlyReports,
@@ -221,7 +230,7 @@ describe(DetailedTvlController.name, () => {
           ),
         })
 
-        expect(result?.hourly).toEqual({
+        expect(result.data.hourly).toEqual({
           types: ['timestamp', USDC.symbol.toLowerCase(), 'usd'],
           data: getProjectAssetChartData(
             fakeReports.hourlyReports,

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -25,7 +25,7 @@ import {
 } from './detailedTvl'
 import { generateDetailedTvlApiResponse } from './generateDetailedTvlApiResponse'
 
-interface DetailedControllerBehaviorOptions {
+interface DetailedControllerOptions {
   errorOnUnsyncedDetailedTvl: boolean
 }
 
@@ -59,7 +59,7 @@ export class DetailedTvlController {
     private readonly tokens: Token[],
     private readonly logger: Logger,
     private readonly aggregatedConfigHash: Hash256,
-    private readonly options: DetailedControllerBehaviorOptions,
+    private readonly options: DetailedControllerOptions,
   ) {
     this.logger = this.logger.for(this)
   }

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -25,7 +25,7 @@ import {
 } from './detailedTvl'
 import { generateDetailedTvlApiResponse } from './generateDetailedTvlApiResponse'
 
-interface DetailedControllerOptions {
+interface DetailedTvlControllerOptions {
   errorOnUnsyncedDetailedTvl: boolean
 }
 
@@ -59,7 +59,7 @@ export class DetailedTvlController {
     private readonly tokens: Token[],
     private readonly logger: Logger,
     private readonly aggregatedConfigHash: Hash256,
-    private readonly options: DetailedControllerOptions,
+    private readonly options: DetailedTvlControllerOptions,
   ) {
     this.logger = this.logger.for(this)
   }

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -174,7 +174,7 @@ export class DetailedTvlController {
       syncedReportsAmount,
       unsyncedReportsAmount,
       isSynced,
-      latestTimestamp: latestTimestamp,
+      latestTimestamp,
     }
 
     return result

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -25,7 +25,7 @@ import {
 } from './detailedTvl'
 import { generateDetailedTvlApiResponse } from './generateDetailedTvlApiResponse'
 
-interface DetailedControllerBehaviorFlags {
+interface DetailedControllerBehaviorOptions {
   skipUnsyncedDetailedTvl: boolean
 }
 
@@ -59,7 +59,7 @@ export class DetailedTvlController {
     private readonly tokens: Token[],
     private readonly logger: Logger,
     private readonly aggregatedConfigHash: Hash256,
-    private readonly flags: DetailedControllerBehaviorFlags,
+    private readonly options: DetailedControllerBehaviorOptions,
   ) {
     this.logger = this.logger.for(this)
   }
@@ -77,7 +77,7 @@ export class DetailedTvlController {
       }
     }
 
-    if (!dataTimings.isSynced && this.flags.skipUnsyncedDetailedTvl) {
+    if (!dataTimings.isSynced && this.options.skipUnsyncedDetailedTvl) {
       return {
         result: 'error',
         error: 'UNSYNCED_DATA_SKIPPED',

--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -26,7 +26,7 @@ import {
 import { generateDetailedTvlApiResponse } from './generateDetailedTvlApiResponse'
 
 interface DetailedControllerBehaviorOptions {
-  skipUnsyncedDetailedTvl: boolean
+  errorOnUnsyncedDetailedTvl: boolean
 }
 
 type DetailedTvlResult =
@@ -36,7 +36,7 @@ type DetailedTvlResult =
     }
   | {
       result: 'error'
-      error: 'UNSYNCED_DATA_SKIPPED' | 'NO_DATA'
+      error: 'DATA_NOT_FULLY_SYNCED' | 'NO_DATA'
     }
 
 type DetailedAssetTvlResult =
@@ -77,10 +77,10 @@ export class DetailedTvlController {
       }
     }
 
-    if (!dataTimings.isSynced && this.options.skipUnsyncedDetailedTvl) {
+    if (!dataTimings.isSynced && this.options.errorOnUnsyncedDetailedTvl) {
       return {
         result: 'error',
-        error: 'UNSYNCED_DATA_SKIPPED',
+        error: 'DATA_NOT_FULLY_SYNCED',
       }
     }
 

--- a/packages/backend/src/api/routers/TvlRouter.ts
+++ b/packages/backend/src/api/routers/TvlRouter.ts
@@ -61,7 +61,7 @@ export function createTvlRouter(
         await detailedTvlController.getDetailedTvlApiResponse()
 
       if (detailedTvlResult.result === 'error') {
-        if (detailedTvlResult.error === 'UNSYNCED_DATA_SKIPPED') {
+        if (detailedTvlResult.error === 'DATA_NOT_FULLY_SYNCED') {
           ctx.status = 422
         }
 

--- a/packages/backend/src/api/routers/TvlRouter.ts
+++ b/packages/backend/src/api/routers/TvlRouter.ts
@@ -57,14 +57,22 @@ export function createTvlRouter(
 
   if (features.detailedTvlEnabled) {
     router.get('/api/detailed-tvl', async (ctx) => {
-      const data = await detailedTvlController.getDetailedTvlApiResponse()
+      const detailedTvlResult =
+        await detailedTvlController.getDetailedTvlApiResponse()
 
-      if (!data) {
-        ctx.status = 404
+      if (detailedTvlResult.result === 'error') {
+        if (detailedTvlResult.error === 'UNSYNCED_DATA_SKIPPED') {
+          ctx.status = 422
+        }
+
+        if (detailedTvlResult.error === 'NO_DATA') {
+          ctx.status = 404
+        }
+
         return
       }
 
-      ctx.body = data
+      ctx.body = detailedTvlResult.data
     })
 
     router.get(
@@ -82,7 +90,7 @@ export function createTvlRouter(
         async (ctx) => {
           const { assetId, chainId, assetType, projectId } = ctx.params
 
-          const chart =
+          const detailedAssetData =
             await detailedTvlController.getDetailedAssetTvlApiResponse(
               projectId,
               ChainId(+chainId),
@@ -90,12 +98,19 @@ export function createTvlRouter(
               assetType,
             )
 
-          if (!chart) {
-            ctx.status = 404
+          if (detailedAssetData.result === 'error') {
+            if (detailedAssetData.error === 'NO_DATA') {
+              ctx.status = 404
+            }
+
+            if (detailedAssetData.error === 'INVALID_PROJECT_OR_ASSET') {
+              ctx.status = 400
+            }
+
             return
           }
 
-          ctx.body = chart
+          ctx.body = detailedAssetData.data
         },
       ),
     )

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -54,6 +54,7 @@ export interface ClockConfig {
 export interface TvlConfig {
   readonly enabled: boolean
   readonly detailedTvlEnabled: boolean
+  readonly skipUnsyncedDetailedTvl: boolean
   readonly coingeckoApiKey: string | undefined
   readonly ethereum: EthereumTvlConfig | false
   readonly arbitrum: ArbitrumTvlConfig | false

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -54,7 +54,7 @@ export interface ClockConfig {
 export interface TvlConfig {
   readonly enabled: boolean
   readonly detailedTvlEnabled: boolean
-  readonly skipUnsyncedDetailedTvl: boolean
+  readonly errorOnUnsyncedDetailedTvl: boolean
   readonly coingeckoApiKey: string | undefined
   readonly ethereum: EthereumTvlConfig | false
   readonly arbitrum: ArbitrumTvlConfig | false

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -12,6 +12,10 @@ export function getLocalConfig(): Config {
 
   const tvlEnabled = getEnv.boolean('TVL_ENABLED', true)
   const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', true)
+  const skipUnsyncedDetailedTvl = getEnv.boolean(
+    'SKIP_UNSYNCED_DETAILED_TVL',
+    false,
+  )
   const ethereumTvlEnabled = getEnv.boolean('ETHEREUM_TVL_ENABLED', true)
   const arbitrumTvlEnabled = getEnv.boolean('ARBITRUM_TVL_ENABLED', false)
   const activityEnabled = getEnv.boolean('ACTIVITY_ENABLED', false)
@@ -53,7 +57,8 @@ export function getLocalConfig(): Config {
 
     tvl: {
       enabled: tvlEnabled,
-      detailedTvlEnabled: detailedTvlEnabled,
+      detailedTvlEnabled,
+      skipUnsyncedDetailedTvl,
       coingeckoApiKey: process.env.COINGECKO_API_KEY, // this is optional
       ethereum: ethereumTvlEnabled && {
         alchemyApiKey: getEnv('ETHEREUM_ALCHEMY_API_KEY'),

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -11,7 +11,7 @@ export function getLocalConfig(): Config {
   dotenv()
 
   const tvlEnabled = getEnv.boolean('TVL_ENABLED', true)
-  const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', true)
+  const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', false)
   const skipUnsyncedDetailedTvl = getEnv.boolean(
     'SKIP_UNSYNCED_DETAILED_TVL',
     false,

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -12,8 +12,8 @@ export function getLocalConfig(): Config {
 
   const tvlEnabled = getEnv.boolean('TVL_ENABLED', true)
   const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', false)
-  const skipUnsyncedDetailedTvl = getEnv.boolean(
-    'SKIP_UNSYNCED_DETAILED_TVL',
+  const errorOnUnsyncedDetailedTvl = getEnv.boolean(
+    'ERROR_ON_UNSYNCED_DETAILED_TVL',
     false,
   )
   const ethereumTvlEnabled = getEnv.boolean('ETHEREUM_TVL_ENABLED', true)
@@ -58,7 +58,7 @@ export function getLocalConfig(): Config {
     tvl: {
       enabled: tvlEnabled,
       detailedTvlEnabled,
-      skipUnsyncedDetailedTvl,
+      errorOnUnsyncedDetailedTvl,
       coingeckoApiKey: process.env.COINGECKO_API_KEY, // this is optional
       ethereum: ethereumTvlEnabled && {
         alchemyApiKey: getEnv('ETHEREUM_ALCHEMY_API_KEY'),

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -9,6 +9,10 @@ import { getGitCommitHash } from './getGitCommitHash'
 export function getProductionConfig(): Config {
   const arbitrumTvlEnabled = getEnv.boolean('ARBITRUM_TVL_ENABLED', false)
   const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', false)
+  const skipUnsyncedDetailedTvl = getEnv.boolean(
+    'SKIP_UNSYNCED_DETAILED_TVL',
+    false,
+  )
 
   const updateMonitorEnabled = getEnv.boolean('WATCHMODE_ENABLED', false)
   const discordEnabled =
@@ -59,6 +63,7 @@ export function getProductionConfig(): Config {
     },
     tvl: {
       detailedTvlEnabled,
+      skipUnsyncedDetailedTvl,
       enabled: true,
       coingeckoApiKey: getEnv('COINGECKO_API_KEY'),
       ethereum: {

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -9,8 +9,8 @@ import { getGitCommitHash } from './getGitCommitHash'
 export function getProductionConfig(): Config {
   const arbitrumTvlEnabled = getEnv.boolean('ARBITRUM_TVL_ENABLED', false)
   const detailedTvlEnabled = getEnv.boolean('DETAILED_TVL_ENABLED', false)
-  const skipUnsyncedDetailedTvl = getEnv.boolean(
-    'SKIP_UNSYNCED_DETAILED_TVL',
+  const errorOnUnsyncedDetailedTvl = getEnv.boolean(
+    'ERROR_ON_UNSYNCED_DETAILED_TVL',
     false,
   )
 
@@ -63,7 +63,7 @@ export function getProductionConfig(): Config {
     },
     tvl: {
       detailedTvlEnabled,
-      skipUnsyncedDetailedTvl,
+      errorOnUnsyncedDetailedTvl,
       enabled: true,
       coingeckoApiKey: getEnv('COINGECKO_API_KEY'),
       ethereum: {

--- a/packages/backend/src/core/reports/AggregatedReportUpdater.ts
+++ b/packages/backend/src/core/reports/AggregatedReportUpdater.ts
@@ -33,6 +33,10 @@ export class AggregatedReportUpdater {
     )
   }
 
+  getConfigHash() {
+    return this.configHash
+  }
+
   async start() {
     const known = await this.aggregatedReportStatusRepository.getByConfigHash(
       this.configHash,

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -121,6 +121,7 @@ export function createTvlModule(
     config.tokens,
     logger,
     aggregatedReportUpdater.getConfigHash(),
+    { skipUnsyncedDetailedTvl: config.tvl.skipUnsyncedDetailedTvl },
   )
 
   const dydxController = new DydxController(db.aggregatedReportRepository)

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -121,7 +121,7 @@ export function createTvlModule(
     config.tokens,
     logger,
     aggregatedReportUpdater.getConfigHash(),
-    { skipUnsyncedDetailedTvl: config.tvl.skipUnsyncedDetailedTvl },
+    { errorOnUnsyncedDetailedTvl: config.tvl.errorOnUnsyncedDetailedTvl },
   )
 
   const dydxController = new DydxController(db.aggregatedReportRepository)

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -81,8 +81,26 @@ export function createTvlModule(
   )
 
   // #endregion
-  // #region api
+  // #region submodules
 
+  const submodules: (TvlSubmodule | undefined)[] = [
+    createEthereumTvlSubmodule(db, priceUpdater, config, logger, http, clock),
+    createNativeTvlSubmodule(db, priceUpdater, config, logger, clock),
+    createArbitrumTvlSubmodule(db, priceUpdater, config, logger, http, clock),
+  ]
+
+  // #endregion
+
+  const aggregatedReportUpdater = new AggregatedReportUpdater(
+    submodules.flatMap((x) => x?.updaters ?? []),
+    db.aggregatedReportRepository,
+    db.aggregatedReportStatusRepository,
+    clock,
+    config.projects,
+    logger,
+  )
+
+  // #region api
   const blocksController = new BlocksController(db.blockNumberRepository)
   const tvlController = new TvlController(
     db.reportStatusRepository,
@@ -102,6 +120,7 @@ export function createTvlModule(
     config.projects,
     config.tokens,
     logger,
+    aggregatedReportUpdater.getConfigHash(),
   )
 
   const dydxController = new DydxController(db.aggregatedReportRepository)
@@ -113,21 +132,6 @@ export function createTvlModule(
   const dydxRouter = createDydxRouter(dydxController)
 
   // #endregion
-
-  const submodules: (TvlSubmodule | undefined)[] = [
-    createEthereumTvlSubmodule(db, priceUpdater, config, logger, http, clock),
-    createNativeTvlSubmodule(db, priceUpdater, config, logger, clock),
-    createArbitrumTvlSubmodule(db, priceUpdater, config, logger, http, clock),
-  ]
-
-  const aggregatedReportUpdater = new AggregatedReportUpdater(
-    submodules.flatMap((x) => x?.updaters ?? []),
-    db.aggregatedReportRepository,
-    db.aggregatedReportStatusRepository,
-    clock,
-    config.projects,
-    logger,
-  )
 
   const start = async () => {
     logger = logger.for('TvlModule')

--- a/packages/backend/src/peripherals/database/AggregatedReportStatusRepository.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportStatusRepository.ts
@@ -49,6 +49,27 @@ export class AggregatedReportStatusRepository extends BaseRepository {
     return await knex('aggregated_reports_status').delete()
   }
 
+  async findCountsForHash(
+    configHash: Hash256,
+  ): Promise<{ matching: number; different: number }> {
+    const knex = await this.knex()
+
+    const [matchingRowsCount, differentRowsCount] = await Promise.all([
+      knex('aggregated_reports_status')
+        .where({ config_hash: configHash.toString() })
+        .count('config_hash'),
+
+      knex('aggregated_reports_status')
+        .where('config_hash', '<>', configHash.toString())
+        .count('config_hash'),
+    ])
+
+    return {
+      matching: Number(matchingRowsCount[0].count),
+      different: Number(differentRowsCount[0].count),
+    }
+  }
+
   async getBetween(
     from: UnixTime,
     to: UnixTime,


### PR DESCRIPTION
Resolves L2B-2016

## What's changed

Simplified timestamp logic. No status field, only conditional check beforehand is enough tho.
Optimization at the end of the day, instead of few longer queries we could do the one generic one in the first place since once we got Aggregated Report for given timestamp in place we are also sure plain reports have been generated since aggregated reports are simply basic reports' summary 🤯 

Query benchmark, down below, works as if no changes were made.

Also, we agreed to enable returning 404 if data is in unsycned state. It's optional and controllable via backend feature flag.

Ah, yeah and sync status - get the latest aggregated config hash, count aggregated reports updated with this hash and with different hash (those haven't been synced yet). If the amount of different hashes is not equal to `0` that means data is mid-way through re-indexing process. Plain and simple. Also, if there are no different hashes in case of fresh database i.e. locally no data will be returned since there are no timestamps to query for.

Query written on the knee 😅 - this is production database roa 
![image](https://github.com/l2beat/l2beat/assets/67391475/ecae91d3-ee6c-4dd0-9c9b-aab105133f41)


