### PR TITLE
Minor chart fixes

### DIFF
--- a/packages/frontend/src/components/chart/Chart.tsx
+++ b/packages/frontend/src/components/chart/Chart.tsx
@@ -95,7 +95,7 @@ export function Chart(props: ChartProps) {
             <ChartHover />
             <Logo className="absolute bottom-2 right-2 z-30 h-[25px] w-[60px] opacity-20" />
             <div
-              className="absolute -bottom-4 -left-4 top-0 -right-4 z-25 group-data-[interactivity-disabled]/chart:hidden"
+              className="absolute -bottom-4 -left-4 top-0 -right-4 z-40 group-data-[interactivity-disabled]/chart:hidden"
               data-role="chart-canvas-interaction-zone"
             />
             <ChartEmptyState />
@@ -109,7 +109,7 @@ export function Chart(props: ChartProps) {
             <ChartLabels className={props.metaChart ? 'hidden' : undefined} />
             <div
               data-role="chart-milestones"
-              className="absolute bottom-0 w-[100%] group-data-[interactivity-disabled]/chart:hidden"
+              className="absolute bottom-0 z-40 w-[100%] group-data-[interactivity-disabled]/chart:hidden"
             />
           </div>
           <div className="flex justify-between">

--- a/packages/frontend/src/components/chart/ChartHover.tsx
+++ b/packages/frontend/src/components/chart/ChartHover.tsx
@@ -14,7 +14,7 @@ export function ChartHover() {
         className={cx(
           'absolute z-50 rounded-lg py-2 px-3 text-right text-2xs md:py-3 md:px-4 md:text-xs',
           'bg-gray-100 shadow-[0_4px_8px_rgba(0,0,0,0.25)] dark:bg-gray-750',
-          'select-none',
+          'pointer-events-none select-none',
           'flex flex-col items-start justify-center',
           'transition-[bottom] duration-[50ms] ease-linear',
         )}

--- a/packages/frontend/src/scripts/charts/renderer/ChartRenderer.ts
+++ b/packages/frontend/src/scripts/charts/renderer/ChartRenderer.ts
@@ -144,12 +144,17 @@ export class ChartRenderer {
       this.onWindowMoveEvent(e.touches[0]),
     )
 
-    this.canvasInteractionZone.addEventListener('mousemove', (e) =>
-      this.onCanvasMoveEvent(e),
-    )
-    this.canvasInteractionZone.addEventListener('touchmove', (e) =>
-      this.onCanvasMoveEvent(e.touches[0]),
-    )
+    const interactiveZones = [
+      this.milestonesWrapper,
+      this.canvasInteractionZone,
+    ]
+
+    interactiveZones.forEach((zone) => {
+      zone.addEventListener('mousemove', (e) => this.onCanvasMoveEvent(e))
+      zone.addEventListener('touchmove', (e) =>
+        this.onCanvasMoveEvent(e.touches[0]),
+      )
+    })
   }
 
   private renderMilestones(points: Point<unknown>[]) {

--- a/packages/frontend/src/scripts/charts/renderer/milestones.ts
+++ b/packages/frontend/src/scripts/charts/renderer/milestones.ts
@@ -6,7 +6,7 @@ export function renderMilestone(x: number, url: string) {
   const left = x - MILESTONE_SIZE / 2
   const top = -MILESTONE_SIZE / 2
   return `
-  <div class="absolute z-40 select-none scale-75  md:scale-100" style="left: ${left}px; top: ${top}px">
+  <div class="absolute select-none scale-75 md:scale-100" style="left: ${left}px; top: ${top}px">
     ${isMobile() ? '' : `<a href="${url}" target="_blank">`}
       <svg
         width="${MILESTONE_SIZE}"

--- a/packages/frontend/src/scripts/charts/view-controller/hovers.ts
+++ b/packages/frontend/src/scripts/charts/view-controller/hovers.ts
@@ -105,7 +105,7 @@ export function renderDetailedTvlHover(
 
 function renderMilestoneLink(link: string) {
   return `
-  <a href="${link}" class="font-semibold pointer-events-auto text-blue-700 underline transition-colors hover:text-blue-550 dark:text-blue-500 dark:hover:text-blue-550" target="_blank" rel="noreferrer noopener">
+  <a href="${link}" class="font-semibold pointer-events-auto text-blue-700 z-50 underline transition-colors hover:text-blue-550 dark:text-blue-500 dark:hover:text-blue-550" target="_blank" rel="noreferrer noopener">
     Learn more
   </a>`
 }

--- a/packages/frontend/src/scripts/charts/view-controller/hovers.ts
+++ b/packages/frontend/src/scripts/charts/view-controller/hovers.ts
@@ -105,7 +105,7 @@ export function renderDetailedTvlHover(
 
 function renderMilestoneLink(link: string) {
   return `
-  <a href="${link}" class="font-semibold text-blue-700 underline transition-colors hover:text-blue-550 dark:text-blue-500 dark:hover:text-blue-550" target="_blank" rel="noreferrer noopener">
+  <a href="${link}" class="font-semibold pointer-events-auto text-blue-700 underline transition-colors hover:text-blue-550 dark:text-blue-500 dark:hover:text-blue-550" target="_blank" rel="noreferrer noopener">
     Learn more
   </a>`
 }


### PR DESCRIPTION
## Summary

I noticed that hovering over desktop milestones behaves weirdly when two of them are close to each other. This PR aims to fix it.


## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6e9a926</samp>

*  Fix chart hover tooltip and milestone icons not showing up by increasing their z-index and enabling pointer events ([link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-aa97966834e46135486f7af43f458eaf24fe88005046e7845f46ff767ed3abd1L98-R98), [link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-aa97966834e46135486f7af43f458eaf24fe88005046e7845f46ff767ed3abd1L112-R112), [link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-b5f297154dcd2339bfc11964f96948058eaf24f138a7aeee68d339447f32a4bdL17-R17), [link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-ad3e3d6b5d6eb492d07a0699111f2ea5a59197c4acfa7d03fc833a57b740e6edL147-R157), [link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-b833e817f755dad752de49e6ffaab245ad8e173e78b5a0d1f41aabe82153e8c8L9-R9), [link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-424a00e014ecd8eedae3f3a59d80353963256488642b5e214d3b1bf55468b89eL108-R108))
  * Add `z-40` class to `chart-canvas-interaction-zone` and `chart-milestones` divs in `Chart.tsx` ([link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-aa97966834e46135486f7af43f458eaf24fe88005046e7845f46ff767ed3abd1L98-R98), [link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-aa97966834e46135486f7af43f458eaf24fe88005046e7845f46ff767ed3abd1L112-R112))
  * Add `pointer-events-none` class to `ChartHover` component in `ChartHover.tsx` ([link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-b5f297154dcd2339bfc11964f96948058eaf24f138a7aeee68d339447f32a4bdL17-R17))
  * Create `interactiveZones` array and use `forEach` loop to add event listeners to both `milestonesWrapper` and `canvasInteractionZone` elements in `ChartRenderer.ts` ([link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-ad3e3d6b5d6eb492d07a0699111f2ea5a59197c4acfa7d03fc833a57b740e6edL147-R157))
  * Remove `z-40` class from `renderMilestone` function in `milestones.ts` ([link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-b833e817f755dad752de49e6ffaab245ad8e173e78b5a0d1f41aabe82153e8c8L9-R9))
  * Add `pointer-events-auto` and `z-50` classes to `renderMilestoneLink` function in `hovers.ts` ([link](https://github.com/l2beat/l2beat/pull/2077/files?diff=unified&w=0#diff-424a00e014ecd8eedae3f3a59d80353963256488642b5e214d3b1bf55468b89eL108-R108))