### PR TITLE
Handle archived projects in Liveness

### DIFF
--- a/packages/backend/src/api/controllers/liveness/LivenessController.test.ts
+++ b/packages/backend/src/api/controllers/liveness/LivenessController.test.ts
@@ -168,6 +168,7 @@ function mockProjectConfig(
     .map((projectId) =>
       mockObject<Project>({
         projectId,
+        isArchived: false,
         livenessConfig: mockObject<Project['livenessConfig']>({
           duplicateData: [],
           functionCalls: [],

--- a/packages/backend/src/api/controllers/liveness/LivenessController.ts
+++ b/packages/backend/src/api/controllers/liveness/LivenessController.ts
@@ -17,38 +17,40 @@ export class LivenessController {
     console.time('getLiveness')
 
     await Promise.all(
-      this.projects.map(async (project) => {
-        if (project.livenessConfig === undefined) {
-          return
-        }
-        console.time(`getWithType ${project.projectId.toString()}`)
-        const records = await this.livenessRepository.getWithType(
-          project.projectId,
-        )
-        console.timeEnd(`getWithType ${project.projectId.toString()}`)
+      this.projects
+        .filter((p) => !p.isArchived)
+        .map(async (project) => {
+          if (project.livenessConfig === undefined) {
+            return
+          }
+          console.time(`getWithType ${project.projectId.toString()}`)
+          const records = await this.livenessRepository.getWithType(
+            project.projectId,
+          )
+          console.timeEnd(`getWithType ${project.projectId.toString()}`)
 
-        console.time(`groupedByType ${project.projectId.toString()}`)
-        const groupedByType = groupByType(records)
-        console.timeEnd(`groupedByType ${project.projectId.toString()}`)
+          console.time(`groupedByType ${project.projectId.toString()}`)
+          const groupedByType = groupByType(records)
+          console.timeEnd(`groupedByType ${project.projectId.toString()}`)
 
-        console.time(`intervals ${project.projectId.toString()}`)
-        const intervals = calcIntervalWithAvgsPerProject(groupedByType)
-        console.timeEnd(`intervals ${project.projectId.toString()}`)
+          console.time(`intervals ${project.projectId.toString()}`)
+          const intervals = calcIntervalWithAvgsPerProject(groupedByType)
+          console.timeEnd(`intervals ${project.projectId.toString()}`)
 
-        console.time(`withAnomalies ${project.projectId.toString()}`)
-        const withAnomalies = calculateAnomaliesPerProject(intervals)
-        console.timeEnd(`withAnomalies ${project.projectId.toString()}`)
+          console.time(`withAnomalies ${project.projectId.toString()}`)
+          const withAnomalies = calculateAnomaliesPerProject(intervals)
+          console.timeEnd(`withAnomalies ${project.projectId.toString()}`)
 
-        if (withAnomalies && project.livenessConfig.duplicateData) {
-          for (const duplicateData of project.livenessConfig.duplicateData) {
-            withAnomalies[duplicateData.to] = {
-              ...withAnomalies[duplicateData.from],
+          if (withAnomalies && project.livenessConfig.duplicateData) {
+            for (const duplicateData of project.livenessConfig.duplicateData) {
+              withAnomalies[duplicateData.to] = {
+                ...withAnomalies[duplicateData.from],
+              }
             }
           }
-        }
 
-        projects[project.projectId.toString()] = withAnomalies
-      }),
+          projects[project.projectId.toString()] = withAnomalies
+        }),
     )
 
     console.timeEnd('getLiveness')

--- a/packages/backend/src/api/controllers/liveness/calculateAnomalies.ts
+++ b/packages/backend/src/api/controllers/liveness/calculateAnomalies.ts
@@ -34,14 +34,33 @@ export function calculateAnomaliesPerProject({
   stateUpdates: LivenessRecordsWithIntervalAndDetails | undefined
 }): LivenessApiResponse['projects'][number] {
   const lastHour = UnixTime.now().toStartOf('hour')
-  const anomalies: LivenessAnomaly[] = []
 
+  let batchSubmissionAnomalies: LivenessAnomaly[] | undefined = undefined
   if (batchSubmissions) {
-    anomalies.push(...findAnomalies(batchSubmissions.records, lastHour))
+    const anomalies = findAnomalies(batchSubmissions.records, lastHour)
+    if (anomalies) {
+      batchSubmissionAnomalies = anomalies
+    }
   }
 
+  let stateUpdatesAnomalies: LivenessAnomaly[] | undefined = undefined
   if (stateUpdates) {
-    anomalies.push(...findAnomalies(stateUpdates.records, lastHour))
+    const anomalies = findAnomalies(stateUpdates.records, lastHour)
+    if (anomalies) {
+      stateUpdatesAnomalies = anomalies
+    }
+  }
+
+  let anomalies: LivenessAnomaly[] | undefined = undefined
+
+  if (batchSubmissionAnomalies || stateUpdatesAnomalies) {
+    anomalies = []
+    if (batchSubmissionAnomalies) {
+      anomalies = anomalies.concat(batchSubmissionAnomalies)
+    }
+    if (stateUpdatesAnomalies) {
+      anomalies = anomalies.concat(stateUpdatesAnomalies)
+    }
   }
 
   return {
@@ -68,7 +87,7 @@ export function calculateAnomaliesPerProject({
 function findAnomalies(
   records: LivenessRecordWithInterval[],
   lastHour: UnixTime,
-): LivenessAnomaly[] {
+): LivenessAnomaly[] | undefined {
   const lastRecord = records.at(-1)
   if (lastRecord === undefined) return []
   if (lastRecord.timestamp.gt(lastHour.add(-60, 'days'))) return []
@@ -77,6 +96,7 @@ function findAnomalies(
   const last60Days = records.filter((record) =>
     record.timestamp.gte(timestamp60daysAgo),
   )
+  if (last60Days.length === 0) return undefined
 
   const means = new Map<number, number>()
   const stdDevs = new Map<number, number>()

--- a/packages/backend/src/model/Project.ts
+++ b/packages/backend/src/model/Project.ts
@@ -33,6 +33,7 @@ interface LivenessConfig {
 }
 export interface Project {
   projectId: ProjectId
+  isArchived?: boolean
   type: 'layer2' | 'bridge'
   escrows: ProjectEscrow[]
   transactionApi?: Layer2TransactionApi
@@ -49,6 +50,7 @@ export function layer2ToProject(layer2: Layer2): Project {
   return {
     projectId: layer2.id,
     type: 'layer2',
+    isArchived: layer2.isArchived,
     escrows: layer2.config.escrows.map((escrow) => ({
       address: escrow.address,
       sinceTimestamp: escrow.sinceTimestamp,

--- a/packages/config/src/layer2s/degate.ts
+++ b/packages/config/src/layer2s/degate.ts
@@ -97,6 +97,7 @@ export const degate: Layer2 = {
           functionSignature:
             'function submitBlocks(bool isDataCompressed,bytes data)',
           sinceTimestamp: new UnixTime(1681993655),
+          untilTimestamp: new UnixTime(1695902495),
         },
       ],
     },

--- a/packages/config/src/layer2s/degate2.ts
+++ b/packages/config/src/layer2s/degate2.ts
@@ -96,6 +96,7 @@ export const degate2: Layer2 = {
           functionSignature:
             'function submitBlocks(bool isDataCompressed,bytes data)',
           sinceTimestamp: new UnixTime(1693304819),
+          untilTimestamp: new UnixTime(1699766507),
         },
       ],
     },


### PR DESCRIPTION
This PR will:
- filter out archived projects from API response
- allow anomalies to be undefined (older projects will not have the last 60d of data to calculate)