### PR TITLE
Make sure that discord messages get truncated

### DIFF
--- a/packages/backend/src/core/discovery/utils/diffToMessages.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessages.ts
@@ -105,11 +105,12 @@ export function fieldDiffToMessage(
     message += `+ ${diff.after ?? 'undefined'}\n`
   }
 
-  if (message.length + 1 > maxLength) {
+  const NEW_LINE_BIAS = 1
+  if (message.length + NEW_LINE_BIAS > maxLength) {
     const warningMessage = 'Warning: Message has been truncated\n'
     message =
       warningMessage +
-      hideOverflow(message, maxLength - warningMessage.length - 1)
+      hideOverflow(message, maxLength - warningMessage.length - NEW_LINE_BIAS)
   }
 
   message += '\n'

--- a/packages/backend/src/core/discovery/utils/diffToMessages.ts
+++ b/packages/backend/src/core/discovery/utils/diffToMessages.ts
@@ -50,11 +50,12 @@ export function contractDiffToMessages(
   }
 
   const contractHeader = `${diff.name} | ${diff.address.toString()}\n\n`
-  const messages = diff.diff?.map(fieldDiffToMessage) ?? []
+  const maxLengthAdjusted = maxLength - contractHeader.length
+  const messages =
+    diff.diff?.map((d) => fieldDiffToMessage(d, maxLengthAdjusted)) ?? []
 
   //bundle message is called second time to handle situation when
   //diff in a single contract would result in a message larger than MAX_MESSAGE_LENGTH
-  const maxLengthAdjusted = maxLength - contractHeader.length
   const bundledMessages = bundleMessages(messages, maxLengthAdjusted)
 
   return bundledMessages.map((m) => `${contractHeader}${m}`)
@@ -80,7 +81,18 @@ export function bundleMessages(
   return bundle
 }
 
-export function fieldDiffToMessage(diff: FieldDiff): string {
+function hideOverflow(str: string, maxLength: number) {
+  if (str.length <= maxLength) {
+    return str
+  }
+
+  return `${str.substring(0, maxLength - 3)}...`
+}
+
+export function fieldDiffToMessage(
+  diff: FieldDiff,
+  maxLength = MAX_MESSAGE_LENGTH,
+): string {
   let message = ''
 
   if (diff.key !== undefined) {
@@ -91,6 +103,13 @@ export function fieldDiffToMessage(diff: FieldDiff): string {
   }
   if (diff.after || 'after' in diff) {
     message += `+ ${diff.after ?? 'undefined'}\n`
+  }
+
+  if (message.length + 1 > maxLength) {
+    const warningMessage = 'Warning: Message has been truncated\n'
+    message =
+      warningMessage +
+      hideOverflow(message, maxLength - warningMessage.length - 1)
   }
 
   message += '\n'


### PR DESCRIPTION
Resolves L2B-2044

Discord messages had the ability to become bigger than the `MAX_MESSAGE_LENGTH` if a single field diff gets converted to something bigger than `MAX_MESSAGE_LENGTH`. Right now we are going to prematurely truncate the message and add a warning informing that truncation took place.