### PR TITLE
Add logic for duplicated data in liveness

### DIFF
--- a/packages/backend/src/api/controllers/liveness/LivenessController.ts
+++ b/packages/backend/src/api/controllers/liveness/LivenessController.ts
@@ -1,4 +1,5 @@
-import { LivenessApiResponse } from '@l2beat/shared-pure'
+import { layer2s } from '@l2beat/config'
+import { LivenessApiResponse, LivenessType } from '@l2beat/shared-pure'
 
 import { Project } from '../../../model'
 import { LivenessRepository } from '../../../peripherals/database/LivenessRepository'
@@ -38,6 +39,34 @@ export class LivenessController {
         console.time(`withAnomalies ${project.projectId.toString()}`)
         const withAnomalies = calculateAnomaliesPerProject(intervals)
         console.timeEnd(`withAnomalies ${project.projectId.toString()}`)
+
+        if (withAnomalies) {
+          const l2project = layer2s.find((l) => l.id === project.projectId)
+          const anomalies = withAnomalies.anomalies
+          if (l2project?.config.liveness?.duplicatedData?.batchSubmissions) {
+            withAnomalies.batchSubmissions = { ...withAnomalies.stateUpdates }
+            if (anomalies) {
+              withAnomalies.anomalies = [
+                ...anomalies,
+                ...anomalies.map((a) => ({
+                  ...a,
+                  type: LivenessType('DA'),
+                })),
+              ]
+            }
+          } else if (l2project?.config.liveness?.duplicatedData?.stateUpdates) {
+            withAnomalies.stateUpdates = { ...withAnomalies.batchSubmissions }
+            if (anomalies) {
+              withAnomalies.anomalies = [
+                ...anomalies,
+                ...anomalies.map((a) => ({
+                  ...a,
+                  type: LivenessType('STATE'),
+                })),
+              ]
+            }
+          }
+        }
 
         projects[project.projectId.toString()] = withAnomalies
       }),

--- a/packages/config/src/layer2s/linea.ts
+++ b/packages/config/src/layer2s/linea.ts
@@ -117,6 +117,9 @@ export const linea: Layer2 = {
       startBlock: 1,
     },
     liveness: {
+      duplicatedData: {
+        batchSubmissions: 'stateUpdates',
+      },
       batchSubmissions: [],
       stateUpdates: [
         {

--- a/packages/config/src/layer2s/types/Layer2LivenessConfig.ts
+++ b/packages/config/src/layer2s/types/Layer2LivenessConfig.ts
@@ -1,8 +1,14 @@
 import { EthereumAddress, UnixTime } from '@l2beat/shared-pure'
 
 export interface Layer2LivenessConfig {
+  duplicatedData?: DuplicatedData
   stateUpdates: (FunctionCallParams | TransferParams)[]
   batchSubmissions: (FunctionCallParams | TransferParams)[]
+}
+
+export interface DuplicatedData {
+  stateUpdates?: 'batchSubmissions'
+  batchSubmissions?: 'stateUpdates'
 }
 
 export interface FunctionCallParams {


### PR DESCRIPTION
Resolves L2B-3133 L2B-3095

This PR:
- adds logic to handle situations when batch submission and state updates are posted in the same tx. Now in those cases we need to fill only one config, and specify in new `duplicatedData` property which we want to copy:
![image](https://github.com/l2beat/l2beat/assets/77489537/545b51b8-bb8f-43d4-8560-01553f9a2708)
So in this case we will copy stateUpdates data into batchSubmission
- fills config for Linea
