### PR TITLE
Allow for key-less Coingecko tokens fetching

### DIFF
--- a/packages/config/scripts/tokens/add/index.ts
+++ b/packages/config/scripts/tokens/add/index.ts
@@ -10,6 +10,8 @@ import { getCanonicalTokens } from '../../../src'
 import { getEnv } from '../../checkVerifiedContracts/utils'
 import { getTokenInfo } from './getTokenInfo'
 
+const API_KEY_ENV_FALLBACK = '_FALLBACK'
+
 async function main() {
   const [address, category] = handleCLIParameters()
   if (!address) {
@@ -17,7 +19,9 @@ async function main() {
   }
 
   const http = new HttpClient()
-  const coingeckoClient = new CoingeckoClient(http, getEnv('COINGECKO_API_KEY'))
+  const apiKeyEnv = getEnv('COINGECKO_API_KEY', API_KEY_ENV_FALLBACK)
+  const apiKey = apiKeyEnv === API_KEY_ENV_FALLBACK ? undefined : apiKeyEnv
+  const coingeckoClient = new CoingeckoClient(http, apiKey)
   const provider = new providers.AlchemyProvider(
     'homestead',
     getEnv('CONFIG_ALCHEMY_API_KEY'),

--- a/packages/config/scripts/tokens/add/index.ts
+++ b/packages/config/scripts/tokens/add/index.ts
@@ -10,8 +10,6 @@ import { getCanonicalTokens } from '../../../src'
 import { getEnv } from '../../checkVerifiedContracts/utils'
 import { getTokenInfo } from './getTokenInfo'
 
-const API_KEY_ENV_FALLBACK = '_FALLBACK'
-
 async function main() {
   const [address, category] = handleCLIParameters()
   if (!address) {
@@ -19,9 +17,7 @@ async function main() {
   }
 
   const http = new HttpClient()
-  const apiKeyEnv = getEnv('COINGECKO_API_KEY', API_KEY_ENV_FALLBACK)
-  const apiKey = apiKeyEnv === API_KEY_ENV_FALLBACK ? undefined : apiKeyEnv
-  const coingeckoClient = new CoingeckoClient(http, apiKey)
+  const coingeckoClient = new CoingeckoClient(http, process.env.COINGECKO_API_KEY)
   const provider = new providers.AlchemyProvider(
     'homestead',
     getEnv('CONFIG_ALCHEMY_API_KEY'),

--- a/packages/config/scripts/tokens/add/index.ts
+++ b/packages/config/scripts/tokens/add/index.ts
@@ -17,7 +17,10 @@ async function main() {
   }
 
   const http = new HttpClient()
-  const coingeckoClient = new CoingeckoClient(http, process.env.COINGECKO_API_KEY)
+  const coingeckoClient = new CoingeckoClient(
+    http,
+    process.env.COINGECKO_API_KEY,
+  )
   const provider = new providers.AlchemyProvider(
     'homestead',
     getEnv('CONFIG_ALCHEMY_API_KEY'),


### PR DESCRIPTION
Because the Coingecko free API Tier does not have a key, we need to support having this key not set. Otherwise everybody would need to share the same production key which is not safe or easy to manage