### PR TITLE
Use mock data in local and ci frontend builds

### DIFF
--- a/packages/frontend/gulpfile.js
+++ b/packages/frontend/gulpfile.js
@@ -74,15 +74,22 @@ function serve() {
   app.get('/', (req, res) => {
     res.redirect('/scaling/summary')
   })
+
+  const deploymentEnvironment = process.env.DEPLOYMENT_ENV || 'ci'
+  const apiUrl = {
+    ci: 'https://api.l2beat.com',
+    production: 'https://api.l2beat.com',
+    staging: 'https://staging.l2beat.com',
+    local: 'http://localhost:3000',
+  }[deploymentEnvironment]
+  if (!apiUrl) {
+    throw new Error('Unknown environment: ' + deploymentEnvironment)
+  }
+
   app.use(
     '/api/projects',
     createProxyMiddleware({
-      target:
-        process.env.DEPLOYMENT_ENV === 'local'
-          ? 'http://localhost:3000'
-          : process.env.DEPLOYMENT_ENV === 'staging'
-          ? 'https://staging.l2beat.com'
-          : 'https://api.l2beat.com',
+      target: apiUrl,
       changeOrigin: true,
     }),
   )

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -16,7 +16,7 @@
     "start": "yarn start:staging",
     "start:local": "DEPLOYMENT_ENV=local gulp watch",
     "start:staging": "DEPLOYMENT_ENV=staging gulp watch",
-    "start:production": "gulp watch",
+    "start:production": "DEPLOYMENT_ENV=production gulp watch",
     "test": "mocha",
     "typecheck": "tsc --noEmit",
     "storybook": "storybook dev -p 6006 --no-open",

--- a/packages/frontend/src/build/api/fetchActivityApi.ts
+++ b/packages/frontend/src/build/api/fetchActivityApi.ts
@@ -1,12 +1,46 @@
-import { ActivityApiResponse } from '@l2beat/shared-pure'
+import { layer2s as allLayer2s } from '@l2beat/config'
+import {
+  ActivityApiChart,
+  ActivityApiResponse,
+  UnixTime,
+} from '@l2beat/shared-pure'
 
 import { JsonHttpClient } from '../caching/JsonHttpClient'
+import { Config } from '../config'
 
 export async function fetchActivityApi(
-  apiUrl: string,
+  backend: Config['backend'],
   http: JsonHttpClient,
 ): Promise<ActivityApiResponse> {
-  const url = apiUrl + '/api/activity'
+  if (backend.mock) {
+    return getMockActivityApiResponse()
+  }
+  const url = backend.apiUrl + '/api/activity'
   const json = await http.fetchJson(url)
   return ActivityApiResponse.parse(json)
+}
+
+function getMockActivityApiResponse(): ActivityApiResponse {
+  const result: ActivityApiResponse = {
+    combined: getMockActivityApiChart(),
+    projects: {},
+    ethereum: getMockActivityApiChart(),
+  }
+  for (const project of allLayer2s) {
+    result.projects[project.id.toString()] = getMockActivityApiChart()
+  }
+  return result
+}
+
+function getMockActivityApiChart(): ActivityApiChart {
+  const now = UnixTime.now().toStartOf('day')
+  const chart: ActivityApiChart = {
+    types: ['timestamp', 'daily tx count'],
+    data: [],
+  }
+  for (let i = -365; i <= 0; i++) {
+    const timestamp = now.add(i, 'days')
+    chart.data.push([timestamp, 50])
+  }
+  return chart
 }

--- a/packages/frontend/src/build/api/fetchDetailedTvlApi.ts
+++ b/packages/frontend/src/build/api/fetchDetailedTvlApi.ts
@@ -1,12 +1,112 @@
-import { DetailedTvlApiResponse } from '@l2beat/shared-pure'
+import { layer2s as allLayer2s } from '@l2beat/config'
+import {
+  AssetId,
+  AssetType,
+  ChainId,
+  DetailedTvlApiChart,
+  DetailedTvlApiCharts,
+  DetailedTvlApiResponse,
+  UnixTime,
+} from '@l2beat/shared-pure'
 
 import { JsonHttpClient } from '../caching/JsonHttpClient'
+import { Config } from '../config'
 
 export async function fetchDetailedTvlApi(
-  apiUrl: string,
+  backend: Config['backend'],
   http: JsonHttpClient,
 ): Promise<DetailedTvlApiResponse> {
-  const url = `${apiUrl}/api/detailed-tvl`
+  if (backend.mock) {
+    return getMockDetailedTvlApiResponse()
+  }
+  const url = `${backend.apiUrl}/api/detailed-tvl`
   const json = await http.fetchJson(url)
   return DetailedTvlApiResponse.parse(json)
+}
+
+function getMockDetailedTvlApiResponse(): DetailedTvlApiResponse {
+  const result: DetailedTvlApiResponse = {
+    bridges: getMockDetailedTvlApiCharts(),
+    layers2s: getMockDetailedTvlApiCharts(),
+    combined: getMockDetailedTvlApiCharts(),
+    projects: {},
+  }
+  for (const project of allLayer2s) {
+    result.projects[project.id.toString()] = {
+      charts: getMockDetailedTvlApiCharts(),
+      tokens: {
+        CBV: [
+          {
+            assetId: AssetId.ETH,
+            chainId: ChainId.ETHEREUM,
+            assetType: AssetType('CBV'),
+            usdValue: 100,
+          },
+        ],
+        EBV: [
+          {
+            assetId: AssetId.ETH,
+            chainId: ChainId.ETHEREUM,
+            assetType: AssetType('EBV'),
+            usdValue: 100,
+          },
+        ],
+        NMV: [
+          {
+            assetId: AssetId.ETH,
+            chainId: ChainId.ETHEREUM,
+            assetType: AssetType('NMV'),
+            usdValue: 100,
+          },
+        ],
+      },
+    }
+  }
+  return result
+}
+
+const DETAILED_LABELS: DetailedTvlApiChart['types'] = [
+  'timestamp',
+  'valueUsd',
+  'cbvUsd',
+  'ebvUsd',
+  'nmvUsd',
+  'valueEth',
+  'cbvEth',
+  'ebvEth',
+  'nmvEth',
+]
+
+const MOCK_VALUES = [50, 30, 20, 10, 5, 3, 2, 1] as const
+
+function getMockDetailedTvlApiCharts(): DetailedTvlApiCharts {
+  let now = UnixTime.now().toStartOf('hour')
+  const charts: DetailedTvlApiCharts = {
+    hourly: {
+      types: DETAILED_LABELS,
+      data: [],
+    },
+    sixHourly: {
+      types: DETAILED_LABELS,
+      data: [],
+    },
+    daily: {
+      types: DETAILED_LABELS,
+      data: [],
+    },
+  }
+  for (let i = -7 * 24; i <= 0; i++) {
+    const timestamp = now.add(i, 'hours')
+    charts.hourly.data.push([timestamp, ...MOCK_VALUES])
+  }
+  for (let i = -30 * 4; i <= 0; i++) {
+    const timestamp = now.add(i * 6, 'hours')
+    charts.sixHourly.data.push([timestamp, ...MOCK_VALUES])
+  }
+  now = UnixTime.now().toStartOf('day')
+  for (let i = -365; i <= 0; i++) {
+    const timestamp = now.add(i, 'days')
+    charts.daily.data.push([timestamp, ...MOCK_VALUES])
+  }
+  return charts
 }

--- a/packages/frontend/src/build/api/fetchTvlApi.ts
+++ b/packages/frontend/src/build/api/fetchTvlApi.ts
@@ -1,12 +1,70 @@
-import { TvlApiResponse } from '@l2beat/shared-pure'
+import { bridges as allBridges, layer2s as allLayer2s } from '@l2beat/config'
+import {
+  AssetId,
+  TvlApiCharts,
+  TvlApiResponse,
+  UnixTime,
+} from '@l2beat/shared-pure'
 
 import { JsonHttpClient } from '../caching/JsonHttpClient'
+import { Config } from '../config'
 
 export async function fetchTvlApi(
-  apiUrl: string,
+  backend: Config['backend'],
   http: JsonHttpClient,
 ): Promise<TvlApiResponse> {
-  const url = apiUrl + '/api/tvl'
+  if (backend.mock) {
+    return getMockTvlApiResponse()
+  }
+  const url = backend.apiUrl + '/api/tvl'
   const json = await http.fetchJson(url)
   return TvlApiResponse.parse(json)
+}
+
+function getMockTvlApiResponse(): TvlApiResponse {
+  const result: TvlApiResponse = {
+    bridges: getMockTvlApiCharts(),
+    layers2s: getMockTvlApiCharts(),
+    combined: getMockTvlApiCharts(),
+    projects: {},
+  }
+  for (const project of [...allBridges, ...allLayer2s]) {
+    result.projects[project.id.toString()] = {
+      charts: getMockTvlApiCharts(),
+      tokens: [{ assetId: AssetId.ETH, tvl: 100 }],
+    }
+  }
+  return result
+}
+
+function getMockTvlApiCharts(): TvlApiCharts {
+  let now = UnixTime.now().toStartOf('hour')
+  const charts: TvlApiCharts = {
+    hourly: {
+      types: ['timestamp', 'eth', 'usd'],
+      data: [],
+    },
+    sixHourly: {
+      types: ['timestamp', 'eth', 'usd'],
+      data: [],
+    },
+    daily: {
+      types: ['timestamp', 'eth', 'usd'],
+      data: [],
+    },
+  }
+  for (let i = -7 * 24; i <= 0; i++) {
+    const timestamp = now.add(i, 'hours')
+    charts.hourly.data.push([timestamp, 50, 200])
+  }
+  for (let i = -30 * 4; i <= 0; i++) {
+    const timestamp = now.add(i * 6, 'hours')
+    charts.sixHourly.data.push([timestamp, 50, 200])
+  }
+  now = now.toStartOf('day')
+  for (let i = -365; i <= 0; i++) {
+    const timestamp = now.add(i, 'days')
+    charts.daily.data.push([timestamp, 50, 200])
+  }
+  return charts
 }

--- a/packages/frontend/src/build/buildMetaImages.ts
+++ b/packages/frontend/src/build/buildMetaImages.ts
@@ -14,7 +14,7 @@ main().catch((e) => {
 })
 
 async function main() {
-  const env = process.env.DEPLOYMENT_ENV ?? 'production'
+  const env = process.env.DEPLOYMENT_ENV ?? 'ci'
   console.log(`Using config for ${env}`)
   const config = getConfig(env)
 

--- a/packages/frontend/src/build/buildPages.ts
+++ b/packages/frontend/src/build/buildPages.ts
@@ -24,7 +24,7 @@ main().catch((e) => {
 })
 
 async function main() {
-  const env = process.env.DEPLOYMENT_ENV ?? 'production'
+  const env = process.env.DEPLOYMENT_ENV ?? 'ci'
   console.log(`Using config for ${env}`)
   const config = getConfig(env)
 
@@ -33,14 +33,14 @@ async function main() {
   const http = new JsonHttpClient(httpClient, config.backend.skipCache)
 
   const tvlApiResponse = config.features.detailedTvl
-    ? await fetchDetailedTvlApi(config.backend.apiUrl, http)
-    : await fetchTvlApi(config.backend.apiUrl, http)
+    ? await fetchDetailedTvlApi(config.backend, http)
+    : await fetchTvlApi(config.backend, http)
   printApiInfo(tvlApiResponse)
   tvlSanityCheck(tvlApiResponse)
 
   let activityApiResponse: ActivityApiResponse | undefined = undefined
   if (config.features.activity) {
-    activityApiResponse = await fetchActivityApi(config.backend.apiUrl, http)
+    activityApiResponse = await fetchActivityApi(config.backend, http)
     printActivityInfo(activityApiResponse)
     activitySanityCheck(activityApiResponse)
   }

--- a/packages/frontend/src/build/config/Config.ts
+++ b/packages/frontend/src/build/config/Config.ts
@@ -26,6 +26,7 @@ export interface Config {
   }
   backend: {
     apiUrl: string
+    mock?: boolean
     skipCache: boolean
   }
   layer2s: Layer2[]

--- a/packages/frontend/src/build/config/config.ci.ts
+++ b/packages/frontend/src/build/config/config.ci.ts
@@ -1,0 +1,8 @@
+import { Config } from './Config'
+import { getProductionConfig } from './config.production'
+
+export function getCIConfig(): Config {
+  const config = getProductionConfig()
+  config.backend.mock = true
+  return config
+}

--- a/packages/frontend/src/build/config/index.ts
+++ b/packages/frontend/src/build/config/index.ts
@@ -1,4 +1,5 @@
 import { Config } from './Config'
+import { getCIConfig } from './config.ci'
 import { getLocalConfig } from './config.local'
 import { getProductionConfig } from './config.production'
 import { getStagingConfig } from './config.staging'
@@ -7,6 +8,8 @@ export type { Config }
 
 export function getConfig(env: string): Config {
   switch (env) {
+    case 'ci':
+      return getCIConfig()
     case 'local':
       return getLocalConfig()
     case 'staging':


### PR DESCRIPTION
It can be frustrating that a local build that you're running for the sake of checking that everything works fails because the backend has problems. This is why this PR decouples local and ci builds from needing to call the live backend.