### PR TITLE
Enable omitting missing reports during token breakdown gen

### DIFF
--- a/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/DetailedTvlController.ts
@@ -249,13 +249,13 @@ export class DetailedTvlController {
       this.priceRepository.getByTimestamp(dataTimings.latestTimestamp),
     ])
 
-    const externalAssetsBreakdown = getNonCanonicalAssetsBreakdown(
+    const externalAssetsBreakdown = getNonCanonicalAssetsBreakdown(this.logger)(
       latestReports,
       this.tokens,
       'EBV',
     )
 
-    const nativeAssetsBreakdown = getNonCanonicalAssetsBreakdown(
+    const nativeAssetsBreakdown = getNonCanonicalAssetsBreakdown(this.logger)(
       latestReports,
       this.tokens,
       'NMV',


### PR DESCRIPTION
Base lacks reports causing endpoint to panic and build to fail.

Now missing reports are skipped and warn log is emitted in such case to easily point out any issues with data consistency.

