### PR TITLE
Remove cUSDT from token list

### DIFF
--- a/packages/config/src/bridges/orbit.ts
+++ b/packages/config/src/bridges/orbit.ts
@@ -53,11 +53,6 @@ export const orbit: Bridge = {
         ],
       },
       {
-        address: EthereumAddress('0x378F1CD69e1012cfe8FbeAfFeC02630190fda4d9'),
-        sinceTimestamp: new UnixTime(1603950507),
-        tokens: ['cUSDT'],
-      },
-      {
         address: EthereumAddress('0xBe03a2569d10fd10bDbfE84f5f2E22D9cec4aCd0'),
         sinceTimestamp: new UnixTime(1603950507),
         tokens: ['cDAI'],

--- a/packages/config/src/tokens/tokenList.json
+++ b/packages/config/src/tokens/tokenList.json
@@ -613,19 +613,6 @@
       "type": "CBV"
     },
     {
-      "id": "cusdt-compound-usdt",
-      "name": "Compound USDT",
-      "coingeckoId": "compound-usdt",
-      "address": "0xf650C3d88D12dB855b8bf7D11Be6C55A4e07dCC9",
-      "symbol": "cUSDT",
-      "decimals": 8,
-      "sinceTimestamp": 1586985186,
-      "category": "stablecoin",
-      "iconUrl": "https://assets.coingecko.com/coins/images/11621/large/cUSDT.png?1592113270",
-      "chainId": 1,
-      "type": "CBV"
-    },
-    {
       "id": "cwbtc-compound-wrapped-btc",
       "name": "Compound Wrapped BTC",
       "coingeckoId": "compound-wrapped-btc",


### PR DESCRIPTION
From [Coingecko](https://www.coingecko.com/en/coins/compound-usdt):

>Where can you buy cUSDT?
CUSDT tokens have stopped trading 8 days ago on all exchanges listed on CoinGecko. Information will be updated if market activity resumes.

We can't hold this token in the token list because otherwise our backend is not going to sync any prices. The two projects that even had any value in this token are rhinofi (L2) and Orbit (Bridge), both of them have negligible amounts of it right now ($135k and $5k).
