### PR TITLE
Fix missing Ethereum among tokens to query for

### DIFF
--- a/packages/frontend/src/components/chart/CommonTokenControls.tsx
+++ b/packages/frontend/src/components/chart/CommonTokenControls.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 import { CloseIcon } from '../icons/CloseIcon'
 
 export interface TokenControl {
-  address: string
+  address?: string
   symbol: string
   name: string
   assetType: ValueType
@@ -23,10 +23,17 @@ export function TokenCell({ token }: { token: TokenControl }) {
         data-tvl-endpoint={token.tvlEndpoint}
         data-asset-type={token.assetType}
       />
-      <img
-        src={`https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${token.address}/logo.png`}
-        className="h-4 w-4 rounded-full"
-      />
+      {token.address ? (
+        <img
+          src={`https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${token.address}/logo.png`}
+          className="h-4 w-4 rounded-full"
+        />
+      ) : (
+        <img
+          src="https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/128/color/eth.png"
+          className="h-4 w-4 rounded-full"
+        />
+      )}
       <p className="text-sm" key={token.symbol}>
         <span className={'font-bold'}>{token.name}</span> ({token.symbol})
       </p>

--- a/packages/frontend/src/components/chart/CommonTokenControls.tsx
+++ b/packages/frontend/src/components/chart/CommonTokenControls.tsx
@@ -1,6 +1,7 @@
 import { ValueType } from '@l2beat/shared-pure'
 import React from 'react'
 
+import { EthereumRoundIcon } from '../icons/chart/EthereumRoundIcon'
 import { CloseIcon } from '../icons/CloseIcon'
 
 export interface TokenControl {
@@ -12,6 +13,8 @@ export interface TokenControl {
 }
 
 export function TokenCell({ token }: { token: TokenControl }) {
+  const isNativeEth = !token.address && token.symbol === 'ETH'
+
   return (
     <label className="flex cursor-pointer select-none items-center gap-1.5">
       <input
@@ -23,16 +26,16 @@ export function TokenCell({ token }: { token: TokenControl }) {
         data-tvl-endpoint={token.tvlEndpoint}
         data-asset-type={token.assetType}
       />
-      {token.address ? (
+      {isNativeEth ? (
+        <EthereumRoundIcon className="h-4 w-4 rounded-full" />
+      ) : token.address ? (
         <img
           src={`https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${token.address}/logo.png`}
           className="h-4 w-4 rounded-full"
         />
       ) : (
-        <img
-          src="https://raw.githubusercontent.com/spothq/cryptocurrency-icons/master/128/color/eth.png"
-          className="h-4 w-4 rounded-full"
-        />
+        // Refactor way of displaying unknown tokens - refine icons' sources
+        <span className="font-bold text-yellow-300">?</span>
       )}
       <p className="text-sm" key={token.symbol}>
         <span className={'font-bold'}>{token.name}</span> ({token.symbol})

--- a/packages/frontend/src/components/icons/chart/EthereumRoundIcon.tsx
+++ b/packages/frontend/src/components/icons/chart/EthereumRoundIcon.tsx
@@ -1,0 +1,25 @@
+import React, { SVGAttributes } from 'react'
+
+export function EthereumRoundIcon(props: SVGAttributes<SVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 32 32"
+      {...props}
+    >
+      <g fill="none" fillRule="evenodd">
+        <circle cx="16" cy="16" r="16" fill="#627EEA" />
+        <g fill="#FFF" fillRule="nonzero">
+          <path fillOpacity=".602" d="M16.498 4v8.87l7.497 3.35z" />
+          <path d="M16.498 4L9 16.22l7.498-3.35z" />
+          <path fillOpacity=".602" d="M16.498 21.968v6.027L24 17.616z" />
+          <path d="M16.498 27.995v-6.028L9 17.616z" />
+          <path fillOpacity=".2" d="M16.498 20.573l7.497-4.353-7.497-3.348z" />
+          <path fillOpacity=".602" d="M9 16.22l7.498 4.353v-7.701z" />
+        </g>
+      </g>
+    </svg>
+  )
+}

--- a/packages/frontend/src/utils/project/getChart.ts
+++ b/packages/frontend/src/utils/project/getChart.ts
@@ -50,13 +50,14 @@ function getTokens(
       const symbol = token?.symbol
       const name = token?.name
       const address = token?.address
-      if (symbol && name && address) {
+
+      if (symbol && name) {
         const tvlEndpoint = hasDetailedTVL
           ? `/api/projects/${projectId.toString()}/tvl/chains/${chainId.toString()}/assets/${assetId.toString()}/types/${valueType.toString()}`
           : `/api/projects/${projectId.toString()}/tvl/assets/${assetId.toString()}`
 
         return {
-          address: address.toString(),
+          address: address?.toString(),
           symbol,
           name,
           assetType: valueType,


### PR DESCRIPTION
Resolves L2B-2143

## What's changed
- Do not skip missing addresses
- Handle ETH native coin within chart's token list
- Added deep fallback if token has no address (temp fix since if address is there but trustwallet has no icon for such token we still display default HTML no-image fallback)