### PR TITLE
Update lzOmnichain discovery

### DIFF
--- a/packages/backend/discovery/lzomnichain/ethereum/discovered.json
+++ b/packages/backend/discovery/lzomnichain/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "ethereum",
-  "blockNumber": 17876391,
+  "blockNumber": 17962968,
   "configHash": "0x793b1ec31c66d6ecaeef1247cd5d435add6d670a809cd8db79296bd0e33c8eb0",
   "version": 1,
   "contracts": [
@@ -75,7 +75,12 @@
           "177": 20,
           "181": 20,
           "183": 20,
-          "184": 20
+          "184": 20,
+          "195": 20,
+          "196": 20,
+          "197": 20,
+          "198": 20,
+          "199": 20
         },
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -193,7 +198,7 @@
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
           "167": {
-            "proofType": 2,
+            "proofType": 1,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
           "173": {
@@ -221,6 +226,26 @@
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
           "184": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "195": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "196": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "197": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "198": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "199": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           }
@@ -484,6 +509,41 @@
             "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0x5a54fe5234E811466D5366846283323c954310B2"
+          },
+          "195": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 15,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2"
+          },
+          "196": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 15,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2"
+          },
+          "197": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 15,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2"
+          },
+          "198": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 15,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2"
+          },
+          "199": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 15,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2"
           }
         },
         "endpoint": "0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675",
@@ -627,6 +687,26 @@
           "184": [
             "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
             "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
+          ],
+          "195": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
+          ],
+          "196": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
+          ],
+          "197": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
+          ],
+          "198": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
+          ],
+          "199": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
           ]
         },
         "layerZeroToken": "0x0000000000000000000000000000000000000000",
@@ -663,14 +743,19 @@
           "161": [1, 2],
           "165": 2,
           "166": 2,
-          "167": 2,
+          "167": [2, 1],
           "173": [1, 2],
           "175": [1, 2],
           "176": 2,
           "177": 2,
           "181": 2,
           "183": 2,
-          "184": 2
+          "184": 2,
+          "195": [1, 2],
+          "196": [1, 2],
+          "197": [1, 2],
+          "198": [1, 2],
+          "199": [1, 2]
         },
         "treasuryContract": "0x3773E1E9Deb273fCdf9f80bc88bB387B1e6Ce34d",
         "treasuryZROFees": 0,
@@ -709,7 +794,12 @@
           "177": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "181": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "183": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
-          "184": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251"
+          "184": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
+          "195": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
+          "196": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
+          "197": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
+          "198": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
+          "199": "0x0000000000000000000000005b19bd330a84c049b62d5b0fc2ba120217a18c1c"
         }
       },
       "derivedName": "UltraLightNodeV2"
@@ -757,7 +847,7 @@
           "0xf02CC4dc84aC59Bd6089BAddcEB9d4Ef3AEFb0f0"
         ],
         "getThreshold": 3,
-        "nonce": 546,
+        "nonce": 557,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -839,7 +929,7 @@
           "0x67FC8c432448f9a8d541C17579EF7a142378d5aD"
         ],
         "getThreshold": 2,
-        "nonce": 40,
+        "nonce": 42,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"


### PR DESCRIPTION
Resolves L2B-2167

The update includes adding various destination chains to the LayerZero infrastructure.
The update is not significant from the viewpoint of our UI, as we do not show destination chains or per-chain configurations.