### PR TITLE
Show scaling legend on liveness and summary tab only

### DIFF
--- a/packages/frontend/src/pages/scaling/activity/view/ScalingActivityView.tsx
+++ b/packages/frontend/src/pages/scaling/activity/view/ScalingActivityView.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { ScalingLegend } from '../../../../components/ScalingLegend'
 import { ScalingFilters } from '../../../../components/table/filters/ScalingFilters'
 import { getScalingRowProps } from '../../../../components/table/props/getScalingRowProps'
 import { getScalingActivityColumnsConfig } from '../../../../components/table/props/getScalingTableColumnsConfig'
@@ -20,7 +19,6 @@ export function ScalingActivityView({ items }: ScalingActivityViewProps) {
     <section className="mt-4 flex flex-col gap-y-2 sm:mt-8">
       <ScalingFilters items={items.filter((i) => i.slug !== 'ethereum')} />
       <TableView items={items} columnsConfig={columns} rows={rows} />
-      <ScalingLegend />
     </section>
   )
 }

--- a/packages/frontend/src/pages/scaling/detailed-tvl/view/ScalingDetailedTvlView.tsx
+++ b/packages/frontend/src/pages/scaling/detailed-tvl/view/ScalingDetailedTvlView.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-import { ScalingLegend } from '../../../../components/ScalingLegend'
 import { ScalingFilters } from '../../../../components/table/filters/ScalingFilters'
 import { getScalingRowProps } from '../../../../components/table/props/getScalingRowProps'
 import { getScalingDetailedTvlColumnsConfig } from '../../../../components/table/props/getScalingTableColumnsConfig'
@@ -28,7 +27,6 @@ export function ScalingDetailedTvlView({ items }: ScalingDetailedTvlViewProps) {
         rows={rows}
         columnsConfig={getScalingDetailedTvlColumnsConfig()}
       />
-      <ScalingLegend />
     </section>
   )
 }

--- a/packages/frontend/src/pages/scaling/liveness/view/ScalingLivenessView.tsx
+++ b/packages/frontend/src/pages/scaling/liveness/view/ScalingLivenessView.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import { ScalingLegend } from '../../../../components/ScalingLegend'
 import { ScalingFilters } from '../../../../components/table/filters/ScalingFilters'
 import { getScalingRowProps } from '../../../../components/table/props/getScalingRowProps'
 import { getScalingLivenessColumnsConfig } from '../../../../components/table/props/getScalingTableColumnsConfig'
@@ -24,6 +25,7 @@ export function ScalingLivenessView({ items }: ScalingLivenessViewProps) {
         <LivenessTimeRangeControls />
       </div>
       <TableView columnsConfig={columnsConfig} rows={rows} items={items} />
+      <ScalingLegend />
     </section>
   )
 }

--- a/packages/frontend/src/pages/scaling/risk/view/ScalingRiskView.tsx
+++ b/packages/frontend/src/pages/scaling/risk/view/ScalingRiskView.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import { ActiveIcon } from '../../../../components/icons/symbols/ActiveIcon'
 import { ArchivedIcon } from '../../../../components/icons/symbols/ArchivedIcon'
-import { ScalingLegend } from '../../../../components/ScalingLegend'
 import { ScalingFilters } from '../../../../components/table/filters/ScalingFilters'
 import { getScalingRowProps } from '../../../../components/table/props/getScalingRowProps'
 import { getScalingRiskColumnsConfig } from '../../../../components/table/props/getScalingTableColumnsConfig'
@@ -61,7 +60,6 @@ export function ScalingRiskView({ items }: ScalingRiskViewProps) {
           },
         ]}
       />
-      <ScalingLegend />
     </section>
   )
 }


### PR DESCRIPTION
This pull request removes the scaling legend component from the ScalingActivityView, ScalingDetailedTvlView, and ScalingRiskView components. The scaling legend will now only be displayed on the liveness and summary tabs. This change improves the user experience by reducing clutter and focusing on the relevant information.

Fixes #3199