### PR TITLE
Fix chart hover bug

### DIFF
--- a/packages/frontend/src/components/chart/ChartHover.tsx
+++ b/packages/frontend/src/components/chart/ChartHover.tsx
@@ -66,7 +66,7 @@ export function ChartHover() {
         className={cx(
           'absolute z-50 rounded-lg py-2 px-3 text-right text-2xs md:py-3 md:px-4 md:text-xs',
           'bg-gray-100 shadow-[0_4px_8px_rgba(0,0,0,0.25)] dark:bg-gray-750',
-          'select-none',
+          'pointer-events-none select-none',
           'flex flex-col items-start justify-center',
         )}
       />


### PR DESCRIPTION
Resolves L2B-1959

This PR fix the behaviour: when going fast enough your cursor can end up on the tooltip, which "freezes" the chart until you move out of it