### PR TITLE
Make UpdateMonitor perform multichain updates

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -30,7 +30,7 @@
     "@l2beat/discovery-types": "^0.7.0",
     "@l2beat/backend-tools": "^0.4.0",
     "@l2beat/config": "*",
-    "@l2beat/discovery": "0.27.0",
+    "@l2beat/discovery": "0.27.1",
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
     "@l2beat/uif": "^0.2.2",

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -131,5 +131,4 @@ export interface UpdateMonitorChainConfig {
   multicall: MulticallConfig
   etherscanApiKey: string
   etherscanUrl: string
-  minTimestamp: UnixTime
 }

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -1,7 +1,7 @@
 import { LoggerOptions } from '@l2beat/backend-tools'
 import { Layer2TransactionApi } from '@l2beat/config'
-import { MulticallConfig } from '@l2beat/discovery'
-import { ChainId, Token, UnixTime } from '@l2beat/shared-pure'
+import { DiscoveryChainConfig } from '@l2beat/discovery'
+import { Token, UnixTime } from '@l2beat/shared-pure'
 import { Knex } from 'knex'
 
 import { Project } from '../model'
@@ -123,12 +123,9 @@ export interface DiscordConfig {
   readonly callsPerMinute: number
 }
 
-export interface UpdateMonitorChainConfig {
-  chainId: ChainId
-  rpcUrl: string
-  rpcGetLogsMaxRange?: number
+export interface DiscoveryCacheChainConfig {
   reorgSafeDepth?: number
-  multicall: MulticallConfig
-  etherscanApiKey: string
-  etherscanUrl: string
 }
+
+export type UpdateMonitorChainConfig = DiscoveryChainConfig &
+  DiscoveryCacheChainConfig

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -1,11 +1,9 @@
 import { Env, LoggerOptions } from '@l2beat/backend-tools'
 import { bridges, layer2s, tokenList } from '@l2beat/config'
-import { multicallConfig } from '@l2beat/discovery'
-import { EtherscanClient } from '@l2beat/shared'
+import { getChainConfig } from '@l2beat/discovery'
 import { ChainId, UnixTime } from '@l2beat/shared-pure'
 
 import { bridgeToProject, layer2ToProject } from '../model'
-import { getChainMinTimestamp } from './chains'
 import { Config } from './Config'
 import { getGitCommitHash } from './getGitCommitHash'
 
@@ -217,17 +215,10 @@ export function getLocalConfig(env: Env): Config {
       },
       chains: [
         {
-          chainId: ChainId.ETHEREUM,
-          rpcUrl: env.string('DISCOVERY_ETHEREUM_RPC_URL'),
-          rpcGetLogsMaxRange: env.optionalInteger(
-            'DISCOVERY_ETHEREUM_RPC_GETLOGS_MAX_RANGE',
-          ),
+          ...getChainConfig(ChainId.ETHEREUM),
           reorgSafeDepth: env.optionalInteger(
             'DISCOVERY_ETHEREUM_REORG_SAFE_DEPTH',
           ),
-          multicall: multicallConfig.ethereum,
-          etherscanApiKey: env.string('DISCOVERY_ETHEREUM_ETHERSCAN_API_KEY'),
-          etherscanUrl: EtherscanClient.API_URL,
         },
       ],
     },

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -228,7 +228,6 @@ export function getLocalConfig(env: Env): Config {
           multicall: multicallConfig.ethereum,
           etherscanApiKey: env.string('DISCOVERY_ETHEREUM_ETHERSCAN_API_KEY'),
           etherscanUrl: EtherscanClient.API_URL,
-          minTimestamp: getChainMinTimestamp(ChainId.ETHEREUM),
         },
       ],
     },

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -232,17 +232,15 @@ export function getLocalConfig(env: Env): Config {
             'DISCOVERY_AVALANCHE_REORG_SAFE_DEPTH',
           ),
         },
-//        {
-//          ...getChainConfig(ChainId.BASE),
-//          reorgSafeDepth: env.optionalInteger(
-//            'DISCOVERY_BASE_REORG_SAFE_DEPTH',
-//          ),
-//        },
+        //        {
+        //          ...getChainConfig(ChainId.BASE),
+        //          reorgSafeDepth: env.optionalInteger(
+        //            'DISCOVERY_BASE_REORG_SAFE_DEPTH',
+        //          ),
+        //        },
         {
           ...getChainConfig(ChainId.BSC),
-          reorgSafeDepth: env.optionalInteger(
-            'DISCOVERY_BSC_REORG_SAFE_DEPTH',
-          ),
+          reorgSafeDepth: env.optionalInteger('DISCOVERY_BSC_REORG_SAFE_DEPTH'),
         },
         {
           ...getChainConfig(ChainId.CELO),

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -232,12 +232,6 @@ export function getLocalConfig(env: Env): Config {
             'DISCOVERY_AVALANCHE_REORG_SAFE_DEPTH',
           ),
         },
-        //        {
-        //          ...getChainConfig(ChainId.BASE),
-        //          reorgSafeDepth: env.optionalInteger(
-        //            'DISCOVERY_BASE_REORG_SAFE_DEPTH',
-        //          ),
-        //        },
         {
           ...getChainConfig(ChainId.BSC),
           reorgSafeDepth: env.optionalInteger('DISCOVERY_BSC_REORG_SAFE_DEPTH'),

--- a/packages/backend/src/config/config.local.ts
+++ b/packages/backend/src/config/config.local.ts
@@ -220,6 +220,66 @@ export function getLocalConfig(env: Env): Config {
             'DISCOVERY_ETHEREUM_REORG_SAFE_DEPTH',
           ),
         },
+        {
+          ...getChainConfig(ChainId.ARBITRUM),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_ARBITRUM_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.AVALANCHE),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_AVALANCHE_REORG_SAFE_DEPTH',
+          ),
+        },
+//        {
+//          ...getChainConfig(ChainId.BASE),
+//          reorgSafeDepth: env.optionalInteger(
+//            'DISCOVERY_BASE_REORG_SAFE_DEPTH',
+//          ),
+//        },
+        {
+          ...getChainConfig(ChainId.BSC),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_BSC_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.CELO),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_CELO_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.GNOSIS),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_GNOSIS_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.LINEA),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_LINEA_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.OPTIMISM),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_OPTIMISM_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.POLYGON_POS),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_POLYGON_POS_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.POLYGON_ZKEVM),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_POLYGON_ZKEVM_REORG_SAFE_DEPTH',
+          ),
+        },
       ],
     },
   }

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -214,6 +214,58 @@ export function getProductionConfig(env: Env): Config {
             'DISCOVERY_ETHEREUM_REORG_SAFE_DEPTH',
           ),
         },
+        {
+          ...getChainConfig(ChainId.ARBITRUM),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_ARBITRUM_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.AVALANCHE),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_AVALANCHE_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.BSC),
+          reorgSafeDepth: env.optionalInteger('DISCOVERY_BSC_REORG_SAFE_DEPTH'),
+        },
+        {
+          ...getChainConfig(ChainId.CELO),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_CELO_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.GNOSIS),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_GNOSIS_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.LINEA),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_LINEA_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.OPTIMISM),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_OPTIMISM_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.POLYGON_POS),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_POLYGON_POS_REORG_SAFE_DEPTH',
+          ),
+        },
+        {
+          ...getChainConfig(ChainId.POLYGON_ZKEVM),
+          reorgSafeDepth: env.optionalInteger(
+            'DISCOVERY_POLYGON_ZKEVM_REORG_SAFE_DEPTH',
+          ),
+        },
       ],
     },
   }

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -3,6 +3,7 @@ import { bridges, layer2s, tokenList } from '@l2beat/config'
 import { multicallConfig } from '@l2beat/discovery'
 import { EtherscanClient } from '@l2beat/shared'
 import { ChainId, UnixTime } from '@l2beat/shared-pure'
+import { getChainConfig } from '@l2beat/discovery'
 
 import { bridgeToProject, layer2ToProject } from '../model'
 import { getChainMinTimestamp } from './chains'
@@ -210,17 +211,10 @@ export function getProductionConfig(env: Env): Config {
       },
       chains: [
         {
-          chainId: ChainId.ETHEREUM,
-          rpcUrl: env.string('DISCOVERY_ETHEREUM_RPC_URL'),
-          rpcGetLogsMaxRange: env.optionalInteger(
-            'DISCOVERY_ETHEREUM_RPC_GETLOGS_MAX_RANGE',
-          ),
+          ...getChainConfig(ChainId.ETHEREUM),
           reorgSafeDepth: env.optionalInteger(
             'DISCOVERY_ETHEREUM_REORG_SAFE_DEPTH',
           ),
-          multicall: multicallConfig.ethereum,
-          etherscanApiKey: env.string('DISCOVERY_ETHEREUM_ETHERSCAN_API_KEY'),
-          etherscanUrl: EtherscanClient.API_URL,
         },
       ],
     },

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -221,7 +221,6 @@ export function getProductionConfig(env: Env): Config {
           multicall: multicallConfig.ethereum,
           etherscanApiKey: env.string('DISCOVERY_ETHEREUM_ETHERSCAN_API_KEY'),
           etherscanUrl: EtherscanClient.API_URL,
-          minTimestamp: getChainMinTimestamp(ChainId.ETHEREUM),
         },
       ],
     },

--- a/packages/backend/src/config/config.production.ts
+++ b/packages/backend/src/config/config.production.ts
@@ -1,9 +1,7 @@
 import { Env, LoggerOptions } from '@l2beat/backend-tools'
 import { bridges, layer2s, tokenList } from '@l2beat/config'
-import { multicallConfig } from '@l2beat/discovery'
-import { EtherscanClient } from '@l2beat/shared'
-import { ChainId, UnixTime } from '@l2beat/shared-pure'
 import { getChainConfig } from '@l2beat/discovery'
+import { ChainId, UnixTime } from '@l2beat/shared-pure'
 
 import { bridgeToProject, layer2ToProject } from '../model'
 import { getChainMinTimestamp } from './chains'

--- a/packages/backend/src/core/discovery/UpdateNotifier.ts
+++ b/packages/backend/src/core/discovery/UpdateNotifier.ts
@@ -29,6 +29,14 @@ export class UpdateNotifier {
     diff: DiscoveryDiff[],
     metadata: UpdateMetadata,
   ) {
+    // TODO(radomski): Discord notifications for chains different than
+    // Ethereum are for now disabled. We still want to update the database
+    // with the newest discovery but we don't want to notify about changes on
+    // for example Arbitrum chain since there are a lot of changes that we
+    // have not yet looked at.
+    if (metadata.chainId !== ChainId.ETHEREUM) {
+      return
+    }
     const nonce = await this.getInternalMessageNonce()
     const messages = diffToMessages(name, diff, {
       dependents: metadata.dependents,

--- a/packages/backend/src/core/discovery/createDiscoveryRunner.ts
+++ b/packages/backend/src/core/discovery/createDiscoveryRunner.ts
@@ -30,6 +30,7 @@ export function createDiscoveryRunner(
     http,
     chainConfig.etherscanUrl,
     chainConfig.etherscanApiKey,
+    chainConfig.etherscanUnsupported,
   )
 
   const discoveryCache = new DiscoveryCache(discoveryCacheRepository)

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -23,7 +23,7 @@
     "@l2beat/discovery-types": "^0.7.0",
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
-    "@l2beat/discovery": "0.27.0",
+    "@l2beat/discovery": "0.27.1",
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0-rc.11",
     "ethers": "^5.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,10 +2010,10 @@
   dependencies:
     zod "^3.22.2"
 
-"@l2beat/discovery@0.27.0":
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.27.0.tgz#dbfce736dd874107dc914e923aa6dc1bc578c5f9"
-  integrity sha512-sUTMb5mwCWrsRny/KRbWDtcOoHSZgZt3foMdshJZxgnmgiLKJFG1Z3pi3uv3QsjBPKpqLNfIzoJwjH+FstszIQ==
+"@l2beat/discovery@0.27.1":
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.27.1.tgz#d418783c9b7a5ec8f7025c3b89c30dd43bbbabbe"
+  integrity sha512-RT8AjLyXM6pD9ePaAAKMvrBCt52WsbypcsX442L9pd00ZETiTPE8NLEsM43jtkUtVeeAJJQBMY6JUQ93dhoxZQ==
   dependencies:
     "@l2beat/backend-tools" "^0.5.0"
     "@l2beat/discovery-types" "^0.7.0"


### PR DESCRIPTION
Resolves L2B-2096

Updates are performed and discovery output is stored in the database but we do not send Discord notifications for non-Ethereum changes. This will minimize the spam in the contracts-monitoring channel and allow us to go through the changes once we have some free time on our hands.