### PR TITLE
Implement anomaly indicator changes

### DIFF
--- a/packages/frontend/src/components/AnomalyIndicator.tsx
+++ b/packages/frontend/src/components/AnomalyIndicator.tsx
@@ -45,20 +45,11 @@ export function AnomalyIndicator({ anomalyEntries }: Props) {
     (anomaly) => anomaly.isAnomaly,
   ) as AnomalyEntry[]
 
-  const shouldShowTooltip = data.length > 0
-
   return (
     <span
-      className={classNames(
-        'flex h-6 w-min gap-x-0.5',
-        shouldShowTooltip && 'Tooltip',
-      )}
-      title={
-        shouldShowTooltip
-          ? renderToStaticMarkup(<AnomalyTooltip anomalyEntries={data} />)
-          : undefined
-      }
-      data-tooltip-big={shouldShowTooltip}
+      className="Tooltip flex h-6 w-min gap-x-0.5"
+      title={renderToStaticMarkup(<AnomalyTooltip anomalyEntries={data} />)}
+      data-tooltip-big={true}
       data-testid="anomaly-indicator"
     >
       {anomalyEntries.map((anomaly, i) => (
@@ -78,6 +69,11 @@ function AnomalyTooltip(props: { anomalyEntries: AnomalyEntry[] }) {
   const anomalies = props.anomalyEntries
     .flatMap((anomalyEntry) => anomalyEntry.anomalies)
     .reverse()
+
+  if (anomalies.length === 0) {
+    return <div>No anomalies detected in the last 30 days</div>
+  }
+
   return (
     <div>
       <span>Anomalies from last 30 days:</span>

--- a/packages/frontend/src/components/AnomalyIndicator.tsx
+++ b/packages/frontend/src/components/AnomalyIndicator.tsx
@@ -8,6 +8,7 @@ import { DurationCell } from './table/DurationCell'
 
 interface Props {
   anomalyEntries: AnomalyIndicatorEntry[]
+  showComingSoon?: boolean
 }
 
 export type AnomalyIndicatorEntry = AnomalyEntry | NonAnomalyEntry
@@ -27,7 +28,22 @@ interface NonAnomalyEntry {
   isAnomaly: false
 }
 
-export function AnomalyIndicator({ anomalyEntries }: Props) {
+export function AnomalyIndicator({ anomalyEntries, showComingSoon }: Props) {
+  if (showComingSoon) {
+    return (
+      <div className="w-min select-none text-center">
+        <div className="mx-auto text-gray-500 dark:text-gray-50">
+          Coming soon
+        </div>
+        <div className="flex gap-x-0.5">
+          {range(30).map((_, i) => (
+            <div key={i} className="h-0.5 w-0.5 rounded-full bg-neutral-700" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
   if (anomalyEntries.length === 0) {
     return (
       <div className="w-min select-none text-center">

--- a/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
+++ b/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
@@ -611,7 +611,9 @@ export function getScalingLivenessColumnsConfig() {
         <AnomalyIndicator
           anomalyEntries={project.anomalyEntries}
           showComingSoon={
-            project.slug === 'starknet' || project.slug === 'zksync-era'
+            project.slug === 'starknet' ||
+            project.slug === 'zksync-era' ||
+            project.slug === 'linea'
           }
         />
       ),

--- a/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
+++ b/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
@@ -608,7 +608,12 @@ export function getScalingLivenessColumnsConfig() {
         'Anomalies are based on a Z-score. It measures how far away a data point is from a 30-day rolling average. We consider as anomalies the data points with Z-score > 15.',
       alignCenter: true,
       getValue: (project) => (
-        <AnomalyIndicator anomalyEntries={project.anomalyEntries} />
+        <AnomalyIndicator
+          anomalyEntries={project.anomalyEntries}
+          showComingSoon={
+            project.slug === 'starknet' || project.slug === 'zksync-era'
+          }
+        />
       ),
     },
   ]


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c3b30bc</samp>

Added a `showComingSoon` prop to the `AnomalyIndicator` component to indicate projects with partial anomaly detection support. Updated the scaling table to use this prop for the relevant projects.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c3b30bc</samp>

*  Add optional `showComingSoon` prop to `AnomalyIndicator` component to display a "Coming soon" message for some projects ([link](https://github.com/l2beat/l2beat/pull/2202/files?diff=unified&w=0#diff-66c54063d39e38bf596f4d657625d273140e74c782c8d938f34434f52342e8d3R11), [link](https://github.com/l2beat/l2beat/pull/2202/files?diff=unified&w=0#diff-66c54063d39e38bf596f4d657625d273140e74c782c8d938f34434f52342e8d3L30-R46))
* Simplify `AnomalyIndicator` component to always use `Tooltip` and `AnomalyTooltip` for title attribute ([link](https://github.com/l2beat/l2beat/pull/2202/files?diff=unified&w=0#diff-66c54063d39e38bf596f4d657625d273140e74c782c8d938f34434f52342e8d3L48-R68))
* Modify `AnomalyTooltip` component to return a default message of "No anomalies detected in the last 30 days" if there are no anomalies ([link](https://github.com/l2beat/l2beat/pull/2202/files?diff=unified&w=0#diff-66c54063d39e38bf596f4d657625d273140e74c782c8d938f34434f52342e8d3R88-R92))
* Pass `showComingSoon` prop to `AnomalyIndicator` component in `getScalingLivenessColumnsConfig` function in `getScalingTableColumnsConfig.tsx` file ([link](https://github.com/l2beat/l2beat/pull/2202/files?diff=unified&w=0#diff-752eb6e1932ca22e3d274ed23387fa20d3c7233dd84b50baca187382ab8272bdL611-R616))