### PR TITLE
Update liveness label

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint --ext .ts,.tsx --max-warnings 0 src",
     "start": "yarn start:staging",
     "start:local": "DEPLOYMENT_ENV=local gulp watch",
+    "start:local-mock": "DEPLOYMENT_ENV=local MOCK=true gulp watch",
     "start:staging": "DEPLOYMENT_ENV=staging gulp watch",
     "start:production": "DEPLOYMENT_ENV=production gulp watch",
     "test": "mocha",

--- a/packages/frontend/src/build/config/config.local.ts
+++ b/packages/frontend/src/build/config/config.local.ts
@@ -2,18 +2,20 @@ import { common } from './common'
 import { Config } from './Config'
 
 export function getLocalConfig(): Config {
+  const useMock = process.env.MOCK === 'true'
   return {
     ...common,
     features: {
       ...common.features,
       // The local backend doesn't support activity
-      liveness: false,
-      activity: false,
+      liveness: useMock,
+      activity: useMock,
       buildAllProjectPages: true,
     },
     backend: {
       apiUrl: 'http://localhost:3000',
       skipCache: true,
+      mock: process.env.MOCK === 'true',
     },
   }
 }

--- a/packages/frontend/src/build/config/config.local.ts
+++ b/packages/frontend/src/build/config/config.local.ts
@@ -15,7 +15,7 @@ export function getLocalConfig(): Config {
     backend: {
       apiUrl: 'http://localhost:3000',
       skipCache: true,
-      mock: process.env.MOCK === 'true',
+      mock: useMock,
     },
   }
 }

--- a/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
+++ b/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
@@ -450,7 +450,7 @@ export function getScalingLivenessColumnsConfig() {
         <LivenessTimeRangeCell
           last30Days={'30-day average intervals'}
           last90Days={'90-day average intervals'}
-          max={'max-day average intervals'}
+          max={'all-time average intervals'}
         />
       ),
       columns: [


### PR DESCRIPTION
This PR changes "MAX-DAY" label to "ALL-TIME" on liveness table. It also adds a new script, start:local-mock, to the package.json file. The start:local-mock script sets the DEPLOYMENT_ENV environment variable to "local" and the MOCK environment variable to "true" before running the gulp watch command. This allows developers to run the application locally with mock data.

Fixes #3203