### PR TITLE
Replace Gitcoin Round link to the direct one

### DIFF
--- a/packages/frontend/src/components/gitcoin/TopBar.tsx
+++ b/packages/frontend/src/components/gitcoin/TopBar.tsx
@@ -6,7 +6,7 @@ export function GitcoinTopBar() {
   return (
     <a
       className="TopBar-Gitcoin flex hidden flex-col items-center justify-center bg-[#0d0533] p-2 text-center text-xs font-bold text-white md:flex-row md:space-x-5 md:text-sm"
-      href="https://explorer.gitcoin.co/#/round/424/0x222ea76664ed77d18d4416d2b2e77937b76f0a35"
+      href="https://explorer.gitcoin.co/#/round/424/0x222ea76664ed77d18d4416d2b2e77937b76f0a35/0x222ea76664ed77d18d4416d2b2e77937b76f0a35-27"
       target="_blank"
     >
       <p>We are taking part in Gitcoin Grants 18!</p>


### PR DESCRIPTION
Gitcoin had some hiccups regarding website navigation. That has been fixed now. 