### PR TITLE
Fix regression in the build upcoming project pages

### DIFF
--- a/packages/frontend/src/pages/scaling-detailedTvl/props/getScalingDetailedTvlView.ts
+++ b/packages/frontend/src/pages/scaling-detailedTvl/props/getScalingDetailedTvlView.ts
@@ -1,9 +1,5 @@
 import { Layer2 } from '@l2beat/config'
-import {
-  assert,
-  DetailedTvlApiResponse,
-  TvlApiResponse,
-} from '@l2beat/shared-pure'
+import { DetailedTvlApiResponse, TvlApiResponse } from '@l2beat/shared-pure'
 
 import { Config } from '../../../build/config'
 import { getTokens } from '../../../utils/project/getChart'
@@ -36,8 +32,7 @@ function getScalingDetailedTvlViewEntry(
   isVerified?: boolean,
 ): ScalingDetailedTvlViewEntry {
   const projectData = tvlApiResponse.projects[project.id.toString()]
-  assert(projectData?.charts.hourly.types.length === 9)
-  const charts = projectData.charts
+  const charts = projectData?.charts
   const { parts, partsWeeklyChange } = getDetailedTvlWithChange(charts)
 
   return {

--- a/packages/frontend/src/pages/scaling-projects/props/getProjectHeader.ts
+++ b/packages/frontend/src/pages/scaling-projects/props/getProjectHeader.ts
@@ -35,7 +35,9 @@ export function getProjectHeader(
   const getDetailed = (
     chart: TvlApiCharts | DetailedTvlApiCharts | undefined,
   ) => {
-    assert(chart?.hourly.types.length === 9)
+    if (chart) {
+      assert(chart.hourly.types.length === 9)
+    }
     const { parts, partsWeeklyChange } = getDetailedTvlWithChange(chart)
     return {
       tvl: parts.tvl,
@@ -47,7 +49,9 @@ export function getProjectHeader(
   }
 
   const getBasic = (chart: TvlApiCharts | DetailedTvlApiCharts | undefined) => {
-    assert(chart?.hourly.types.length === 3)
+    if (chart) {
+      assert(chart.hourly.types.length === 3)
+    }
     const { tvl, tvlWeeklyChange } = getTvlWithChange(chart)
     return {
       tvl,

--- a/packages/frontend/src/utils/project/getHeader.ts
+++ b/packages/frontend/src/utils/project/getHeader.ts
@@ -18,7 +18,7 @@ export function getHeader(
   const hourly =
     tvlApiResponse.projects[project.id.toString()]?.charts.hourly.data ?? []
   const tvl = hourly.at(-1)?.[1] ?? 0
-  const tvlSevenDaysAgo = hourly[0][1]
+  const tvlSevenDaysAgo = hourly.at(0)?.[1] ?? 0
   const tvlWeeklyChange = getPercentageChange(tvl, tvlSevenDaysAgo)
 
   const activityData =

--- a/packages/frontend/src/utils/tvl/getTvlWitchChange.ts
+++ b/packages/frontend/src/utils/tvl/getTvlWitchChange.ts
@@ -7,7 +7,7 @@ export function getTvlWithChange(
 ) {
   const data = charts?.hourly.data ?? []
   const tvl = data.at(-1)?.[1] ?? 0
-  const tvlSevenDaysAgo = data[0][1]
+  const tvlSevenDaysAgo = data.at(0)?.[1] ?? 0
   const tvlWeeklyChange = getPercentageChange(tvl, tvlSevenDaysAgo)
   return { tvl, tvlWeeklyChange }
 }
@@ -23,10 +23,10 @@ export function getDetailedTvlWithChange(
     native: data.at(-1)?.[4] ?? 0,
   }
   const partsSevenDaysAgo = {
-    tvl: data[0][1],
-    canonical: data[0][2],
-    external: data[0][3] ?? 0,
-    native: data[0][4] ?? 0,
+    tvl: data.at(0)?.[1] ?? 0,
+    canonical: data.at(0)?.[2] ?? 0,
+    external: data.at(0)?.[3] ?? 0,
+    native: data.at(0)?.[4] ?? 0,
   }
   const partsWeeklyChange = {
     tvl: getPercentageChange(parts.tvl, partsSevenDaysAgo.tvl),


### PR DESCRIPTION
This PR fixes a regression where projects that were upcoming and did not have any escrows failed to build because we were reading undefined values from an TVL API response. This was correctly handled pre-L2 Assets because of all the changes the correct behaviour got lost. This change helps #1809 to actually build.