### PR TITLE
Skip updating the diff history file if any configuration done

### DIFF
--- a/packages/backend/src/tools/updateDiffHistory.ts
+++ b/packages/backend/src/tools/updateDiffHistory.ts
@@ -22,9 +22,11 @@ import { rimraf } from 'rimraf'
 void updateDiffHistoryFile()
 
 async function updateDiffHistoryFile() {
-  if(process.argv.filter((v) => v.startsWith('-')).length > 0) {
-      console.log("Discovery run with non-default configuration, skipping updating the diff history file...")
-      process.exit(0)
+  if (process.argv.filter((v) => v.startsWith('-')).length > 0) {
+    console.log(
+      'Discovery run with non-default configuration, skipping updating the diff history file...',
+    )
+    process.exit(0)
   }
 
   console.log('Updating diff history file...')

--- a/packages/backend/src/tools/updateDiffHistory.ts
+++ b/packages/backend/src/tools/updateDiffHistory.ts
@@ -22,6 +22,11 @@ import { rimraf } from 'rimraf'
 void updateDiffHistoryFile()
 
 async function updateDiffHistoryFile() {
+  if(process.argv.filter((v) => v.startsWith('-')).length > 0) {
+      console.log("Discovery run with non-default configuration, skipping updating the diff history file...")
+      process.exit(0)
+  }
+
   console.log('Updating diff history file...')
   const params = process.argv.filter((v) => !v.startsWith('-'))
   const chainName = params[2]


### PR DESCRIPTION
Resolves L2B-3020

This solution will skip running the update of the diff history file when any argument is given to the actual discovery. My thinking about why we want this goes like this:

(All possible configuration options that you can send to discovery)
- `--help`, nothing changed because we didn't even run discovery, no diff will ever be generated
- `--dry-run`, nothing is written to the disk, changes are shown on terminal, no diff will ever be generated
- `--dev`, if any changes are actually written to disk they are because of us, no external diff are generated here
- `--block-number`, most of the time this is used for going back in time, the generated diff would be backwards, we don't want that
- `--sources-folder`, if we save source code to a new directory, the updating of the diff will fail because it assumes that sources are stored at `.code`
- `--discovery-filename`, the entire discovery will be written to a different place, the comparison will be inadequate, because the script assumes that new changes are in `discovered.json`

This reasoning led me to suggest that we should skip updating the `diffHistory.md` if any customisation argument is provided.