### PR TITLE
UPDATE: tech provider for upcoming L2 Kinto

### DIFF
--- a/packages/config/src/layer2s/kinto.ts
+++ b/packages/config/src/layer2s/kinto.ts
@@ -14,7 +14,7 @@ export const kinto: Layer2 = {
       'Kinto is the first KYCed Layer 2 capable of supporting both modern financial institutions and decentralized protocols.',
     purpose: 'DeFi',
     category: 'Optimistic Rollup',
-    provider: 'OP Stack',
+    provider: 'Arbitrum',
     links: {
       websites: ['https://kinto.xyz'],
       apps: [],


### PR DESCRIPTION
Kinto is switching from Optimism to Arbitrum stack, press release can be found here: https://www.theblock.co/post/263948/ethereum-layer-2-kinto-migrates-to-arbitrum-ecosystem