### PR TITLE
Add ChainId to ProjectDiscovery constructor

### DIFF
--- a/packages/config/src/discovery/ProjectDiscovery.test.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.test.ts
@@ -1,3 +1,4 @@
+import { ChainId } from '@l2beat/shared-pure'
 import { expect, mockObject } from 'earl'
 
 import { contractStub, discoveredJsonStub } from '../test/stubs/discoveredJson'
@@ -8,7 +9,11 @@ describe(ProjectDiscovery.name, () => {
     readFileSync: () => JSON.stringify(discoveredJsonStub),
   })
   const projectName = 'ExampleProject'
-  const discovery = new ProjectDiscovery('ExampleProject', fsMock)
+  const discovery = new ProjectDiscovery(
+    'ExampleProject',
+    ChainId.ETHEREUM,
+    fsMock,
+  )
 
   describe(ProjectDiscovery.prototype.getContract.name, () => {
     it('should return contract for given address', () => {
@@ -103,4 +108,22 @@ describe(ProjectDiscovery.name, () => {
       })
     },
   )
+
+  it('reads configurations for different chainIds', () => {
+    const fsMock = mockObject<Filesystem>({
+      readFileSync: () => JSON.stringify(discoveredJsonStub),
+    })
+    const discovery = new ProjectDiscovery(
+      'ExampleProject',
+      ChainId.ARBITRUM,
+      fsMock,
+    )
+    const contract = discovery.getContract(contractStub.address)
+
+    expect(JSON.stringify(contract)).toEqual(JSON.stringify(contractStub))
+    expect(fsMock.readFileSync).toHaveBeenNthCalledWith(
+      1,
+      expect.includes('/ExampleProject/arbitrum/'),
+    )
+  })
 })

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -10,6 +10,7 @@ import type {
 } from '@l2beat/discovery-types'
 import {
   assert,
+  ChainId,
   EthereumAddress,
   gatherAddressesFromUpgradeability,
   UnixTime,
@@ -64,6 +65,7 @@ export class ProjectDiscovery {
   private readonly config: DiscoveryConfig
   constructor(
     public readonly projectName: string,
+    public readonly chainId: ChainId = ChainId.ETHEREUM,
     private readonly fs: Filesystem = filesystem,
   ) {
     this.discovery = this.getDiscoveryJson(projectName)
@@ -72,7 +74,11 @@ export class ProjectDiscovery {
 
   private getDiscoveryJson(project: string): DiscoveryOutput {
     const discoveryFile = this.fs.readFileSync(
-      path.resolve(`../backend/discovery/${project}/ethereum/discovered.json`),
+      path.resolve(
+        `../backend/discovery/${project}/${ChainId.getName(
+          this.chainId,
+        )}/discovered.json`,
+      ),
     )
 
     return JSON.parse(discoveryFile) as DiscoveryOutput
@@ -80,7 +86,11 @@ export class ProjectDiscovery {
 
   private getConfigJson(project: string): DiscoveryConfig {
     const configFile = this.fs.readFileSync(
-      path.resolve(`../backend/discovery/${project}/ethereum/config.jsonc`),
+      path.resolve(
+        `../backend/discovery/${project}/${ChainId.getName(
+          this.chainId,
+        )}/config.jsonc`,
+      ),
     )
 
     const errors: ParseError[] = []


### PR DESCRIPTION
Resolves L2B-2935

Now you can includes contracts, permissions and other things from the `discovered.json` on other chains. To do that simply create a new variable in the `.ts` configuration file with the second argument being equal to the chain ID that you want to read the discovery for. For example to read the `discovered.json` for Arbitrum that is discovered on Arbitrum not on Ethereum you could create the following variable:

```typescript
const discoveryL2 = new ProjectDiscovery('arbitrum', ChainId.ARBITRUM)
discoveryL2.getContractDetails(...) // Just use it as you would the normal `discovery` object
```