### PR TITLE
Update state validation for Kroma and Arbitrum

### DIFF
--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -280,7 +280,7 @@ export const arbitrum: Layer2 = {
     stateValidation: {
       value: 'Fraud proofs (INT)',
       description:
-        'Fraud proofs allow WHITELISTED actors watching the chain to prove that the state is incorrect. Interactive proofs (INT) require multiple transactions over time to resolve.',
+        'Fraud proofs allow WHITELISTED actors watching the chain to prove that the state is incorrect. Interactive proofs (INT) require multiple transactions over time to resolve. The challenge protocol can be subject to delay attacks.',
       sentiment: 'warning',
       sources: [
         {
@@ -345,7 +345,7 @@ export const arbitrum: Layer2 = {
     stateCorrectness: {
       name: 'Fraud proofs ensure state correctness',
       description:
-        'After some period of time, the published state root is assumed to be correct. For a certain time period, one of the whitelisted actors can submit a fraud proof that shows that the state was incorrect.',
+        'After some period of time, the published state root is assumed to be correct. For a certain time period, one of the whitelisted actors can submit a fraud proof that shows that the state was incorrect. The protocol can be subject to delay attacks.',
       risks: [
         {
           category: 'Funds can be stolen if',
@@ -365,6 +365,10 @@ export const arbitrum: Layer2 = {
         {
           text: 'RollupUser.sol#L288 - Etherscan source code, onlyValidator modifier',
           href: 'https://etherscan.io/address/0xA0Ed0562629D45B88A34a342f20dEb58c46C15ff#code#F1#L288',
+        },
+        {
+          text: 'Solutions to Delay Attacks on Rollups',
+          href: 'https://medium.com/offchainlabs/solutions-to-delay-attacks-on-rollups-434f9d05a07a',
         },
       ],
     },

--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -345,7 +345,7 @@ export const arbitrum: Layer2 = {
     stateCorrectness: {
       name: 'Fraud proofs ensure state correctness',
       description:
-        'After some period of time, the published state root is assumed to be correct. For a certain time period, one of the whitelisted actors can submit a fraud proof that shows that the state was incorrect. The protocol can be subject to delay attacks.',
+        'After some period of time, the published state root is assumed to be correct. For a certain time period, one of the whitelisted actors can submit a fraud proof that shows that the state was incorrect. The challenge protocol can be subject to delay attacks.',
       risks: [
         {
           category: 'Funds can be stolen if',

--- a/packages/config/src/layer2s/kroma.ts
+++ b/packages/config/src/layer2s/kroma.ts
@@ -95,7 +95,13 @@ export const kroma: Layer2 = {
     },
   },
   riskView: makeBridgeCompatible({
-    stateValidation: RISK_VIEW.STATE_FP_INT_ZK,
+    stateValidation: {
+      ...RISK_VIEW.STATE_FP_INT_ZK,
+      description:
+        RISK_VIEW.STATE_FP_INT_ZK.description +
+        ' The challenge protocol can be subject to delay attacks and can fail under certain conditions.',
+      sentiment: 'warning',
+    },
     dataAvailability: {
       ...RISK_VIEW.DATA_ON_CHAIN,
       sources: [
@@ -159,7 +165,7 @@ export const kroma: Layer2 = {
       rollupNodeSourceAvailable: true,
     },
     stage1: {
-      stateVerificationOnL1: true,
+      stateVerificationOnL1: false,
       fraudProofSystemAtLeast5Outsiders: true,
       usersHave7DaysToExit: false,
       usersCanExitWithoutCooperation: true,
@@ -179,7 +185,7 @@ export const kroma: Layer2 = {
         Once the single block of disagreement is found, CHALLENGER is required to present zkProof of the fraud. When the proof is validated, the incorrect\
         state output is deleted. The Security Council can always override the result of the challenge, it can also delete any L2 state root at any time. If\
         the malicious ATTESTER and CHALLENGER collude and are willing to spend bonds, they can perform a delay attack by engaging in continuous challenge\
-        resulting in lack of finalization of the L2 state root on L1.',
+        resulting in lack of finalization of the L2 state root on L1. The protocol can also fail under certain conditions.',
       references: [
         {
           text: 'Colosseum.sol#L300 - Etherscan source code, createChallenge function',
@@ -192,6 +198,10 @@ export const kroma: Layer2 = {
         {
           text: 'Colosseum.sol#L434 - Etherscan source code, proveFault function',
           href: 'https://etherscan.io/address/0x7526F997ea040B3949415c3a44e708273863AA2b#code#F1#L434',
+        },
+        {
+          text: 'KROMA-020: lack of validation segments and proofs in Colosseum.sol - ChainLight security audit',
+          href: 'https://drive.google.com/file/d/13TUxZ9KPyvUXNZGddALcJLin-xmp_Fkj/view',
         },
       ],
       risks: [


### PR DESCRIPTION
- **Kroma**: state validation turned yellow from green and added a link about soundness attack
- **Arbitrum**: added description regarding delay attacks