### PR TITLE
Update Chart's scale

### DIFF
--- a/packages/frontend/src/components/chart/configure/update/view/calculateTicks.ts
+++ b/packages/frontend/src/components/chart/configure/update/view/calculateTicks.ts
@@ -9,7 +9,7 @@ export function calculateTicks(
 }
 
 function calculateLinTicks(ticks: number, values: number[]) {
-  const min = Math.min(...values)
+  const min = Math.min(0)
   const max = Math.max(...values)
   if (min === max) {
     if (min === 0) {


### PR DESCRIPTION
Currently the scale on most of the charts does not start from zero, which is a bit misleading, this PR aims to improve it.

Before:
![image](https://github.com/l2beat/l2beat/assets/72789647/480085c2-1c4d-4586-b370-9a030775eeb3)


After:
![image](https://github.com/l2beat/l2beat/assets/72789647/37efb4aa-22dd-44d3-8ae7-05edb3c938fb)
