### PR TITLE
Rerun discoveries

### DIFF
--- a/packages/backend/discovery/arbitrum/ethereum/discovered.json
+++ b/packages/backend/discovery/arbitrum/ethereum/discovered.json
@@ -220,8 +220,6 @@
         "outbox": "0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840",
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd",
         "paused": false,
-        "requireUnresolved": [],
-        "requireUnresolvedExists": [],
         "rollupDeploymentBlock": 15411056,
         "rollupEventInbox": "0x57Bd336d579A51938619271a7Cc137a46D0501B1",
         "sequencerInbox": "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",

--- a/packages/backend/discovery/aztecconnect/ethereum/discovered.json
+++ b/packages/backend/discovery/aztecconnect/ethereum/discovered.json
@@ -197,20 +197,6 @@
         "getEscapeHatchStatus": [false, 380],
         "getImplementationVersion": 2,
         "getPendingDefiInteractionHashesLength": 1,
-        "getSupportedAssetsLength": 15,
-        "getSupportedBridgesLength": 18,
-        "lastRollupTimeStamp": 1697171759,
-        "LISTER_ROLE": "0xf94103142c1baabe9ac2b5d1487bf783de9e69cfeea9a72f5c9c94afd7877b8c",
-        "OWNER_ROLE": "0xb19546dff01e856fb3f010c267a7b1c60363cf8a4664e21cc89c26224620214e",
-        "paused": false,
-        "prevDefiInteractionsHash": "0x2af92273d78efd009fae4e0897c43f99376179a19d59997e5146c64b12da5e90",
-        "RESUME_ROLE": "0x2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c7",
-        "rollupProviders": [
-          "0xA173BDdF4953C1E8be2cA0695CFc07502Ff3B1e7",
-          "0xD64791E747188b0e5061fC65b56Bf20FeE2e3321"
-        ],
-        "rollupStateHash": "0xdb86e1696a16af893e15fa495f12c340002fc26fa7a149a6c3c8269992e7bf08",
-        "verifier": "0x71c0Ab7dF00F00E4ec2990D4F1C8302c1D178f69",
         "getSupportedAsset": [
           "0x6B175474E89094C44Da98b954EedeAC495271d0F",
           "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0",
@@ -228,6 +214,7 @@
           "0x7C07F7aBe10CE8e33DC6C5aD68FE033085256A84",
           "0x378cb52b00F9D0921cb46dFc099CFf73b42419dC"
         ],
+        "getSupportedAssetsLength": 15,
         "getSupportedBridge": [
           "0xaeD181779A8AAbD8Ce996949853FEA442C2CDB47",
           "0x381abF150B53cc699f0dBBBEF3C5c0D1fA4B3Efd",
@@ -247,7 +234,20 @@
           "0x5594808e8A7b44da9D2382E6d72ad50a3e2571E0",
           "0x5594808e8A7b44da9D2382E6d72ad50a3e2571E0",
           "0xA915B9C104F865105Caa29E122C8e558cC22bd41"
-        ]
+        ],
+        "getSupportedBridgesLength": 18,
+        "lastRollupTimeStamp": 1697171759,
+        "LISTER_ROLE": "0xf94103142c1baabe9ac2b5d1487bf783de9e69cfeea9a72f5c9c94afd7877b8c",
+        "OWNER_ROLE": "0xb19546dff01e856fb3f010c267a7b1c60363cf8a4664e21cc89c26224620214e",
+        "paused": false,
+        "prevDefiInteractionsHash": "0x2af92273d78efd009fae4e0897c43f99376179a19d59997e5146c64b12da5e90",
+        "RESUME_ROLE": "0x2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c7",
+        "rollupProviders": [
+          "0xA173BDdF4953C1E8be2cA0695CFc07502Ff3B1e7",
+          "0xD64791E747188b0e5061fC65b56Bf20FeE2e3321"
+        ],
+        "rollupStateHash": "0xdb86e1696a16af893e15fa495f12c340002fc26fa7a149a6c3c8269992e7bf08",
+        "verifier": "0x71c0Ab7dF00F00E4ec2990D4F1C8302c1D178f69"
       },
       "derivedName": "RollupProcessorV2"
     }

--- a/packages/backend/discovery/dydx/ethereum/discovered.json
+++ b/packages/backend/discovery/dydx/ethereum/discovered.json
@@ -3,7 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 18282753,
   "configHash": "0x47112df1ee28df32b58382bb684b9b5696e568eba2d4f1fb8268d1e432381939",
-  "version": 2,
+  "version": 3,
   "contracts": [
     {
       "name": "MerkleDistributor",
@@ -13,6 +13,7 @@
         "implementation": "0xFE1d5439625a9524a80F66670733129E80E0C112",
         "admin": "0x6C5cd3aD7A16Ae207D221908E6b997d9B0DcD7b0"
       },
+      "implementations": ["0xFE1d5439625a9524a80F66670733129E80E0C112"],
       "sinceTimestamp": 1627709502,
       "values": {
         "accessControl": {
@@ -436,6 +437,7 @@
         "implementation": "0xBE607a58206180fef691bf1B5aE9670174284388",
         "admin": "0xAc5D8bCD13da463bea96c75f9085c4e40037F790"
       },
+      "implementations": ["0xBE607a58206180fef691bf1B5aE9670174284388"],
       "sinceTimestamp": 1627709656,
       "values": {
         "accessControl": {
@@ -539,6 +541,7 @@
         "implementation": "0x0AdA60E07717Ab19E4A466f5f0ac68A66e3995Ce",
         "admin": "0x40D6992cbd03E0DC1c2DE9606D29Cb245E737a5d"
       },
+      "implementations": ["0x0AdA60E07717Ab19E4A466f5f0ac68A66e3995Ce"],
       "sinceTimestamp": 1627708861,
       "values": {
         "owner": "0x64c7d40c07EFAbec2AafdC243bF59eaF2195c6dc",
@@ -575,6 +578,7 @@
         "implementation": "0x31D76F5Db8F40D28886Bf00F3be5F157472Bf77A",
         "admin": "0x6aaD0BCfbD91963Cf2c8FB042091fd411FB05b3C"
       },
+      "implementations": ["0x31D76F5Db8F40D28886Bf00F3be5F157472Bf77A"],
       "sinceTimestamp": 1627709015,
       "values": {
         "accessControl": {
@@ -904,6 +908,13 @@
           "0xa306989BA6BcacdECCf3C0614FfF2B8C668e3CaE"
         ]
       },
+      "implementations": [
+        "0x2C0df87E073755139101b35c0A51e065291cc2d3",
+        "0x5d8cC5659db74EEbF19aA2Bb39973F9339012AC5",
+        "0x3FeD7bF5Bf3E738bc30fBe61B048fDcb82368545",
+        "0xDF9c117Cad37F2ED8C99E36A40317D8CC340D4a0",
+        "0xc43f5526124877F9125E3B48101DcA6D7c6B4Ea3"
+      ],
       "sinceTimestamp": 1613033682,
       "values": {
         "configurationDelay": 0,

--- a/packages/backend/discovery/lzomnichain/ethereum/discovered.json
+++ b/packages/backend/discovery/lzomnichain/ethereum/discovered.json
@@ -892,12 +892,12 @@
         "isReceivingPayload": false,
         "isSendingPayload": false,
         "latestVersion": 3,
-        "owner": "0xCDa8e3ADD00c95E5035617F970096118Ca2F4C92",
         "libraryLookup": [
           "0x5B19bd330A84c049b62D5B0FC2bA120217a18C1C",
           "0x4D73AdB72bC3DD368966edD0f0b2148401A178E2",
           "0xbE4fB271cfB7bcbB47EA9573321c7bfe309fc220"
-        ]
+        ],
+        "owner": "0xCDa8e3ADD00c95E5035617F970096118Ca2F4C92"
       },
       "derivedName": "Endpoint"
     },

--- a/packages/backend/discovery/mantle/ethereum/discovered.json
+++ b/packages/backend/discovery/mantle/ethereum/discovered.json
@@ -49,11 +49,6 @@
         "minimumStakeSecondQuorum": 0,
         "NUMBER_OF_QUORUMS": 2,
         "numOperators": 10,
-        "owner": "0x2F44BD2a54aC3fB20cd7783cF94334069641daC9",
-        "permissionManager": "0xBcF6d8273DAF842b6Fc288b08E48C438Fa911D01",
-        "pubkeyCompendium": "0x92986cd63C3409b7dA2882624B6d6E7Cf660707a",
-        "serviceManager": "0x5BD63a7ECc13b955C4F57e3F12A64c10263C14c1",
-        "strategiesConsideredAndMultipliersLength": [1, 1],
         "operatorList": [
           "0x1888e4aC2Ab37A73B33448B87bABdD1ce1dcBAbe",
           "0x717c3DC6Df69c316d6Ac593077BC84Cc86f214A4",
@@ -65,7 +60,12 @@
           "0xcEb157a9bB9c80a845d5924e8CEAA591Caf705a5",
           "0x0B6F2C77C3740A5e6f88A4eCdd02C10BE8a2e323",
           "0x8A3D6c77E5BAcE8cb0822B28E4Fc56FC06fB5645"
-        ]
+        ],
+        "owner": "0x2F44BD2a54aC3fB20cd7783cF94334069641daC9",
+        "permissionManager": "0xBcF6d8273DAF842b6Fc288b08E48C438Fa911D01",
+        "pubkeyCompendium": "0x92986cd63C3409b7dA2882624B6d6E7Cf660707a",
+        "serviceManager": "0x5BD63a7ECc13b955C4F57e3F12A64c10263C14c1",
+        "strategiesConsideredAndMultipliersLength": [1, 1]
       },
       "derivedName": "BLSRegistry"
     },

--- a/packages/backend/discovery/metis/ethereum/config.jsonc
+++ b/packages/backend/discovery/metis/ethereum/config.jsonc
@@ -203,7 +203,7 @@
     "MToken": {
       // isOwner() compares caller to 0x00.. which gives true for call()
       // and returns false for multicall(). Let's ignore it.
-      "ignoreMethods": ["isOwner"] // 
+      "ignoreMethods": ["isOwner"]
     }
   }
 }

--- a/packages/backend/discovery/metis/ethereum/config.jsonc
+++ b/packages/backend/discovery/metis/ethereum/config.jsonc
@@ -6,7 +6,8 @@
   "names": {
     "0x10739F09f6e62689c0aA8A1878816de9e166d6f9": "ChainStorageContainer",
     "0xf209815E595Cdf3ed0aAF9665b1772e608AB9380": "StateCommitmentChain",
-    "0x48fE1f85ff8Ad9D088863A42Af54d06a1328cF21": "Metis Multisig"
+    "0x48fE1f85ff8Ad9D088863A42Af54d06a1328cF21": "Metis Multisig",
+    "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e": "MToken"
   },
   "overrides": {
     "0x918778e825747a892b17C66fe7D24C618262867d": {
@@ -198,6 +199,11 @@
     },
     "Metis Multisig": {
       "ignoreInWatchMode": ["nonce"]
+    },
+    "MToken": {
+      // isOwner() compares caller to 0x00.. which gives true for call()
+      // and returns false for multicall(). Let's ignore it.
+      "ignoreMethods": ["isOwner"] // 
     }
   }
 }

--- a/packages/backend/discovery/metis/ethereum/discovered.json
+++ b/packages/backend/discovery/metis/ethereum/discovered.json
@@ -2,7 +2,7 @@
   "name": "metis",
   "chain": "ethereum",
   "blockNumber": 18340232,
-  "configHash": "0x5eca465843ed06c8c121ad03b227879a4fa5953046064db3cc2eef2919673b14",
+  "configHash": "0x57741a5b03b4c4f6979a475f03c8d046003af59b7730a391c37b5fedc7dd8026",
   "version": 3,
   "contracts": [
     {
@@ -32,11 +32,11 @@
       "values": {
         "DEFAULT_CHAINID": 1088,
         "getGlobalMetadata": "0x0000000000000000000000000000000000006528f4bb0000884234",
-        "length": 18814,
-        "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
-        "owner": "StateCommitmentChain",
         "getGlobalMetadataByChainId": "0x0000000000000000000000000000000000006528f4bb0000884234",
-        "lengthByChainId": 18814
+        "length": 18814,
+        "lengthByChainId": 18814,
+        "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
+        "owner": "StateCommitmentChain"
       },
       "derivedName": "ChainStorageContainer"
     },
@@ -213,12 +213,12 @@
       "sinceTimestamp": 1607734167,
       "values": {
         "decimals": 18,
-        "isOwner": true,
         "name": "Metis Token",
         "owner": "0x0000000000000000000000000000000000000000",
         "symbol": "Metis",
         "totalSupply": "5410000510000000000000000"
-      }
+      },
+      "derivedName": "MToken"
     },
     {
       "name": "ChainStorageContainer",
@@ -231,11 +231,11 @@
         "DEFAULT_CHAINID": 1088,
         "get": [],
         "getGlobalMetadata": "0x000000000000000000000000000000000000000000000000000000",
-        "length": 0,
-        "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
-        "owner": "CanonicalTransactionChain",
         "getGlobalMetadataByChainId": "0x000000000000000000000000000000000000000000000000000000",
-        "lengthByChainId": 0
+        "length": 0,
+        "lengthByChainId": 0,
+        "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
+        "owner": "CanonicalTransactionChain"
       }
     },
     {
@@ -273,13 +273,13 @@
         "DEFAULT_CHAINID": 1088,
         "FRAUD_PROOF_WINDOW": 604800,
         "getLastSequencerTimestamp": 1697182907,
-        "getTotalBatches": 18814,
-        "getTotalElements": 8929844,
-        "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
-        "SEQUENCER_PUBLISH_WINDOW": 12592000,
         "getLastSequencerTimestampByChainId": 1697182907,
+        "getTotalBatches": 18814,
         "getTotalBatchesByChainId": 18814,
-        "getTotalElementsByChainId": 8929844
+        "getTotalElements": 8929844,
+        "getTotalElementsByChainId": 8929844,
+        "libAddressManager": "0x918778e825747a892b17C66fe7D24C618262867d",
+        "SEQUENCER_PUBLISH_WINDOW": 12592000
       },
       "derivedName": "StateCommitmentChain"
     },

--- a/packages/backend/discovery/nova/ethereum/discovered.json
+++ b/packages/backend/discovery/nova/ethereum/discovered.json
@@ -468,8 +468,6 @@
         "outbox": "0xD4B80C3D7240325D18E645B49e6535A3Bf95cc58",
         "owner": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd",
         "paused": false,
-        "requireUnresolved": [],
-        "requireUnresolvedExists": [],
         "rollupDeploymentBlock": 15016829,
         "rollupEventInbox": "0x304807A7ed6c1296df2128E6ff3836e477329CD2",
         "sequencerInbox": "0x211E1c4c7f1bF5351Ac850Ed10FD68CFfCF6c21b",

--- a/packages/backend/discovery/opticsV2/ethereum/discovered.json
+++ b/packages/backend/discovery/opticsV2/ethereum/discovered.json
@@ -206,9 +206,9 @@
         "recoveryActiveAt": 0,
         "recoveryManager": "0x2bB2a5A724170357cb691841F40d26A950d8C33D",
         "recoveryTimelock": 1209600,
+        "routers": "0x000000000000000000000000d13ac1024d266b73180ca7445ca0e78b3acfe8ce",
         "VERSION": 0,
-        "xAppConnectionManager": "0x8A926cE79f83A5A4C234BeE93feAFCC85b1E40cD",
-        "routers": "0x000000000000000000000000d13ac1024d266b73180ca7445ca0e78b3acfe8ce"
+        "xAppConnectionManager": "0x8A926cE79f83A5A4C234BeE93feAFCC85b1E40cD"
       },
       "derivedName": "GovernanceRouter"
     }

--- a/packages/backend/discovery/polynetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/polynetwork/ethereum/discovered.json
@@ -128,9 +128,6 @@
         "chainId": 2,
         "feeCollector": "0x0E860F44d73F9FDbaF5E9B19aFC554Bf3C8E8A57",
         "isOwner": false,
-        "maxLockProxyIndex": 7,
-        "owner": "0x0E860F44d73F9FDbaF5E9B19aFC554Bf3C8E8A57",
-        "paused": false,
         "lockProxyIndexMap": [
           "0x250e76987d838a75310c34bf422ea9f1AC4Cc906",
           "0x7b9Bb72F187B3cb2CaA9Cf1cE95A938f0a66DB54",
@@ -139,7 +136,10 @@
           "0xf6378141BC900020a438F3914e4C3ceA29907b27",
           "0x669E211454Ee9AAaf4C229A8985F5D20D3B5d1BC",
           "0x51ba447DaD1de30b91286471BcB570F69ECE968D"
-        ]
+        ],
+        "maxLockProxyIndex": 7,
+        "owner": "0x0E860F44d73F9FDbaF5E9B19aFC554Bf3C8E8A57",
+        "paused": false
       },
       "derivedName": "PolyWrapper"
     },

--- a/packages/backend/discovery/portal/ethereum/discovered.json
+++ b/packages/backend/discovery/portal/ethereum/discovered.json
@@ -73,12 +73,6 @@
         "getGuardianSetExpiry": 0,
         "governanceChainId": 1,
         "governanceContract": "0x0000000000000000000000000000000000000000000000000000000000000004",
-        "isFork": false,
-        "messageFee": 0,
-        "quorum": [
-          1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11, 12, 13, 13, 14,
-          15, 15, 16, 17, 17, 18, 19, 19, 20
-        ],
         "guardianSet": [
           [
             "0x58CC3AE5C097b213cE3c81979e1B9f9570746AA5",
@@ -102,6 +96,12 @@
             "0x6FbEBc898F403E4773E95feB15E80C9A99c8348d"
           ],
           0
+        ],
+        "isFork": false,
+        "messageFee": 0,
+        "quorum": [
+          1, 1, 2, 3, 3, 4, 5, 5, 6, 7, 7, 8, 9, 9, 10, 11, 11, 12, 13, 13, 14,
+          15, 15, 16, 17, 17, 18, 19, 19, 20
         ]
       },
       "derivedName": "Implementation"

--- a/packages/backend/discovery/stargate/ethereum/discovered.json
+++ b/packages/backend/discovery/stargate/ethereum/discovered.json
@@ -13,10 +13,6 @@
       },
       "sinceTimestamp": 1647504676,
       "values": {
-        "allPoolsLength": 12,
-        "defaultFeeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
-        "owner": "0x65bb797c2B9830d891D87288F029ed8dACc19705",
-        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
         "allPools": [
           "0xdf0770dF86a8034b3EFEf0A1Bb3c889B8332FF56",
           "0x38EA452219524Bb87e18dE1C24D3bB59510BD783",
@@ -30,7 +26,11 @@
           "0xd8772edBF88bBa2667ed011542343b0eDDaCDa47",
           "0x430Ebff5E3E80A6C58E7e6ADA1d90F5c28AA116d",
           "0x1CE66c52C36757Daf6551eDc04800A0Ec9983A09"
-        ]
+        ],
+        "allPoolsLength": 12,
+        "defaultFeeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
+        "owner": "0x65bb797c2B9830d891D87288F029ed8dACc19705",
+        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98"
       },
       "derivedName": "Factory"
     },
@@ -44,6 +44,10 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [true, 111, 3, 6000, 99496914172, 54761770454, 0, 99047900899],
+          [true, 109, 3, 4000, 85085341776, 41206346063, 0, 136891892331]
+        ],
         "convertRate": 1000000000000,
         "decimals": 6,
         "defaultLPMode": false,
@@ -67,11 +71,7 @@
         "token": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
         "totalLiquidity": 336236743772,
         "totalSupply": 336229630938,
-        "totalWeight": 10000,
-        "chainPaths": [
-          [true, 111, 3, 6000, 99496914172, 54761770454, 0, 99047900899],
-          [true, 109, 3, 4000, 85085341776, 41206346063, 0, 136891892331]
-        ]
+        "totalWeight": 10000
       },
       "derivedName": "Pool"
     },
@@ -85,30 +85,6 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
-        "convertRate": 1,
-        "decimals": 18,
-        "defaultLPMode": false,
-        "defaultSwapMode": false,
-        "deltaCredit": "488748432362629156997",
-        "eqFeePool": "6332880753174241946",
-        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
-        "getChainPathsLength": 6,
-        "localDecimals": 18,
-        "lpDeltaBP": 500,
-        "mintFeeBalance": 0,
-        "mintFeeBP": 0,
-        "name": "Stargate Ether Vault-LP",
-        "poolId": 13,
-        "protocolFeeBalance": "9914313581258940172",
-        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
-        "sharedDecimals": 18,
-        "stopSwap": false,
-        "swapDeltaBP": 500,
-        "symbol": "S*SGETH",
-        "token": "0x72E2F4830b9E45d52F80aC08CB2bEC0FeF72eD9c",
-        "totalLiquidity": "10904693910448351966829",
-        "totalSupply": "10903802123831834846908",
-        "totalWeight": 12250,
         "chainPaths": [
           [true, 11, 13, 0, 0, 0, 0, 0],
           [true, 10, 13, 0, 0, 0, 0, 0],
@@ -152,7 +128,31 @@
             0,
             "37833708505838754596"
           ]
-        ]
+        ],
+        "convertRate": 1,
+        "decimals": 18,
+        "defaultLPMode": false,
+        "defaultSwapMode": false,
+        "deltaCredit": "488748432362629156997",
+        "eqFeePool": "6332880753174241946",
+        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
+        "getChainPathsLength": 6,
+        "localDecimals": 18,
+        "lpDeltaBP": 500,
+        "mintFeeBalance": 0,
+        "mintFeeBP": 0,
+        "name": "Stargate Ether Vault-LP",
+        "poolId": 13,
+        "protocolFeeBalance": "9914313581258940172",
+        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
+        "sharedDecimals": 18,
+        "stopSwap": false,
+        "swapDeltaBP": 500,
+        "symbol": "S*SGETH",
+        "token": "0x72E2F4830b9E45d52F80aC08CB2bEC0FeF72eD9c",
+        "totalLiquidity": "10904693910448351966829",
+        "totalSupply": "10903802123831834846908",
+        "totalWeight": 12250
       },
       "derivedName": "Pool"
     },
@@ -166,30 +166,6 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
-        "convertRate": 1,
-        "decimals": 18,
-        "defaultLPMode": false,
-        "defaultSwapMode": false,
-        "deltaCredit": "62224885687691679755290",
-        "eqFeePool": "381146136996511391005",
-        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
-        "getChainPathsLength": 6,
-        "localDecimals": 18,
-        "lpDeltaBP": 250,
-        "mintFeeBalance": 0,
-        "mintFeeBP": 0,
-        "name": "Wootrade Network-LP",
-        "poolId": 20,
-        "protocolFeeBalance": "56001722362230329919",
-        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
-        "sharedDecimals": 18,
-        "stopSwap": false,
-        "swapDeltaBP": 250,
-        "symbol": "S*WOO",
-        "token": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
-        "totalLiquidity": "18647074850810089906963",
-        "totalSupply": "18633864400320544730901",
-        "totalWeight": 6,
         "chainPaths": [
           [
             true,
@@ -251,7 +227,31 @@
             "4221311694413335898517",
             "1210064641185105807062"
           ]
-        ]
+        ],
+        "convertRate": 1,
+        "decimals": 18,
+        "defaultLPMode": false,
+        "defaultSwapMode": false,
+        "deltaCredit": "62224885687691679755290",
+        "eqFeePool": "381146136996511391005",
+        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
+        "getChainPathsLength": 6,
+        "localDecimals": 18,
+        "lpDeltaBP": 250,
+        "mintFeeBalance": 0,
+        "mintFeeBP": 0,
+        "name": "Wootrade Network-LP",
+        "poolId": 20,
+        "protocolFeeBalance": "56001722362230329919",
+        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
+        "sharedDecimals": 18,
+        "stopSwap": false,
+        "swapDeltaBP": 250,
+        "symbol": "S*WOO",
+        "token": "0x4691937a7508860F876c9c0a2a617E7d9E945D4B",
+        "totalLiquidity": "18647074850810089906963",
+        "totalSupply": "18633864400320544730901",
+        "totalWeight": 6
       },
       "derivedName": "Pool"
     },
@@ -295,30 +295,6 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
-        "convertRate": 1,
-        "decimals": 6,
-        "defaultLPMode": false,
-        "defaultSwapMode": false,
-        "deltaCredit": 1256930872660,
-        "eqFeePool": 140437727,
-        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
-        "getChainPathsLength": 25,
-        "localDecimals": 6,
-        "lpDeltaBP": 500,
-        "mintFeeBalance": 0,
-        "mintFeeBP": 0,
-        "name": "Tether USD-LP",
-        "poolId": 2,
-        "protocolFeeBalance": 6057076643,
-        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
-        "sharedDecimals": 6,
-        "stopSwap": false,
-        "swapDeltaBP": 500,
-        "symbol": "S*USDT",
-        "token": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-        "totalLiquidity": 48145636880583,
-        "totalSupply": 48094819848599,
-        "totalWeight": 11000,
         "chainPaths": [
           [true, 6, 1, 0, 0, 0, 0, 0],
           [true, 6, 2, 0, 0, 0, 0, 0],
@@ -345,7 +321,31 @@
           [true, 112, 21, 0, 0, 0, 0, 0],
           [true, 184, 1, 500, 191210299895, 2205957683120, 0, 229605996045],
           [true, 177, 2, 500, 0, 0, 2275788265750, 0]
-        ]
+        ],
+        "convertRate": 1,
+        "decimals": 6,
+        "defaultLPMode": false,
+        "defaultSwapMode": false,
+        "deltaCredit": 1256930872660,
+        "eqFeePool": 140437727,
+        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
+        "getChainPathsLength": 25,
+        "localDecimals": 6,
+        "lpDeltaBP": 500,
+        "mintFeeBalance": 0,
+        "mintFeeBP": 0,
+        "name": "Tether USD-LP",
+        "poolId": 2,
+        "protocolFeeBalance": 6057076643,
+        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
+        "sharedDecimals": 6,
+        "stopSwap": false,
+        "swapDeltaBP": 500,
+        "symbol": "S*USDT",
+        "token": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+        "totalLiquidity": 48145636880583,
+        "totalSupply": 48094819848599,
+        "totalWeight": 11000
       },
       "derivedName": "Pool"
     },
@@ -359,6 +359,9 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [true, 151, 19, 1, 479703515398, 136755653065, 0, 479703515398]
+        ],
         "convertRate": 1,
         "decimals": 6,
         "defaultLPMode": false,
@@ -382,10 +385,7 @@
         "token": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
         "totalLiquidity": 1356965779710,
         "totalSupply": 1356755945392,
-        "totalWeight": 1,
-        "chainPaths": [
-          [true, 151, 19, 1, 479703515398, 136755653065, 0, 479703515398]
-        ]
+        "totalWeight": 1
       },
       "derivedName": "Pool"
     },
@@ -422,6 +422,9 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [true, 111, 14, 1, 88271816551, 27812608353, 0, 71338239570]
+        ],
         "convertRate": 1000000000000,
         "decimals": 6,
         "defaultLPMode": false,
@@ -445,10 +448,7 @@
         "token": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
         "totalLiquidity": 81687596412,
         "totalSupply": 81671391768,
-        "totalWeight": 1,
-        "chainPaths": [
-          [true, 111, 14, 1, 88271816551, 27812608353, 0, 71338239570]
-        ]
+        "totalWeight": 1
       },
       "derivedName": "Pool"
     },
@@ -521,6 +521,19 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [true, 2, 11, 0, 0, 0, 0, 0],
+          [
+            true,
+            102,
+            11,
+            1,
+            "992722863555684261192581",
+            "995674005448033705697379",
+            0,
+            "1000383369432597449883646"
+          ]
+        ],
         "convertRate": 1,
         "decimals": 18,
         "defaultLPMode": false,
@@ -544,20 +557,7 @@
         "token": "0x0C10bF8FcB7Bf5412187A595ab97a3609160b5c6",
         "totalLiquidity": "1001172309172618842512034",
         "totalSupply": "1001018613455916062544920",
-        "totalWeight": 1,
-        "chainPaths": [
-          [true, 2, 11, 0, 0, 0, 0, 0],
-          [
-            true,
-            102,
-            11,
-            1,
-            "992722863555684261192581",
-            "995674005448033705697379",
-            0,
-            "1000383369432597449883646"
-          ]
-        ]
+        "totalWeight": 1
       },
       "derivedName": "Pool"
     },
@@ -617,6 +617,23 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [true, 106, 16, 1, 94784633182, 90804473943, 0, 83503296297],
+          [true, 111, 16, 1, 38110701165, 88988982959, 0, 183941813782],
+          [
+            true,
+            102,
+            16,
+            1,
+            94948043174,
+            25410034760,
+            58066994037,
+            83558210465
+          ],
+          [true, 110, 16, 1, 226016195834, 83476593647, 435150, 83738473339],
+          [true, 109, 16, 1, 269596369586, 83476949963, 78834, 417071932065],
+          [true, 151, 16, 1, 1177796472, 83476593647, 435150, 25002666694]
+        ],
         "convertRate": 1000000000000,
         "decimals": 6,
         "defaultLPMode": false,
@@ -640,24 +657,7 @@
         "token": "0x8D6CeBD76f18E1558D4DB88138e2DeFB3909fAD6",
         "totalLiquidity": 500862172782,
         "totalSupply": 500677133607,
-        "totalWeight": 6,
-        "chainPaths": [
-          [true, 106, 16, 1, 94784633182, 90804473943, 0, 83503296297],
-          [true, 111, 16, 1, 38110701165, 88988982959, 0, 183941813782],
-          [
-            true,
-            102,
-            16,
-            1,
-            94948043174,
-            25410034760,
-            58066994037,
-            83558210465
-          ],
-          [true, 110, 16, 1, 226016195834, 83476593647, 435150, 83738473339],
-          [true, 109, 16, 1, 269596369586, 83476949963, 78834, 417071932065],
-          [true, 151, 16, 1, 1177796472, 83476593647, 435150, 25002666694]
-        ]
+        "totalWeight": 6
       },
       "derivedName": "Pool"
     },
@@ -696,6 +696,28 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [
+            true,
+            102,
+            17,
+            0,
+            "28039408689374173025356",
+            1433941682010602,
+            0,
+            "26884557183508763951068"
+          ],
+          [
+            true,
+            151,
+            17,
+            1,
+            "313521409411276632573",
+            "247459469621323200674",
+            0,
+            "8047075031461657256297"
+          ]
+        ],
         "convertRate": 1,
         "decimals": 18,
         "defaultLPMode": false,
@@ -719,29 +741,7 @@
         "token": "0x9E32b13ce7f2E80A01932B42553652E053D6ed8e",
         "totalLiquidity": "860549880629724402679",
         "totalSupply": "860159211606059216193",
-        "totalWeight": 1,
-        "chainPaths": [
-          [
-            true,
-            102,
-            17,
-            0,
-            "28039408689374173025356",
-            1433941682010602,
-            0,
-            "26884557183508763951068"
-          ],
-          [
-            true,
-            151,
-            17,
-            1,
-            "313521409411276632573",
-            "247459469621323200674",
-            0,
-            "8047075031461657256297"
-          ]
-        ]
+        "totalWeight": 1
       },
       "derivedName": "Pool"
     },
@@ -755,30 +755,6 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
-        "convertRate": 1,
-        "decimals": 6,
-        "defaultLPMode": false,
-        "defaultSwapMode": false,
-        "deltaCredit": 1979029582188,
-        "eqFeePool": 16931936789,
-        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
-        "getChainPathsLength": 24,
-        "localDecimals": 6,
-        "lpDeltaBP": 500,
-        "mintFeeBalance": 0,
-        "mintFeeBP": 0,
-        "name": "USD Coin-LP",
-        "poolId": 1,
-        "protocolFeeBalance": 10729627043,
-        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
-        "sharedDecimals": 6,
-        "stopSwap": false,
-        "swapDeltaBP": 500,
-        "symbol": "S*USDC",
-        "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-        "totalLiquidity": 46857587639893,
-        "totalSupply": 46822086359727,
-        "totalWeight": 10501,
         "chainPaths": [
           [true, 6, 1, 0, 0, 0, 0, 0],
           [true, 6, 2, 0, 0, 0, 0, 0],
@@ -804,7 +780,31 @@
           [true, 110, 2, 592, 572427909489, 1558663680712, 0, 572172321621],
           [true, 112, 21, 0, 0, 0, 0, 0],
           [true, 184, 1, 500, 130263489016, 515799528665, 0, 209899370536]
-        ]
+        ],
+        "convertRate": 1,
+        "decimals": 6,
+        "defaultLPMode": false,
+        "defaultSwapMode": false,
+        "deltaCredit": 1979029582188,
+        "eqFeePool": 16931936789,
+        "feeLibrary": "0x8C3085D9a554884124C998CDB7f6d7219E9C1e6F",
+        "getChainPathsLength": 24,
+        "localDecimals": 6,
+        "lpDeltaBP": 500,
+        "mintFeeBalance": 0,
+        "mintFeeBP": 0,
+        "name": "USD Coin-LP",
+        "poolId": 1,
+        "protocolFeeBalance": 10729627043,
+        "router": "0x8731d54E9D02c286767d56ac03e8037C07e01e98",
+        "sharedDecimals": 6,
+        "stopSwap": false,
+        "swapDeltaBP": 500,
+        "symbol": "S*USDC",
+        "token": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+        "totalLiquidity": 46857587639893,
+        "totalSupply": 46822086359727,
+        "totalWeight": 10501
       },
       "derivedName": "Pool"
     },
@@ -818,6 +818,10 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [true, 111, 15, 1, 3255415220, 6439751638, 0, 1697328510],
+          [true, 110, 15, 1, 6013865470, 7670168530, 0, 2855983061]
+        ],
         "convertRate": 1000000000000,
         "decimals": 6,
         "defaultLPMode": false,
@@ -841,11 +845,7 @@
         "token": "0x5f98805A4E8be255a32880FDeC7F6728C6568bA0",
         "totalLiquidity": 106884291552,
         "totalSupply": 106864849709,
-        "totalWeight": 2,
-        "chainPaths": [
-          [true, 111, 15, 1, 3255415220, 6439751638, 0, 1697328510],
-          [true, 110, 15, 1, 6013865470, 7670168530, 0, 2855983061]
-        ]
+        "totalWeight": 2
       },
       "derivedName": "Pool"
     },
@@ -859,6 +859,11 @@
       "values": {
         "batched": true,
         "BP_DENOMINATOR": 10000,
+        "chainPaths": [
+          [true, 111, 7, 1829, 113199927895, 71138602717, 0, 134489682895],
+          [true, 106, 7, 4489, 584068941801, 170529228611, 0, 384231728233],
+          [true, 110, 7, 3682, 4690088266, 138906075998, 0, 165099545004]
+        ],
         "convertRate": 1000000000000,
         "decimals": 6,
         "defaultLPMode": false,
@@ -882,12 +887,7 @@
         "token": "0x853d955aCEf822Db058eb8505911ED77F175b99e",
         "totalLiquidity": 171126841012,
         "totalSupply": 171124407564,
-        "totalWeight": 10000,
-        "chainPaths": [
-          [true, 111, 7, 1829, 113199927895, 71138602717, 0, 134489682895],
-          [true, 106, 7, 4489, 584068941801, 170529228611, 0, 384231728233],
-          [true, 110, 7, 3682, 4690088266, 138906075998, 0, 165099545004]
-        ]
+        "totalWeight": 10000
       },
       "derivedName": "Pool"
     }


### PR DESCRIPTION
Since our discovery supports multicall, function ordering has been fixed to be always alphabetical (and some other issues been fixed, see PRs in tools). This PR is just rerunning discovery with the most recent discovery version on existing projects, and the same block number, to update the output. A tiny fix was needed for metis (irrelevant for update monitoring).