### PR TITLE
Update the State updates tooltip

### DIFF
--- a/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
+++ b/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
@@ -468,7 +468,7 @@ export function getScalingLivenessColumnsConfig() {
         },
         {
           name: 'State updates',
-          tooltip: 'The longest period of time between batch submissions',
+          tooltip: 'How often state roots are submitted to the L1',
           getValue: (project) => {
             return (
               <LivenessDurationTimeRangeCell


### PR DESCRIPTION
The State updates tooltip on the Liveness page was showing incorrect text (for the Max column that got removed). 


