### PR TITLE
Add warning to manta pacific

### DIFF
--- a/packages/config/src/layer2s/mantapacific.ts
+++ b/packages/config/src/layer2s/mantapacific.ts
@@ -31,6 +31,8 @@ export const mantapacific: Layer2 = {
     slug: 'mantapacific',
     description:
       'Manta Pacific is an optimistic rollup empowering EVM-native zero-knowledge (ZK) applications and general dapps with a scalable, cost-effective environment to deploy simply using Solidity. Manta Pacific plans to eventually leverage Celestia for data availability to lower gas costs for users across all applications in its ecosystem.',
+    warning:
+      'Fraud proof system is currently under development. Users need to trust block Proposer to submit correct L1 state roots.',
     purpose: 'Universal',
     category: 'Optimistic Rollup',
     provider: 'OP Stack',


### PR DESCRIPTION
Resolves L2B-2837

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1170bb5</samp>

Add warning message to `mantapacific` layer 2 configuration in `packages/config/src/layer2s/mantapacific.ts`. The message alerts users of the potential security risks of using Manta Pacific before the fraud proof system is deployed.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1170bb5</samp>

* Add a warning message to the `mantapacific` layer 2 configuration object ([link](https://github.com/l2beat/l2beat/pull/2063/files?diff=unified&w=0#diff-e0a28e2fa4888682616ef5e93ee66d7fad00f3610fc1ad11dec8a64db1020fb0R34-R35))