### PR TITLE
Allow for the second flavor of Discord invite links

### DIFF
--- a/packages/config/src/test/projects.test.ts
+++ b/packages/config/src/test/projects.test.ts
@@ -125,7 +125,7 @@ describe('projects', () => {
       for (const link of links) {
         it(link, () => {
           if (link.includes('discord')) {
-            expect(link).toMatchRegex(/^https:\/\/discord\.gg\/[\w-]+$/)
+            expect(link).toMatchRegex(/^https:\/\/discord\.(gg|com\/invite)\/[\w-]+$/)
           } else if (link.includes('t.me')) {
             expect(link).toMatchRegex(/^https:\/\/t\.me\/(joinchat\/)?\w+$/)
           } else if (link.includes('medium')) {

--- a/packages/config/src/test/projects.test.ts
+++ b/packages/config/src/test/projects.test.ts
@@ -125,7 +125,9 @@ describe('projects', () => {
       for (const link of links) {
         it(link, () => {
           if (link.includes('discord')) {
-            expect(link).toMatchRegex(/^https:\/\/discord\.(gg|com\/invite)\/[\w-]+$/)
+            expect(link).toMatchRegex(
+              /^https:\/\/discord\.(gg|com\/invite)\/[\w-]+$/,
+            )
           } else if (link.includes('t.me')) {
             expect(link).toMatchRegex(/^https:\/\/t\.me\/(joinchat\/)?\w+$/)
           } else if (link.includes('medium')) {


### PR DESCRIPTION
Discord invite links come in two flavours

- https://discord.gg/code
- https://discord.com/invite/code

This change allows for adding the second flavour of invite links into the project social media links