### PR TITLE
Fix expandable container gradient

### DIFF
--- a/packages/frontend/src/components/ExpandableContainer.tsx
+++ b/packages/frontend/src/components/ExpandableContainer.tsx
@@ -19,7 +19,7 @@ export function ExpandableContainer(props: ExpandableContainerProps) {
         )}
       >
         <div>{props.children}</div>
-        <div className="ExpandableContainerContentGradient pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-white dark:to-black " />
+        <div className="ExpandableContainerContentGradient pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-b from-transparent to-white dark:to-neutral-900 " />
       </div>
       <div className="ExpandableContainerButton mx-auto mt-1 flex w-min cursor-pointer items-center justify-center rounded-md border border-pink-900 px-8 py-2 transition hover:bg-pink-900 hover:bg-opacity-25">
         <div className="flex gap-2.5">


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 216a643</samp>

Improved the dark mode UI of the l2beat website by changing the gradient color of the `ExpandableContainer` component to match the theme.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 216a643</samp>

* Change the gradient color of the expandable container in dark mode to match the theme and improve the contrast ([link](https://github.com/l2beat/l2beat/pull/2074/files?diff=unified&w=0#diff-5fb43f27830c0918c0db8dc2ef4f8556dd0392362f6089fbeaa057eb0325659dL22-R22))