### PR TITLE
Fix local storage helper for strings

### DIFF
--- a/packages/frontend/src/scripts/local-storage/LocalStorage.ts
+++ b/packages/frontend/src/scripts/local-storage/LocalStorage.ts
@@ -29,10 +29,10 @@ export const LocalStorage = {
     key: T,
     value: LocalStorageKeyType<T>,
   ) => {
-    localStorage.setItem(
-      `${LOCAL_STORAGE_PREFIX}-${key}`,
-      JSON.stringify(value),
-    )
+    const stringifiedValue =
+      typeof value === 'string' ? value : JSON.stringify(value)
+
+    localStorage.setItem(`${LOCAL_STORAGE_PREFIX}-${key}`, stringifiedValue)
   },
 
   getItem: <T extends LocalStorageKeys>(


### PR DESCRIPTION
When using JSON.stringify() on string it will output '"content"'. Although in localStorage we need to save 'content' to make it work properly.