### PR TITLE
Fix BUSD rename on chain

### DIFF
--- a/packages/config/src/tokens/tokenList.json
+++ b/packages/config/src/tokens/tokenList.json
@@ -341,7 +341,7 @@
     },
     {
       "id": "busd-binance-usd",
-      "name": "Binance USD",
+      "name": "BUSD",
       "coingeckoId": "binance-usd",
       "address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
       "symbol": "BUSD",


### PR DESCRIPTION
Binance USD `name()` used to return `"Binance USD"`, but now returns `"BUSD"`.