### PR TITLE
Add index to `liveness` table

### DIFF
--- a/packages/backend/src/peripherals/database/migrations/088_liveness_index.ts
+++ b/packages/backend/src/peripherals/database/migrations/088_liveness_index.ts
@@ -1,0 +1,26 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server. 
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema.alterTable('liveness', (table) => {
+    table.index('liveness_configuration_id')
+  })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.alterTable('liveness', (table) => {
+    table.dropIndex('liveness_configuration_id')
+  })
+}


### PR DESCRIPTION
This PR will introduce index to `liveness` table, on the column `liveness_configuration_id`.

There is a significant speedup of `/api/liveness` response time, from 7-12s to a more constant 5s

![image](https://github.com/l2beat/l2beat/assets/72789647/3c58878f-e71e-4155-9fb4-902070151156)
