### PR TITLE
Import ChainId from discovery instead of shared-pure

### DIFF
--- a/packages/backend/src/core/discovery/tests/config.test.ts
+++ b/packages/backend/src/core/discovery/tests/config.test.ts
@@ -1,6 +1,6 @@
 import { bridges, layer2s } from '@l2beat/config'
-import { ConfigReader, DiscoveryConfig } from '@l2beat/discovery'
-import { assert, ChainId, EthereumAddress } from '@l2beat/shared-pure'
+import { ChainId,ConfigReader, DiscoveryConfig } from '@l2beat/discovery'
+import { assert, EthereumAddress } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 import { isEqual } from 'lodash'
 

--- a/packages/backend/src/core/discovery/tests/config.test.ts
+++ b/packages/backend/src/core/discovery/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { bridges, layer2s } from '@l2beat/config'
-import { ChainId,ConfigReader, DiscoveryConfig } from '@l2beat/discovery'
+import { ChainId, ConfigReader, DiscoveryConfig } from '@l2beat/discovery'
 import { assert, EthereumAddress } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 import { isEqual } from 'lodash'


### PR DESCRIPTION
If someone adds a new ChainId to the shared-pure, this test will fails because we are mixing two different chainIds. One is defined in the discovery package and the other is defined in the shared-pure. This is the first step towards completely removing ChainIds from discovery.

This is a fix for #2213.