### PR TITLE
Fix circulating supplies sync process

### DIFF
--- a/packages/backend/src/core/totalSupply/CirculatingSupplyUpdater.test.ts
+++ b/packages/backend/src/core/totalSupply/CirculatingSupplyUpdater.test.ts
@@ -165,7 +165,7 @@ describe(CirculatingSupplyUpdater.name, () => {
               [tokens[1].id, { earliest: HOUR_09, latest: HOUR_12 }],
             ]),
           ),
-          addOrUpdateMany: mockFn().returns([]),
+          addMany: mockFn().returns([]),
         })
 
       const coingeckoQueryService = mockObject<CoingeckoQueryService>({
@@ -241,7 +241,7 @@ describe(CirculatingSupplyUpdater.name, () => {
       const CirculatingSupplyRepository =
         mockObject<CirculatingSupplyRepository>({
           findDataBoundaries: mockFn().returns(new Map([])),
-          addOrUpdateMany: mockFn().returns([]),
+          addMany: mockFn().returns([]),
         })
 
       const coingeckoQueryService = mockObject<CoingeckoQueryService>({
@@ -291,7 +291,7 @@ describe(CirculatingSupplyUpdater.name, () => {
       const CirculatingSupplyRepository =
         mockObject<CirculatingSupplyRepository>({
           findDataBoundaries: mockFn().returns(new Map()),
-          addOrUpdateMany: mockFn().returns([]),
+          addMany: mockFn().returns([]),
         })
       coingeckoQueryService = mockObject<CoingeckoQueryService>({
         getCirculatingSupplies: mockFn().returns([]),
@@ -447,7 +447,7 @@ describe(CirculatingSupplyUpdater.name, () => {
 
       const circulatingSupplyRepository =
         mockObject<CirculatingSupplyRepository>({
-          addOrUpdateMany: mockFn().returns([]),
+          addMany: mockFn().returns([]),
         })
       const tokens = [fakeToken(AssetId('uni-uniswap'))]
 
@@ -477,9 +477,7 @@ describe(CirculatingSupplyUpdater.name, () => {
         undefined,
       )
 
-      expect(
-        circulatingSupplyRepository.addOrUpdateMany,
-      ).toHaveBeenOnlyCalledWith([
+      expect(circulatingSupplyRepository.addMany).toHaveBeenOnlyCalledWith([
         {
           assetId: tokens[0].id,
           circulatingSupply: 100,

--- a/packages/backend/src/core/totalSupply/CirculatingSupplyUpdater.ts
+++ b/packages/backend/src/core/totalSupply/CirculatingSupplyUpdater.ts
@@ -165,6 +165,6 @@ export class CirculatingSupplyUpdater {
         chainId: this.chainId,
       }))
 
-    await this.circulatingSupplyRepository.addOrUpdateMany(records)
+    await this.circulatingSupplyRepository.addMany(records)
   }
 }

--- a/packages/backend/src/peripherals/coingecko/CoingeckoQueryService.ts
+++ b/packages/backend/src/peripherals/coingecko/CoingeckoQueryService.ts
@@ -112,7 +112,10 @@ export class CoingeckoQueryService {
         to,
         address,
       )
-      assert(data.prices.length > 0, "Can't get data from Coingecko")
+      assert(
+        data.prices.length > 0,
+        `Can't get data from Coingecko for ${coingeckoId.toString()} from ${from.toNumber()} to ${to.toNumber()}`,
+      )
       return data
     } else {
       const results = await Promise.allSettled(
@@ -136,7 +139,7 @@ export class CoingeckoQueryService {
         if (result.status === 'fulfilled') {
           assert(
             result.value.prices.length > 0,
-            "Can't get data from Coingecko",
+            `Can't get data from Coingecko for ${coingeckoId.toString()} from ${from.toNumber()} to ${to.toNumber()} (one of batches)`,
           )
 
           marketChartRangeData.prices.push(...result.value.prices)

--- a/packages/backend/src/peripherals/coingecko/CoingeckoQueryService.ts
+++ b/packages/backend/src/peripherals/coingecko/CoingeckoQueryService.ts
@@ -79,6 +79,9 @@ export class CoingeckoQueryService {
     const result: QueryResultPoint[] = []
 
     for (let i = 0; i < timestamps.length; i++) {
+      if (timestamps[i].lt(from)) {
+        continue
+      }
       const price = pickedPrices[i].value
       const marketCap = pickedMarketCaps[i].value
 
@@ -109,10 +112,7 @@ export class CoingeckoQueryService {
         to,
         address,
       )
-      assert(
-        data.prices.length > 0,
-        `Can't get data from Coingecko for ${coingeckoId.toString()} from ${from.toNumber()} to ${to.toNumber()}`,
-      )
+      assert(data.prices.length > 0, "Can't get data from Coingecko")
       return data
     } else {
       const results = await Promise.allSettled(
@@ -136,7 +136,7 @@ export class CoingeckoQueryService {
         if (result.status === 'fulfilled') {
           assert(
             result.value.prices.length > 0,
-            `Can't get data from Coingecko for ${coingeckoId.toString()} from ${from.toNumber()} to ${to.toNumber()} (one of batches)`,
+            "Can't get data from Coingecko",
           )
 
           marketChartRangeData.prices.push(...result.value.prices)
@@ -237,10 +237,6 @@ export function generateRangesToCallHourly(from: UnixTime, to: UnixTime) {
 // e.g. 123456789 -> 123450000
 export function approximateCirculatingSupply(marketCap: number, price: number) {
   const circulatingSupplyRaw = marketCap / price
-  assert(
-    circulatingSupplyRaw >= 1,
-    'Circulating supply cannot be less than one',
-  )
 
   // reduce variation in the result by disregarding least significant parts
   const log = Math.floor(Math.log10(circulatingSupplyRaw))

--- a/packages/backend/src/peripherals/coingecko/CoingeckoQueryService.ts
+++ b/packages/backend/src/peripherals/coingecko/CoingeckoQueryService.ts
@@ -238,6 +238,11 @@ export function generateRangesToCallHourly(from: UnixTime, to: UnixTime) {
 export function approximateCirculatingSupply(marketCap: number, price: number) {
   const circulatingSupplyRaw = marketCap / price
 
+  assert(
+    circulatingSupplyRaw >= 1,
+    'Circulating supply cannot be less than one',
+  )
+
   // reduce variation in the result by disregarding least significant parts
   const log = Math.floor(Math.log10(circulatingSupplyRaw))
   const digitsToClear = Math.max(log - 4, 0)

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -206,48 +206,6 @@ describe(CirculatingSupplyRepository.name, () => {
       expect(result).toEqualUnsorted([...DATA, ...newRows])
     })
 
-    it('existing rows only', async () => {
-      const existingRows: CirculatingSupplyRecord[] = [
-        {
-          timestamp: DATA[0].timestamp,
-          circulatingSupply: DATA[0].circulatingSupply,
-          assetId: DATA[0].assetId,
-          chainId: ChainId.ETHEREUM,
-        },
-        {
-          timestamp: DATA[1].timestamp,
-          circulatingSupply: DATA[1].circulatingSupply,
-          assetId: DATA[1].assetId,
-          chainId: ChainId.ETHEREUM,
-        },
-      ]
-      await repository.addOrUpdateMany(existingRows)
-
-      const result = await repository.getAll()
-      expect(result).toEqualUnsorted(existingRows)
-    })
-
-    it('mixed: existing and new rows', async () => {
-      const mixedRows: CirculatingSupplyRecord[] = [
-        {
-          timestamp: DATA[1].timestamp,
-          circulatingSupply: DATA[1].circulatingSupply,
-          assetId: DATA[1].assetId,
-          chainId: ChainId.ETHEREUM,
-        },
-        {
-          timestamp: START.add(2, 'hours'),
-          circulatingSupply: C_SUPPLY,
-          assetId: AssetId('dai-dai-stablecoin'),
-          chainId: ChainId.ETHEREUM,
-        },
-      ]
-      await repository.addOrUpdateMany(mixedRows)
-
-      const result = await repository.getAll()
-      expect(result).toEqualUnsorted([DATA[0], ...mixedRows])
-    })
-
     it('skips empty row modification', async () => {
       await expect(repository.addOrUpdateMany([])).not.toBeRejected()
     })

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -37,7 +37,7 @@ describe(CirculatingSupplyRepository.name, () => {
 
   beforeEach(async () => {
     await repository.deleteAll()
-    await repository.addOrUpdateMany(DATA)
+    await repository.addMany(DATA)
   })
 
   describe(CirculatingSupplyRepository.prototype.getByTimestamp.name, () => {
@@ -62,7 +62,7 @@ describe(CirculatingSupplyRepository.name, () => {
           ChainId.ETHEREUM,
         ),
       ]
-      await repository.addOrUpdateMany(additionalData)
+      await repository.addMany(additionalData)
 
       const result = await repository.getByTimestamp(ChainId.ETHEREUM, START)
 
@@ -85,7 +85,7 @@ describe(CirculatingSupplyRepository.name, () => {
         mockCirculatingSupply(C_SUPPLY, 2, ASSET_1, ChainId.ETHEREUM),
       ]
 
-      await repository.addOrUpdateMany(data)
+      await repository.addMany(data)
 
       const result = await repository.getByTimestamp(ChainId.ETHEREUM, START)
       expect(result).toEqual([
@@ -110,7 +110,7 @@ describe(CirculatingSupplyRepository.name, () => {
         mockCirculatingSupply(C_SUPPLY, 2, ASSET_2, ChainId.ETHEREUM),
       ]
 
-      await repository.addOrUpdateMany(data)
+      await repository.addMany(data)
 
       const result = await repository.getByTimestamp(ChainId.ETHEREUM, START)
       expect(result).toEqualUnsorted([
@@ -151,7 +151,7 @@ describe(CirculatingSupplyRepository.name, () => {
           mockCirculatingSupply(C_SUPPLY, 1, ASSET_2, ChainId.ETHEREUM),
         ]
 
-        await repository.addOrUpdateMany(DATA)
+        await repository.addMany(DATA)
         const result = await repository.findDataBoundaries()
 
         expect(result).toEqual(
@@ -184,7 +184,7 @@ describe(CirculatingSupplyRepository.name, () => {
     },
   )
 
-  describe(CirculatingSupplyRepository.prototype.addOrUpdateMany.name, () => {
+  describe(CirculatingSupplyRepository.prototype.addMany.name, () => {
     it('new rows only', async () => {
       const newRows: CirculatingSupplyRecord[] = [
         {
@@ -200,14 +200,14 @@ describe(CirculatingSupplyRepository.name, () => {
           chainId: ChainId.ETHEREUM,
         },
       ]
-      await repository.addOrUpdateMany(newRows)
+      await repository.addMany(newRows)
 
       const result = await repository.getAll()
       expect(result).toEqualUnsorted([...DATA, ...newRows])
     })
 
     it('skips empty row modification', async () => {
-      await expect(repository.addOrUpdateMany([])).not.toBeRejected()
+      await expect(repository.addMany([])).not.toBeRejected()
     })
   })
 

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
@@ -44,10 +44,7 @@ export class CirculatingSupplyRepository extends BaseRepository {
 
     const rows = circulatingSupplies.map(toRow)
     const knex = await this.knex()
-    await knex('circulating_supplies')
-      .insert(rows)
-      .onConflict(['chain_id', 'unix_timestamp', 'asset_id'])
-      .merge()
+    await knex.batchInsert('circulating_supplies', rows, 10_000)
     return rows.length
   }
 

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
@@ -36,8 +36,8 @@ export class CirculatingSupplyRepository extends BaseRepository {
     return rows.map(toRecord)
   }
 
-  async addOrUpdateMany(circulatingSupplies: CirculatingSupplyRecord[]) {
-    this.logger.info('addOrUpdateMany', {
+  async addMany(circulatingSupplies: CirculatingSupplyRecord[]) {
+    this.logger.info('addMany', {
       chainId: circulatingSupplies[0].chainId.toString(),
       rows: circulatingSupplies.length,
     })


### PR DESCRIPTION
There were two issues:
- insert to the DB was too big, refactored into batchInsert
- assert was throwing because our logic was querying 7 days before to ensure we have the data, those older records are now filtered out