### PR TITLE
Fix CI

### DIFF
--- a/packages/config/src/test/config.ts
+++ b/packages/config/src/test/config.ts
@@ -1,7 +1,13 @@
 import { getEnv } from '@l2beat/backend-tools'
 
+// Github actions sets env as an empty string when secret is not set
+// this resulted in a bug on the outside contributors PRs
+// workaround: getting and optional string and then doing OR (||)
+// eslint is disabled because nullish coalescing (??) will not give expected result
+
 interface Config {
   alchemyApiKey?: string
+  coingeckoApiKey?: string
 }
 
 export const config: Config = {
@@ -9,4 +15,8 @@ export const config: Config = {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getEnv().optionalString('CONFIG_ALCHEMY_API_KEY') ||
     'mlGD422scpwVOpn3lye_swHEebbKQy0D',
+
+  coingeckoApiKey:
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    getEnv().optionalString('COINGECKO_API_KEY') || undefined,
 }

--- a/packages/config/src/test/config.ts
+++ b/packages/config/src/test/config.ts
@@ -7,8 +7,6 @@ interface Config {
 export const config: Config = {
   alchemyApiKey:
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    getEnv().string(
-      'CONFIG_ALCHEMY_API_KEY',
-      'mlGD422scpwVOpn3lye_swHEebbKQy0D',
-    ),
+    getEnv().optionalString('CONFIG_ALCHEMY_API_KEY') ||
+    'mlGD422scpwVOpn3lye_swHEebbKQy0D',
 }

--- a/packages/config/src/tokens/tokens.test.ts
+++ b/packages/config/src/tokens/tokens.test.ts
@@ -87,7 +87,7 @@ describe('tokens', () => {
 
           if (message) {
             // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-            throw new Error('Multicall failed: ' + message)
+            throw new Error('Multicall failed. Alchemy error: ' + message)
           } else {
             throw error
           }

--- a/packages/config/src/tokens/tokens.test.ts
+++ b/packages/config/src/tokens/tokens.test.ts
@@ -128,10 +128,7 @@ describe('tokens', () => {
       this.timeout(10000)
 
       const http = new HttpClient()
-      const coingeckoClient = new CoingeckoClient(
-        http,
-        process.env.COINGECKO_API_KEY,
-      )
+      const coingeckoClient = new CoingeckoClient(http, config.coingeckoApiKey)
 
       const coinsList = await coingeckoClient.getCoinList({
         includePlatform: true,

--- a/packages/config/src/tokens/tokens.test.ts
+++ b/packages/config/src/tokens/tokens.test.ts
@@ -74,8 +74,25 @@ describe('tokens', () => {
                 [x.address, DECIMALS],
               ],
         )
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        const data: string[] = (await contract.functions.aggregate(calls))[1]
+        let data: string[] = []
+
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          data = (await contract.functions.aggregate(calls))[1]
+        } catch (error) {
+          // @ts-expect-error Alchemy error is not typed
+          const errorBody = error.error.body
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          const message = JSON.parse(errorBody).error.message
+
+          if (message) {
+            // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+            throw new Error('Multicall failed: ' + message)
+          } else {
+            throw error
+          }
+        }
+
         for (let i = 0; i < calls.length; i += 3) {
           const nameResult = data[i]
           const symbolResult = data[i + 1]


### PR DESCRIPTION
This PR will fix CI issues on outside contributors PR introduced during migration to backend-tools

preview of the most important part of the code:

```
// Github actions sets env as an empty string when secret is not set
// this resulted in a bug on the outside contributors PRs
// workaround: getting and optional string and then doing OR (||)
// eslint is disabled because nullish coalescing (??) will not give expected result

... 
alchemyApiKey:
    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
    getEnv().optionalString('CONFIG_ALCHEMY_API_KEY') ||
    'mlGD422scpwVOpn3lye_swHEebbKQy0D',
```