### PR TITLE
Fix discovery dashboard

### DIFF
--- a/packages/backend/src/api/controllers/status/discovery/props/utils/getFunctions.ts
+++ b/packages/backend/src/api/controllers/status/discovery/props/utils/getFunctions.ts
@@ -1,5 +1,6 @@
 import { deduplicateAbi } from '@l2beat/discovery'
 import type { ContractParameters } from '@l2beat/discovery-types'
+import { EthereumAddress } from '@l2beat/shared-pure'
 import { ethers } from 'ethers'
 
 import { getAddresses } from './getAddresses'
@@ -13,7 +14,7 @@ export function getViewABI(
     return new ethers.utils.Interface([])
   }
 
-  const addresses = getAddresses(contract)
+  const addresses = getAddresses(contract).filter(addr => addr !== EthereumAddress.ZERO)
 
   const abis = addresses
     .map((address) => {

--- a/packages/backend/src/api/controllers/status/discovery/props/utils/getFunctions.ts
+++ b/packages/backend/src/api/controllers/status/discovery/props/utils/getFunctions.ts
@@ -14,7 +14,9 @@ export function getViewABI(
     return new ethers.utils.Interface([])
   }
 
-  const addresses = getAddresses(contract).filter(addr => addr !== EthereumAddress.ZERO)
+  const addresses = getAddresses(contract).filter(
+    (addr) => addr !== EthereumAddress.ZERO,
+  )
 
   const abis = addresses
     .map((address) => {


### PR DESCRIPTION
Resolves L2B-3274

In the zodiac modules the values can be not set (zeroes) and we need to filter them out