### PR TITLE
Liveness small fixes

### DIFF
--- a/packages/backend/src/core/liveness/utils/getLivenessConfigHash.test.ts
+++ b/packages/backend/src/core/liveness/utils/getLivenessConfigHash.test.ts
@@ -64,4 +64,46 @@ describe(getLivenessConfigHash.name, () => {
 
     expect(hash1).not.toEqual(hash2)
   })
+
+  it('does not change hash when project without liveness is added', () => {
+    const projects: Project[] = [
+      {
+        projectId: ProjectId('project1'),
+        type: 'layer2',
+        escrows: [],
+        livenessConfig: {
+          transfers: [
+            {
+              projectId: ProjectId('project1'),
+              from: EthereumAddress.random(),
+              to: EthereumAddress.random(),
+              sinceTimestamp: UnixTime.now(),
+              type: LivenessType('DA'),
+            },
+          ],
+          functionCalls: [
+            {
+              projectId: ProjectId('project1'),
+              address: EthereumAddress.random(),
+              selector: '0x12345678',
+              sinceTimestamp: UnixTime.now(),
+              type: LivenessType('DA'),
+            },
+          ],
+        },
+      },
+    ]
+
+    const hash1 = getLivenessConfigHash(projects)
+
+    projects.push({
+      projectId: ProjectId('project2'),
+      type: 'layer2',
+      escrows: [],
+    })
+
+    const hash2 = getLivenessConfigHash(projects)
+
+    expect(hash1).toEqual(hash2)
+  })
 })

--- a/packages/backend/src/core/liveness/utils/getLivenessConfigHash.ts
+++ b/packages/backend/src/core/liveness/utils/getLivenessConfigHash.ts
@@ -5,7 +5,8 @@ import { Project } from '../../../model'
 const LIVENESS_LOGIC_VERSION = 0
 
 export function getLivenessConfigHash(projects: Project[]): Hash256 {
-  return hashJson([getEntries(projects), LIVENESS_LOGIC_VERSION])
+  const projectsWithLiveness = projects.filter((p) => p.livenessConfig)
+  return hashJson([getEntries(projectsWithLiveness), LIVENESS_LOGIC_VERSION])
 }
 
 // TODO: is JSON.stringify the best way to do this?

--- a/packages/shared/src/services/bigquery/BigQueryClient.ts
+++ b/packages/shared/src/services/bigquery/BigQueryClient.ts
@@ -5,7 +5,7 @@ import { BigQuerySDKWrapper } from './BigQuerySDKWrapper'
 const bytesInGb = 1_000_000_000
 // Currently the biggest query that we do takes around 5.1 GB
 // this limit ensures that there are no surprises and we do not overpay
-const LIMIT = 6 * bytesInGb
+const LIMIT = 7 * bytesInGb
 
 export class BigQueryClient {
   constructor(


### PR DESCRIPTION
Resolves L2B-3110 L2B-3111

This PR:
- adds filtering out logic of projects without liveness config when creating configuration hash
- increase BigQuery query limit to 7GB