### PR TITLE
Adding sinceTimestamp for escrows is now optional

### DIFF
--- a/packages/backend/discovery/across-v2/ethereum/discovered.json
+++ b/packages/backend/discovery/across-v2/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1578581061,
       "values": {
         "decimals": 18,
         "getMember": ["0x7b292034084A41B9D441B71b6E3557Edd0463fa8"],
@@ -27,6 +28,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671752303,
       "values": {
         "l1ERC20GatewayRouter": "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef",
         "l1Inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
@@ -43,6 +45,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1692391799,
       "values": {
         "l1StandardBridge": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
         "l1Weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
@@ -56,6 +59,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1651747441,
       "values": {
         "l1StandardBridge": "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00",
         "l1Weth": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
@@ -69,6 +73,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1651578211,
       "values": {
         "depositManager": "0x401F6c983eA34274ec46f84D70b31C151321188b",
         "erc20Predicate": "0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf",
@@ -84,6 +89,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1578580941,
       "values": {
         "isOwner": false,
         "owner": "0x7b292034084A41B9D441B71b6E3557Edd0463fa8"
@@ -95,6 +101,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1677231527,
       "values": {
         "bond": "5000000000000000000000",
         "finder": "0x40f941E48A552bF496B154Af6bf55725f18D77c3",
@@ -110,7 +117,8 @@
       "address": "0x527E872a5c3f0C7c24Fe33F2593cFB890a285084",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1651577227
     },
     {
       "name": "Ethereum_SpokePool",
@@ -120,6 +128,7 @@
         "implementation": "0x326510c1bf9d85Fb73d0AB8d20Aa5BbE9c7561e9",
         "admin": "0x0000000000000000000000000000000000000000"
       },
+      "sinceTimestamp": 1682355155,
       "values": {
         "chainId": 1,
         "crossDomainAdmin": "0xc186fA914353c44b2E33eBE05f21846F1048bEda",
@@ -144,6 +153,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1677230459,
       "values": {
         "finder": "0x40f941E48A552bF496B154Af6bf55725f18D77c3",
         "getCurrentTime": 1695297923,
@@ -161,7 +171,8 @@
       "address": "0x7dB69eb9F52eD773E9b03f5068A1ea0275b2fD9d",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1651576251
     },
     {
       "name": "EmergencyProposalExecutor",
@@ -170,6 +181,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1597806870,
       "values": {
         "domainSeparator": "0xc6747c7ca6899274b3575cd632681f9db9a0788dd1b7c7379382739baa6aa665",
         "getChainId": 1,
@@ -190,6 +202,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1677231923,
       "values": {
         "emergencyProposals": [],
         "executor": "0x8180D59b7175d4064bDFA8138A58e9baBFFdA44a",
@@ -208,6 +221,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1692392063,
       "values": {
         "dai": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         "daiOptimismBridge": "0x10E6593CDda8c58a1d0f14C5164B376352a55f2F",
@@ -226,6 +240,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1636157803,
       "values": {
         "domainSeparator": "0xbb022dfb1fe065f2a2c6ea647af6240343ff4b980bc3c1183ecd630958c3b59e",
         "getChainId": 1,
@@ -247,7 +262,8 @@
       "address": "0xBbc6009fEfFc27ce705322832Cb2068F8C1e0A58",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1618347170
     },
     {
       "name": "HubPool",
@@ -255,6 +271,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1653167916,
       "values": {
         "bondAmount": "450000000000000000",
         "bondToken": "0xee1DC6BCF1Ee967a350e9aC6CaaAA236109002ea",
@@ -324,6 +341,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691158667,
       "values": {
         "getL1CallValue": 1000000000000000,
         "L1_GAS_TO_L2_GAS_PER_PUB_DATA_LIMIT": 800,
@@ -341,6 +359,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1692831647,
       "values": {
         "decimals": 18,
         "hubPool": "0xc186fA914353c44b2E33eBE05f21846F1048bEda",

--- a/packages/backend/discovery/aevo/ethereum/discovered.json
+++ b/packages/backend/discovery/aevo/ethereum/discovered.json
@@ -14,6 +14,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x8CfF5bDb1B428B979E3D87087dA8549A28065DDB"
       },
+      "sinceTimestamp": 1679193095,
       "values": {
         "MESSAGE_VERSION": 1,
         "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292622990",
@@ -36,6 +37,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1679193047,
       "values": {
         "addressManager": "0x7a616b25E7c96fc4d652966d7DDAbB51dE28eCc1",
         "isUpgrading": false,
@@ -51,6 +53,7 @@
         "implementation": "0x20F1380A78492227A9B2366242335D684aF22507",
         "admin": "0x27ff92b30Cae00dABCF8045cc68fc9dcB67C5019"
       },
+      "sinceTimestamp": 1679193071,
       "values": {
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
         "messenger": "0x11dd2d9B5ec142dbAFBEFEA82a75985Eae4e12b0",
@@ -67,6 +70,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1680797639,
       "values": {
         "domainSeparator": "0x0f634ad56005ddbd68dc52233931a858f740b8ab706671c42b055efef561257e",
         "getChainId": 1,
@@ -91,6 +95,7 @@
         "implementation": "0x098927F692C86fA1722115652b9d2d7BE8cBa6D3",
         "admin": "0x27ff92b30Cae00dABCF8045cc68fc9dcB67C5019"
       },
+      "sinceTimestamp": 1679193119,
       "values": {
         "GUARDIAN": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
         "L2_ORACLE": "0x909E51211e959339EFb14b36f5A50955a8ae3770",
@@ -108,6 +113,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1679193059,
       "values": {
         "owner": "0x27ff92b30Cae00dABCF8045cc68fc9dcB67C5019"
       },
@@ -121,6 +127,7 @@
         "implementation": "0x0af92E6944900abA4B9BAC1417bA13ED6F45c27f",
         "admin": "0x27ff92b30Cae00dABCF8045cc68fc9dcB67C5019"
       },
+      "sinceTimestamp": 1679193083,
       "values": {
         "CHALLENGER": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
         "FINALIZATION_PERIOD_SECONDS": 3600,
@@ -145,6 +152,7 @@
         "implementation": "0xA872bca05c9F8A97CC36D879e43B33dB8ed7b69E",
         "admin": "0x27ff92b30Cae00dABCF8045cc68fc9dcB67C5019"
       },
+      "sinceTimestamp": 1679193155,
       "values": {
         "batcherHash": "0x889e21d7BA3d6dD62e75d4980A4Ad1349c61599d",
         "gasLimit": 30000000,

--- a/packages/backend/discovery/allbridge/ethereum/discovered.json
+++ b/packages/backend/discovery/allbridge/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "allbridge",
+  "chain": "ethereum",
   "blockNumber": 17321271,
   "configHash": "0x93d4ddbdf45c48e50296f6ea9e52c0c535908ed407738973689e4d9f45a7b2ad",
+  "version": 2,
   "contracts": [
     {
       "name": "USDC_POOL",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1669206935,
       "values": {
         "a": 20,
         "accRewardPerShareP": "293881805566878551",
@@ -36,6 +38,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1662595853,
       "values": {
         "owner": "0x01a494079DCB715f622340301463cE50cd69A4D0"
       },
@@ -48,6 +51,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636666899,
       "values": {
         "owner": "0x4BE5ef97B7cfD37F536324c7F18A2FfdE5892074"
       },
@@ -59,6 +63,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1662596119,
       "values": {
         "allbridgeMessenger": "0x366a900eFE79aE7244C4d1d279EE4a702AdBEE50",
         "chainId": 1,
@@ -76,6 +81,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1662596190,
       "values": {
         "a": 20,
         "accRewardPerShareP": "188388856323130911",
@@ -102,6 +108,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636634854,
       "values": {
         "owner": "0x83f53C078bF81F6d8B79E01e2eD36c473A960c5E"
       },
@@ -113,6 +120,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636635220,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -145,6 +153,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1669207319,
       "values": {
         "a": 20,
         "accRewardPerShareP": "21665218338930481943850442658",
@@ -171,6 +180,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1662998060,
       "values": {
         "owner": "0x01a494079DCB715f622340301463cE50cd69A4D0"
       },

--- a/packages/backend/discovery/amarok/ethereum/discovered.json
+++ b/packages/backend/discovery/amarok/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671624563,
       "values": {
         "AMB": "0x4C36d2919e407f0Cc2Ee3c993ccF8ac26d9CE64e",
         "delay": 604800,
@@ -33,6 +34,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1693742291,
       "values": {
         "domainSeparator": "0x629aade541ce1b7d73beab1242554404bc43e210de8d86b5a43700596c5cb2b2",
         "getChainId": 1,
@@ -48,7 +50,8 @@
       "address": "0x28A9e7bbed277092E2431F186E1aF898962d4E92",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1671623183
     },
     {
       "name": "Connext Multisig",
@@ -57,6 +60,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1671651491,
       "values": {
         "domainSeparator": "0x60b1292375dabe167590dda781ba4f2d4f046f849a3b9cbcd167e98c3cfd098a",
         "getChainId": 1,
@@ -89,6 +93,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1686151595,
       "values": {
         "AMB": "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1",
         "delay": 604800,
@@ -110,6 +115,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1688715011,
       "values": {
         "AMB": "0x27428DD2d3DD32A4D7f7C497eAaa23130d894911",
         "delay": 604800,
@@ -132,6 +138,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671619367,
       "values": {
         "delay": 604800,
         "owner": "0x4d50a469fc788a3c0CdC8Fd67868877dCb246625",
@@ -151,7 +158,8 @@
       "address": "0x7D2596D7E44b0990611d390Fbb0Bd24e64845694",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1671622727
     },
     {
       "name": "ConnextBridge",
@@ -173,6 +181,7 @@
           "0x3Bcf4185443A339517aD4e580067f178d1B68E1D"
         ]
       },
+      "sinceTimestamp": 1671625595,
       "values": {
         "aavePool": "0x0000000000000000000000000000000000000000",
         "aavePortalFee": 0,
@@ -439,6 +448,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671625079,
       "values": {
         "AMB": "0xfe5e5D361b2ad62c541bAb87C45a0B9B018389a2",
         "checkpointManager": "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287",
@@ -463,6 +473,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671630995,
       "values": {
         "AMB": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
         "delay": 604800,
@@ -488,6 +499,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671622763,
       "values": {
         "connectors": [
           "0x66a425f09cfd613d40A986B3ef800AA7604C8eeE",
@@ -526,6 +538,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1693608707,
       "values": {
         "domainSeparator": "0xa721cba4d2f32af7fbfd7a202a7c61a16ec27fc0140de338b2f91560251fd997",
         "getChainId": 1,
@@ -548,6 +561,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671623231,
       "values": {
         "AMB": "0x0000000000000000000000000000000000000000",
         "delay": 604800,

--- a/packages/backend/discovery/apex/ethereum/discovered.json
+++ b/packages/backend/discovery/apex/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "apex",
+  "chain": "ethereum",
   "blockNumber": 17705531,
   "configHash": "0xf318b1d0c2dad0392e1b6e4d71389461b890be5513385cf3cb3cd32804f37186",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "Committee",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1671630143,
       "values": {
         "constructorArgs": [
           [
@@ -48,6 +49,7 @@
           "0xC532d2976209A56DdF4a99B844130f7c0daCa7B6"
         ]
       },
+      "sinceTimestamp": 1660252039,
       "values": {
         "configurationDelay": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,
@@ -97,6 +99,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1660252035,
       "values": {
         "hasRegisteredFact": false,
         "identify": "StarkWare_PerpetualEscapeVerifier_2021_2"
@@ -109,6 +112,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1672216439,
       "values": {
         "domainSeparator": "0x297308a751114e4f0f8a219d1ff2f770e6c333f1f2698b3adf7b531e33f22e03",
         "getChainId": 1,
@@ -128,6 +132,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661254231,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,

--- a/packages/backend/discovery/aptos/ethereum/discovered.json
+++ b/packages/backend/discovery/aptos/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661529370,
       "values": {
         "feeEnabled": false,
         "nativeBP": 0,
@@ -26,6 +27,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661529280,
       "values": {
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -48,6 +50,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1666143827,
       "values": {
         "aptosChainId": 108,
         "BP_DENOMINATOR": 10000,
@@ -69,6 +72,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661280206,
       "values": {
         "endpoint": "0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675"
       }
@@ -79,6 +83,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647316591,
       "values": {
         "BLOCK_VERSION": 65535,
         "chainId": 1,
@@ -101,6 +106,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1666154051,
       "values": {
         "domainSeparator": "0x7588aafbe9e42e355ced617c936d778c5e3ff7bfa0974486b6b88f83c6457bce",
         "getChainId": 1,
@@ -123,6 +129,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1648243585,
       "values": {
         "domainSeparator": "0x567922b7bf591eff89c84c8a0039bbda9499c5f39de9b1c4dde48a8c912f31b9",
         "getChainId": 1,

--- a/packages/backend/discovery/arbitrum/ethereum/discovered.json
+++ b/packages/backend/discovery/arbitrum/ethereum/discovered.json
@@ -13,6 +13,7 @@
         "implementation": "0x0eA7372338a589e7f0b00E463a53AA464ef04e17",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1661457944,
       "values": {
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
         "l2ToL1BatchNum": 0,
@@ -32,6 +33,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1622243344,
       "values": {
         "implementation": "0xc4940069140142236D4065b866018f7b2BeC77fD",
         "owner": "0xC12BA48c781F6e392B49Db2E25Cd0c28cD77531A"
@@ -45,6 +47,7 @@
         "implementation": "0xD03bFe2CE83632F4E618a97299cc91B1335BB2d9",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1661457944,
       "values": {
         "batchCount": 347832,
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
@@ -64,6 +67,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661455968,
       "values": {
         "prover0": "0x499A4f574f2e4F8837E242adEc86223Ef7DeEfcC",
         "proverHostIo": "0xb965b08A826D4C7634e0Df4c5eF5E1d1f9b5D13A",
@@ -79,6 +83,7 @@
         "implementation": "0x86f0cf42Ad673B3D666d103E009EC142D1298a17",
         "admin": "0x5613AF0474EB9c528A34701A5b1662E3C8FA0678"
       },
+      "sinceTimestamp": 1678968515,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -107,7 +112,8 @@
       "address": "0x499A4f574f2e4F8837E242adEc86223Ef7DeEfcC",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1661455916
     },
     {
       "name": "Inbox",
@@ -117,6 +123,7 @@
         "implementation": "0x5aED5f8A1e3607476F1f81c3d8fe126deB0aFE94",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1622243344,
       "values": {
         "allowListEnabled": false,
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
@@ -131,6 +138,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661457944,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
       },
@@ -142,6 +150,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1678968395,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
       },
@@ -155,6 +164,7 @@
         "implementation": "0x806421D09cDb253aa9d128a658e60c0B95eFFA01",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1661457944,
       "values": {
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
         "rollup": "0x5eF0D09d1E6204141B4d37530808eD19f60FBa35"
@@ -166,6 +176,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661456194,
       "values": {
         "owner": "0x0000000000000000000000000000000000000000"
       }
@@ -179,6 +190,7 @@
         "adminImplementation": "0x72f193d0F305F532C87a4B9D0A2F407a3F4f585f",
         "userImplementation": "0xA0Ed0562629D45B88A34a342f20dEb58c46C15ff"
       },
+      "sinceTimestamp": 1661457944,
       "values": {
         "baseStake": "1000000000000000000",
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
@@ -226,6 +238,7 @@
         "implementation": "0x263a68002876E307804168795519da0B32CC62fE",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1622243344,
       "values": {
         "beacon": "0x14797f5432f699Cb4d4dB04DF599B74952d78d7b",
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
@@ -249,6 +262,7 @@
         "implementation": "0x52595021fA01B3E14EC6C88953AFc8E35dFf423c",
         "admin": "0x9aD46fac0Cf7f790E5be05A0F15223935A0c0aDa"
       },
+      "sinceTimestamp": 1623784095,
       "values": {
         "counterpartGateway": "0x5288c571Fd7aD117beA99bF60FE0846C4E84F933",
         "defaultGateway": "0xa3A7B6F88361F48403514059F1F16C8E78d60EeC",
@@ -266,6 +280,7 @@
         "implementation": "0x360861b7b245c968128F0a53d281aDb1Df760711",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1630296149,
       "values": {
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
         "isMaster": false,
@@ -289,6 +304,7 @@
         "implementation": "0x1066CEcC8880948FE55e427E94F1FF221d626591",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1661457944,
       "values": {
         "activeOutbox": "0x0000000000000000000000000000000000000000",
         "allowedDelayedInboxList": [
@@ -314,6 +330,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661456194,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd",
         "template": "0x5Bc5FB83950bBbF156E433c5c098bFe533Db4021"
@@ -325,6 +342,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1623784062,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
       },
@@ -336,6 +354,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661456147,
       "values": {
         "ARBITRUM_STAKERS": [
           [
@@ -352,7 +371,8 @@
       "address": "0xA10c7CE4b876998858b1a9E12b10092229539400",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1632133470
     },
     {
       "name": "L1ERC20Gateway",
@@ -362,6 +382,7 @@
         "implementation": "0xb4299A1F5f26fF6a98B7BA35572290C359fde900",
         "admin": "0x9aD46fac0Cf7f790E5be05A0F15223935A0c0aDa"
       },
+      "sinceTimestamp": 1623784100,
       "values": {
         "cloneableProxyHash": "0x4b11cb57b978697e0aec0c18581326376d6463fd3f6699cbe78ee5935617082d",
         "counterpartGateway": "0x09e9222E96E7B4AE2a407B98d48e330053351EEe",
@@ -377,14 +398,16 @@
       "address": "0xb556F3Bb0FdCFeAf81a1c393e024a69a3327B676",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1661455968
     },
     {
       "name": "OneStepProverHostIo",
       "address": "0xb965b08A826D4C7634e0Df4c5eF5E1d1f9b5D13A",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1661455968
     },
     {
       "name": "OutboxEntry",
@@ -392,6 +415,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1630185130,
       "values": {
         "isMaster": true,
         "numRemaining": 0,
@@ -406,6 +430,7 @@
         "implementation": "0xC8D26aB9e132C79140b3376a0Ac7932E4680Aa45",
         "admin": "0x9aD46fac0Cf7f790E5be05A0F15223935A0c0aDa"
       },
+      "sinceTimestamp": 1623867835,
       "values": {
         "counterpartGateway": "0x096760F208390250649E3e8763348E783AEF5562",
         "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
@@ -420,7 +445,8 @@
       "address": "0xd315Ac3a82E8EDAA84b347F478e0F59801747970",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1661455968
     },
     {
       "name": "L1DaiGateway",
@@ -428,6 +454,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1632133584,
       "values": {
         "counterpartGateway": "0x467194771dAe2967Aef3ECbEDD3Bf9a310C76C65",
         "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
@@ -446,6 +473,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1622243344,
       "values": {
         "owner": "0xC12BA48c781F6e392B49Db2E25Cd0c28cD77531A"
       }
@@ -458,6 +486,7 @@
         "implementation": "0x1c78B622961f27Ccc2f9BA65E2ba5d5eB301a445",
         "admin": "0x554723262467F125Ac9e1cDFa9Ce15cc53822dbD"
       },
+      "sinceTimestamp": 1661457944,
       "values": {
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
         "osp": "0x3E1f62AA8076000c3218493FE3e0Ae40bcB9A1DF",
@@ -474,6 +503,7 @@
         "implementation": "0x61dC65001A8De4138DAD5167e43FF0FB0AB8D3B3",
         "admin": "0x5613AF0474EB9c528A34701A5b1662E3C8FA0678"
       },
+      "sinceTimestamp": 1678968515,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -516,6 +546,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1692138791,
       "values": {
         "domainSeparator": "0x24555dff42c3faa8a2ff9680ac37e71d6f765373e9cf30c226d13e5c1cebe593",
         "getChainId": 1,

--- a/packages/backend/discovery/aztec/ethereum/discovered.json
+++ b/packages/backend/discovery/aztec/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "aztec",
+  "chain": "ethereum",
   "blockNumber": 17378164,
   "configHash": "0xe2a93d58ae1c112d7b8332ec0805a1148e3d5f61c498a0ce0198e92c81db0c82",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "AztecFeeDistributor",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1619631231,
       "values": {
         "convertConstant": 3155360,
         "factory": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
@@ -29,6 +30,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1614799636,
       "values": {
         "dataRoot": "0x14c2a9b5b41a31c6926b4bdcf9cec77e72c0559f0f9b0bd9044c0bce0000d406",
         "dataSize": 914176,
@@ -99,7 +101,8 @@
       "address": "0xd3a6D9De4cbC2CC7529361941e85b1c3269CcBb1",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1639321684
     },
     {
       "name": "Aztec Multisig",
@@ -108,6 +111,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1610552620,
       "values": {
         "domainSeparator": "0xf37d5181cb1c7c67c7e79d1dd66f78e41f525d498f652270e8f68c486406872b",
         "getChainId": 1,

--- a/packages/backend/discovery/aztecconnect/ethereum/discovered.json
+++ b/packages/backend/discovery/aztecconnect/ethereum/discovered.json
@@ -12,6 +12,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1653687769,
       "values": {
         "domainSeparator": "0xbb4c14311b94437fa30194d9467b3c7f175456bf8c6bc27bf3b2b2770c5dac19",
         "getChainId": 1,
@@ -45,6 +46,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1668605483,
       "values": {
         "domainSeparator": "0x29b99d4dc1bacc29c16bb544f33927846f031d20c47063cabf7042d4912df697",
         "getChainId": 1,
@@ -78,6 +80,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1668604175,
       "values": {
         "domainSeparator": "0xc211ddb07f51d4255fd887fac104189ce72ce524985eb9914e66bb9dc5b058c0",
         "getChainId": 1,
@@ -97,7 +100,8 @@
       "address": "0xA1BBa894a6D39D79C0D1ef9c68a2139c84B81487",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1654638146
     },
     {
       "name": "Verifier28x32",
@@ -105,6 +109,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1675077215,
       "values": {
         "getVerificationKeyHash": "0x8c16a95cccbb8c49aaf2bf27970df31180f348dfd3bbda93acb7fa800840ce5d"
       }
@@ -115,6 +120,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1654638154,
       "values": {
         "owner": "0xE298a76986336686CC3566469e3520d23D1a8aaD"
       }
@@ -126,6 +132,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1610552620,
       "values": {
         "domainSeparator": "0xf37d5181cb1c7c67c7e79d1dd66f78e41f525d498f652270e8f68c486406872b",
         "getChainId": 1,
@@ -147,6 +154,7 @@
         "implementation": "0x8430Be7B8fd28Cc58EA70A25C9c7A624F26f5D09",
         "admin": "0xC5b735d05c26579B701Be9bED253Bb588503B26B"
       },
+      "sinceTimestamp": 1654638194,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {

--- a/packages/backend/discovery/base/ethereum/discovered.json
+++ b/packages/backend/discovery/base/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "addressManager": "0x8EfB6B5c4767B09Dc9AA6Af4eAA89F749522BaE2",
         "isUpgrading": false,
@@ -25,6 +26,7 @@
         "implementation": "0x3d2c2f8f95CAba644eA25319c4c08594b8DC0359",
         "admin": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "BRIDGE": "0x3154Cf16ccdb4C6d922629664174b904d80F2C35",
         "version": "1.1.0"
@@ -38,6 +40,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1685980643,
       "values": {
         "domainSeparator": "0xf3474c66ee08325b410c3f442c878d01ec97dd55a415a307e9d7d2ea24336289",
         "getChainId": 1,
@@ -63,6 +66,7 @@
         "implementation": "0x3F3C0F6bC115E698E35038E1759E9c31032E590c",
         "admin": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
         "messenger": "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
@@ -80,6 +84,7 @@
         "implementation": "0x5FB30336A8d0841cf15d452afA297cB6D10877D7",
         "admin": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "GUARDIAN": "0x14536667Cd30e52C0b458BaACcB9faDA7046E056",
         "L2_ORACLE": "0x56315b90c40730925ec5485cf004d835058518A0",
@@ -99,6 +104,7 @@
         "implementation": "0xf2460D3433475C8008ceFfe8283F07EB1447E39a",
         "admin": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "CHALLENGER": "0x6F8C5bA3F59ea3E76300E3BEcDC231D656017824",
         "FINALIZATION_PERIOD_SECONDS": 604800,
@@ -123,6 +129,7 @@
         "implementation": "0x3311aC7F72bb4108d9f4D5d50E7623B1498A9eC0",
         "admin": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "messenger": "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
         "MESSENGER": "0x866E82a600A1414e583f7F13623F1aC5d58b0Afa",
@@ -138,6 +145,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1689917711,
       "values": {
         "L2_OUTPUT_ORACLE_PROXY": "0x56315b90c40730925ec5485cf004d835058518A0",
         "OP_SIGNER": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
@@ -152,6 +160,7 @@
         "implementation": "0x6481ff79597Fe4F77E1063f615ec5BDaDDEFfd4B",
         "admin": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "batcherHash": "0x5050F69a9786F081509234F1a7F4684b5E5b76C9",
         "gasLimit": 30000000,
@@ -181,6 +190,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1689804143,
       "values": {
         "domainSeparator": "0xe84c799b3c2ca46c34ff8fa9bfdb5533a5e36e90aadfb803c75e31eac995151d",
         "getChainId": 1,
@@ -203,6 +213,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x81C4Bd600793EBd1C0323604E1F455fE50A951F8"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "MESSAGE_VERSION": 1,
         "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292721416",
@@ -225,6 +236,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1686793895,
       "values": {
         "owner": "0x0475cBCAebd9CE8AfA5025828d5b98DFb67E059E"
       }
@@ -236,6 +248,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1684875515,
       "values": {
         "domainSeparator": "0x88aac3dc27cc1618ec43a87b3df21482acd24d172027ba3fbb5a5e625d895a0b",
         "getChainId": 1,
@@ -260,6 +273,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1610850364,
       "values": {
         "domainSeparator": "0x4e6a6554de0308f5ece8ff736beed8a1b876d16f5c27cac8e466d7de0c703890",
         "getModules": [],

--- a/packages/backend/discovery/beamer-bridge-v2/ethereum/discovered.json
+++ b/packages/backend/discovery/beamer-bridge-v2/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1680258323,
       "values": {
         "owner": "0x42405d66fdA09dbDaC90Ff25fC5a4C2353f43E70"
       },
@@ -22,6 +23,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1680258335,
       "values": {
         "owner": "0x42405d66fdA09dbDaC90Ff25fC5a4C2353f43E70",
         "resolver": "0xCb60516819a28431233195A8b7E0227C288B61AD"
@@ -34,6 +36,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1680258563,
       "values": {
         "nativeMessenger": "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1",
         "owner": "0x42405d66fdA09dbDaC90Ff25fC5a4C2353f43E70"
@@ -46,6 +49,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1680258503,
       "values": {
         "bridge": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
         "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
@@ -59,6 +63,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1680258347,
       "values": {
         "chains": {
           "1": {
@@ -114,6 +119,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1680258311,
       "values": {
         "owner": "0x42405d66fdA09dbDaC90Ff25fC5a4C2353f43E70"
       },
@@ -125,6 +131,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1680258395,
       "values": {
         "l1Resolver": "0xCb60516819a28431233195A8b7E0227C288B61AD",
         "liquidityProviders": ["0xdC256EC77E97448d29D88118e55C82067150b768"],

--- a/packages/backend/discovery/bobanetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/bobanetwork/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "bobanetwork",
+  "chain": "ethereum",
   "blockNumber": 17619337,
   "configHash": "0x33ca51c13c33399a88621568b90684739dd62f2a15c97649de215f4e831197d6",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "L1CrossDomainMessenger_2",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635387044,
       "values": {
         "libAddressManager": "0x8376ac6C3f73a25Dd994E0b0669ca7ee0C02F089",
         "owner": "0x1f2414D0af8741Bc822dBc2f88069c2b2907a840",
@@ -25,6 +26,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635385967,
       "values": {
         "getGlobalMetadata": "0x00000000000000000000000000000000000064a3ce1f00000fbd0e",
         "length": 16893,
@@ -39,6 +41,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635385259,
       "values": {
         "getGlobalMetadata": "0x0000000000000000010cd85e0064a3cb660000005f4f00000fbd0e",
         "length": 18688,
@@ -52,7 +55,8 @@
       "address": "0x1A26ef6575B7BBB864d984D9255C069F6c361a14",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1631815326
     },
     {
       "name": "L1MultiMessageRelayerFast",
@@ -60,6 +64,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1643231911,
       "values": {
         "libAddressManager": "0x8376ac6C3f73a25Dd994E0b0669ca7ee0C02F089"
       }
@@ -70,6 +75,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635385547,
       "values": {
         "getGlobalMetadata": "0x000000000000000000000000000000000000000000000000000000",
         "length": 0,
@@ -84,6 +90,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635387559,
       "values": {
         "libAddressManager": "0x8376ac6C3f73a25Dd994E0b0669ca7ee0C02F089"
       }
@@ -94,6 +101,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635386681,
       "values": {
         "libAddressManager": "0x8376ac6C3f73a25Dd994E0b0669ca7ee0C02F089"
       }
@@ -107,6 +115,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x12Acf6E3ca96A60fBa0BBFd14D2Fe0EB6ae47820"
       },
+      "sinceTimestamp": 1628792652,
       "values": {
         "libAddressManager": "0x8376ac6C3f73a25Dd994E0b0669ca7ee0C02F089",
         "owner": "0x1f2414D0af8741Bc822dBc2f88069c2b2907a840",
@@ -121,6 +130,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1628790631,
       "values": {
         "Boba_GasPriceOracle": "0x5d0763cf905DA3689B072FD19baD8dF823b2c349",
         "BobaBillingContract": "0x4a792F51CCc616b82EF74d2478C732e161c5E6b1",
@@ -147,6 +157,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1688058755,
       "values": {
         "depositL2Gas": 0,
         "l2NFTBridge": "0x0000000000000000000000000000000000000000",
@@ -160,7 +171,8 @@
       "address": "0xC891F466e53f40603250837282eAE4e22aD5b088",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1640044157
     },
     {
       "name": "L1LiquidityPool",
@@ -168,6 +180,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1688058275,
       "values": {
         "currentDepositInfoHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "l1CrossDomainMessenger": "0x0000000000000000000000000000000000000000",
@@ -194,6 +207,7 @@
         "implementation": "0xAf41c681143Cb91f218959375f4452A604504833",
         "admin": "0x1f2414D0af8741Bc822dBc2f88069c2b2907a840"
       },
+      "sinceTimestamp": 1628793901,
       "values": {
         "currentDepositInfoHash": "0xc64671bef9775ff63adc5ca2a6431f80c537ba9ef4bc39420856130d54cf78ee",
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
@@ -209,6 +223,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635386294,
       "values": {
         "batches": "0x13992B9f327faCA11568BE18a8ad3E9747e87d93",
         "FRAUD_PROOF_WINDOW": 604800,
@@ -226,6 +241,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635386025,
       "values": {
         "batches": "0x17148284d2da2f38c96346f1776C1BF7D7691231",
         "enqueueGasCost": 60000,

--- a/packages/backend/discovery/brine/ethereum/discovered.json
+++ b/packages/backend/discovery/brine/ethereum/discovered.json
@@ -3,7 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 17821210,
   "configHash": "0xb03efc49cd04c082e7001d53a82ab71dc71138acc2d59a1754f4120db954c9ac",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "StarkExchange",
@@ -23,6 +23,7 @@
         },
         "proxyGovernance": ["0x303775491494a08b07365938787274F742a81F63"]
       },
+      "sinceTimestamp": 1657453320,
       "values": {
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,
@@ -72,6 +73,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1678120703,
       "values": {
         "domainSeparator": "0xdc841842a6a324de5b6a29714a4394558c78638216ef50f533783d49856a58c0",
         "getChainId": 1,
@@ -100,6 +102,7 @@
           "0x21F9eC47b19d95b5C2DDFB6Ae5D4F92fAdacAEc4"
         ]
       },
+      "sinceTimestamp": 1635077695,
       "values": {
         "CALL_PROXY_VERSION": "3.1.0",
         "callProxyImplementation": "0x6cB3EE90C50a38A0e4662bB7e7E6e40B91361BF6",
@@ -119,6 +122,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657550175,
       "values": {
         "constructorArgs": [
           [
@@ -142,6 +146,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657453372,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,
@@ -155,6 +160,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1674001487,
       "values": {
         "getBootloaderConfig": [
           "2962621603719000361370283216422448934312521782617806945663080079725495842070",
@@ -176,6 +182,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657453372,
       "values": {
         "hasRegisteredFact": false,
         "identify": "StarkWare_OrderRegistry_2021_1"

--- a/packages/backend/discovery/canvasconnect/ethereum/discovered.json
+++ b/packages/backend/discovery/canvasconnect/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "canvasconnect",
+  "chain": "ethereum",
   "blockNumber": 17044496,
   "configHash": "0xc88c50f0bc156a7977f6aef4367f3e9a5ce62209b7ccbf5bee8ad3ac8e6571e3",
+  "version": 2,
   "contracts": [
     {
       "name": "GpsFactRegistryAdapter",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657453372,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,
@@ -35,6 +37,7 @@
         },
         "proxyGovernance": ["0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A"]
       },
+      "sinceTimestamp": 1674388691,
       "values": {
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,
@@ -82,6 +85,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657453372,
       "values": {
         "hasRegisteredFact": false,
         "identify": "StarkWare_OrderRegistry_2021_1"
@@ -93,6 +97,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1674737735,
       "values": {
         "constructorArgs": [
           [

--- a/packages/backend/discovery/cbridge/ethereum/discovered.json
+++ b/packages/backend/discovery/cbridge/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1639581534,
       "values": {
         "delayPeriod": 1800,
         "epochLength": 1800,
@@ -27,6 +28,7 @@
         "implementation": "0x479ec366ae4EC016cE25B918BdEa8f78d4fa5dd8",
         "admin": "0x520d812604E7b2ce71819FDBFE9aC40E56327F8f"
       },
+      "sinceTimestamp": 1649432556,
       "values": {
         "feeBase": 15000000000000,
         "feePerByte": 150000000000,
@@ -46,6 +48,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1649432377,
       "values": {
         "owner": "0x0000000000000000000000000000000000000000"
       }
@@ -56,6 +59,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1650529338,
       "values": {
         "delayPeriod": 1800,
         "epochLength": 1800,
@@ -70,6 +74,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1638346811,
       "values": {
         "addseq": 5080,
         "delayPeriod": 1800,
@@ -106,6 +111,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1676671175,
       "values": {
         "getVoters": [
           [
@@ -129,6 +135,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1651661389,
       "values": {
         "delayPeriod": 1800,
         "epochLength": 1800,
@@ -144,6 +151,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1690520231,
       "values": {
         "owner": "0x1b9dFC56e38b0F92448659C114e2347Bd803911c"
       },
@@ -155,6 +163,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1666193927,
       "values": {
         "owner": "0xF380166F8490F24AF32Bf47D1aA217FBA62B6575"
       }
@@ -165,6 +174,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1639553135,
       "values": {
         "delayPeriod": 1800,
         "epochLength": 1800,
@@ -197,6 +207,7 @@
         "implementation": "0xaE41e6a597f4c65646e94E330D8BAd218Bec7896",
         "admin": "0x8E339115b295DeD49880eA62C1F06d1dbec3496b"
       },
+      "sinceTimestamp": 1691384579,
       "values": {
         "governors": [
           "0xED9fdF5B16F9F254bec5Ad389B80B48225186655",
@@ -233,6 +244,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656926298,
       "values": {
         "getVoters": [
           [

--- a/packages/backend/discovery/connext/ethereum/discovered.json
+++ b/packages/backend/discovery/connext/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "connext",
+  "chain": "ethereum",
   "blockNumber": 17129653,
   "configHash": "0xdcf91d8c4968003c2e4d896e5f39e668d06ba2866c5a0383fa2be56a70ca45ac",
+  "version": 2,
   "contracts": [
     {
       "name": "TransactionManager",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636004546,
       "values": {
         "assetOwnershipTimestamp": 0,
         "delay": 604800,
@@ -33,6 +35,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636004546,
       "values": {
         "getTransactionManager": "0x31eFc4AeAA7c39e54A33FDc3C46ee2Bd70ae0A09"
       }

--- a/packages/backend/discovery/debridge/ethereum/discovered.json
+++ b/packages/backend/discovery/debridge/ethereum/discovered.json
@@ -13,6 +13,7 @@
         "implementation": "0x797161BCC625155D2302251404ccB93c2632658e",
         "admin": "0xE4427af3555CD9303D728C491364FAdFDD7494Fe"
       },
+      "sinceTimestamp": 1637595390,
       "values": {
         "BPS_DENOMINATOR": 10000,
         "callProxy": "0x8a0C79F5532f3b2a16AD1E4282A5DAF81928a824",
@@ -46,6 +47,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1637442903,
       "values": {
         "domainSeparator": "0x1e756d21e24d2471c566451e17756f6febc40c36cb31d6437730beb1c93c306c",
         "getChainId": 1,
@@ -73,6 +75,7 @@
         "implementation": "0x4c7CA8fcFFE77281A8B81D4580CFf8257d785491",
         "admin": "0xE4427af3555CD9303D728C491364FAdFDD7494Fe"
       },
+      "sinceTimestamp": 1637613802,
       "values": {
         "debridgeAddress": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
         "deBridgeTokenAdmin": "0x6bec1faF33183e1Bc316984202eCc09d46AC92D5",
@@ -90,6 +93,7 @@
         "implementation": "0xBd3d657AE87671eC6f8D6272A9f431a7c4a9B6f8",
         "admin": "0xE4427af3555CD9303D728C491364FAdFDD7494Fe"
       },
+      "sinceTimestamp": 1637625277,
       "values": {
         "DEBRIDGE_GATE_ROLE": "0xd5a6101e940ba33e226d2395b16238ab3063d7ee83d7b3ff59cb92988b395437",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -106,6 +110,7 @@
         "implementation": "0xfE7De3c1e1BD252C67667B56347cABFC6df08dF4",
         "admin": "0xE4427af3555CD9303D728C491364FAdFDD7494Fe"
       },
+      "sinceTimestamp": 1637621914,
       "values": {
         "confirmationThreshold": 3,
         "currentBlock": 18166545,
@@ -140,6 +145,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1637430511,
       "values": {
         "domainSeparator": "0xd9512e4bd742ce576138697d48c92dcc7b1776e492c423a4c0c37e3aa6999b8e",
         "getChainId": 1,
@@ -161,6 +167,7 @@
         "implementation": "0x37a52ddb753c924f8C914de65ef00b5210Caa83C",
         "admin": "0xE4427af3555CD9303D728C491364FAdFDD7494Fe"
       },
+      "sinceTimestamp": 1637651844,
       "values": {
         "debridgeGate": "0x43dE2d77BF8027e25dBD179B491e8d64f38398aA",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -176,6 +183,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693372043,
       "values": {
         "decimals": 18,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -195,6 +203,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637594986,
       "values": {
         "owner": "0x6bec1faF33183e1Bc316984202eCc09d46AC92D5"
       }

--- a/packages/backend/discovery/degate/ethereum/discovered.json
+++ b/packages/backend/discovery/degate/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "degate",
+  "chain": "ethereum",
   "blockNumber": 17434695,
   "configHash": "0xadf196f9058092e27299c4f7165d10c2012663548dc91fb005ef32fa8beb5e31",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "BlockVerifier",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1681985879,
       "values": {
         "owner": "0xd8C695DfAab475f55327Ce269096923EFECa2e0F",
         "pendingOwner": "0x0000000000000000000000000000000000000000"
@@ -22,6 +23,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1684401563,
       "values": {
         "getOwners": [
           "0xf5020ADf433645c451A4809eac0d6F680709f11B",
@@ -43,6 +45,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1681989995,
       "values": {
         "blockVerifierAddress": "0x1c602313cDDC68C5789aCb7df0C92a93B0E04C9e",
         "forcedWithdrawalFee": "10000000000000000",
@@ -61,6 +64,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1681993655,
       "values": {
         "blockSubmitters": [
           "0x84A00D39C3c95e839202E19F892F17743d6370a0",
@@ -79,6 +83,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1614841682,
       "values": {
         "getOwners": [
           "0xf5020ADf433645c451A4809eac0d6F680709f11B",
@@ -100,6 +105,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1681991243,
       "values": {
         "exchange": "0xe63602a9B3DFE983187525AC985Fec4F57B24eD5",
         "owner": "0x2028834B2c0A36A918c10937EeA71BE4f932da52",
@@ -112,6 +118,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1681991219,
       "values": {
         "allowOnchainTransferFrom": false,
         "domainSeparator": "0x5630f2c00e81e2223458dcd1f7c1a754cd6cc2a258d90b829e325489c7002912",

--- a/packages/backend/discovery/degate2/ethereum/discovered.json
+++ b/packages/backend/discovery/degate2/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693304819,
       "values": {
         "blockSubmitters": ["0x4e3FE240B50A445fc6137a6363aC3593Af173b8a"],
         "open": false,
@@ -26,6 +27,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693304687,
       "values": {
         "blockVerifierAddress": "0x707B12e8921b442D4015eb03c86E66F3b8042Dd2",
         "forcedWithdrawalFee": "10000000000000000",
@@ -44,6 +46,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693304675,
       "values": {
         "owner": "0xacD3A62F3eED1BfE4fF0eC8240d645c1F5477F82",
         "pendingOwner": "0x0000000000000000000000000000000000000000"
@@ -55,6 +58,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1614841682,
       "values": {
         "getOwners": [
           "0xf5020ADf433645c451A4809eac0d6F680709f11B",
@@ -76,6 +80,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693304795,
       "values": {
         "allowOnchainTransferFrom": false,
         "domainSeparator": "0xe28bada2629b92fae534318e0ab97ecdfab14b258848e76b6e6282f6fbbdb0dd",
@@ -133,6 +138,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693304807,
       "values": {
         "exchange": "0x9C8f884B15a1fcd5B4bcEb8647DC2D15165906c7",
         "owner": "0xacD3A62F3eED1BfE4fF0eC8240d645c1F5477F82",

--- a/packages/backend/discovery/deversifi/ethereum/discovered.json
+++ b/packages/backend/discovery/deversifi/ethereum/discovered.json
@@ -3,7 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 17968886,
   "configHash": "0x49293ad07e522b8e81cc67951023c79b9dbc188acb13f998535dd92fd197676f",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "Committee",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1603626845,
       "values": {
         "constructorArgs": [
           [
@@ -36,6 +37,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691481095,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,
@@ -49,6 +51,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626352379,
       "values": {
         "hasRegisteredFact": true,
         "identify": "StarkWare_OrderRegistry_2021_1"
@@ -75,6 +78,7 @@
           "0xCCa5De1e10c05c50C51ac551D9182cd31aca1889"
         ]
       },
+      "sinceTimestamp": 1590491810,
       "values": {
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,
@@ -119,6 +123,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1683214307,
       "values": {
         "domainSeparator": "0x00e7276e9f285a9b73208ee52227fedeba51adac2fc7b3bb3b5c2a78ea7234df",
         "getChainId": 1,

--- a/packages/backend/discovery/dydx/ethereum/discovered.json
+++ b/packages/backend/discovery/dydx/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "dydx",
+  "chain": "ethereum",
   "blockNumber": 17622125,
   "configHash": "0x051a1cdd442c27020469b0364825496f871a9ecf736da91d664ff1026594d876",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "MerkleDistributor",
@@ -13,6 +13,7 @@
         "implementation": "0xFE1d5439625a9524a80F66670733129E80E0C112",
         "admin": "0x6C5cd3aD7A16Ae207D221908E6b997d9B0DcD7b0"
       },
+      "sinceTimestamp": 1627709502,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -68,14 +69,16 @@
       "address": "0x04D4E67F8B6c67D63219Cd088bC45E8e89fE6D73",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1612752384
     },
     {
       "name": "CpuOods",
       "address": "0x0c6dEc0B366b1bb4C14597cf1Da8b4af2E7799b5",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1612752351
     },
     {
       "name": "MerkleStatementContract",
@@ -83,6 +86,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752351,
       "values": {
         "hasRegisteredFact": true
       }
@@ -93,6 +97,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627709848,
       "values": {
         "LIQUIDITY_STAKING": "0x5Aa653A076c1dbB47cec8C1B4d152444CAD91941",
         "MERKLE_DISTRIBUTOR": "0x01d3348601968aB85b4bb028979006eac235a588",
@@ -106,6 +111,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752276,
       "derivedName": "PedersenHashPointsYColumn"
     },
     {
@@ -114,6 +120,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752200,
       "values": {
         "getCompiledProgram": [
           "1226245742482522112",
@@ -348,7 +355,8 @@
       "address": "0x1F5459AA7857291112A8172ae1328248948d9d13",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1612752229
     },
     {
       "name": "TreasuryProxyAdmin",
@@ -356,6 +364,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627708831,
       "values": {
         "owner": "0x64c7d40c07EFAbec2AafdC243bF59eaF2195c6dc"
       },
@@ -367,6 +376,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752363,
       "values": {
         "constructorArgs": [
           [
@@ -392,6 +402,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752276,
       "derivedName": "EcdsaPointsXColumn"
     },
     {
@@ -402,6 +413,7 @@
         "implementation": "0xBE607a58206180fef691bf1B5aE9670174284388",
         "admin": "0xAc5D8bCD13da463bea96c75f9085c4e40037F790"
       },
+      "sinceTimestamp": 1627709656,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -490,6 +502,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1620888418,
       "values": {
         "hasRegisteredFact": false,
         "identify": "StarkWare_PerpetualEscapeVerifier_2021_2"
@@ -503,6 +516,7 @@
         "implementation": "0x0AdA60E07717Ab19E4A466f5f0ac68A66e3995Ce",
         "admin": "0x40D6992cbd03E0DC1c2DE9606D29Cb245E737a5d"
       },
+      "sinceTimestamp": 1627708861,
       "values": {
         "owner": "0x64c7d40c07EFAbec2AafdC243bF59eaF2195c6dc",
         "REVISION": 1
@@ -514,6 +528,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626145373,
       "values": {
         "getAdmin": "0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2",
         "getDelay": 172800,
@@ -537,6 +552,7 @@
         "implementation": "0x31D76F5Db8F40D28886Bf00F3be5F157472Bf77A",
         "admin": "0x6aaD0BCfbD91963Cf2c8FB042091fd411FB05b3C"
       },
+      "sinceTimestamp": 1627709015,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -613,6 +629,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627708955,
       "values": {
         "owner": "0xEcaE9BF44A21d00E2350a42127A377Bf5856d84B"
       },
@@ -624,6 +641,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627709450,
       "values": {
         "owner": "0x64c7d40c07EFAbec2AafdC243bF59eaF2195c6dc"
       },
@@ -635,6 +653,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626145334,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -674,6 +693,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1615417556,
       "values": {
         "constructorArgs": [
           "0x1dd8945200f5a09D6Fe0ed68494c2ac41cd02E2D",
@@ -695,6 +715,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1613033682,
       "values": {
         "constructorArgs": [
           [
@@ -715,6 +736,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627709172,
       "values": {
         "DYDX_TOKEN": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
         "STAKED_DYDX_TOKEN": "0x65f7BA4Ec257AF7c55fd5854E5f6356bBd0fb8EC"
@@ -727,6 +749,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626053832,
       "values": {
         "_mintingRestrictedBefore": 1784041200,
         "_totalSupplySnapshotsCount": 1,
@@ -755,6 +778,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627709600,
       "values": {
         "CHAINLINK_TOKEN": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
         "JOB_ID": "0x6365366562393532363736373431666438323462626636643132313163313031",
@@ -770,6 +794,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752231,
       "derivedName": "PedersenHashPointsXColumn"
     },
     {
@@ -778,6 +803,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627710079,
       "values": {
         "getAdmin": "0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2",
         "getDelay": 777600,
@@ -801,6 +827,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627709620,
       "values": {
         "owner": "0x64c7d40c07EFAbec2AafdC243bF59eaF2195c6dc"
       },
@@ -812,6 +839,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627709382,
       "values": {
         "dydx": "0x92D6C1e31e14520e676a687F0a93788B716BEff5",
         "lastUpdate": 1686803003,
@@ -829,6 +857,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752276,
       "derivedName": "EcdsaPointsYColumn"
     },
     {
@@ -850,6 +879,7 @@
           "0xa306989BA6BcacdECCf3C0614FfF2B8C668e3CaE"
         ]
       },
+      "sinceTimestamp": 1613033682,
       "values": {
         "configurationDelay": 0,
         "DEPOSIT_CANCEL_DELAY": 604800,
@@ -896,6 +926,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626145414,
       "values": {
         "getAdmin": "0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2",
         "getDelay": 0,
@@ -916,7 +947,8 @@
       "address": "0xeCa5Da0287D407a23f7c0a13a9AAD87c7fBC10A3",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1615417455
     },
     {
       "name": "LongTimelockExecutor",
@@ -924,6 +956,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626145348,
       "values": {
         "getAdmin": "0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2",
         "getDelay": 604800,
@@ -945,6 +978,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752200,
       "values": {
         "hasRegisteredFact": true
       }
@@ -955,6 +989,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1681722659,
       "values": {
         "gpsContract": "0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3",
         "hasRegisteredFact": true,
@@ -969,6 +1004,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1612752351,
       "values": {
         "hasRegisteredFact": true
       }
@@ -979,6 +1015,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627913849,
       "values": {
         "MAIN_GOVERNORS_TO_REMOVE": [
           "0x47FB811bE111F2F0Df7dff81EFFe890da6D74080"

--- a/packages/backend/discovery/gravity/ethereum/discovered.json
+++ b/packages/backend/discovery/gravity/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "gravity",
+  "chain": "ethereum",
   "blockNumber": 17065004,
   "configHash": "0x758ac62a67058b3e0d7b566f6cd60fb5eae8d88090fc9042ac6932a406ded906",
+  "version": 2,
   "contracts": [
     {
       "name": "Gravity",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1639416372,
       "values": {
         "state_gravityId": "0x677261766974792d6272696467652d6d61696e6e657400000000000000000000",
         "state_lastEventNonce": 39098,

--- a/packages/backend/discovery/hop/ethereum/discovered.json
+++ b/packages/backend/discovery/hop/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "hop",
+  "chain": "ethereum",
   "blockNumber": 16154924,
   "configHash": "0x0a88b91a8c286dec34e7b69f534199ba36da7672dafdc8ba4a70fe617319dfd6",
+  "version": 2,
   "contracts": [
     {
       "name": "Hop Multisig",
@@ -11,6 +12,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1625076853,
       "values": {
         "domainSeparator": "0x62766f0ec4bb63fc0cf61622e436018804fdac93d59b3a03e6318b6bf34dd76c",
         "getModules": [],
@@ -32,6 +34,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1628225875,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -50,6 +53,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1625550046,
       "values": {
         "admin": "0x1ec078551A5ac8F0f51fAc57Ffc48Ea7d9A86E9d",
         "delay": 86400,
@@ -65,6 +69,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1623907245,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -83,6 +88,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1631654328,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -101,6 +107,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626739308,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -119,6 +126,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1664398079,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -137,6 +145,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1663897247,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -156,6 +165,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1633066189,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -173,6 +183,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1635022634,
       "values": {
         "CHALLENGE_AMOUNT_DIVISOR": 10,
         "challengePeriod": 86400,
@@ -191,6 +202,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1654646429,
       "values": {
         "BALLOT_TYPEHASH": "0x150214d74d59b7d1e90c73fc22ef3d991dd0a76b046543d4d80ab92d2a50328f",
         "COUNTING_MODE": "support=bravo&quorum=for,abstain",
@@ -213,6 +225,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1654646382,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {

--- a/packages/backend/discovery/hyphen/ethereum/discovered.json
+++ b/packages/backend/discovery/hyphen/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "hyphen",
+  "chain": "ethereum",
   "blockNumber": 16154924,
   "configHash": "0xdd92ae53409543a6d875508a549aa2f067a636f8d3eccb0ae42b9f5aa434d7c6",
+  "version": 2,
   "contracts": [
     {
       "name": "ProxyAdmin",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647128852,
       "values": {
         "owner": "0x129443cA2a9Dec2020808a2868b38dDA457eaCC7"
       }
@@ -22,6 +24,7 @@
         "implementation": "0x256415A1f9468E5405abdAfD9B76c4f24451d7E7",
         "admin": "0x13a4cC0750296bB72Eb0006febec306551A4f472"
       },
+      "sinceTimestamp": 1647128990,
       "values": {
         "baseGas": 21000,
         "getExecutorManager": "0xbd761D917fB77381B4398Bda89C7F0d9A2BD1399",
@@ -37,6 +40,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647128800,
       "values": {
         "getAllExecutors": [
           "0xEEFD474e80B6CAEA43F212D964409c473684E3fe",
@@ -55,6 +59,7 @@
         "implementation": "0x79E559AC5b499A5676e28f0074e29763F6c2A27e",
         "admin": "0x13a4cC0750296bB72Eb0006febec306551A4f472"
       },
+      "sinceTimestamp": 1652360689,
       "values": {
         "owner": "0xD76b82204BE75Ab9610B04CF27c4F4a34291D5E6",
         "paused": false
@@ -68,6 +73,7 @@
         "implementation": "0x52a592fFE0377b351c8FD99189e5333ec362d66A",
         "admin": "0x13a4cC0750296bB72Eb0006febec306551A4f472"
       },
+      "sinceTimestamp": 1647128942,
       "values": {
         "BASE_DIVISOR": "1000000000000000000",
         "getFeeAccumulatedOnNft": [],

--- a/packages/backend/discovery/immutablex/ethereum/discovered.json
+++ b/packages/backend/discovery/immutablex/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "immutablex",
+  "chain": "ethereum",
   "blockNumber": 17271523,
   "configHash": "0xb1c3e28b03c79d1b3f5f4c08ccf0bb526f2177ffeba21774258a69efb2b8e438",
+  "version": 2,
   "contracts": [
     {
       "name": "Committee",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1616668125,
       "values": {
         "constructorArgs": [
           [
@@ -35,6 +37,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626352379,
       "values": {
         "hasRegisteredFact": true,
         "identify": "StarkWare_OrderRegistry_2021_1"
@@ -58,6 +61,7 @@
         },
         "proxyGovernance": ["0x9C41deab42Bae7c0ec4DB3cECc0faD86F4D6EC91"]
       },
+      "sinceTimestamp": 1615389188,
       "values": {
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 259200,
@@ -98,6 +102,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1640107463,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,
@@ -112,6 +117,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1683124943,
       "values": {
         "domainSeparator": "0x0733691424a2d0bc85b95e6971bb8e89e60325c348f87b405049bcf97a719593",
         "getChainId": 1,

--- a/packages/backend/discovery/kroma/ethereum/discovered.json
+++ b/packages/backend/discovery/kroma/ethereum/discovered.json
@@ -13,6 +13,7 @@
         "implementation": "0x14126FFa3889a026A79F0f99FaE80B3dc9E38095",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880579,
       "values": {
         "COLOSSEUM": "0x713C2BEd44eB45D490afB8D4d1aA6F12290B829a",
         "FINALIZATION_PERIOD_SECONDS": 604800,
@@ -37,6 +38,7 @@
         "implementation": "0x595E1b330892Fcbf18b2BF099DE501Ad4d6A07C4",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880651,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -81,6 +83,7 @@
         "implementation": "0x381F53695230BAF83a39D1a08304D233A35730Fa",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880555,
       "values": {
         "GUARDIAN": "0x3de211088dF516da72efe68D386b561BEE256Ec4",
         "L2_ORACLE": "0x180c77aE51a9c505a43A2C7D81f8CE70cacb93A6",
@@ -100,6 +103,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693288019,
       "values": {
         "POSEIDON2": "0xFd234971881a7c72965175fA8E438c97B2Dcd273"
       }
@@ -112,6 +116,7 @@
         "implementation": "0x2af8a383C395EBa6551E674EeD02344936fE36f5",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880543,
       "values": {
         "batcherHash": "0x41b8cD6791De4D8f9E0eaF7861aC506822AdcE12",
         "gasLimit": 30000000,
@@ -143,6 +148,7 @@
         "implementation": "0x2BB1c629c46a4018fBe2538a98da7162F8355583",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880627,
       "values": {
         "COLOSSEUM": "0x713C2BEd44eB45D490afB8D4d1aA6F12290B829a",
         "getOwners": ["0x3aa00bb915A8e78b0523E4c365e3E70A19d329e6"],
@@ -162,6 +168,7 @@
         "implementation": "0x675924D68200F2C967Ba12349d5d510676C7214c",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880591,
       "values": {
         "MESSAGE_VERSION": 0,
         "messageNonce": 14,
@@ -187,6 +194,7 @@
         "implementation": "0xbB1cDB5Cc35B1c9801DA8772aCBcDbd323A912D9",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693287695,
       "values": {
         "MESSENGER": "0x46B8bB4C5dd27bB42807Db477af4d1a7C8A5B746",
         "OTHER_BRIDGE": "0x420000000000000000000000000000000000000A",
@@ -200,6 +208,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693287587,
       "values": {
         "owner": "0x22605A12cB77Fe420B0cC1263cEb58a77352FDc1"
       },
@@ -213,6 +222,7 @@
         "implementation": "0x7E79726560B140fd6e089547bD049509F5423BFf",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693287719,
       "values": {
         "version": "0.1.4"
       }
@@ -225,6 +235,7 @@
         "implementation": "0x7526F997ea040B3949415c3a44e708273863AA2b",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880615,
       "values": {
         "BISECTION_TIMEOUT": 3600,
         "challengedRoots": [],
@@ -249,6 +260,7 @@
         "implementation": "0x404133EdF24F56b7dD9c6d89Fb56bb35244461B4",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880603,
       "values": {
         "MESSENGER": "0x46B8bB4C5dd27bB42807Db477af4d1a7C8A5B746",
         "OTHER_BRIDGE": "0x4200000000000000000000000000000000000009",
@@ -264,6 +276,7 @@
         "implementation": "0x2a51e099CC7AF922CcDe7F3db909DC7b71B8D030",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880663,
       "values": {
         "BALLOT_TYPEHASH": "0x150214d74d59b7d1e90c73fc22ef3d991dd0a76b046543d4d80ab92d2a50328f",
         "clock": 18147311,
@@ -300,6 +313,7 @@
         "implementation": "0x54140F4Cd6e6665BE0151eD5a8aC949EC2942439",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880639,
       "values": {
         "clock": 18147311,
         "CLOCK_MODE": "mode=blocknumber&from=default",
@@ -334,6 +348,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693288007,
       "derivedName": ""
     },
     {
@@ -344,6 +359,7 @@
         "implementation": "0x6e1781678ffE6CDc109fd3bC0833c47BD0F23de1",
         "admin": "0x665c23A5722B6A237fa6Be2B49c0A94504db1edd"
       },
+      "sinceTimestamp": 1693880567,
       "values": {
         "L2_ORACLE": "0x180c77aE51a9c505a43A2C7D81f8CE70cacb93A6",
         "MAX_UNBOND": 10,

--- a/packages/backend/discovery/l2beat-starkware/ethereum/discovered.json
+++ b/packages/backend/discovery/l2beat-starkware/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "l2beat-starkware",
+  "chain": "ethereum",
   "blockNumber": 17031968,
   "configHash": "0x80112d572c320dae60a1cc29c37f837881984f02c13575f623751c96992ac434",
+  "version": 2,
   "contracts": [
     {
       "name": "CpuFrilessVerifier",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1674001487,
       "values": {
         "constructorArgs": [
           [
@@ -37,7 +39,8 @@
       "address": "0x0C099caf7a87e4eB28bcd8D0608063f8a69bb434",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673992475
     },
     {
       "name": "CpuFrilessVerifier",
@@ -45,6 +48,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673984999,
       "values": {
         "constructorArgs": [
           [
@@ -76,6 +80,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1678120703,
       "values": {
         "domainSeparator": "0xdc841842a6a324de5b6a29714a4394558c78638216ef50f533783d49856a58c0",
         "getChainId": 1,
@@ -95,21 +100,24 @@
       "address": "0x297951a67D1BF7795500C3802d21a8C846D9C962",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673985335
     },
     {
       "name": "CpuOods",
       "address": "0x3405F644F9390C3478f42Fd205CE6920CcAF3280",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673984999
     },
     {
       "name": "PoseidonPoseidonFullRoundKey0Column",
       "address": "0x37070Fd8051f63E5A6D7E87026e086Cc19db1aBe",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998775
     },
     {
       "name": "FriStatementContract",
@@ -117,6 +125,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673984999,
       "values": {
         "hasRegisteredFact": true
       }
@@ -126,7 +135,8 @@
       "address": "0x43A1C0bBa540e1C98d4b413F876250bdCFd0b9e0",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673992751
     },
     {
       "name": "SHARPVerifierProxy",
@@ -142,6 +152,7 @@
           "0x21F9eC47b19d95b5C2DDFB6Ae5D4F92fAdacAEc4"
         ]
       },
+      "sinceTimestamp": 1635077695,
       "values": {
         "CALL_PROXY_VERSION": "3.1.0",
         "callProxyImplementation": "0x6cB3EE90C50a38A0e4662bB7e7E6e40B91361BF6",
@@ -160,42 +171,48 @@
       "address": "0x4bf82e627D57cB3F455E740bcDA25848cDbd2FF7",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673992475
     },
     {
       "name": "CpuConstraintPoly",
       "address": "0x4CF5c11321d54b83bDAE84bBbd018c26621d2950",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673985047
     },
     {
       "name": "PoseidonPoseidonPartialRoundKey1Column",
       "address": "0x4d0E80AB34ee2B19295F2CaC3101d03452D874b8",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998775
     },
     {
       "name": "PoseidonPoseidonFullRoundKey2Column",
       "address": "0x4FB05b7CC348C5a72C59a3f307baf66e3CA1F835",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998775
     },
     {
       "name": "PedersenHashPointsYColumn",
       "address": "0x519DA5F74503dA351EbBED889111377d33096002",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673984999
     },
     {
       "name": "CpuOods",
       "address": "0x52314e0b25b024c34480Ac3c75cfE98c2Ed6aa4a",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673985335
     },
     {
       "name": "MerkleStatementContract",
@@ -203,6 +220,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673984999,
       "values": {
         "hasRegisteredFact": true
       }
@@ -212,7 +230,8 @@
       "address": "0x593a71DC43e9B67FE009d7C76B6EfA925FB329B1",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673984999
     },
     {
       "name": "CairoBootloaderProgram",
@@ -220,6 +239,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673984795,
       "values": {
         "getCompiledProgram": [
           "290341444919459839",
@@ -793,6 +813,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673985047,
       "values": {
         "constructorArgs": [
           [
@@ -822,14 +843,16 @@
       "address": "0x68293272FEA2D6e74572BC18ffaD11F21344e090",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998775
     },
     {
       "name": "CpuConstraintPoly",
       "address": "0x691ca565B7416B681e4f9Fb56A1283Ae8b34E55e",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673992475
     },
     {
       "name": "SHARPVerifier",
@@ -837,6 +860,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1674001487,
       "values": {
         "constructorArgs": [
           "0x5d07afFAfc8721Ef3dEe4D11A2D1484CBf6A9dDf",
@@ -874,6 +898,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673992751,
       "values": {
         "constructorArgs": [
           [
@@ -903,7 +928,8 @@
       "address": "0x812c2AD2161D099724A99C8114c539b9e5b449cd",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998775
     },
     {
       "name": "CpuFrilessVerifier",
@@ -911,6 +937,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673985335,
       "values": {
         "constructorArgs": [
           [
@@ -940,21 +967,24 @@
       "address": "0x8518F459A698038B4CCED66C042c48C6bB5B17fe",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673985047
     },
     {
       "name": "CpuConstraintPoly",
       "address": "0x89B7a7276cBc8Cb35Ec11fAE9da83b20Db3edf20",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998859
     },
     {
       "name": "CpuConstraintPoly",
       "address": "0x943248dA0FFd5834Da56c5AD5308E2E2991378EB",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673984795
     },
     {
       "name": "CpuFrilessVerifier",
@@ -962,6 +992,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673985527,
       "values": {
         "constructorArgs": [
           [
@@ -991,21 +1022,24 @@
       "address": "0xb4711a4614368516529d6118C97905aB4B28e267",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998775
     },
     {
       "name": "CpuConstraintPoly",
       "address": "0xBE8bd7a41ba7DC7b995a53368e7fFE30Fd2BC447",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673985335
     },
     {
       "name": "PedersenHashPointsXColumn",
       "address": "0xc4f21318937017B8aBe5fDc0D48f58dBc1d18940",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673984795
     },
     {
       "name": "CpuFrilessVerifier",
@@ -1013,6 +1047,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673992475,
       "values": {
         "constructorArgs": [
           [
@@ -1040,21 +1075,24 @@
       "address": "0xc9E067AF5d00eb4aA2E73843ac36AfF83C5CeeD3",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998859
     },
     {
       "name": "EcdsaPointsYColumn",
       "address": "0xcA59f6FD499ffF50c78Ffb420a9bcd0d273abf29",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673984999
     },
     {
       "name": "CpuConstraintPoly",
       "address": "0xd0aAdECA2d25AEFde0da214d27b04b6ea20D7418",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673998775
     },
     {
       "name": "CpuFrilessVerifier",
@@ -1062,6 +1100,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673998859,
       "values": {
         "constructorArgs": [
           [
@@ -1096,7 +1135,8 @@
       "address": "0xED219933b58e9c00E66682356588d42C7932EE8E",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1673985335
     },
     {
       "name": "MemoryPageFactRegistry",
@@ -1104,6 +1144,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673984795,
       "values": {
         "hasRegisteredFact": true
       }

--- a/packages/backend/discovery/layer2financezk/ethereum/discovered.json
+++ b/packages/backend/discovery/layer2financezk/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "layer2financezk",
+  "chain": "ethereum",
   "blockNumber": 17271618,
   "configHash": "0xcaa1cbc5c03ede6a2281b93df0293fc741b921d5ec4594bef060e7fddcf5817c",
+  "version": 2,
   "contracts": [
     {
       "name": "GnosisSafe",
@@ -11,6 +12,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1678120703,
       "values": {
         "domainSeparator": "0xdc841842a6a324de5b6a29714a4394558c78638216ef50f533783d49856a58c0",
         "getChainId": 1,
@@ -38,6 +40,7 @@
           "0x21F9eC47b19d95b5C2DDFB6Ae5D4F92fAdacAEc4"
         ]
       },
+      "sinceTimestamp": 1635077695,
       "values": {
         "CALL_PROXY_VERSION": "3.1.0",
         "callProxyImplementation": "0x6cB3EE90C50a38A0e4662bB7e7E6e40B91361BF6",
@@ -56,6 +59,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626352379,
       "values": {
         "hasRegisteredFact": true,
         "identify": "StarkWare_OrderRegistry_2021_1"
@@ -67,6 +71,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1674001487,
       "values": {
         "getBootloaderConfig": [
           "2962621603719000361370283216422448934312521782617806945663080079725495842070",
@@ -87,6 +92,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1640107463,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,
@@ -112,6 +118,7 @@
         },
         "proxyGovernance": ["0x1E153596BceB29c6EAE88DDB290eBeCC3FE9735e"]
       },
+      "sinceTimestamp": 1645130774,
       "values": {
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,
@@ -160,6 +167,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1648452641,
       "values": {
         "EXP_TIME": 2000000,
         "nonce": 23,
@@ -175,7 +183,8 @@
       "unverified": true,
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1650870230
     }
   ],
   "eoas": [

--- a/packages/backend/discovery/linea/ethereum/discovered.json
+++ b/packages/backend/discovery/linea/ethereum/discovered.json
@@ -13,6 +13,7 @@
         "implementation": "0x6ccfD65b0b14F67259C77Ca6267104e058dDB292",
         "admin": "0x5B0bb17755FBa06028530682E2FD5bc373931768"
       },
+      "sinceTimestamp": 1691067875,
       "values": {
         "messageService": "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
         "owner": "0x892bb7EeD71efB060ab90140e7825d8127991DD3",
@@ -31,6 +32,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691067827,
       "values": {
         "_decimals": 0,
         "bridge": "0x0000000000000000000000000000000000000000",
@@ -56,6 +58,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691086259,
       "values": {
         "owner": "0x892bb7EeD71efB060ab90140e7825d8127991DD3"
       },
@@ -69,6 +72,7 @@
         "implementation": "0x0eC393209674090368C592A591B25811e490BF36",
         "admin": "0x41fAD3Df1B07B647D120D055259E474fE8046eb5"
       },
+      "sinceTimestamp": 1691086271,
       "values": {
         "balance": 7081106509900,
         "messageService": "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
@@ -85,6 +89,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691067863,
       "values": {
         "owner": "0x892bb7EeD71efB060ab90140e7825d8127991DD3"
       },
@@ -97,6 +102,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1689149759,
       "values": {
         "domainSeparator": "0xf720f1fd8bfacb497aa1c16a19a7f17ba6e7bfba9ae23c73812ce40727956e08",
         "getChainId": 1,
@@ -122,6 +128,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691067839,
       "values": {
         "implementation": "0x36f274C1C197F277EA3C57859729398FCc8a3763",
         "owner": "0x892bb7EeD71efB060ab90140e7825d8127991DD3"
@@ -133,14 +140,16 @@
       "address": "0xa4F1155202D36348097b7488b0D2365fA91f8CaC",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1689160607
     },
     {
       "name": "PlonkVerifierFull",
       "address": "0xc01E6807DB9Fb9cC75E9Fe622ba8e7f3eB9f2B32",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1689158687
     },
     {
       "name": "PlonkVerifierFull2",
@@ -148,6 +157,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691501627,
       "derivedName": "PlonkVerifierFull"
     },
     {
@@ -158,6 +168,7 @@
         "implementation": "0xb32c3D0dDb0063FfB15E8a50b40cC62230D820B3",
         "admin": "0xF5058616517C068C7b8c7EbC69FF636Ade9066d6"
       },
+      "sinceTimestamp": 1689159923,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -212,6 +223,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1689150959,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -250,6 +262,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1689158711,
       "values": {
         "owner": "0xd6B95c960779c72B8C6752119849318E5d550574"
       }

--- a/packages/backend/discovery/loopring/ethereum/discovered.json
+++ b/packages/backend/discovery/loopring/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "loopring",
+  "chain": "ethereum",
   "blockNumber": 17372169,
   "configHash": "0x71c69dca4c3c23fc3f8221dd539a87e439d2df4d316861c926c5424356e7524e",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "ExchangeV3",
@@ -13,6 +13,7 @@
         "implementation": "0x26d8Ba776a067C5928841985bCe342f75BAE7E82",
         "owner": "0xDd2A08a1c1A28c1A571E098914cA10F2877D9c97"
       },
+      "sinceTimestamp": 1603950102,
       "values": {
         "domainSeparator": "0xf35e902e19c9d66a100a3d9b39430a988f9b8d41331d6f346f5c540ef8803264",
         "getAgentRegistry": "0x39B9bf169a7e225ba037C443A40460c77438ea14",
@@ -54,6 +55,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1616396742,
       "values": {
         "blockSubmitters": [
           "0x2b263f55Bf2125159Ce8Ec2Bb575C649f822ab46",
@@ -84,6 +86,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1603946693,
       "values": {
         "owner": "0xDd2A08a1c1A28c1A571E098914cA10F2877D9c97",
         "pendingOwner": "0x0000000000000000000000000000000000000000"
@@ -96,6 +99,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1583852946,
       "values": {
         "DAO_PERDENTAGE": 20,
         "daoAddress": "0xe6FcAA61d9354dBb2320d9DcAFA9C1486Cf93907",
@@ -123,6 +127,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1603946469,
       "values": {
         "owner": "0xDd2A08a1c1A28c1A571E098914cA10F2877D9c97",
         "pendingOwner": "0x0000000000000000000000000000000000000000"
@@ -134,6 +139,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1603949642,
       "values": {
         "exchange": "0x0BABA1Ad5bE3a5C0a66E7ac838a129Bf948f1eA4",
         "owner": "0x96f16FdB8Cd37C02DEeb7025C1C7618E1bB34d97",
@@ -147,6 +153,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1554948637,
       "values": {
         "decimals": 18,
         "name": "LoopringCoin V2",
@@ -162,6 +169,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1606289169,
       "values": {
         "domainSeparator": "0xf45dfd6bdfe82ca616c58cff61bef38014e7194f65f8d7ba32eb9022170c8d1d",
         "getChainId": 1,
@@ -186,6 +194,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1603955371,
       "values": {
         "blockVerifierAddress": "0x6150343E0F43A17519c0327c41eDd9eBE88D01ef",
         "forcedWithdrawalFee": "20000000000000000",
@@ -207,6 +216,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1574241665,
       "values": {
         "getTotalStaking": "606431271716973870704527",
         "lrcAddress": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",

--- a/packages/backend/discovery/lzomnichain/ethereum/discovered.json
+++ b/packages/backend/discovery/lzomnichain/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661529370,
       "values": {
         "feeEnabled": false,
         "nativeBP": 0,
@@ -28,7 +29,8 @@
         "type": "EIP1967 proxy",
         "implementation": "0x154c7B3Eee18ABCFaede98fae00e58e7737d96dE",
         "admin": "0x967bAf657ec4d4b1cb00b06f7Cc6E8BA604e3AC8"
-      }
+      },
+      "sinceTimestamp": 1669425971
     },
     {
       "name": "UltraLightNodeV2",
@@ -36,6 +38,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661529280,
       "values": {
         "chainAddressSizeMap": {
           "101": 20,
@@ -828,6 +831,7 @@
         "implementation": "0x3eEA8d627ab6983fFFc7027ee623Fd7699343fc1",
         "admin": "0x967bAf657ec4d4b1cb00b06f7Cc6E8BA604e3AC8"
       },
+      "sinceTimestamp": 1661536020,
       "derivedName": ""
     },
     {
@@ -836,6 +840,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661280206,
       "values": {
         "endpoint": "0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675"
       }
@@ -847,6 +852,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1647498793,
       "values": {
         "domainSeparator": "0x10cd04a3b7d65ccac18caff2fefc4c51c80b1d61ab414834e49fc8fbdd62f6be",
         "getChainId": 1,
@@ -870,6 +876,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647316591,
       "values": {
         "BLOCK_VERSION": 65535,
         "chainId": 1,
@@ -897,6 +904,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661448939,
       "values": {
         "owner": "0x7B80f2924E3Ad59a55f4bcC38AB63480599Be6c8"
       }
@@ -907,6 +915,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647504559,
       "values": {
         "chainId": 1,
         "decimals": 18,
@@ -926,6 +935,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1648243585,
       "values": {
         "domainSeparator": "0x567922b7bf591eff89c84c8a0039bbda9499c5f39de9b1c4dde48a8c912f31b9",
         "getChainId": 1,

--- a/packages/backend/discovery/mantapacific/ethereum/discovered.json
+++ b/packages/backend/discovery/mantapacific/ethereum/discovered.json
@@ -13,6 +13,7 @@
         "implementation": "0x1E5e634981564fc645dcbC6546aE618d7870B30a",
         "admin": "0xa2DCa85BB892De55D8B262d1806114733106e8D1"
       },
+      "sinceTimestamp": 1694224883,
       "values": {
         "CHALLENGER": "0x4b1A788B20bb85eb19f8e9B69B8a584e7fA29fe5",
         "FINALIZATION_PERIOD_SECONDS": 259200,
@@ -35,6 +36,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1694224835,
       "values": {
         "owner": "0xa2DCa85BB892De55D8B262d1806114733106e8D1"
       }
@@ -47,6 +49,7 @@
         "implementation": "0x62b257A1b1fC81c4e6E5Dc5b47F1E6184341Cd58",
         "admin": "0xa2DCa85BB892De55D8B262d1806114733106e8D1"
       },
+      "sinceTimestamp": 1694224907,
       "values": {
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
         "messenger": "0x635ba609680c55C3bDd0B3627b4c5dB21b13c310",
@@ -65,6 +68,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x9cDDc6F65eD67Ef19743fFDFD53501457ce8B51f"
       },
+      "sinceTimestamp": 1694224919,
       "values": {
         "MESSAGE_VERSION": 1,
         "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292620262",
@@ -89,6 +93,7 @@
         "implementation": "0xeF01a6aE995791FfFcA3d70bDA7B91E5Fa1aD0aE",
         "admin": "0xa2DCa85BB892De55D8B262d1806114733106e8D1"
       },
+      "sinceTimestamp": 1694224895,
       "values": {
         "batcherHash": "0xA76E31D8471D569EfDd3D95d1b11Ce6710f4533F",
         "gasLimit": 30000000,
@@ -119,6 +124,7 @@
         "implementation": "0x445c62F4948f3B08a6bB1DbC51Ef985b3Eb199F1",
         "admin": "0xa2DCa85BB892De55D8B262d1806114733106e8D1"
       },
+      "sinceTimestamp": 1694224871,
       "values": {
         "GUARDIAN": "0x4b1A788B20bb85eb19f8e9B69B8a584e7fA29fe5",
         "L2_ORACLE": "0x30c789674ad3B458886BBC9abf42EEe19EA05C1D",
@@ -136,6 +142,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1694224847,
       "values": {
         "addressManager": "0x3Ad319BB4872F8cB75a26Ac30CC4bD2d56b67b05",
         "isUpgrading": false,

--- a/packages/backend/discovery/mantle/ethereum/discovered.json
+++ b/packages/backend/discovery/mantle/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687930847,
       "values": {
         "pauser": "0x2F44BD2a54aC3fB20cd7783cF94334069641daC9",
         "unpauser": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
@@ -23,6 +24,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687241639,
       "values": {
         "owner": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
@@ -36,6 +38,7 @@
         "implementation": "0x64F4244eEA17a361bb919A28F614C3ad1aC565ad",
         "admin": "0x47D58744D8515d9aaEAf961bc03625118bd91EBb"
       },
+      "sinceTimestamp": 1687932047,
       "values": {
         "delegation": "0xeA4F1fE4928f1f83a450899C068bcd455BaF4798",
         "forceDeregister": "0x0000000000000000000000000000000000000000",
@@ -73,6 +76,7 @@
         "implementation": "0x7C4813A9AF2FEA4ca765a26b05d128926E94e72E",
         "admin": "0x2Cd33d3DC4d6Ea24B6941e4741F4Bf4772929e83"
       },
+      "sinceTimestamp": 1687930955,
       "values": {
         "delegation": "0xeA4F1fE4928f1f83a450899C068bcd455BaF4798",
         "DEPOSIT_TYPEHASH": "0x0a564d4cfe5cb0d4ee082aab2ca54b8c48e129485a8f7c77766ab5ef0c3566f1",
@@ -91,6 +95,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687952507,
       "values": {
         "batches": "0x5Dd48eF85B99E3e3d711Ca8B41cBC07dA1677F3E",
         "enqueueGasCost": 60000,
@@ -116,6 +121,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687930823,
       "values": {
         "owner": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       }
@@ -127,6 +133,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1686902471,
       "values": {
         "domainSeparator": "0x509138b8efbf4ec65dfd2396c0fbf689e8a0193b00f12ce81d154ffd0de8f6af",
         "getChainId": 1,
@@ -151,6 +158,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687952795,
       "values": {
         "libAddressManager": "0x6968f3F16C3e64003F02E121cf0D5CCBf5625a42"
       }
@@ -163,6 +171,7 @@
         "implementation": "0xF7576237087F808eB39531cA490b4F8eFd4a0c69",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687956143,
       "values": {
         "getTssGroupInfo": [
           1,
@@ -219,6 +228,7 @@
         "implementation": "0xCd368c1d80120b0Dd92447c87eB570154f8e685c",
         "admin": "0x0cac2B1a172ac24012621101634DD5ABD6399ADd"
       },
+      "sinceTimestamp": 1687241795,
       "values": {
         "decimals": 18,
         "DOMAIN_SEPARATOR": "0x4657b7bac12b34fb80f1848c560d6e440dfccdffe8b83f2dc958a534c89b0622",
@@ -242,6 +252,7 @@
         "implementation": "0xA1C7B28B4743248584725fEf31516fD4Ea72aEA8",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687961051,
       "values": {
         "blockFinalizationVerifier": "0x0000000000000000000000000000000000000000",
         "blockInitiationVerifier": "0x0000000000000000000000000000000000000000",
@@ -263,6 +274,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1686825851,
       "values": {
         "domainSeparator": "0xdb0a463cc9b4cc346b69933f9ff0173d72743028edaa3a32cb04fecaf0d12dcc",
         "getChainId": 1,
@@ -286,6 +298,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687931879,
       "values": {
         "owner": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       }
@@ -296,6 +309,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687931903,
       "values": {
         "pauser": "0x2F44BD2a54aC3fB20cd7783cF94334069641daC9",
         "unpauser": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
@@ -309,6 +323,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1683509999,
       "values": {
         "domainSeparator": "0xc2040462c2819b7e5f0c5e3926088f96c882d435e0b03cef5b72ef73cdfaf7d4",
         "getChainId": 1,
@@ -341,6 +356,7 @@
         "implementation": "0xDF401d4229Fc6cA52238f7e55A04FA8EBc24C55a",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1688282303,
       "values": {
         "BLOCK_STALE_MEASURE": 500,
         "dataManageAddress": "0x5BD63a7ECc13b955C4F57e3F12A64c10263C14c1",
@@ -366,6 +382,7 @@
         "implementation": "0xAB42127980a3bff124E6465e097a5fC97228827e",
         "admin": "0x47D58744D8515d9aaEAf961bc03625118bd91EBb"
       },
+      "sinceTimestamp": 1687931975,
       "values": {
         "adversaryThresholdBasisPoints": 4000,
         "BIP_MULTIPLIER": 10000,
@@ -400,6 +417,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687951931,
       "values": {
         "getGlobalMetadata": "0x000000000000000001149d1a006501d2680000004f2a000067b8be",
         "length": 9474,
@@ -417,6 +435,7 @@
         "implementationName": "BVM_L1CrossDomainMessenger",
         "implementation": "0x4692363048d0F32a2dE7816860D48fff0c61B24B"
       },
+      "sinceTimestamp": 1687953527,
       "values": {
         "getPauseOwner": "0x2F44BD2a54aC3fB20cd7783cF94334069641daC9",
         "libAddressManager": "0x6968f3F16C3e64003F02E121cf0D5CCBf5625a42",
@@ -431,6 +450,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687951883,
       "values": {
         "BondManager": "0x31aBe1c466C2A8b95fd84258dD1471472979B650",
         "CanonicalTransactionChain": "0x291dc3819b863e19b0a9b9809F8025d2EB4aaE93",
@@ -460,6 +480,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1684377983,
       "values": {
         "domainSeparator": "0xc1d265aa3661784e967614a86ab34bbccd5c4a901612dfe9cde9f949b055b09f",
         "getChainId": 1,
@@ -480,6 +501,7 @@
         "implementation": "0x09b276F9EcB83Fb6a37970e655863B04143Dc431",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687956431,
       "values": {
         "delegation": "0xd4B5E3D46D202C3523C3Ad89dfe74eC272BFC96A",
         "delegationManager": "0xA90FCe37D274e673f3850b835F18790542b1755d",
@@ -512,6 +534,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1686827603,
       "values": {
         "domainSeparator": "0x7d78093058bf4da0080823e097f898933ef67a743628dcf5350d61aafd425780",
         "getChainId": 1,
@@ -535,6 +558,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687953815,
       "values": {
         "batches": "0xd3f0BD982D72e28cccc69e0A9dA439e9D587b3bD",
         "FRAUD_PROOF_WINDOW": 604800,
@@ -556,6 +580,7 @@
         "implementation": "0xC159F0B28a7bd4b4924e762207275a4475C09fd5",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687955255,
       "values": {
         "delegation": "0xd4B5E3D46D202C3523C3Ad89dfe74eC272BFC96A",
         "investmentManager": "0xA90FCe37D274e673f3850b835F18790542b1755d",
@@ -571,6 +596,7 @@
         "implementation": "0x18Dd3cBE484f955217165FEaC6fe928D04a56a72",
         "admin": "0x47D58744D8515d9aaEAf961bc03625118bd91EBb"
       },
+      "sinceTimestamp": 1687931999,
       "values": {
         "IS_TEST": false,
         "permissionManager": "0xBcF6d8273DAF842b6Fc288b08E48C438Fa911D01"
@@ -585,6 +611,7 @@
         "implementation": "0x6B6e0dC564d4603452E40752ecDAa0e9630B38A2",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687954103,
       "values": {
         "l1MantleAddress": "0x3c3a81e81dc49A522A592e7622A7E711c06bf354",
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
@@ -600,6 +627,7 @@
         "implementation": "0x1872Ce78A362c58D093EE107cAdeE2667b7Bd993",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687960751,
       "values": {
         "rollupAddress": "0xD1328C9167e0693B689b5aa5a024379d4e437858"
       },
@@ -613,6 +641,7 @@
         "implementation": "0x988DdC2b0ad9Ba5Ade892E1BF848308e8c7A9187",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687954967,
       "values": {
         "delegation": "0xd4B5E3D46D202C3523C3Ad89dfe74eC272BFC96A",
         "delegationSlasher": "0x910265C29c099eAc87EF6d374b6f3bE45B516EB7",
@@ -636,6 +665,7 @@
         "implementation": "0x9FEcF38689349a5CFf97526610CdB27618edc6b9",
         "admin": "0x2Cd33d3DC4d6Ea24B6941e4741F4Bf4772929e83"
       },
+      "sinceTimestamp": 1687931291,
       "values": {
         "explanation": "Base InvestmentStrategy implementation to inherit from for more complex implementations",
         "investmentManager": "0x23754725a49c0f003C349A6C7869fF8609a7CEfd",
@@ -656,6 +686,7 @@
         "implementation": "0xAb00B934DE01c1b4931047125C2ba5B3d6186b85",
         "admin": "0x2Cd33d3DC4d6Ea24B6941e4741F4Bf4772929e83"
       },
+      "sinceTimestamp": 1687930979,
       "values": {
         "owner": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f",
         "permissionPerson": "0x207E804758e28F2b3fD6E4219671B327100b82f8"
@@ -670,6 +701,7 @@
         "implementation": "0x6EE53D3d6e622Ac0296369445AFB3CBBDc57C066",
         "admin": "0x47D58744D8515d9aaEAf961bc03625118bd91EBb"
       },
+      "sinceTimestamp": 1687932023,
       "values": {
         "challengeUtils": "0xCDC78c5eaea2dE33B00a9200Ee1700937fb0f55D",
         "dataLayrServiceManager": "0x5BD63a7ECc13b955C4F57e3F12A64c10263C14c1",
@@ -685,6 +717,7 @@
         "implementation": "0x9FEcF38689349a5CFf97526610CdB27618edc6b9",
         "admin": "0x2Cd33d3DC4d6Ea24B6941e4741F4Bf4772929e83"
       },
+      "sinceTimestamp": 1687931243,
       "values": {
         "explanation": "Base InvestmentStrategy implementation to inherit from for more complex implementations",
         "investmentManager": "0x23754725a49c0f003C349A6C7869fF8609a7CEfd",
@@ -705,6 +738,7 @@
         "implementation": "0xd8d731624d97a66e012E62208cFc921d7033c564",
         "admin": "0x47D58744D8515d9aaEAf961bc03625118bd91EBb"
       },
+      "sinceTimestamp": 1687931951,
       "values": {
         "getZeroPolyMerkleRoot": []
       },
@@ -718,6 +752,7 @@
         "implementation": "0x242a33ca49C564caFC9C83C700b79f1074c42A0D",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687961351,
       "values": {
         "assertions": "0xa0d79E982bfD3C2ccD09D2E374ddC75fe328f317",
         "baseStakeAmount": 0,
@@ -758,6 +793,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1687952219,
       "values": {
         "getGlobalMetadata": "0x0000000000000000000000000000000000006501d253000067b0ca",
         "length": 4333,
@@ -774,6 +810,7 @@
         "implementation": "0x7126F676ac359eCE8D5244120FF9E78eD3222246",
         "admin": "0x4e59e778a0fb77fBb305637435C62FaeD9aED40f"
       },
+      "sinceTimestamp": 1687954679,
       "values": {
         "DELEGATION_TYPEHASH": "0xb2a21c2f78b6ef501475a2971550fe4cedb86f0dec990e23909bfb01fd61c54c",
         "delegationManager": "0xA90FCe37D274e673f3850b835F18790542b1755d",
@@ -792,6 +829,7 @@
         "implementation": "0xAdA69A18B30B3B9235AB2748116bB9195e16aDba",
         "admin": "0x2Cd33d3DC4d6Ea24B6941e4741F4Bf4772929e83"
       },
+      "sinceTimestamp": 1687930907,
       "values": {
         "DELEGATION_TYPEHASH": "0xb2a21c2f78b6ef501475a2971550fe4cedb86f0dec990e23909bfb01fd61c54c",
         "DOMAIN_SEPARATOR": "0xbc7bcb096dfed433b8cff98aee0d5bcc22202e4870ee9b36c93c2fb0303b87e6",

--- a/packages/backend/discovery/metis/ethereum/discovered.json
+++ b/packages/backend/discovery/metis/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "metis",
+  "chain": "ethereum",
   "blockNumber": 17272120,
   "configHash": "0x1a8c7f109e78f0dcd6581b9313d6f003a8b207a956032357d114b7ef323afca7",
+  "version": 2,
   "contracts": [
     {
       "name": "L1CrossDomainMessenger",
@@ -13,6 +14,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x8bF439ef7167023F009E24b21719Ca5f768Ecb36"
       },
+      "sinceTimestamp": 1637076488,
       "values": {
         "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
         "owner": "0xDD6FFC7D9a4Fb420b637747edc6456340d12d377",
@@ -25,6 +27,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637070395,
       "values": {
         "DEFAULT_CHAINID": 1088,
         "getGlobalMetadata": "0x00000000000000000000000000000000000064636c37000056ddb9",
@@ -42,6 +45,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637047500,
       "values": {
         "DEFAULT_CHAINID": 1088,
         "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
@@ -56,6 +60,7 @@
         "implementation": "0xa0cfE8Af2AB5C9232714647702DbACf862EA4798",
         "admin": "0x48fE1f85ff8Ad9D088863A42Af54d06a1328cF21"
       },
+      "sinceTimestamp": 1637077208,
       "values": {
         "addressmgr": "0x918778e825747a892b17C66fe7D24C618262867d",
         "DEFAULT_CHAINID": 1088,
@@ -71,6 +76,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1636927409,
       "values": {
         "domainSeparator": "0xfb4b712c4b7702310419a72c040b8486f1f9e8b0b84ae19732273a65d3a840c5",
         "getChainId": 1,
@@ -94,6 +100,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637070766,
       "values": {
         "batches": "0x38473Feb3A6366757A249dB2cA4fBB2C663416B7",
         "DEFAULT_CHAINID": 1088,
@@ -120,7 +127,8 @@
       "unverified": true,
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1637083067
     },
     {
       "name": "MVM_CanonicalTransaction",
@@ -130,6 +138,7 @@
         "implementation": "0xC878771A4ff7466B7be8b59FB8766719AEa8d562",
         "admin": "0x48fE1f85ff8Ad9D088863A42Af54d06a1328cF21"
       },
+      "sinceTimestamp": 1649638297,
       "values": {
         "CONFIG_OWNER_KEY": "METIS_MANAGER",
         "getStakeBaseCost": "100000000000000000",
@@ -154,6 +163,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1649859244,
       "values": {
         "CONFIG_OWNER_KEY": "METIS_MANAGER",
         "discount": 0,
@@ -169,6 +179,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637047108,
       "values": {
         "_1088_MVM_FraudVerifier": "0xe70DD4dE81D282B3fa92A6700FEE8339d2d9b5cb",
         "_1088_MVM_Proposer": "0x9cB01d516D930EF49591a05B09e0D33E6286689D",
@@ -195,6 +206,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1607734167,
       "values": {
         "decimals": 18,
         "isOwner": true,
@@ -210,6 +222,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637047833,
       "values": {
         "DEFAULT_CHAINID": 1088,
         "get": [],
@@ -229,6 +242,7 @@
         "implementation": "0x47b5A78E127Dfd521532Fdca89651c832Acb7e0E",
         "admin": "0x48fE1f85ff8Ad9D088863A42Af54d06a1328cF21"
       },
+      "sinceTimestamp": 1649719906,
       "values": {
         "activeChallenges": 0,
         "challenges": [],
@@ -248,6 +262,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637071157,
       "values": {
         "batches": "0x10739F09f6e62689c0aA8A1878816de9e166d6f9",
         "DEFAULT_CHAINID": 1088,
@@ -271,6 +286,7 @@
         "implementation": "0x7b5AFdA01ef32d95858A22E5fc0a6821A12CDAe5",
         "admin": "0x48fE1f85ff8Ad9D088863A42Af54d06a1328cF21"
       },
+      "sinceTimestamp": 1637089464,
       "values": {
         "addressmgr": "0x918778e825747a892b17C66fe7D24C618262867d",
         "CONFIG_OWNER_KEY": "METIS_MANAGER",
@@ -283,6 +299,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1637071895,
       "values": {
         "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d"
       }

--- a/packages/backend/discovery/myria/ethereum/discovered.json
+++ b/packages/backend/discovery/myria/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "myria",
+  "chain": "ethereum",
   "blockNumber": 17039298,
   "configHash": "0x3a9dc943b43efbe78df09c89e26fd75fd12cff9b3dc9b74adeea7fe25c550c39",
+  "version": 2,
   "contracts": [
     {
       "name": "Committee",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1659542607,
       "values": {
         "constructorArgs": [
           [
@@ -45,6 +47,7 @@
         },
         "proxyGovernance": ["0xc49Ec6Bb817E17a9Ca5B738ca330db403cc74245"]
       },
+      "sinceTimestamp": 1659542607,
       "values": {
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,
@@ -89,6 +92,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657453372,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,
@@ -102,6 +106,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657453372,
       "values": {
         "hasRegisteredFact": false,
         "identify": "StarkWare_OrderRegistry_2021_1"

--- a/packages/backend/discovery/nova/ethereum/discovered.json
+++ b/packages/backend/discovery/nova/ethereum/discovered.json
@@ -10,7 +10,8 @@
       "address": "0x1efb116EBC38CE895Eb2E5e009234E0E0836f2F5",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1656050046
     },
     {
       "name": "SequencerInbox",
@@ -20,6 +21,7 @@
         "implementation": "0xD03bFe2CE83632F4E618a97299cc91B1335BB2d9",
         "admin": "0x71D78dC7cCC0e037e12de1E50f5470903ce37148"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "batchCount": 20392,
         "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",
@@ -38,6 +40,7 @@
         "implementation": "0xC8D26aB9e132C79140b3376a0Ac7932E4680Aa45",
         "admin": "0xa8f7DdEd54a726eB873E98bFF2C95ABF2d03e560"
       },
+      "sinceTimestamp": 1656312893,
       "values": {
         "counterpartGateway": "0xbf544970E6BD77b21C6492C281AB60d0770451F4",
         "inbox": "0xc4448b71118c9071Bcb9734A0EAc55D18A153949",
@@ -52,6 +55,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656050159,
       "values": {
         "NOVA_STAKERS": [
           [
@@ -71,6 +75,7 @@
         "implementation": "0x32642eE509001D02615951090c7c56D6000e22C2",
         "admin": "0x71D78dC7cCC0e037e12de1E50f5470903ce37148"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",
         "rollup": "0xFb209827c58283535b744575e11953DCC4bEAD88"
@@ -84,6 +89,7 @@
         "implementation": "0x86f0cf42Ad673B3D666d103E009EC142D1298a17",
         "admin": "0x5613AF0474EB9c528A34701A5b1662E3C8FA0678"
       },
+      "sinceTimestamp": 1678968515,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -113,6 +119,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1678968395,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
       },
@@ -124,6 +131,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656050166,
       "values": {
         "owner": "0x0000000000000000000000000000000000000000"
       }
@@ -134,6 +142,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
       },
@@ -144,7 +153,8 @@
       "address": "0x7a6C0503107858f82a790E481024134092e19979",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1656050046
     },
     {
       "name": "OneStepProofEntry",
@@ -152,6 +162,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656050046,
       "values": {
         "prover0": "0x8323B58C522690E6aFae94044825F0c79A93d236",
         "proverHostIo": "0x9CBC3F14a57CE6eAD0e770F528E2f1E8b8C37613",
@@ -164,7 +175,8 @@
       "address": "0x8323B58C522690E6aFae94044825F0c79A93d236",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1656050037
     },
     {
       "name": "L1DaiGateway",
@@ -172,6 +184,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1659620276,
       "values": {
         "counterpartGateway": "0x10E6593CDda8c58a1d0f14C5164B376352a55f2F",
         "inbox": "0xc4448b71118c9071Bcb9734A0EAc55D18A153949",
@@ -189,14 +202,16 @@
       "address": "0x9CBC3F14a57CE6eAD0e770F528E2f1E8b8C37613",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1656050046
     },
     {
       "name": "L1Escrow",
       "address": "0xA2e996f0cb33575FA0E36e8f62fCd4a9b897aAd3",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1659620187
     },
     {
       "name": "ChallengeManager",
@@ -206,6 +221,7 @@
         "implementation": "0x7a18bB9DbAF1202F3fc977e42E3C360d522e4566",
         "admin": "0x71D78dC7cCC0e037e12de1E50f5470903ce37148"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",
         "osp": "0x7AdcA86896c4220f19B2f7f9746e7A99E57B0Fc5",
@@ -220,6 +236,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656312664,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
       },
@@ -233,6 +250,7 @@
         "implementation": "0xb4299A1F5f26fF6a98B7BA35572290C359fde900",
         "admin": "0xa8f7DdEd54a726eB873E98bFF2C95ABF2d03e560"
       },
+      "sinceTimestamp": 1656312805,
       "values": {
         "cloneableProxyHash": "0xe95e7b13b0b76934e55320c0f1a812918ec818f61a9b36660d64d803eeecb91a",
         "counterpartGateway": "0xcF9bAb7e53DDe48A6DC4f286CB14e05298799257",
@@ -250,6 +268,7 @@
         "implementation": "0x1066CEcC8880948FE55e427E94F1FF221d626591",
         "admin": "0x71D78dC7cCC0e037e12de1E50f5470903ce37148"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "activeOutbox": "0x0000000000000000000000000000000000000000",
         "allowedDelayedInboxList": [
@@ -272,6 +291,7 @@
         "implementation": "0x1b2676D32E2f7430a564DD4560641F990dFE3D6a",
         "admin": "0x71D78dC7cCC0e037e12de1E50f5470903ce37148"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "allowListEnabled": false,
         "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",
@@ -287,6 +307,7 @@
         "implementation": "0x52595021fA01B3E14EC6C88953AFc8E35dFf423c",
         "admin": "0xa8f7DdEd54a726eB873E98bFF2C95ABF2d03e560"
       },
+      "sinceTimestamp": 1656312748,
       "values": {
         "counterpartGateway": "0x21903d3F8176b1a0c17E953Cd896610Be9fFDFa8",
         "defaultGateway": "0xB2535b988dcE19f9D71dfB22dB6da744aCac21bf",
@@ -304,6 +325,7 @@
         "implementation": "0x7439d8d4F3b9d9B6222f3E9760c75a47e08a7b3f",
         "admin": "0x71D78dC7cCC0e037e12de1E50f5470903ce37148"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",
         "l2ToL1BatchNum": 0,
@@ -322,6 +344,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656050166,
       "values": {
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd",
         "template": "0x6Ab7A2f1a4febCD40A58b0205bFDA9CAf614b779"
@@ -335,6 +358,7 @@
         "implementation": "0x962d70fc48F3465404bC77B03f104746B25a1d1b",
         "admin": "0x5613AF0474EB9c528A34701A5b1662E3C8FA0678"
       },
+      "sinceTimestamp": 1678968515,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -376,6 +400,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1692138791,
       "values": {
         "domainSeparator": "0x24555dff42c3faa8a2ff9680ac37e71d6f765373e9cf30c226d13e5c1cebe593",
         "getChainId": 1,
@@ -407,6 +432,7 @@
         "adminImplementation": "0x72f193d0F305F532C87a4B9D0A2F407a3F4f585f",
         "userImplementation": "0xA0Ed0562629D45B88A34a342f20dEb58c46C15ff"
       },
+      "sinceTimestamp": 1656050353,
       "values": {
         "baseStake": "1000000000000000000",
         "bridge": "0xC1Ebd02f738644983b6C4B2d440b8e77DdE276Bd",

--- a/packages/backend/discovery/omgnetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/omgnetwork/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "omgnetwork",
+  "chain": "ethereum",
   "blockNumber": 16154924,
   "configHash": "0xa4e02f6100911105fdffefc7c17367050ef667ca4c7cd19e397d30aca9217312",
+  "version": 2,
   "contracts": [
     {
       "name": "Erc20Vault",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1584424719,
       "values": {
         "depositVerifiers": [
           "0xD876aeb3a443FBC03B7349AAc115E9054563CD82",
@@ -25,6 +27,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1584424347,
       "values": {
         "authority": "0x22405c1782913fb676bc74Ef54a60727B0e1026F",
         "CHILD_BLOCK_INTERVAL": 1000,
@@ -46,6 +49,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1584424507,
       "values": {
         "depositVerifiers": [
           "0x649f37203c365DE759c8fc8CA35beBF5448F70Be",
@@ -62,6 +66,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1584427515,
       "values": {
         "BOND_LOWER_BOUND_DIVISOR": 2,
         "BOND_UPPER_BOUND_MULTIPLIER": 2,
@@ -80,6 +85,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1584424482,
       "derivedName": ""
     },
     {
@@ -89,6 +95,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1584424677,
       "derivedName": ""
     }
   ],

--- a/packages/backend/discovery/omni/ethereum/discovered.json
+++ b/packages/backend/discovery/omni/ethereum/discovered.json
@@ -12,6 +12,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1600956399,
       "values": {
         "domainSeparator": "0x877c70937e5670b3f50eb943a4e9d65fbd9bc8ce060659a7dc0543885a0ca59e",
         "getChainId": 1,
@@ -46,6 +47,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1686042107,
       "values": {
         "domainSeparator": "0xaee10730379a3d6df2303789b1843342698bd85d618cdf13a5f75b84e16d88eb",
         "getChainId": 1,
@@ -68,6 +70,7 @@
         "admin": "0x42F38ec5A75acCEc50054671233dfAC9C0E7A3F6",
         "implementation": "0x82B67a43b69914E611710C62e629dAbB2f7AC6AB"
       },
+      "sinceTimestamp": 1579258532,
       "values": {
         "allowReentrantRequests": false,
         "decimalShift": 0,
@@ -99,6 +102,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1634280699,
       "values": {
         "getModuleInterfacesVersion": [1, 0, 0],
         "owner": "0x42F38ec5A75acCEc50054671233dfAC9C0E7A3F6",
@@ -111,6 +115,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1634280299,
       "values": {
         "bridgeContract": "0x0000000000000000000000000000000000000000",
         "decimals": 0,
@@ -132,6 +137,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1634281216,
       "values": {
         "aaveReceiver": "0x5eD64f02588C8B75582f2f8eFd7A5521e3F897CC",
         "getModuleInterfacesVersion": [1, 0, 0],
@@ -152,6 +158,7 @@
         "admin": "0x42F38ec5A75acCEc50054671233dfAC9C0E7A3F6",
         "implementation": "0x8eB3b7D8498a6716904577b2579e1c313d48E347"
       },
+      "sinceTimestamp": 1596501090,
       "values": {
         "bridgeContract": "0x4C36d2919e407f0Cc2Ee3c993ccF8ac26d9CE64e",
         "getBridgeInterfacesVersion": [3, 3, 1],
@@ -175,6 +182,7 @@
         "admin": "0x42F38ec5A75acCEc50054671233dfAC9C0E7A3F6",
         "implementation": "0xD83893F31AA1B6B9D97C9c70D3492fe38D24d218"
       },
+      "sinceTimestamp": 1579258396,
       "values": {
         "deployedAtBlock": 9298321,
         "F_ADDR": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",

--- a/packages/backend/discovery/optimism/ethereum/discovered.json
+++ b/packages/backend/discovery/optimism/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "optimism",
+  "chain": "ethereum",
   "blockNumber": 17718368,
   "configHash": "0xf38079963f297bf5743c96341ff36cdebfa76552c8e09b39f43a9d3f5fc184ef",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "L1DAITokenBridge",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1625675779,
       "values": {
         "escrow": "0x467194771dAe2967Aef3ECbEDD3Bf9a310C76C65",
         "isOpen": 1,
@@ -29,6 +30,7 @@
         "implementation": "0x5efa852e92800D1C982711761e45c3FE39a2b6D8",
         "admin": "0x543bA4AADBAb8f9025686Bd03993043599c6fB04"
       },
+      "sinceTimestamp": 1685377403,
       "values": {
         "batcherHash": "0x6887246668a3b87F54DeB3b94Ba47a6f63F32985",
         "gasLimit": 30000000,
@@ -60,6 +62,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x2150Bc3c64cbfDDbaC9815EF615D6AB8671bfe43"
       },
+      "sinceTimestamp": 1624400997,
       "values": {
         "MESSAGE_VERSION": 1,
         "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292639084",
@@ -83,6 +86,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1678243007,
       "values": {
         "domainSeparator": "0xc7edf91fb84ec337ffa25b6f502a8c52c3dd4ea86d452728767d2836fa3819e3",
         "getChainId": 1,
@@ -100,7 +104,8 @@
       "address": "0x467194771dAe2967Aef3ECbEDD3Bf9a310C76C65",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1625675683
     },
     {
       "name": "ProxyAdmin",
@@ -108,6 +113,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1685377355,
       "values": {
         "addressManager": "0xdE1FCfB0851916CA5101820A69b13a4E276bd81F",
         "isUpgrading": false,
@@ -120,6 +126,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636654670,
       "values": {
         "batches": "0xD16463EF9b0338CE3D73309028ef1714D220c024",
         "enqueueGasCost": 60000,
@@ -145,6 +152,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1620680982,
       "values": {
         "nominatedOwner": "0x0000000000000000000000000000000000000000",
         "owner": "0xEb3107117FEAd7de89Cd14D463D340A2E6917769"
@@ -156,6 +164,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1624400753,
       "values": {
         "getGlobalMetadata": "0x000000000000000000000000000000000000618d50d100003e24ec",
         "length": 4302,
@@ -172,6 +181,7 @@
         "implementation": "0xBFB731Cd36D26c2a7287716DE857E4380C73A64a",
         "admin": "0x543bA4AADBAb8f9025686Bd03993043599c6fB04"
       },
+      "sinceTimestamp": 1624401464,
       "values": {
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
         "messenger": "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1",
@@ -187,6 +197,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1610850364,
       "values": {
         "domainSeparator": "0x4e6a6554de0308f5ece8ff736beed8a1b876d16f5c27cac8e466d7de0c703890",
         "getModules": [],
@@ -212,6 +223,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636654521,
       "values": {
         "getGlobalMetadata": "0x000000000000000000000000000000000000647f5a9f000645c276",
         "length": 111420,
@@ -226,6 +238,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636654763,
       "values": {
         "batches": "0xb0ddFf09c4019e31960de11bD845E836078E8EbE",
         "FRAUD_PROOF_WINDOW": 604800,
@@ -245,6 +258,7 @@
         "implementation": "0x28a55488fef40005309e2DA0040DbE9D300a64AB",
         "admin": "0x543bA4AADBAb8f9025686Bd03993043599c6fB04"
       },
+      "sinceTimestamp": 1685377379,
       "values": {
         "GUARDIAN": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
         "L2_ORACLE": "0xdfe97868233d1aa22e815a266982f2cf17685a27",
@@ -262,6 +276,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636654402,
       "values": {
         "getGlobalMetadata": "0x00000000000000000109d84900647f56130000057119000645c276",
         "length": 854468,
@@ -276,6 +291,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1624400033,
       "values": {
         "BondManager": "0x0000000000000000000000000000000000000000",
         "OVM_BondManager": "0x0000000000000000000000000000000000000000",
@@ -308,6 +324,7 @@
         "implementation": "0xd2E67B6a032F0A9B1f569E63ad6C38f7342c2e00",
         "admin": "0x543bA4AADBAb8f9025686Bd03993043599c6fB04"
       },
+      "sinceTimestamp": 1685377367,
       "values": {
         "CHALLENGER": "0x9BA6e03D8B90dE867373Db8cF1A58d2F7F006b3A",
         "computeL2Timestamp": [],
@@ -332,6 +349,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1583108804,
       "values": {
         "domainSeparator": "0x812bd2187bbdb6f18e0fde445c3e46e10661c15c4af7f51d5795d4dec4fb4caa",
         "getChainId": 1,

--- a/packages/backend/discovery/orbit/ethereum/discovered.json
+++ b/packages/backend/discovery/orbit/ethereum/discovered.json
@@ -3,7 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 17913544,
   "configHash": "0x98346feb853bf4d73e55ef73d1ee2696d7405012638b5b207c0ee6d84fe2c6f7",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "ETH Vault",
@@ -12,6 +12,7 @@
         "type": "call implementation proxy",
         "implementation": "0xC3430BC8C2C05FC6b42114BF7F82a3e2f3Ee9454"
       },
+      "sinceTimestamp": 1603950507,
       "values": {
         "bridgingFee": 0,
         "chain": "ETH",
@@ -58,6 +59,7 @@
         "implementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55",
         "admin": "0xFb504CD4eD46024B83c4337044995CF112205f18"
       },
+      "sinceTimestamp": 1649902126,
       "values": {
         "getAdmin": "0xFb504CD4eD46024B83c4337044995CF112205f18",
         "getImplementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55"
@@ -73,6 +75,7 @@
         "implementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55",
         "admin": "0xFb504CD4eD46024B83c4337044995CF112205f18"
       },
+      "sinceTimestamp": 1649903842,
       "values": {
         "getAdmin": "0xFb504CD4eD46024B83c4337044995CF112205f18",
         "getImplementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55"
@@ -88,6 +91,7 @@
         "implementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55",
         "admin": "0xFb504CD4eD46024B83c4337044995CF112205f18"
       },
+      "sinceTimestamp": 1649902155,
       "values": {
         "getAdmin": "0xFb504CD4eD46024B83c4337044995CF112205f18",
         "getImplementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55"
@@ -103,6 +107,7 @@
         "implementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55",
         "admin": "0xFb504CD4eD46024B83c4337044995CF112205f18"
       },
+      "sinceTimestamp": 1649905062,
       "values": {
         "getAdmin": "0xFb504CD4eD46024B83c4337044995CF112205f18",
         "getImplementation": "0xdbF3C7e0a1493B81B295547ae3D0711417481A55"
@@ -115,6 +120,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1649901966,
       "values": {
         "owner": "0x1Bf68A9d1EaEe7826b3593C20a0ca93293cb489a"
       }

--- a/packages/backend/discovery/pNetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/pNetwork/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "pNetwork",
+  "chain": "ethereum",
   "blockNumber": 17288492,
   "configHash": "0x54844ed628d7d1a3ce56c214e349f5d45c391d569e0e5c50f22aac3fc9e8ecfe",
+  "version": 2,
   "contracts": [
     {
       "name": "ERC20 Vault V1",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1620212602,
       "values": {
         "PNETWORK": "0xDffE7AC6B538B4A7Fd81c98C5fba0415d63fB132"
       },
@@ -21,6 +23,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1592411070,
       "values": {
         "adminOperator": "0x0000000000000000000000000000000000000000",
         "decimals": 18,
@@ -53,6 +56,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626265622,
       "values": {
         "PNETWORK": "0x14C4d33549d2A9e17d7dF6Cf180162A575D4cBe9"
       },
@@ -65,6 +69,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1672744007,
       "values": {
         "domainSeparator": "0xf76d498488b878a740c7f1971da177216c0beb62c0b78ee3d1406b28757136ce",
         "getChainId": 1,
@@ -86,6 +91,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1664208791,
       "values": {
         "owner": "0x364B37Bbd812c76f3E8b0C1F62a2E33A21cFD496"
       }
@@ -96,6 +102,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1565610264,
       "values": {
         "version": "1.0.0"
       }
@@ -106,6 +113,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1640866403,
       "values": {
         "owner": "0xb5977b683c64fce80A1f5b587964b6f77Ee6CfDB"
       }
@@ -118,6 +126,7 @@
         "implementation": "0x34D085516f9D7794192aDB10C995d9c532E335aF",
         "admin": "0xDc2c547F6b6a89F1D96d66d50fDCbD69979Aee2a"
       },
+      "sinceTimestamp": 1640867581,
       "values": {
         "ETHPNT_TOKEN_ADDRESS": "0xf4eA6B892853413bD9d9f1a5D3a620A0ba39c5b2",
         "ORIGIN_CHAIN_ID": "0x005fe7f9",
@@ -134,6 +143,7 @@
         "implementation": "0x8474a898677C3bc97f35A86c387aE34Bf272C860",
         "admin": "0xB6D14DdFBE01AC537accBe35cCd771C30D53c535"
       },
+      "sinceTimestamp": 1664208803,
       "values": {
         "decimals": 18,
         "DOMAIN_SEPARATOR": "0xdb94fb7fdbffd548b5e058fcd76cc73c6bfae4843b728c540043b00b4ff00049",

--- a/packages/backend/discovery/polygon-plasma/ethereum/discovered.json
+++ b/packages/backend/discovery/polygon-plasma/ethereum/discovered.json
@@ -3,7 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 17968859,
   "configHash": "0xa6a26ac439c39e55635de77dc8b7d61f6879f86db46a10d9a9931ac93a2b3111",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "SlashingManager",
@@ -12,6 +12,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1593189719,
       "derivedName": ""
     },
     {
@@ -20,6 +21,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1628665504,
       "values": {
         "CHAINID": 15001,
         "networkId": "0x3a99"
@@ -31,6 +33,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1590850580,
       "values": {
         "counter": 2751556,
         "isOwner": false,
@@ -57,6 +60,7 @@
         "isUpgradable": true,
         "implementation": "0x4ef5123a30e4CFeC02B3E2F5Ce97F1328B29f7de"
       },
+      "sinceTimestamp": 1590850831,
       "values": {
         "exitNft": "0xDF74156420Bd57ab387B195ed81EcA36F9fABAca",
         "exitWindow": 0,
@@ -75,6 +79,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1590849877,
       "values": {
         "erc20Predicate": "0x158d5fa3Ef8e4dDA8a5367deCF76b94E7efFCe95",
         "erc721Predicate": "0x54150f44c785D412Ec262fe895Cc3B689c72F49B",
@@ -99,6 +104,7 @@
         "isUpgradable": true,
         "implementation": "0xDdaC6D3A2a787b1F4bf26AB6FAF519ae3F1a94cf"
       },
+      "sinceTimestamp": 1590850640,
       "values": {
         "childChain": "0xD9c7C4ED4B66858301D0cb28Cc88bf655Fe34861",
         "governance": "0x6e7a5820baD6cebA8Ef5ea69c0C92EbbDAc9CE48",
@@ -120,6 +126,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1628665528,
       "values": {
         "CHAINID": 15001,
         "networkId": "0x3a99"
@@ -134,6 +141,7 @@
         "implementation": "0xbA9Ac3C9983a3e967f0f387c75cCbD38Ad484963",
         "extension": "0xef49Ea6996073752b6840CDA34773FFA78F78166"
       },
+      "sinceTimestamp": 1593189690,
       "values": {
         "accountStateRoot": "0x85d7a8f1697e2a84910d571af5875abfdb954c6050766f6866a6bb9fc7c660ca",
         "auctionPeriod": 20,
@@ -192,6 +200,7 @@
         "implementation": "0x0672777617CAA1E778083a4f74eBC997262C9EdD",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1616774452,
       "values": {
         "implementation": "0x0672777617CAA1E778083a4f74eBC997262C9EdD",
         "owner": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf",
@@ -207,6 +216,7 @@
         "isUpgradable": true,
         "implementation": "0x98165b71cdDea047C0A49413350C40571195fd07"
       },
+      "sinceTimestamp": 1590849863,
       "values": {
         "implementation": "0x98165b71cdDea047C0A49413350C40571195fd07",
         "isOwner": false,
@@ -220,6 +230,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1555778052,
       "values": {
         "decimals": 18,
         "name": "Matic Token",
@@ -236,6 +247,7 @@
         "isUpgradable": true,
         "implementation": "0x536c55cFe4892E581806e10b38dFE8083551bd03"
       },
+      "sinceTimestamp": 1590849960,
       "values": {
         "_nextHeaderBlock": 497900000,
         "CHAINID": 137,
@@ -257,6 +269,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1590840981,
       "values": {
         "decimals": 18,
         "name": "Wrapped Ether",
@@ -271,6 +284,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1593189612,
       "values": {
         "getAccountStateRoot": "0x85d7a8f1697e2a84910d571af5875abfdb954c6050766f6866a6bb9fc7c660ca",
         "getStakerDetails": [
@@ -287,7 +301,8 @@
       "address": "0xc4FA447A0e77Eff9717b09C057B40570813bb642",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1593189596
     },
     {
       "name": "Timelock",
@@ -295,6 +310,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1630059303,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -329,6 +345,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1590839660,
       "derivedName": ""
     },
     {
@@ -337,6 +354,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1590850785,
       "values": {
         "getApproved": [],
         "ownerOf": []
@@ -349,6 +367,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1636705816,
       "values": {
         "activeAmount": 0,
         "commissionRate_deprecated": 0,
@@ -380,6 +399,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1593593561,
       "values": {
         "domainSeparator": "0x3bc292918071cc597c13d3994268d3c83097b8388d750481c8cbce67a284ed5c",
         "getModules": [],

--- a/packages/backend/discovery/polygon-pos/ethereum/discovered.json
+++ b/packages/backend/discovery/polygon-pos/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "polygon-pos",
+  "chain": "ethereum",
   "blockNumber": 17770180,
   "configHash": "0xac0e650429335471436f5a7062a14488f3a41f97824925e0c15d306720a1ad44",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "ERC1155Predicate",
@@ -13,6 +13,7 @@
         "implementation": "0x62D7e87677ac7e3bd02c198e3FABeFFdBc5eB2A3",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1598437004,
       "values": {
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "implementation": "0x62D7e87677ac7e3bd02c198e3FABeFFdBc5eB2A3",
@@ -31,6 +32,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1617750281,
       "values": {
         "CUSTOM_EVENT_SIG": "0x93f3e547dcb3ce9c356bb293f12e44f70fc24105d675b782bd639333aab70df7",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -44,6 +46,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1627373890,
       "values": {
         "rootChainManager": "0xA0c68C638235ee32657e8f720a23ceC1bFc77C77",
         "WITHDRAWN_EVENT_SIG": "0x7084f5476618d8e60b11ef0d7d3f06914655adb8793e28ff7f018d4c76d505d5"
@@ -56,6 +59,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1590850580,
       "values": {
         "counter": 2730237,
         "isOwner": false,
@@ -82,6 +86,7 @@
         "implementation": "0xDb161A896Be50a020B636D6B60DA7c59817412a5",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1613107769,
       "values": {
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "implementation": "0xDb161A896Be50a020B636D6B60DA7c59817412a5",
@@ -102,6 +107,7 @@
         "implementation": "0x608669d4914Eec1E20408Bc4c9eFFf27BB8cBdE5",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1598436664,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -129,6 +135,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1657162305,
       "values": {
         "rootChainManager": "0xA0c68C638235ee32657e8f720a23ceC1bFc77C77",
         "WITHDRAWN_EVENT_SIG": "0x7084f5476618d8e60b11ef0d7d3f06914655adb8793e28ff7f018d4c76d505d5"
@@ -143,6 +150,7 @@
         "implementation": "0x54006763154c764da4AF42a8c3cfc25Ea29765D5",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1598437971,
       "values": {
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "implementation": "0x54006763154c764da4AF42a8c3cfc25Ea29765D5",
@@ -162,6 +170,7 @@
         "isUpgradable": true,
         "implementation": "0x536c55cFe4892E581806e10b38dFE8083551bd03"
       },
+      "sinceTimestamp": 1590849960,
       "values": {
         "_nextHeaderBlock": 487420000,
         "CHAINID": 137,
@@ -185,6 +194,7 @@
         "implementation": "0x7FBd00c577cAA70318BCF1c6c11e23732823b387",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1598436896,
       "values": {
         "BATCH_LIMIT": 20,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -205,6 +215,7 @@
         "implementation": "0x0f92D459B20D21F6bf9E02056EA9165d3f78bA62",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1613100777,
       "values": {
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "implementation": "0x0f92D459B20D21F6bf9E02056EA9165d3f78bA62",
@@ -224,6 +235,7 @@
         "implementation": "0x37D26DC2890b35924b40574BAc10552794771997",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1598436547,
       "values": {
         "checkpointManagerAddress": "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287",
         "childChainManagerAddress": "0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa",
@@ -261,7 +273,8 @@
       "address": "0xA6FA4fB5f76172d178d61B04b0ecd319C5d1C0aa",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1598436340
     },
     {
       "name": "Timelock",
@@ -269,6 +282,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1630059303,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -304,6 +318,7 @@
         "implementation": "0xf17461C73d32f7545ADfdd478a6eC5a382F5A58f",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1630304491,
       "values": {
         "CHAIN_EXIT_EVENT_SIG": "0xc7b80b68f1c661da97dbd7e6e143a0c7c587dfc522cb2ac508b9084fecc492bc",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -323,6 +338,7 @@
         "implementation": "0xd515C8fF03eC79e7d5B3410c036f738e7f396C90",
         "admin": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf"
       },
+      "sinceTimestamp": 1598436766,
       "values": {
         "BATCH_LIMIT": 20,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -342,6 +358,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1593593561,
       "values": {
         "domainSeparator": "0x3bc292918071cc597c13d3994268d3c83097b8388d750481c8cbce67a284ed5c",
         "getModules": [],

--- a/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "polygonzkevm",
+  "chain": "ethereum",
   "blockNumber": 17321205,
   "configHash": "0x43e651fe1c268ac0de6b340bf40139e7b547454c95a20c3d6b625dd9205ba41c",
+  "version": 2,
   "contracts": [
     {
       "name": "ProxyAdmin",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1679653103,
       "values": {
         "owner": "0xEf1462451C30Ea7aD8555386226059Fe837CA4EF"
       },
@@ -22,6 +24,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1678956815,
       "values": {
         "domainSeparator": "0xd8cfae7b548133655e0a54436471b813794d3d208ff7a47b740e06ea90b3d0b8",
         "getChainId": 1,
@@ -43,6 +46,7 @@
         "implementation": "0x5ac4182A1dd41AeEf465E40B82fd326BF66AB82C",
         "admin": "0x0F99738B2Fc14D77308337f3e2596b63aE7BCC4A"
       },
+      "sinceTimestamp": 1679653127,
       "values": {
         "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
         "isEmergencyState": false,
@@ -58,6 +62,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1678429487,
       "values": {
         "domainSeparator": "0x33ea3e28c0dfd2e84cb64bd76585cb4f6ed8e2e6f5fe17293c8c09fa01db36d7",
         "getChainId": 1,
@@ -82,6 +87,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1679653091,
       "derivedName": "FflonkVerifier"
     },
     {
@@ -92,6 +98,7 @@
         "implementation": "0xe262Ea2782e2e8dbFe354048c3B5d6DE9603EfEF",
         "admin": "0x0F99738B2Fc14D77308337f3e2596b63aE7BCC4A"
       },
+      "sinceTimestamp": 1679653163,
       "values": {
         "_HALT_AGGREGATION_TIMEOUT": 604800,
         "admin": "0x242daE44F5d8fb54B198D03a94dA45B5a4413e21",
@@ -124,6 +131,7 @@
         "implementation": "0xbc1ea504fC54D078514eFCCA1F6860B5219B6BC3",
         "admin": "0x0F99738B2Fc14D77308337f3e2596b63aE7BCC4A"
       },
+      "sinceTimestamp": 1679653151,
       "values": {
         "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
         "rollupAddress": "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
@@ -136,6 +144,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1679653187,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {

--- a/packages/backend/discovery/polynetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/polynetwork/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1634543659,
       "values": {
         "chainId": 2,
         "EthCrossChainDataAddress": "0xcF2afe102057bA5c16f899271045a0A37fCb10f2",
@@ -26,6 +27,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1599099893,
       "values": {
         "isOwner": false,
         "managerProxyContract": "0x5a51E2ebF8D136926b9cA7b59B60464E7C44d2Eb",
@@ -40,6 +42,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1651740937,
       "values": {
         "managerProxyContract": "0x5a51E2ebF8D136926b9cA7b59B60464E7C44d2Eb",
         "owner": "0x52D858ef5e0A768C80C38617eB8a7680f4D4d459"
@@ -52,6 +55,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1692602387,
       "values": {
         "isOwner": false,
         "managerProxyContract": "0x5a51E2ebF8D136926b9cA7b59B60464E7C44d2Eb",
@@ -65,6 +69,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1666256303,
       "values": {
         "isOwner": false,
         "managerProxyContract": "0x5a51E2ebF8D136926b9cA7b59B60464E7C44d2Eb",
@@ -78,6 +83,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1597302116,
       "values": {
         "getEthCrossChainManager": "0x14413419452Aaf089762A0c5e95eD2A13bBC488C",
         "isOwner": false,
@@ -93,6 +99,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1691038067,
       "derivedName": ""
     },
     {
@@ -101,6 +108,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1643007876,
       "values": {
         "isOwner": false,
         "managerProxyContract": "0x5a51E2ebF8D136926b9cA7b59B60464E7C44d2Eb",
@@ -115,6 +123,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1643008142,
       "values": {
         "chainId": 2,
         "feeCollector": "0x0E860F44d73F9FDbaF5E9B19aFC554Bf3C8E8A57",
@@ -140,6 +149,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1597287911,
       "values": {
         "EthToPolyTxHashIndex": 70252,
         "getEthTxHashIndex": 70252,
@@ -155,6 +165,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1669106303,
       "values": {
         "isOwner": false,
         "managerProxyContract": "0x5a51E2ebF8D136926b9cA7b59B60464E7C44d2Eb",

--- a/packages/backend/discovery/portal/ethereum/discovered.json
+++ b/packages/backend/discovery/portal/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1663610147,
       "values": {
         "chainId": 0,
         "decimals": 0,
@@ -40,6 +41,7 @@
         "implementation": "0x299b4F6066d231521d11FAE8331fb1A4fe794F58",
         "admin": "0x0000000000000000000000000000000000000000"
       },
+      "sinceTimestamp": 1631535967,
       "values": {
         "chainId": 2,
         "evmChainId": 1,
@@ -61,6 +63,7 @@
         "implementation": "0x3c3d457f1522D3540AB3325Aa5f1864E34cBA9D0",
         "admin": "0x0000000000000000000000000000000000000000"
       },
+      "sinceTimestamp": 1628093444,
       "values": {
         "chainId": 2,
         "evmChainId": 1,

--- a/packages/backend/discovery/publicgoodsnetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/publicgoodsnetwork/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1689106799,
       "values": {
         "owner": "0xc6A8d2c5d0F068BE745f6A770378F01ca1714cc4"
       },
@@ -23,6 +24,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1689022727,
       "values": {
         "domainSeparator": "0xa0c95424e029e9dbcafbbe66805964a70e72f893827f7da4fd8b501d4e245990",
         "getChainId": 1,
@@ -47,6 +49,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1680797639,
       "values": {
         "domainSeparator": "0x0f634ad56005ddbd68dc52233931a858f740b8ab706671c42b055efef561257e",
         "getChainId": 1,
@@ -71,6 +74,7 @@
         "implementation": "0x463B3777d3DD6a90234b594D1f94002267CE7948",
         "admin": "0xc6A8d2c5d0F068BE745f6A770378F01ca1714cc4"
       },
+      "sinceTimestamp": 1689106883,
       "values": {
         "batcherHash": "0x99526b0e49A95833E734EB556A6aBaFFAb0Ee167",
         "gasLimit": 30000000,
@@ -102,6 +106,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x1d8180D739D01dC97e837478af8d494215C5EF5e"
       },
+      "sinceTimestamp": 1689106835,
       "values": {
         "MESSAGE_VERSION": 1,
         "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292633702",
@@ -126,6 +131,7 @@
         "implementation": "0x76983dfED43C7ae7ebB592A92Be2BE972cAE4348",
         "admin": "0xc6A8d2c5d0F068BE745f6A770378F01ca1714cc4"
       },
+      "sinceTimestamp": 1689106823,
       "values": {
         "CHALLENGER": "0x39E13D1AB040F6EA58CE19998edCe01B3C365f84",
         "FINALIZATION_PERIOD_SECONDS": 604800,
@@ -150,6 +156,7 @@
         "implementation": "0x436e9FC7894e26718637f086d42B4a06439C8ae0",
         "admin": "0xc6A8d2c5d0F068BE745f6A770378F01ca1714cc4"
       },
+      "sinceTimestamp": 1689106847,
       "values": {
         "GUARDIAN": "0x39E13D1AB040F6EA58CE19998edCe01B3C365f84",
         "L2_ORACLE": "0xA38d0c4E6319F9045F20318BA5f04CDe94208608",
@@ -167,6 +174,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1689106787,
       "values": {
         "addressManager": "0x09d5DbA52F0ee2C4A5E94FD5C802bD74Ca9cAD3e",
         "isUpgrading": false,
@@ -181,6 +189,7 @@
         "implementation": "0x459bA3BD8fb18CCBf557Ae9Fab13ceD2542B0d8E",
         "admin": "0xc6A8d2c5d0F068BE745f6A770378F01ca1714cc4"
       },
+      "sinceTimestamp": 1689106811,
       "values": {
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
         "messenger": "0x97BAf688E5d0465E149d1d5B497Ca99392a6760e",

--- a/packages/backend/discovery/pulseChain/ethereum/discovered.json
+++ b/packages/backend/discovery/pulseChain/ethereum/discovered.json
@@ -3,7 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 17968825,
   "configHash": "0xe6029cfb8a71ff69155d2b2234227629c32dca8b437e49b598a4a5ac21ef21bb",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "ForeignOmnibridge",
@@ -13,6 +13,7 @@
         "admin": "0x13A9594a2696D3c35F9D6E4Be6b332f699C57801",
         "implementation": "0xB7DF1E00ae030e966E635ede273625240546B873"
       },
+      "sinceTimestamp": 1684141499,
       "values": {
         "bridgeContract": "0xd0764FAe29E0a6a96fF685f71CfC685456D5636c",
         "getBridgeInterfacesVersion": [3, 3, 0],
@@ -37,6 +38,7 @@
         "admin": "0xDf5d165A7EB95D26355c56d53799B7da1240e585",
         "implementation": "0x95B303987A60C71504D99Aa1b13B4DA07b0790ab"
       },
+      "sinceTimestamp": 1684140779,
       "values": {
         "deployedAtBlock": 17264123,
         "F_ADDR": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
@@ -67,6 +69,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1684141547,
       "values": {
         "bridge": "0x1715a3E4A142d8b698131108995174F37aEBA10D",
         "owner": "0x610094aB29D1bf683719d2Ce3495d8635A47bfc6"
@@ -79,6 +82,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1684141535,
       "values": {
         "getModuleInterfacesVersion": [1, 0, 0],
         "owner": "0x610094aB29D1bf683719d2Ce3495d8635A47bfc6",
@@ -91,6 +95,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1684141523,
       "values": {
         "bridgeContract": "0x0000000000000000000000000000000000000000",
         "decimals": 0,
@@ -114,6 +119,7 @@
         "admin": "0xDf5d165A7EB95D26355c56d53799B7da1240e585",
         "implementation": "0xe98699957d3504aCD57ffF861E4b77b57eB02467"
       },
+      "sinceTimestamp": 1684140863,
       "values": {
         "allowReentrantRequests": false,
         "decimalShift": 0,

--- a/packages/backend/discovery/skale-ima/ethereum/discovered.json
+++ b/packages/backend/discovery/skale-ima/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "skale-ima",
+  "chain": "ethereum",
   "blockNumber": 17619955,
   "configHash": "0x087b9989306e11a8d2db2c0ced551a809b035a18b56eeb2752b5d5589cea5ee1",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "ProxyAdminOwner",
@@ -12,6 +12,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1601280823,
       "values": {
         "domainSeparator": "0xfe553e7fa2b6b6eabfd8b489f5d70c9409db0501fd37f91a9f6f48239e815eaa",
         "getChainId": 1,
@@ -36,6 +37,7 @@
         "implementation": "0xE8d18a64e5bD3C3e96e7c163Dc67FF97296b6304",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1626720238,
       "values": {
         "contractManagerOfSkaleManager": "0xC04A10Fd5e6513242558f47331568aBD6185a310",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -54,6 +56,7 @@
         "implementation": "0x2f90BeD90fa0Cc605B86b8623612a2638EB4019a",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1626719733,
       "values": {
         "contractManagerOfSkaleManager": "0xC04A10Fd5e6513242558f47331568aBD6185a310",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -72,6 +75,7 @@
         "implementation": "0xffC647d4Cef8FB8b365e6B11a0156972e9343f6A",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1626719564,
       "values": {
         "CONSTANT_SETTER_ROLE": "0x96e3fc3be15159903e053027cff8a23f39a990e0194abcd8ac1cf1b355b8b93c",
         "contractManagerOfSkaleManager": "0xC04A10Fd5e6513242558f47331568aBD6185a310",
@@ -92,6 +96,7 @@
         "implementation": "0x676FAFCE73F5a304988C519407AAc06bD117CdD0",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1626719338,
       "values": {
         "contractManagerOfSkaleManager": "0xC04A10Fd5e6513242558f47331568aBD6185a310",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -108,6 +113,7 @@
         "implementation": "0xAD64712a9F3F7Ca4e7064381135082AAA68F56d5",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1626720065,
       "values": {
         "contractManagerOfSkaleManager": "0xC04A10Fd5e6513242558f47331568aBD6185a310",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -126,6 +132,7 @@
         "implementation": "0x64e4cd4Fe42eAB98AcD15fddaC657B1537aa5190",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1626719196,
       "values": {
         "CHAIN_CONNECTOR_ROLE": "0x2785f35fe7d8743aa971942d8474737bb31895d396eff2cc688a481e0221e191",
         "communityPool": "0x588801cA36558310D91234aFC2511502282b1621",
@@ -153,6 +160,7 @@
         "implementation": "0xc616EaF17c5e3349c1Fa493459494BB4DD0FD788",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1626719900,
       "values": {
         "ARBITER_ROLE": "0xbb08418a67729a078f87bbc8d02a770929bb68f5bfdf134ae2ead6ed38e2f4ae",
         "contractManagerOfSkaleManager": "0xC04A10Fd5e6513242558f47331568aBD6185a310",
@@ -172,6 +180,7 @@
         "implementation": "0xF99F446340483C5d9D63697a60232ECb9274E1e7",
         "admin": "0xA35d3Ffc3812F6caD1Ac64FDE740a98bfb900627"
       },
+      "sinceTimestamp": 1650021217,
       "values": {
         "contractManagerOfSkaleManager": "0xe8c7E5C70B8a8c9C3896e59062EA3A879270AB4A",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -188,6 +197,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626716630,
       "values": {
         "owner": "0x13fD1622F0E7e50A87B79cb296cbAf18362631C0"
       }

--- a/packages/backend/discovery/sollet/ethereum/discovered.json
+++ b/packages/backend/discovery/sollet/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "sollet",
+  "chain": "ethereum",
   "blockNumber": 16154924,
   "configHash": "0x2a42f8edc6b02f8f675f2d9072b53f04698bb68a005708388a29d466b2a6cc29",
+  "version": 2,
   "contracts": [
     {
       "name": "SplTokenSwap",
@@ -10,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1599794859,
       "values": {
         "owner": "0x067D382e61c06Cea2815069D9D97fd3ee5df2361",
         "paused": false

--- a/packages/backend/discovery/sorare/ethereum/discovered.json
+++ b/packages/backend/discovery/sorare/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "sorare",
+  "chain": "ethereum",
   "blockNumber": 17412704,
   "configHash": "0x2f28a2386707886cf2bf5985a0e42484b84840f69fd84e6e5194de0d734eb58e",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "OrderRegistry",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626352379,
       "values": {
         "hasRegisteredFact": true,
         "identify": "StarkWare_OrderRegistry_2021_1"
@@ -22,6 +23,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1630836435,
       "values": {
         "constructorArgs": [
           [
@@ -44,6 +46,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1678702991,
       "values": {
         "gpsContract": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60",
         "hasRegisteredFact": true,
@@ -58,6 +61,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1678893035,
       "values": {
         "domainSeparator": "0x64888abcdd0f52553103448c88733d35152e1c39d91e8df2cc280809053bbf5f",
         "getChainId": 1,
@@ -92,6 +96,7 @@
           "0xCc928977e4a75d25099e7DA7B6Fd79Dac2f9fD2B"
         ]
       },
+      "sinceTimestamp": 1626352527,
       "values": {
         "defaultVaultWithdrawalLock": 0,
         "DEPOSIT_CANCEL_DELAY": 172800,

--- a/packages/backend/discovery/stargate/ethereum/discovered.json
+++ b/packages/backend/discovery/stargate/ethereum/discovered.json
@@ -3,7 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 17968752,
   "configHash": "0xf4647eea5ee0ad585f71dba48ec65cef3f4adc4f85acfd27e20911a18c090333",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "Factory",
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647504676,
       "values": {
         "allPoolsLength": 12,
         "defaultFeeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
@@ -39,6 +40,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1668459527,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -79,6 +81,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656354769,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -159,6 +162,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1677032255,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -257,6 +261,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647504669,
       "values": {
         "layerZeroEndpoint": "0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675",
         "owner": "0x65bb797c2B9830d891D87288F029ed8dACc19705",
@@ -270,6 +275,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661529370,
       "values": {
         "feeEnabled": false,
         "nativeBP": 0,
@@ -285,6 +291,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647511860,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -348,6 +355,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673830559,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -387,6 +395,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661529280,
       "values": {
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -409,6 +418,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1668459587,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -448,6 +458,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1661280206,
       "values": {
         "endpoint": "0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675"
       }
@@ -459,6 +470,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1647498793,
       "values": {
         "domainSeparator": "0x10cd04a3b7d65ccac18caff2fefc4c51c80b1d61ab414834e49fc8fbdd62f6be",
         "getChainId": 1,
@@ -482,6 +494,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647316591,
       "values": {
         "BLOCK_VERSION": 65535,
         "chainId": 1,
@@ -503,6 +516,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1656354769,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -552,6 +566,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647504658,
       "values": {
         "bridge": "0x296F55F8Fb28E498B858d0BcDA06D955B2Cb3f97",
         "factory": "0x06D538690AF257Da524f25D0CD52fD85b1c2173E",
@@ -567,6 +582,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1686244907,
       "values": {
         "DELTA_1": "600000000000000000",
         "DELTA_2": "50000000000000000",
@@ -596,6 +612,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1668566243,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -650,6 +667,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1648243585,
       "values": {
         "domainSeparator": "0x567922b7bf591eff89c84c8a0039bbda9499c5f39de9b1c4dde48a8c912f31b9",
         "getChainId": 1,
@@ -672,6 +690,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1673830559,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -730,6 +749,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1647511732,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -792,6 +812,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1668459587,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
@@ -832,6 +853,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1668459527,
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,

--- a/packages/backend/discovery/starknet/ethereum/discovered.json
+++ b/packages/backend/discovery/starknet/ethereum/discovered.json
@@ -12,6 +12,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1692867743,
       "values": {
         "domainSeparator": "0x07112ea70e3b813e71d47e25500e17035517d3b51bd3c8d3500ccf54424e8f00",
         "getChainId": 1,
@@ -32,6 +33,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1652101038,
       "derivedName": "L1Escrow"
     },
     {
@@ -47,6 +49,7 @@
           "0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"
         ]
       },
+      "sinceTimestamp": 1657137600,
       "values": {
         "getUpgradeActivationDelay": 604800,
         "governors": [
@@ -73,6 +76,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1672587635,
       "values": {
         "domainSeparator": "0xfbf46e0cae4a0b01c142fd1c393d4058f5af0efa75d9b1a23dee605fdb7aaf81",
         "getChainId": 1,
@@ -94,6 +98,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1672587815,
       "values": {
         "domainSeparator": "0xb6cf2054f0384f47744cb3c2cbc3f6a9881e00205c03bf14afc7a6a862a8b9c6",
         "getChainId": 1,
@@ -114,6 +119,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1666446647,
       "values": {
         "ceiling": "5000000000000000000000000",
         "dai": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
@@ -139,6 +145,7 @@
           "0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"
         ]
       },
+      "sinceTimestamp": 1647857148,
       "values": {
         "bridgedToken": "0x0000000000000000000000000000000000000000",
         "depositorAddress": "0x0000000000000000000000000000000000000000",
@@ -175,6 +182,7 @@
           "0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"
         ]
       },
+      "sinceTimestamp": 1657137615,
       "values": {
         "getUpgradeActivationDelay": 604800,
         "governors": [
@@ -204,6 +212,7 @@
         "isFinal": false,
         "proxyGovernance": ["0x5751a83170BeA11fE7CdA5D599B04153C021f21A"]
       },
+      "sinceTimestamp": 1685452751,
       "values": {
         "getUpgradeActivationDelay": 0,
         "governors": ["0x5751a83170BeA11fE7CdA5D599B04153C021f21A"],
@@ -233,6 +242,7 @@
           "0x83C0A700114101D1283D1405E2c8f21D3F03e988"
         ]
       },
+      "sinceTimestamp": 1636978914,
       "values": {
         "configHash": "671483050609816861429812414688707376174032882875357307847551691140236175837",
         "getMaxL1MsgFee": "1000000000000000000",
@@ -274,6 +284,7 @@
         "isFinal": false,
         "proxyGovernance": ["0x5751a83170BeA11fE7CdA5D599B04153C021f21A"]
       },
+      "sinceTimestamp": 1685880791,
       "values": {
         "getUpgradeActivationDelay": 0,
         "governors": ["0x5751a83170BeA11fE7CdA5D599B04153C021f21A"],
@@ -304,6 +315,7 @@
           "0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"
         ]
       },
+      "sinceTimestamp": 1657137639,
       "values": {
         "getUpgradeActivationDelay": 604800,
         "governors": [

--- a/packages/backend/discovery/symbiosis/ethereum/discovered.json
+++ b/packages/backend/discovery/symbiosis/ethereum/discovered.json
@@ -11,6 +11,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693215407,
       "values": {
         "metaRouter": "0x1DCfbC3fA01b2a86bC3a3f43479cCe9E8D438Adc"
       }
@@ -21,6 +22,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1668406715,
       "values": {
         "owner": "0x5112EbA9bc2468Bb5134CBfbEAb9334EdaE7106a"
       },
@@ -32,6 +34,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1693215407,
       "values": {
         "metaRouterGateway": "0x0A0B7D1eea99e6189995432fec8172bB2dFFF847"
       }
@@ -42,6 +45,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1643968066,
       "values": {
         "owner": "0x0ee552336134B6f8F0a72927b6124f8A81865928"
       },
@@ -54,6 +58,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1668412331,
       "values": {
         "domainSeparator": "0xccc4d4f74988d0bce955a06b16641953bb625b9cc161a33d515a2555d06794ab",
         "getChainId": 1,
@@ -78,6 +83,7 @@
         "implementation": "0x7057aB3fB2BeE9c18e0cDe4240DE4ff7f159E365",
         "admin": "0x1Da522B35363c1eda4833bc121c8F3c67B2caa75"
       },
+      "sinceTimestamp": 1668406727,
       "values": {
         "currentChainId": 1,
         "mpc": "0xf56c3D7F385143f4E478ef5993b8266323B72657",
@@ -96,6 +102,7 @@
         "implementation": "0x086488E659253FF26D0C743325C059FB57Ca7934",
         "admin": "0x1Da522B35363c1eda4833bc121c8F3c67B2caa75"
       },
+      "sinceTimestamp": 1668406751,
       "values": {
         "bridge": "0x5523985926Aa12BA58DC5Ad00DDca99678D7227E",
         "metaRouter": "0x1DCfbC3fA01b2a86bC3a3f43479cCe9E8D438Adc",
@@ -116,6 +123,7 @@
         "implementation": "0x61608F9520C311052D88Bc7d0c2c4Cba1c964662",
         "admin": "0x3901611dfDA3Aed75C37Ba59f2c76E8309dc98FA"
       },
+      "sinceTimestamp": 1643968081,
       "derivedName": ""
     }
   ],

--- a/packages/backend/discovery/synapse/ethereum/discovered.json
+++ b/packages/backend/discovery/synapse/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "synapse",
+  "chain": "ethereum",
   "blockNumber": 17620009,
   "configHash": "0x7f5b5661d230aca74956b184647ad600ae0db124a982bff7a24f73c9193dd9a5",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "SynapseBridge",
@@ -13,6 +13,7 @@
         "implementation": "0x31fe393815822edacBd81C2262467402199EFD0D",
         "admin": "0x7B3C1f09088Bdc9f136178E170aC668C8Ed095f2"
       },
+      "sinceTimestamp": 1629082107,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -41,6 +42,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1630038897,
       "values": {
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
@@ -73,6 +75,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1628970480,
       "values": {
         "domainSeparator": "0x8c2034447704652155262224ded80d817537f663fe2aa23efb2f627783672c6c",
         "getChainId": 1,
@@ -93,6 +96,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1629075985,
       "values": {
         "owner": "0x647489df0673E17dB3163c47d5233EBB6F5cAc70"
       }

--- a/packages/backend/discovery/zkspace/ethereum/discovered.json
+++ b/packages/backend/discovery/zkspace/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "zkspace",
+  "chain": "ethereum",
   "blockNumber": 17442401,
   "configHash": "0x6fdb3e12ba6696f7e5f76d2b8399a7b189acd85c15ca93fde175459e121fa715",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "VerifierExit",
@@ -13,6 +13,7 @@
         "implementation": "0x41455808B3109AD0f79672C44D75933D3529FEaE",
         "admin": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390"
       },
+      "sinceTimestamp": 1639569183,
       "values": {
         "getMaster": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390",
         "getTarget": "0x41455808B3109AD0f79672C44D75933D3529FEaE"
@@ -31,6 +32,7 @@
           "0x6A4E7dd4c546Ca2DD84b48803040732fC30206D7"
         ]
       },
+      "sinceTimestamp": 1639569183,
       "values": {
         "EMPTY_STRING_KECCAK": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "exodusMode": false,
@@ -69,6 +71,7 @@
         "implementation": "0x6659174CdB0c445B897aEd25181f293E468941a5",
         "admin": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390"
       },
+      "sinceTimestamp": 1639569183,
       "values": {
         "getMaster": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390",
         "getTarget": "0x6659174CdB0c445B897aEd25181f293E468941a5",
@@ -86,6 +89,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1639573625,
       "values": {
         "listingCap": 1000,
         "listingCount": 64,
@@ -105,6 +109,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1639569183,
       "values": {
         "getMaster": "0xfCAE399eA757DDf0a4020198C59BF2270c2B05Be",
         "mainContract": "0x5CDAF83E077DBaC2692b5864CA18b61d67453Be8",
@@ -130,6 +135,7 @@
         "implementation": "0x44DedA2C824458A5DfE1e363c679dea33f1ffA39",
         "admin": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390"
       },
+      "sinceTimestamp": 1639569183,
       "values": {
         "getMaster": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390",
         "getTarget": "0x44DedA2C824458A5DfE1e363c679dea33f1ffA39"
@@ -143,6 +149,7 @@
         "implementation": "0x5f3bE7846efC473552C5619b929F7d4aa640fb54",
         "admin": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390"
       },
+      "sinceTimestamp": 1639569183,
       "values": {
         "allPairsLength": 64,
         "getMaster": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390",
@@ -159,6 +166,7 @@
         "implementation": "0xD06986022EFE62A5BC8258299e4495Bb27567BE0",
         "admin": "0xB0C7E781f70C0B8E3e62F1766a4Be6e435431390"
       },
+      "sinceTimestamp": 1639569183,
       "values": {
         "baseURI": "",
         "contractURI": "",
@@ -181,6 +189,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1606014225,
       "values": {
         "decimals": 18,
         "name": "Zks",

--- a/packages/backend/discovery/zkswap/ethereum/discovered.json
+++ b/packages/backend/discovery/zkswap/ethereum/discovered.json
@@ -13,6 +13,7 @@
         "implementation": "0x9d3fdf9b4782753d12f6262bf22B6322608962b8",
         "admin": "0x714B2D10210f2A3a7AA614F949259C87613689aB"
       },
+      "sinceTimestamp": 1613135194,
       "values": {
         "getMaster": "0x714B2D10210f2A3a7AA614F949259C87613689aB",
         "getTarget": "0x9d3fdf9b4782753d12f6262bf22B6322608962b8",
@@ -30,6 +31,7 @@
         "implementation": "0x165dFA76DFD3F6ad6Ad614aE4566C2E9262E532F",
         "admin": "0x714B2D10210f2A3a7AA614F949259C87613689aB"
       },
+      "sinceTimestamp": 1613135194,
       "values": {
         "getMaster": "0x714B2D10210f2A3a7AA614F949259C87613689aB",
         "getTarget": "0x165dFA76DFD3F6ad6Ad614aE4566C2E9262E532F"
@@ -42,6 +44,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1613135141,
       "values": {
         "EMPTY_STRING_KECCAK": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "exodusMode": false,
@@ -68,6 +71,7 @@
         "implementation": "0x65Fab217f1948af2D7A8eEB11fF111B0993C5Df8",
         "admin": "0x714B2D10210f2A3a7AA614F949259C87613689aB"
       },
+      "sinceTimestamp": 1613135194,
       "values": {
         "getMaster": "0x714B2D10210f2A3a7AA614F949259C87613689aB",
         "getTarget": "0x65Fab217f1948af2D7A8eEB11fF111B0993C5Df8"
@@ -80,6 +84,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1613135194,
       "values": {
         "getMaster": "0x7D1a14eeD7af8e26f24bf08BA6eD7A339AbcF037",
         "mainContract": "0x8ECa806Aecc86CE90Da803b080Ca4E3A9b8097ad",
@@ -102,6 +107,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1613135171,
       "derivedName": ""
     },
     {
@@ -112,6 +118,7 @@
         "implementation": "0x2F70F6D864F8F597a0ef57aDDf24323DFAb5797f",
         "admin": "0x714B2D10210f2A3a7AA614F949259C87613689aB"
       },
+      "sinceTimestamp": 1613135194,
       "values": {
         "EMPTY_STRING_KECCAK": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "exodusMode": false,
@@ -144,6 +151,7 @@
         "implementation": "0xd12F4D8329584F36aEd67f807F42D9a02bEb9534",
         "admin": "0x714B2D10210f2A3a7AA614F949259C87613689aB"
       },
+      "sinceTimestamp": 1613135194,
       "values": {
         "getMaster": "0x714B2D10210f2A3a7AA614F949259C87613689aB",
         "getTarget": "0xd12F4D8329584F36aEd67f807F42D9a02bEb9534"

--- a/packages/backend/discovery/zkswap2/ethereum/discovered.json
+++ b/packages/backend/discovery/zkswap2/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "zkswap2",
+  "chain": "ethereum",
   "blockNumber": 16767881,
   "configHash": "0x879a7179f610639a3c172e2a1a3b2f58ea32b2e0ac512188d2f4541dc49309b3",
+  "version": 2,
   "contracts": [
     {
       "name": "UpgradeGatekeeper",
@@ -11,6 +12,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626059966,
       "values": {
         "getMaster": "0x9D7397204F32e0Ee919Ea3475630cdf131086255",
         "mainContract": "0x6dE5bDC580f55Bc9dAcaFCB67b91674040A247e3",
@@ -32,6 +34,7 @@
         "implementation": "0x94b9401945a9bc06CE5B69e6dB3c6B671aABc829",
         "admin": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7"
       },
+      "sinceTimestamp": 1626059966,
       "values": {
         "getMaster": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7",
         "getTarget": "0x94b9401945a9bc06CE5B69e6dB3c6B671aABc829"
@@ -45,6 +48,7 @@
         "implementation": "0xf2c351f22b148A9fF583a0F81701471a74E7338e",
         "admin": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7"
       },
+      "sinceTimestamp": 1626059966,
       "values": {
         "EMPTY_STRING_KECCAK": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "exodusMode": false,
@@ -79,6 +83,7 @@
         "implementation": "0x95269f9E76540459c797089034dc74b48dF780a2",
         "admin": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7"
       },
+      "sinceTimestamp": 1626059966,
       "values": {
         "getMaster": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7",
         "getTarget": "0x95269f9E76540459c797089034dc74b48dF780a2",
@@ -95,6 +100,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626159962,
       "values": {
         "listingCap": 1000,
         "listingCount": 72,
@@ -117,6 +123,7 @@
         "implementation": "0x17e51B3659884d70a306906B5BDD73D1c64a3892",
         "admin": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7"
       },
+      "sinceTimestamp": 1626059966,
       "values": {
         "getMaster": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7",
         "getTarget": "0x17e51B3659884d70a306906B5BDD73D1c64a3892"
@@ -130,6 +137,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626059893,
       "derivedName": ""
     },
     {
@@ -140,6 +148,7 @@
         "implementation": "0xB2639bA16c7A5b0C55cA22D77CdA3D7ED88A5c89",
         "admin": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7"
       },
+      "sinceTimestamp": 1626059966,
       "values": {
         "allPairsLength": 72,
         "getMaster": "0x0DCCe462ddEA102D3ecf84A991d3ecFC251e02C7",
@@ -153,6 +162,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626059878,
       "values": {
         "EMPTY_STRING_KECCAK": "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
         "exodusMode": false,
@@ -179,6 +189,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1606014225,
       "values": {
         "decimals": 18,
         "name": "Zks",

--- a/packages/backend/discovery/zksync/ethereum/discovered.json
+++ b/packages/backend/discovery/zksync/ethereum/discovered.json
@@ -12,6 +12,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1612680486,
       "values": {
         "domainSeparator": "0xb6ece672e8e44cdf87193dcee0001432734caf5c8dd0d2b5ee44e98b5dbbc0f5",
         "getModules": [],
@@ -35,6 +36,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1621970023,
       "values": {
         "domainSeparator": "0x0612918ac0a704543b30ac33fe529b71be8e02810fe3dff217f7d9f5448442bc",
         "getModules": [],
@@ -59,6 +61,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1587354416,
       "values": {
         "domainSeparator": "0x8c5e6abcda42210fa2b28fcb8c59671ec835bf9c06954d07036009a0c6646557",
         "getChainId": 1,
@@ -81,6 +84,7 @@
         "implementation": "0x3FBc7C6c2437dE24F91b2Ca61Fc7AD3D2D62F4c8",
         "admin": "0x38A43F4330f24fe920F943409709fc9A6084C939"
       },
+      "sinceTimestamp": 1592218707,
       "values": {
         "defaultFactory": "0x7C770595a2Be9A87CF49B35eA9bC534f1a59552D",
         "networkGovernor": "0xE24f4870Ab85DE8E356C5fC56138587206c70d99",
@@ -96,6 +100,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1645178700,
       "values": {
         "governance": "0x34460C0EB5074C29A9F6FE13b8e7E23A0D08aF01",
         "listingCap": 64000,
@@ -112,6 +117,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1592218707,
       "values": {
         "getMaster": "0xE24f4870Ab85DE8E356C5fC56138587206c70d99",
         "mainContract": "0xaBEA9132b05A70803a4E85094fD0e1800777fBEF",
@@ -135,6 +141,7 @@
         "implementation": "0xf7Bd436a05678B647D74a88ffcf4445Efc43BDfC",
         "admin": "0x38A43F4330f24fe920F943409709fc9A6084C939"
       },
+      "sinceTimestamp": 1592218707,
       "derivedName": "Verifier"
     },
     {
@@ -143,6 +150,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1626171128,
       "values": {
         "baseURI": "",
         "name": "zkSync NFT Factory Contract",
@@ -160,6 +168,7 @@
         "implementation": "0x8e972b354E6933275513C355Ee14D44A832aD2d9",
         "additional": "0x2eaa1377e0fC95dE998B9fA7611E9D67ebA534fD"
       },
+      "sinceTimestamp": 1592218707,
       "values": {
         "approvedUpgradeNoticePeriod": 1814400,
         "exodusMode": false,
@@ -197,7 +206,8 @@
       "address": "0xAfC2F2D803479A2AF3A72022D54cc0901a0ec0d6",
       "upgradeability": {
         "type": "immutable"
-      }
+      },
+      "sinceTimestamp": 1557156465
     },
     {
       "name": "ZkSync Multisig",
@@ -206,6 +216,7 @@
         "type": "gnosis safe",
         "masterCopy": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F"
       },
+      "sinceTimestamp": 1585581484,
       "values": {
         "domainSeparator": "0xcd86f82218dc46b5501da06e0b96a9cf73cd8f35153e9da3a481f79b6be5ff63",
         "getModules": [],

--- a/packages/backend/discovery/zksync2/ethereum/discovered.json
+++ b/packages/backend/discovery/zksync2/ethereum/discovered.json
@@ -18,6 +18,7 @@
           "0x2E64926BE35412f7710A3E097Ba076740bF97CC0"
         ]
       },
+      "sinceTimestamp": 1676315375,
       "values": {
         "facetAddresses": [
           "0xdC7c3D03845EfE2c4a9E758A70a68BA6bba9FaC4",
@@ -149,6 +150,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1679602559,
       "values": {
         "executionDelay": 75600,
         "owner": "0x4e4943346848c4867F81dFb37c4cA9C5715A7828",
@@ -164,6 +166,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1692018551,
       "values": {
         "get_verification_key": [
           67108864,
@@ -292,6 +295,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1666872275,
       "values": {
         "domainSeparator": "0xd3e32b4e9e95656dc35c609ae0fbcc0cea466ebecc8227025a2d3edc728b79fb",
         "getChainId": 1,
@@ -319,6 +323,7 @@
         "implementation": "0x7FB17101A744e156e63d5fF6A4775fb48756577c",
         "admin": "0x4e4943346848c4867F81dFb37c4cA9C5715A7828"
       },
+      "sinceTimestamp": 1676370683,
       "values": {
         "l2Bridge": "0x11f943b2c77b743AB90f4A0Ae7d5A4e7FCA3E102",
         "l2TokenBeacon": "0x1Eb710030273e529A6aD7E1e14D4e601765Ba3c6",
@@ -332,6 +337,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1679581139,
       "values": {
         "owner": "0x4e4943346848c4867F81dFb37c4cA9C5715A7828",
         "pendingOwner": "0x0000000000000000000000000000000000000000"

--- a/packages/backend/discovery/zora/ethereum/discovered.json
+++ b/packages/backend/discovery/zora/ethereum/discovered.json
@@ -13,6 +13,7 @@
         "implementation": "0x43260ee547c3965bb2a0174763bb8FEcC650BA4A",
         "admin": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49"
       },
+      "sinceTimestamp": 1686694031,
       "values": {
         "GUARDIAN": "0xC72aE5c7cc9a332699305E29F68Be66c73b60542",
         "L2_ORACLE": "0x9E6204F750cD866b299594e2aC9eA824E2e5f95c",
@@ -32,6 +33,7 @@
         "implementation": "0xbF6acaF315477b15D638bf4d91eA48FA79b58335",
         "admin": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49"
       },
+      "sinceTimestamp": 1686693995,
       "values": {
         "l2TokenBridge": "0x4200000000000000000000000000000000000010",
         "messenger": "0xdC40a14d9abd6F410226f1E6de71aE03441ca506",
@@ -49,6 +51,7 @@
         "implementation": "0xDBCdA21518AF39E7feb9748F6718D3db11591461",
         "admin": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49"
       },
+      "sinceTimestamp": 1686694055,
       "values": {
         "messenger": "0xdC40a14d9abd6F410226f1E6de71aE03441ca506",
         "MESSENGER": "0xdC40a14d9abd6F410226f1E6de71aE03441ca506",
@@ -65,6 +68,7 @@
         "implementation": "0x9eedde6b4D3263b97209Ba860eDF3Fc6a8fB6a44",
         "admin": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49"
       },
+      "sinceTimestamp": 1686694007,
       "values": {
         "CHALLENGER": "0xcA4571b1ecBeC86Ea2E660d242c1c29FcB55Dc72",
         "FINALIZATION_PERIOD_SECONDS": 604800,
@@ -89,6 +93,7 @@
         "implementation": "0x17fb7c8Ce213F1A7691ee41EA880ABf6eBC6fa95",
         "admin": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49"
       },
+      "sinceTimestamp": 1686694067,
       "values": {
         "batcherHash": "0x625726c858dBF78c0125436C943Bf4b4bE9d9033",
         "gasLimit": 30000000,
@@ -119,6 +124,7 @@
         "implementation": "0x84ee4b9673598ca2FbDad4Ba4a27A58D6328Ec46",
         "admin": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49"
       },
+      "sinceTimestamp": 1686694043,
       "values": {
         "BRIDGE": "0x3e2Ea9B92B7E48A52296fD261dc26fd995284631",
         "version": "1.1.0"
@@ -131,6 +137,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1686592343,
       "values": {
         "domainSeparator": "0x04d8b03931757beb3d5d2234a3218674c5274d5c0532403b2f9d22ee0cecb958",
         "getChainId": 1,
@@ -155,6 +162,7 @@
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"
       },
+      "sinceTimestamp": 1686592547,
       "values": {
         "domainSeparator": "0xac8a89558305fc00b7a2686ab2bda0fb7e97f96a30b075fcc453b727c8172bda",
         "getChainId": 1,
@@ -178,6 +186,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1686693947,
       "values": {
         "addressManager": "0xEF8115F2733fb2033a7c756402Fc1deaa56550Ef",
         "isUpgrading": false,
@@ -193,6 +202,7 @@
         "implementationName": "OVM_L1CrossDomainMessenger",
         "implementation": "0x363B4B1ADa52E50353f746999bd9E94395190d2C"
       },
+      "sinceTimestamp": 1686694019,
       "values": {
         "MESSAGE_VERSION": 1,
         "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292620217",
@@ -215,6 +225,7 @@
       "upgradeability": {
         "type": "immutable"
       },
+      "sinceTimestamp": 1686693947,
       "values": {
         "owner": "0xD4ef175B9e72cAEe9f1fe7660a6Ec19009903b49"
       },

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -53,7 +53,7 @@
     "zod": "^3.22.2"
   },
   "devDependencies": {
-    "@l2beat/discovery-types": "^0.1.0",
+    "@l2beat/discovery-types": "^0.3.0",
     "@types/basic-auth": "^1.1.3",
     "@types/deep-diff": "^1.0.2",
     "@types/koa": "^2.13.5",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@koa/router": "^12.0.0",
     "@l2beat/config": "*",
-    "@l2beat/discovery": "0.4.0",
+    "@l2beat/discovery": "0.4.1",
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
     "@sentry/node": "^7.52.1",
@@ -53,7 +53,7 @@
     "zod": "^3.22.2"
   },
   "devDependencies": {
-    "@l2beat/discovery-types": "^0.3.0",
+    "@l2beat/discovery-types": "^0.3.1",
     "@types/basic-auth": "^1.1.3",
     "@types/deep-diff": "^1.0.2",
     "@types/koa": "^2.13.5",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@koa/router": "^12.0.0",
     "@l2beat/config": "*",
-    "@l2beat/discovery": "0.2.1",
+    "@l2beat/discovery": "0.4.0",
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
     "@sentry/node": "^7.52.1",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,6 +31,6 @@
     "jsonc-parser": "^3.2.0"
   },
   "devDependencies": {
-    "@l2beat/discovery-types": "^0.1.0"
+    "@l2beat/discovery-types": "^0.3.0"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,6 +31,6 @@
     "jsonc-parser": "^3.2.0"
   },
   "devDependencies": {
-    "@l2beat/discovery-types": "^0.3.0"
+    "@l2beat/discovery-types": "^0.3.1"
   }
 }

--- a/packages/config/scripts/checkVerifiedContracts/addresses.ts
+++ b/packages/config/scripts/checkVerifiedContracts/addresses.ts
@@ -47,7 +47,6 @@ function gatherAddressesFromUpgradeability(
     case 'call implementation proxy':
     case 'EIP897 proxy':
     case 'Eternal Storage proxy':
-    case 'Optics Beacon proxy':
       result.push(item.implementation)
       break
     case 'StarkWare proxy':
@@ -80,6 +79,11 @@ function gatherAddressesFromUpgradeability(
     case 'zkSpace proxy':
       result.push(item.implementation)
       result.push(...item.additional)
+      break
+    case 'Optics Beacon proxy':
+      result.push(item.upgradeBeacon)
+      result.push(item.beaconController)
+      result.push(item.implementation)
       break
     case 'Reference':
     case 'immutable':

--- a/packages/config/scripts/checkVerifiedContracts/addresses.ts
+++ b/packages/config/scripts/checkVerifiedContracts/addresses.ts
@@ -47,6 +47,7 @@ function gatherAddressesFromUpgradeability(
     case 'call implementation proxy':
     case 'EIP897 proxy':
     case 'Eternal Storage proxy':
+    case 'Optics Beacon proxy':
       result.push(item.implementation)
       break
     case 'StarkWare proxy':

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -99,17 +99,22 @@ export class ProjectDiscovery {
     address: EthereumAddress
     name?: string
     description?: string
-    sinceTimestamp: UnixTime
+    sinceTimestamp?: UnixTime
     tokens: string[] | '*'
     upgradableBy?: string[]
     upgradeDelay?: string
   }): ProjectEscrow {
     const contract = this.getContractByAddress(address.toString())
+    const timestamp = sinceTimestamp?.toNumber() ?? contract.sinceTimestamp
+    assert(
+      timestamp,
+      'No timestamp was found for an escrow. Possible solutions:\n1. Run discovery for that address to capture the sinceTimestamp.\n2. Provide your own sinceTimestamp that will override the value from discovery.',
+    )
 
     return {
       address,
       newVersion: true,
-      sinceTimestamp,
+      sinceTimestamp: new UnixTime(timestamp),
       tokens,
       contract: {
         name: name ?? contract.name,

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -276,7 +276,6 @@ export const arbitrum: Layer2 = {
     escrows: [
       discovery.getEscrowDetails({
         address: EthereumAddress('0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a'),
-        sinceTimestamp: new UnixTime(1661450734),
         tokens: ['ETH'],
         description:
           'Contract managing Inboxes and Outboxes. It escrows ETH sent to L2.',
@@ -284,7 +283,6 @@ export const arbitrum: Layer2 = {
       }),
       discovery.getEscrowDetails({
         address: EthereumAddress('0xcEe284F754E854890e311e3280b767F80797180d'),
-        sinceTimestamp: new UnixTime(1623867835),
         tokens: '*',
         description:
           'Main entry point for users depositing ERC20 tokens that require minting custom token on L2.',
@@ -292,7 +290,6 @@ export const arbitrum: Layer2 = {
       }),
       discovery.getEscrowDetails({
         address: EthereumAddress('0xa3A7B6F88361F48403514059F1F16C8E78d60EeC'),
-        sinceTimestamp: new UnixTime(1623784100),
         tokens: '*',
         description:
           'Main entry point for users depositing ERC20 tokens. Upon depositing, on L2 a generic, "wrapped" token will be minted.',
@@ -300,7 +297,6 @@ export const arbitrum: Layer2 = {
       }),
       discovery.getEscrowDetails({
         address: EthereumAddress('0xA10c7CE4b876998858b1a9E12b10092229539400'),
-        sinceTimestamp: new UnixTime(1632133470),
         tokens: ['DAI'],
         description:
           'DAI Vault for custom DAI Gateway. Fully controlled by MakerDAO governance.',

--- a/packages/frontend/src/utils/project/getContractSection.ts
+++ b/packages/frontend/src/utils/project/getContractSection.ts
@@ -248,6 +248,26 @@ function makeTechnologyContract(
               isAdmin: false,
             })
           break
+        case 'Optics Beacon proxy':
+          links.push({
+            name: 'Upgarde Beacon',
+            href: `https://etherscan.io/address/${item.upgradeability.upgradeBeacon.toString()}#code`,
+            address: item.upgradeability.upgradeBeacon.toString(),
+            isAdmin: false,
+          })
+          links.push({
+            name: 'Implementation (Upgradable)',
+            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            address: item.upgradeability.implementation.toString(),
+            isAdmin: false,
+          })
+          links.push({
+            name: 'Beacon Controller',
+            href: `https://etherscan.io/address/${item.upgradeability.beaconController.toString()}#code`,
+            address: item.upgradeability.beaconController.toString(),
+            isAdmin: true,
+          })
+          break
 
         // Ignore types
         case 'immutable':

--- a/packages/shared-pure/package.json
+++ b/packages/shared-pure/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.22.2"
   },
   "devDependencies": {
-    "@l2beat/discovery-types": "^0.1.0",
+    "@l2beat/discovery-types": "^0.3.0",
     "prom-client": "^14.1.0"
   }
 }

--- a/packages/shared-pure/package.json
+++ b/packages/shared-pure/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.22.2"
   },
   "devDependencies": {
-    "@l2beat/discovery-types": "^0.3.0",
+    "@l2beat/discovery-types": "^0.3.1",
     "prom-client": "^14.1.0"
   }
 }

--- a/packages/shared-pure/src/utils/gatherAddressesFromUpgradeability.ts
+++ b/packages/shared-pure/src/utils/gatherAddressesFromUpgradeability.ts
@@ -18,7 +18,6 @@ export function gatherAddressesFromUpgradeability(
     case 'call implementation proxy':
     case 'EIP897 proxy':
     case 'Eternal Storage proxy':
-    case 'Optics Beacon proxy':
       result.push(item.implementation)
       break
     case 'StarkWare proxy':
@@ -57,6 +56,11 @@ export function gatherAddressesFromUpgradeability(
     case 'zkSpace proxy':
       result.push(item.implementation)
       result.push(...item.additional)
+      break
+    case 'Optics Beacon proxy':
+      result.push(item.upgradeBeacon)
+      result.push(item.beaconController)
+      result.push(item.implementation)
       break
     case 'immutable':
       // Ignoring types because no (admin/user)implementation included in them

--- a/packages/shared-pure/src/utils/gatherAddressesFromUpgradeability.ts
+++ b/packages/shared-pure/src/utils/gatherAddressesFromUpgradeability.ts
@@ -18,6 +18,7 @@ export function gatherAddressesFromUpgradeability(
     case 'call implementation proxy':
     case 'EIP897 proxy':
     case 'Eternal Storage proxy':
+    case 'Optics Beacon proxy':
       result.push(item.implementation)
       break
     case 'StarkWare proxy':

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,15 +1899,6 @@
     dotenv "^16.3.1"
     error-stack-parser "^2.1.4"
 
-"@l2beat/discovery-types@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery-types/-/discovery-types-0.1.0.tgz#80dd68f0b27c927a13d01ce7d53dd96d26dd2783"
-  integrity sha512-c7G8JowA2iJM56QWjXqwllkeWU3IibK53GcHYP8BBC0d1NyGAlLrDSN7H9oGZT0YFISioKPvEUdCYFA6Zwk6rA==
-  dependencies:
-    chalk "^4.1.2"
-    dotenv "^16.3.1"
-    error-stack-parser "^2.1.4"
-
 "@l2beat/discovery-types@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@l2beat/discovery-types/-/discovery-types-0.3.0.tgz#73368982ef8cb43869f9ad3bf863d06d11943c54"
@@ -1915,32 +1906,13 @@
   dependencies:
     zod "^3.22.2"
 
-"@l2beat/discovery@^0.4.0":
+"@l2beat/discovery@0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.4.0.tgz#173c700cd4e83fe72b5b1ea65bc12b5f5e9330db"
   integrity sha512-c2SFK98jDdHXxwZnyae6/UDxEBhvGaaZdmKPijXlKTsAnOlXV/pJbOBhnaX4aOwHWhdYtwq5qQMX2/66z2D2Og==
   dependencies:
     "@l2beat/backend-tools" "^0.3.0"
     "@l2beat/discovery-types" "^0.3.0"
-    chalk "^4.1.2"
-    deep-diff "^1.0.2"
-    dotenv "^16.0.3"
-    ethers "^5.7.2"
-    jsonc-parser "^3.2.0"
-    lodash "^4.17.21"
-    mkdirp "^3.0.0"
-    node-fetch "^2.6.7"
-    prettier "^3.0.3"
-    rimraf "^5.0.0"
-    zod "^3.22.2"
-
-"@l2beat/discovery@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.2.1.tgz#77de13a741773614c4df620fe8e87d2bd9d50c84"
-  integrity sha512-HR1TG9PkwHkIjXBGPWcCf67QCnpcbnoICoefPOATAMeDqF9Y6KhL+5OybBCDCNBg1KPuGqECyKmYrrIei11yEQ==
-  dependencies:
-    "@l2beat/backend-tools" "^0.3.0"
-    "@l2beat/discovery-types" "^0.1.0"
     chalk "^4.1.2"
     deep-diff "^1.0.2"
     dotenv "^16.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,20 +1899,20 @@
     dotenv "^16.3.1"
     error-stack-parser "^2.1.4"
 
-"@l2beat/discovery-types@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery-types/-/discovery-types-0.3.0.tgz#73368982ef8cb43869f9ad3bf863d06d11943c54"
-  integrity sha512-pM8PKNtrm7QesJ228ciPn4iUUVdTh2gYuKbP1eTGf79EKns+hoK6BYPYh/PHGM1GDlxXmyu5Ny56vCtV2QD4Dw==
+"@l2beat/discovery-types@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery-types/-/discovery-types-0.3.1.tgz#6acde1a029db9c40affc7644e4cc0c3d5b4a0e62"
+  integrity sha512-mqDKmvdhBtNYg5KXNmE5KNK8ko9sAiMU1BpJUG1ffR1isq8u2bfUCzHRXCy+fnZzX6G0NAEG7LvYzU1LS2nVOA==
   dependencies:
     zod "^3.22.2"
 
-"@l2beat/discovery@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.4.0.tgz#173c700cd4e83fe72b5b1ea65bc12b5f5e9330db"
-  integrity sha512-c2SFK98jDdHXxwZnyae6/UDxEBhvGaaZdmKPijXlKTsAnOlXV/pJbOBhnaX4aOwHWhdYtwq5qQMX2/66z2D2Og==
+"@l2beat/discovery@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.4.1.tgz#b9865c0a33d2742e92776fe525c8ac390410a8a6"
+  integrity sha512-FCd09wYzCDvygq/JQu11jfdxxNerVbsEaa/9Hd8u7B2dOsjJIW3lkYuAvcKVrWiHj7+QYzsWy7k9vSgmrc5qyQ==
   dependencies:
     "@l2beat/backend-tools" "^0.3.0"
-    "@l2beat/discovery-types" "^0.3.0"
+    "@l2beat/discovery-types" "^0.3.1"
     chalk "^4.1.2"
     deep-diff "^1.0.2"
     dotenv "^16.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,6 +1904,34 @@
   resolved "https://registry.yarnpkg.com/@l2beat/discovery-types/-/discovery-types-0.1.0.tgz#80dd68f0b27c927a13d01ce7d53dd96d26dd2783"
   integrity sha512-c7G8JowA2iJM56QWjXqwllkeWU3IibK53GcHYP8BBC0d1NyGAlLrDSN7H9oGZT0YFISioKPvEUdCYFA6Zwk6rA==
   dependencies:
+    chalk "^4.1.2"
+    dotenv "^16.3.1"
+    error-stack-parser "^2.1.4"
+
+"@l2beat/discovery-types@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery-types/-/discovery-types-0.3.0.tgz#73368982ef8cb43869f9ad3bf863d06d11943c54"
+  integrity sha512-pM8PKNtrm7QesJ228ciPn4iUUVdTh2gYuKbP1eTGf79EKns+hoK6BYPYh/PHGM1GDlxXmyu5Ny56vCtV2QD4Dw==
+  dependencies:
+    zod "^3.22.2"
+
+"@l2beat/discovery@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.4.0.tgz#173c700cd4e83fe72b5b1ea65bc12b5f5e9330db"
+  integrity sha512-c2SFK98jDdHXxwZnyae6/UDxEBhvGaaZdmKPijXlKTsAnOlXV/pJbOBhnaX4aOwHWhdYtwq5qQMX2/66z2D2Og==
+  dependencies:
+    "@l2beat/backend-tools" "^0.3.0"
+    "@l2beat/discovery-types" "^0.3.0"
+    chalk "^4.1.2"
+    deep-diff "^1.0.2"
+    dotenv "^16.0.3"
+    ethers "^5.7.2"
+    jsonc-parser "^3.2.0"
+    lodash "^4.17.21"
+    mkdirp "^3.0.0"
+    node-fetch "^2.6.7"
+    prettier "^3.0.3"
+    rimraf "^5.0.0"
     zod "^3.22.2"
 
 "@l2beat/discovery@0.2.1":


### PR DESCRIPTION
Resolves L2B-2344

**WARNING**:

This is to be merged only when [#26 tools](https://github.com/l2beat/tools/pull/26) is merged. After which in this PR the dependency needs to be updated to use the newest version of discovery from l2beat/tools.

---

If you're using `discovery.getEscrowDetails` it will pull out the timestamp from the contract creation date. Right now discovery assumes that each escrow is a contract and escrows that are EOAs are not using `getEscrowDetails` anyway.

Tests using arbitrum.ts:

```
m@mateuszs-mbp config % node -r esbuild-register
Welcome to Node.js v16.20.1.
Type ".help" for more information.
> const z3 = require('./src/layer2s/arbitrum.ts')
undefined
> z3.arbitrum.config.escrows.map(e => e.sinceTimestamp)
[
  UnixTime { timestamp: 1661457944 },
  UnixTime { timestamp: 1623867835 },
  UnixTime { timestamp: 1623784100 },
  UnixTime { timestamp: 1632133470 },
  UnixTime { timestamp: 1622243344 }
]
> 
```

This was the old sinceTimestamps, they are now the same or fixed (applies only to the first four entries)
```
sinceTimestamp: new UnixTime(1661450734),
sinceTimestamp: new UnixTime(1623867835),
sinceTimestamp: new UnixTime(1623784100),
sinceTimestamp: new UnixTime(1632133470),
```