### PR TITLE
Filter out upcoming projects in TVLController

### DIFF
--- a/packages/backend/src/api/controllers/tvl/TvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/TvlController.ts
@@ -148,6 +148,7 @@ export class TvlController {
     console.time('[Aggregate endpoint]: setup')
 
     const projectIdsFilter = [...layer2s, ...bridges]
+      .filter((project) => !project.isUpcoming)
       .filter((project) => slugs.includes(project.display.slug))
       .map((project) => project.id)
 


### PR DESCRIPTION
This pull request adds a filter to the TVLController class in order to exclude upcoming projects from the list of project IDs. This change improves the accuracy of the project filtering process.