### PR TITLE
Disable liveness

### DIFF
--- a/packages/frontend/src/build/config/common.ts
+++ b/packages/frontend/src/build/config/common.ts
@@ -19,7 +19,7 @@ export const common: Omit<Config, 'backend'> = {
   features: {
     banner: new Date() <= GITCOIN_19_END,
     gitcoinOption: false,
-    liveness: true,
+    liveness: false,
     hiringBadge: false,
     activity: true,
     tvlBreakdown: true,


### PR DESCRIPTION
Temporary disable liveness because data is not correct and heroku timeouts