### PR TITLE
Add primary key to liveness table

### DIFF
--- a/packages/backend/src/core/liveness/LivenessIndexer.ts
+++ b/packages/backend/src/core/liveness/LivenessIndexer.ts
@@ -185,6 +185,11 @@ export class LivenessIndexer extends ChildIndexer {
   // This function will not be used, but it is required by the UIF.
   // In our case there is no re-org handling so we do not have to worry
   // that our data will become invalid.
+  // Also there is no need to handle the case when the server is randomly shut down during update,
+  // liveness configurations are storing the latest synced timestamp, so even if the server is shut down
+  // without setting new safeHeight. And although the next update will run on the already processed timestamp,
+  // the configuration's lastSyncedTimestamp will filter out already processed configurations
+  // and the data will not be fetched again
   override async invalidate(targetHeight: number): Promise<number> {
     return Promise.resolve(targetHeight)
   }

--- a/packages/backend/src/peripherals/database/migrations/087_liveness_primary_key.ts
+++ b/packages/backend/src/peripherals/database/migrations/087_liveness_primary_key.ts
@@ -1,0 +1,26 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema.alterTable('liveness', (table) => {
+    table.primary(['tx_hash', 'liveness_configuration_id'])
+  })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.alterTable('liveness', (table) => {
+    table.dropPrimary()
+  })
+}


### PR DESCRIPTION
Primary key constraint will be a safe-guard against duplicating data in Liveness.