### PR TITLE
Aztec delay update

### DIFF
--- a/packages/backend/discovery/aptos/ethereum/discovered.json
+++ b/packages/backend/discovery/aptos/ethereum/discovered.json
@@ -1,8 +1,9 @@
 {
-  "chain": "ethereum",
   "name": "aptos",
-  "blockNumber": 16154924,
+  "chain": "ethereum",
+  "blockNumber": 18162849,
   "configHash": "0x958973499ce64958db371146958f80fd0cfab57839c701cb633e6272a9483162",
+  "version": 2,
   "contracts": [
     {
       "name": "TreasuryV2",
@@ -50,7 +51,7 @@
       "values": {
         "aptosChainId": 108,
         "BP_DENOMINATOR": 10000,
-        "bridgeFeeBP": 0,
+        "bridgeFeeBP": 7,
         "emergencyWithdrawEnabled": false,
         "emergencyWithdrawTime": 0,
         "globalPaused": false,
@@ -110,7 +111,7 @@
           "0x9134Ff6E5F2D42ADf0E8Cb7462616f18A8dEF6DC"
         ],
         "getThreshold": 2,
-        "nonce": 1,
+        "nonce": 3,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -133,7 +134,7 @@
           "0x67FC8c432448f9a8d541C17579EF7a142378d5aD"
         ],
         "getThreshold": 2,
-        "nonce": 21,
+        "nonce": 44,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"

--- a/packages/backend/discovery/aztecconnect/ethereum/discovered.json
+++ b/packages/backend/discovery/aztecconnect/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
   "name": "aztecconnect",
   "chain": "ethereum",
-  "blockNumber": 17968968,
+  "blockNumber": 18163333,
   "configHash": "0x1fbc4c99b60324dcfcdd9798955efb7c8dac6d42261720f4c2d433eccdf1f2c5",
-  "version": 1,
+  "version": 2,
   "contracts": [
     {
       "name": "Emergency Multisig",
@@ -134,7 +134,7 @@
           "0x7fb9f93Cc6614dDd76c893EC8b5310674aC3Fc5f"
         ],
         "getThreshold": 1,
-        "nonce": 268,
+        "nonce": 269,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -173,30 +173,30 @@
         "allowThirdPartyContracts": false,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "defiBridgeProxy": "0xA1BBa894a6D39D79C0D1ef9c68a2139c84B81487",
-        "delayBeforeEscapeHatch": 0,
+        "delayBeforeEscapeHatch": 4294967295,
         "EMERGENCY_ROLE": "0xbf233dd2aafeb4d50879c4aa5c81e96d92f6e6945c906a58f9f2d1c1631b4b26",
         "escapeBlockLowerBound": 2160,
         "escapeBlockUpperBound": 2400,
         "getAsyncDefiInteractionHashesLength": 0,
         "getCapped": true,
-        "getDataSize": 24838144,
-        "getDefiInteractionHashesLength": 1,
-        "getEscapeHatchStatus": [false, 1992],
+        "getDataSize": 25180160,
+        "getDefiInteractionHashesLength": 0,
+        "getEscapeHatchStatus": [false, 2027],
         "getImplementationVersion": 2,
-        "getPendingDefiInteractionHashesLength": 1,
+        "getPendingDefiInteractionHashesLength": 0,
         "getSupportedAssetsLength": 15,
         "getSupportedBridgesLength": 18,
-        "lastRollupTimeStamp": 1692677759,
+        "lastRollupTimeStamp": 1695039047,
         "LISTER_ROLE": "0xf94103142c1baabe9ac2b5d1487bf783de9e69cfeea9a72f5c9c94afd7877b8c",
         "OWNER_ROLE": "0xb19546dff01e856fb3f010c267a7b1c60363cf8a4664e21cc89c26224620214e",
         "paused": false,
-        "prevDefiInteractionsHash": "0x27bb6ab66fd6e49c4dfd8e64f1a4cf0f7a88886c701d3922b1c7c58250b8d33a",
+        "prevDefiInteractionsHash": "0x14e0f351ade4ba10438e9b15f66ab2e6389eea5ae870d6e8b2df1418b2e6fd5b",
         "RESUME_ROLE": "0x2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c7",
         "rollupProviders": [
           "0xA173BDdF4953C1E8be2cA0695CFc07502Ff3B1e7",
           "0xD64791E747188b0e5061fC65b56Bf20FeE2e3321"
         ],
-        "rollupStateHash": "0xe2e1e12571e0bb199c71d9bd3718b12ca6b554029160470febb8201e8391551e",
+        "rollupStateHash": "0x21682a30cdd010b8bb7277a55e31c6240c1f1abf51fb06b3c251ea44b43dd80c",
         "verifier": "0xB656f4219f565b93DF57D531B574E17FE0F25939",
         "getSupportedAsset": [
           "0x6B175474E89094C44Da98b954EedeAC495271d0F",

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -151,7 +151,7 @@ export const aztecconnect: Layer2 = {
     },
     proposerFailure: {
       ...RISK_VIEW.PROPOSER_CANNOT_WITHDRAW,
-      description: `Only the whitelisted proposers can publish L2 state roots on L1 within ${escapeHatchDelayString}, so in the event of failure the withdrawals are frozen.`,
+      description: `Only the whitelisted proposers can publish L2 state roots on L1 within ${escapeHatchDelayString} from the last posted root, so in the event of failure the withdrawals are frozen.`,
       sources: [
         {
           contract: 'RollupProcessorV2',

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -2,7 +2,6 @@ import { EthereumAddress, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { assert } from 'console'
 
 import { ProjectDiscovery } from '../discovery/ProjectDiscovery'
-import { formatSeconds } from '../utils/formatSeconds'
 import {
   CONTRACTS,
   DATA_AVAILABILITY,
@@ -23,6 +22,9 @@ const escapeHatchDelaySeconds = discovery.getContractValue<number>(
   'RollupProcessorV2',
   'delayBeforeEscapeHatch',
 )
+
+assert(escapeHatchDelaySeconds === 4294967295) // otherwise change descriptions!!
+const escapeHatchDelayString = '~136 years'
 
 function getAccessControl() {
   const accessControl = discovery.getContractValue<
@@ -73,8 +75,7 @@ export const aztecconnect: Layer2 = {
   display: {
     name: 'Aztec Connect',
     slug: 'aztecconnect',
-    warning:
-      'EOL: Aztec team announced they are going to shut down the rollup infrastructure on March 21st, 2024. The escape hatch delay has been recently increased to 136 years, meaning that users will not be able to exit when the operator will be shut down.',
+    warning: `EOL: Aztec team announced they are going to shut down the rollup infrastructure on March 21st, 2024. The escape hatch delay has been recently increased to ${escapeHatchDelayString}, meaning that users will not be able to exit when the operator will be shut down.`,
     description:
       'Aztec Connect is an open source layer 2 network that aims to bring scalability and privacy to Ethereum. It strives to enable affordable, private crypto payments via zero-knowledge proofs. Additionally it allows to deposit funds into a variety of DeFi Protocols such as LiDo, Element.Fi, etc.',
     purpose: 'Private DeFi',
@@ -212,9 +213,7 @@ export const aztecconnect: Layer2 = {
     },
     operator: {
       ...OPERATOR.CENTRALIZED_OPERATOR,
-      description: `Only specific addresses appointed by the owner are permitted to propose new blocks during regular rollup operation. Periodically a special window is open during which anyone can propose new blocks, but only if the last root was posted more than ${formatSeconds(
-        escapeHatchDelaySeconds,
-      )} ago.`,
+      description: `Only specific addresses appointed by the owner are permitted to propose new blocks during regular rollup operation. Periodically a special window is open during which anyone can propose new blocks, but only if the last root was posted more than ${escapeHatchDelayString} ago.`,
       references: [
         {
           text: 'RollupProcessorV2.sol#L692 - Etherscan source code',
@@ -226,9 +225,7 @@ export const aztecconnect: Layer2 = {
       ...FORCE_TRANSACTIONS.PROPOSE_OWN_BLOCKS,
       description:
         FORCE_TRANSACTIONS.PROPOSE_OWN_BLOCKS.description +
-        ` Periodically the rollup opens a special window during which anyone can propose new blocks. This is only possible if the last root was posted more than ${formatSeconds(
-          escapeHatchDelaySeconds,
-        )} ago.`,
+        ` Periodically the rollup opens a special window during which anyone can propose new blocks. This is only possible if the last root was posted more than ${escapeHatchDelayString} ago.`,
       references: [
         {
           text: 'RollupProcessorV2.sol#L697 - Etherscan source code',
@@ -281,9 +278,7 @@ export const aztecconnect: Layer2 = {
   contracts: {
     addresses: [
       discovery.getContractDetails('RollupProcessorV2', {
-        description: `Main Rollup contract responsible for deposits, withdrawals and accepting transaction batches alongside zkProof. The escape hatch delay is currently set to ${formatSeconds(
-          escapeHatchDelaySeconds,
-        )}`,
+        description: `Main Rollup contract responsible for deposits, withdrawals and accepting transaction batches alongside zkProof. The escape hatch delay is currently set to ${escapeHatchDelayString})}`,
         pausable: {
           paused: discovery.getContractValue('RollupProcessorV2', 'paused'),
           pausableBy: ['Emergency Multisig'],

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -74,7 +74,7 @@ export const aztecconnect: Layer2 = {
     name: 'Aztec Connect',
     slug: 'aztecconnect',
     warning:
-      'EOL: Aztec team announced they are going to shut down the rollup infrastructure on March 21st, 2024.',
+      'EOL: Aztec team announced they are going to shut down the rollup infrastructure on March 21st, 2024. The escape hatch delay has been recently increased to 136 years, meaning that users will not be able to exit when the operator will be shut down.',
     description:
       'Aztec Connect is an open source layer 2 network that aims to bring scalability and privacy to Ethereum. It strives to enable affordable, private crypto payments via zero-knowledge proofs. Additionally it allows to deposit funds into a variety of DeFi Protocols such as LiDo, Element.Fi, etc.',
     purpose: 'Private DeFi',

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -213,7 +213,7 @@ export const aztecconnect: Layer2 = {
     },
     operator: {
       ...OPERATOR.CENTRALIZED_OPERATOR,
-      description: `Only specific addresses appointed by the owner are permitted to propose new blocks during regular rollup operation. Periodically a special window is open during which anyone can propose new blocks, but only if the last root was posted more than ${escapeHatchDelayString} ago.`,
+      description: `Only specific addresses appointed by the owner are permitted to propose new blocks during regular rollup operation. Periodically a special window is open during which anyone can propose new blocks, but only if the last root was posted more than ${escapeHatchDelayString} prior.`,
       references: [
         {
           text: 'RollupProcessorV2.sol#L692 - Etherscan source code',
@@ -225,7 +225,7 @@ export const aztecconnect: Layer2 = {
       ...FORCE_TRANSACTIONS.PROPOSE_OWN_BLOCKS,
       description:
         FORCE_TRANSACTIONS.PROPOSE_OWN_BLOCKS.description +
-        ` Periodically the rollup opens a special window during which anyone can propose new blocks. This is only possible if the last root was posted more than ${escapeHatchDelayString} ago.`,
+        ` Periodically the rollup opens a special window during which anyone can propose new blocks. This is only possible if the last root was posted more than ${escapeHatchDelayString} prior.`,
       references: [
         {
           text: 'RollupProcessorV2.sol#L697 - Etherscan source code',

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -150,7 +150,8 @@ export const aztecconnect: Layer2 = {
       ],
     },
     proposerFailure: {
-      ...RISK_VIEW.PROPOSER_SELF_PROPOSE_ZK,
+      ...RISK_VIEW.PROPOSER_CANNOT_WITHDRAW,
+      description: `Only the whitelisted proposers can publish L2 state roots on L1 within ${escapeHatchDelayString}, so in the event of failure the withdrawals are frozen.`,
       sources: [
         {
           contract: 'RollupProcessorV2',


### PR DESCRIPTION
The escape hatch delay has been changed from zero seconds to 136 years. Previously, during regular time windows, anyone could propose blocks. Now, in addition to those windows, to be able to submit blocks one has to also wait a period of 136 years since the last submitted block.

also, ignore aptos commit