### PR TITLE
Show escrows/contracts/risks for under review projects

### DIFF
--- a/packages/frontend/src/components/project/ContractsSection.tsx
+++ b/packages/frontend/src/components/project/ContractsSection.tsx
@@ -8,6 +8,7 @@ import { RiskList, TechnologyRisk } from './RiskList'
 import { SectionId } from './sectionId'
 import { TechnologyIncompleteShort } from './TechnologyIncomplete'
 import { TokenEntry } from './TokenEntry'
+import { UnderReviewCallout } from './UnderReviewCallout'
 
 export interface ContractsSectionProps {
   id: SectionId
@@ -24,16 +25,17 @@ export interface ContractsSectionProps {
 }
 
 export function ContractsSection(props: ContractsSectionProps) {
-  if (props.contracts.length === 0) {
+  if (
+    props.contracts.length === 0 &&
+    props.escrows.length === 0 &&
+    props.risks.length === 0
+  ) {
     return null
   }
 
   return (
-    <ProjectDetailsSection
-      title={props.title}
-      id={props.id}
-      isUnderReview={props.isUnderReview}
-    >
+    <ProjectDetailsSection title={props.title} id={props.id}>
+      {props.isUnderReview ? <UnderReviewCallout className="mb-4" /> : null}
       {props.isIncomplete && <TechnologyIncompleteShort />}
       {props.architectureImage && (
         <figure className="mt-4 mb-8 text-center">
@@ -47,20 +49,24 @@ export function ContractsSection(props: ContractsSectionProps) {
           </figcaption>
         </figure>
       )}
-      <h3 className="md:text-md font-bold">
-        The system consists of the following smart contracts:
-      </h3>
-      <div className="mt-4 mb-4">
-        {props.contracts.map((contract, i) => (
-          <React.Fragment key={i}>
-            <ContractEntry
-              contract={contract}
-              verificationStatus={props.verificationStatus}
-              className="mt-4 mb-4"
-            />
-          </React.Fragment>
-        ))}
-      </div>
+      {props.contracts.length > 0 && (
+        <>
+          <h3 className="md:text-md font-bold">
+            The system consists of the following smart contracts:
+          </h3>
+          <div className="mt-4 mb-4">
+            {props.contracts.map((contract, i) => (
+              <React.Fragment key={i}>
+                <ContractEntry
+                  contract={contract}
+                  verificationStatus={props.verificationStatus}
+                  className="mt-4 mb-4"
+                />
+              </React.Fragment>
+            ))}
+          </div>
+        </>
+      )}
       {/* @todo: this "if" can be dropped when all escrows will migrate to new form */}
       {props.escrows.length > 0 && (
         <>


### PR DESCRIPTION
Resolves L2B-2368

When project is under review but has any escrows or contracts specified they are replaced with a banner about this project being under review. Make it so that the banner still exists but right now if there is any data to be shown it gets shown.