### PR TITLE
Update liveness config for zksync era & lite

### DIFF
--- a/packages/config/src/layer2s/zksyncera.ts
+++ b/packages/config/src/layer2s/zksyncera.ts
@@ -96,9 +96,9 @@ export const zksyncera: Layer2 = {
           address: EthereumAddress(
             '0x3dB52cE065f728011Ac6732222270b3F2360d919',
           ),
-          selector: '0x7739cbe7',
+          selector: '0xce9dcf16',
           functionSignature:
-            'function proveBlocks((uint64,bytes32,uint64,uint256,bytes32,bytes32,uint256,bytes32),(uint64,bytes32,uint64,uint256,bytes32,bytes32,uint256,bytes32)[], (uint256[],uint256[]) )',
+            'function executeBlocks((uint64,bytes32,uint64,uint256,bytes32,bytes32,uint256,bytes32)[] calldata _newBlocksData)',
           sinceTimestamp: new UnixTime(1679602559),
         },
       ],

--- a/packages/config/src/layer2s/zksynclite.ts
+++ b/packages/config/src/layer2s/zksynclite.ts
@@ -93,9 +93,9 @@ export const zksynclite: Layer2 = {
           address: EthereumAddress(
             '0xaBEA9132b05A70803a4E85094fD0e1800777fBEF',
           ),
-          selector: '0x83981808',
+          selector: '0xb0705b42',
           functionSignature:
-            'function proveBlocks((uint32,uint64,bytes32,uint256,bytes32,bytes32)[] calldata _committedBlocks, (uint256[],uint256[],uint256[],uint8[],uint256[16]) memory _proof)',
+            'function executeBlocks(((uint32,uint64,bytes32,uint256,bytes32,bytes32),bytes[])[] calldata _blocksData)',
           sinceTimestamp: new UnixTime(1592218707),
         },
       ],


### PR DESCRIPTION
Resolves L2B-3130

This PR changes tracking to `executeBlocks` instead of `proveBlocks` for zkSync Era & Lite for state updates