### PR TITLE
Fix flaky sanity checks

### DIFF
--- a/packages/backend/src/core/discovery/UpdateMonitor.test.ts
+++ b/packages/backend/src/core/discovery/UpdateMonitor.test.ts
@@ -649,6 +649,7 @@ const mockDiff: DiscoveryDiff[] = [
 ]
 
 const OPTIONS: DiscoveryRunnerOptions = {
+  logger: Logger.SILENT,
   runSanityCheck: true,
   injectInitialAddresses: true,
 }

--- a/packages/backend/src/core/discovery/UpdateMonitor.test.ts
+++ b/packages/backend/src/core/discovery/UpdateMonitor.test.ts
@@ -649,7 +649,7 @@ const mockDiff: DiscoveryDiff[] = [
 ]
 
 const OPTIONS: DiscoveryRunnerOptions = {
-  logger: Logger.SILENT,
+  logger: Logger.SILENT.for("UpdateMonitor"),
   runSanityCheck: true,
   injectInitialAddresses: true,
 }

--- a/packages/backend/src/core/discovery/UpdateMonitor.test.ts
+++ b/packages/backend/src/core/discovery/UpdateMonitor.test.ts
@@ -649,7 +649,7 @@ const mockDiff: DiscoveryDiff[] = [
 ]
 
 const OPTIONS: DiscoveryRunnerOptions = {
-  logger: Logger.SILENT.for("UpdateMonitor"),
+  logger: Logger.SILENT.for('UpdateMonitor'),
   runSanityCheck: true,
   injectInitialAddresses: true,
 }

--- a/packages/backend/src/core/discovery/UpdateMonitor.ts
+++ b/packages/backend/src/core/discovery/UpdateMonitor.ts
@@ -128,6 +128,7 @@ export class UpdateMonitor {
     )
 
     const discovery = await runner.run(projectConfig, blockNumber, {
+      logger: this.logger,
       runSanityCheck: true,
       injectInitialAddresses: true,
     })
@@ -204,6 +205,7 @@ export class UpdateMonitor {
       },
     )
     return await runner.run(projectConfig, previousDiscovery.blockNumber, {
+      logger: this.logger,
       runSanityCheck: true,
       injectInitialAddresses: true,
     })


### PR DESCRIPTION
Resolves L2B-3018

We (me and @antooni) believe that the errors seen on Sentry were not from the discovery step itself but from the sanity checks that follow it. On papertrail I've noticed that for the discovery part there were no retries and the discovery finished successfully on first try. A few seconds after that successful discovery, it looked like a new discovery on the same project has been started that when it threw a single error it crashed the whole update for that project. It aligns with what we see in the code, `sanityCheck` used `discover` a not the `discoverWithRetries` that does error catching. It has been confirmed with a test that this case is problematic and `sanityCheck` has been switched to use `discoverWithRetries`.