### PR TITLE
Show Detailed TVL only for L2's

### DIFF
--- a/packages/frontend/src/utils/project/getChart.ts
+++ b/packages/frontend/src/utils/project/getChart.ts
@@ -18,7 +18,10 @@ export function getChart(
   activityApiResponse?: ActivityApiResponse,
 ): ChartProps {
   return {
-    type: config?.features.detailedTvl ? 'detailedTvl' : 'tvl',
+    type:
+      config?.features.detailedTvl && project.type === 'layer2'
+        ? 'detailedTvl'
+        : 'tvl',
     tvlEndpoint: `/api/${project.display.slug}-tvl.json`,
     detailedTvlEndpoint: `/api/${project.display.slug}-detailed-tvl.json`,
     activityEndpoint: `/api/activity/${project.display.slug}.json`,


### PR DESCRIPTION
Resolves L2B-2304

This PR makes bridge projects use the default chart version, only the layer 2 projects use the stacked chart from now on.