### PR TITLE
Update Kroma

### DIFF
--- a/packages/backend/discovery/kroma/ethereum/discovered.json
+++ b/packages/backend/discovery/kroma/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "kroma",
   "chain": "ethereum",
-  "blockNumber": 18633895,
+  "blockNumber": 18727907,
   "configHash": "0xc6540caf9913086007e0012168f226eae74899c5ed0c0801bbf273384045476b",
   "version": 3,
   "contracts": [
@@ -19,10 +19,10 @@
         "COLOSSEUM": "0x713C2BEd44eB45D490afB8D4d1aA6F12290B829a",
         "FINALIZATION_PERIOD_SECONDS": 604800,
         "L2_BLOCK_TIME": 2,
-        "latestBlockNumber": 3425400,
-        "latestOutputIndex": 1903,
-        "nextBlockNumber": 3427200,
-        "nextOutputIndex": 1904,
+        "latestBlockNumber": 3994200,
+        "latestOutputIndex": 2219,
+        "nextBlockNumber": 3996000,
+        "nextOutputIndex": 2220,
         "startingBlockNumber": 0,
         "startingTimestamp": 1693880387,
         "SUBMISSION_INTERVAL": 1800,
@@ -91,7 +91,7 @@
         "GUARDIAN": "0x3de211088dF516da72efe68D386b561BEE256Ec4",
         "L2_ORACLE": "0x180c77aE51a9c505a43A2C7D81f8CE70cacb93A6",
         "l2Sender": "0x000000000000000000000000000000000000dEaD",
-        "params": [1000000000, 200000, 18633206],
+        "params": [1000000000, 200000, 18727895],
         "paused": false,
         "SYSTEM_CONFIG": "0x3971EB866AA9b2b8aFEa8a7C816F3b7e8b195a35",
         "VALIDATOR_POOL": "0xFdFF462845953D90719A78Fd12a2d103541d2103",
@@ -175,7 +175,7 @@
       "sinceTimestamp": 1693880591,
       "values": {
         "MESSAGE_VERSION": 0,
-        "messageNonce": 49,
+        "messageNonce": 61,
         "MIN_GAS_CALLDATA_OVERHEAD": 16,
         "MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR": 63,
         "MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR": 64,
@@ -288,7 +288,7 @@
       "sinceTimestamp": 1693880663,
       "values": {
         "BALLOT_TYPEHASH": "0x150214d74d59b7d1e90c73fc22ef3d991dd0a76b046543d4d80ab92d2a50328f",
-        "clock": 18633895,
+        "clock": 18727907,
         "CLOCK_MODE": "mode=blocknumber&from=default",
         "COUNTING_MODE": "support=bravo&quorum=for,abstain",
         "eip712Domain": [
@@ -325,7 +325,7 @@
       "implementations": ["0x108eDc4Df0b9B04dcE9f6FFBD65Dd9895562c14C"],
       "sinceTimestamp": 1693880639,
       "values": {
-        "clock": 18633895,
+        "clock": 18727907,
         "CLOCK_MODE": "mode=blocknumber&from=default",
         "DOMAIN_SEPARATOR": "0x1630586f33defc933258f4512df143dd6bf7adb1b4d039178e748d4cac4813b8",
         "eip712Domain": [
@@ -346,14 +346,14 @@
         "symbol": "KSC",
         "tokenOwners": [
           "0x3aa00bb915A8e78b0523E4c365e3E70A19d329e6",
-          "0x8ECF028Cd647379E580DaA6701A11154750fcd3c",
           "0xe1b712e16Be1Eb098D0b2B846e2f547F9E292851",
-          "0xECe4AAf6A41aa81A164363Ec6C420510617Fc998",
-          "0x5ddcf494A8b6EeE4904934E829109cCF584EAF80",
+          "0x8ECF028Cd647379E580DaA6701A11154750fcd3c",
+          "0xbDeE962137373A755a71C716E01B9946B1a27686",
           "0x7B3225ADc5D908668FaA050246680CBE4e75A93f",
+          "0x5ddcf494A8b6EeE4904934E829109cCF584EAF80",
+          "0xECe4AAf6A41aa81A164363Ec6C420510617Fc998",
           "0x3a4F65D1ACFb2A3F5AD93ef7b240bfa1079052e0",
-          "0x42a4f1958A5d99A62C50eb24a80d1D8b142ea3A1",
-          "0xbDeE962137373A755a71C716E01B9946B1a27686"
+          "0x42a4f1958A5d99A62C50eb24a80d1D8b142ea3A1"
         ],
         "tokens": [0, 3, 4, 5, 6, 7, 8, 9, 10],
         "tokenURI": ["https://nft.kroma.network/sc/1.png"],
@@ -393,7 +393,7 @@
         "TAX_DENOMINATOR": 100,
         "TAX_NUMERATOR": 20,
         "TRUSTED_VALIDATOR": "0x3aa00bb915A8e78b0523E4c365e3E70A19d329e6",
-        "validatorCount": 32,
+        "validatorCount": 35,
         "validators": [
           "0x3aa00bb915A8e78b0523E4c365e3E70A19d329e6",
           "0x81BF552f9Fc83e88012d6C3ab84cF1946Bc55FD0",
@@ -417,16 +417,19 @@
           "0xcfBA39c653cae1C2d8271Ca17752a557335eba3B",
           "0x41852D4F060b7a209FDc073E48fB26eea3D19ca3",
           "0x9E728Dfe00D6e43f67C5A46e420d655053A7cb5F",
-          "0xc931c3C4feBa2b91127bEC5c64c11d78221eD7B7",
+          "0xeFe674F55d86468b69EA2Fe40DE8C3b09C378548",
           "0xcC2351dEB494557b10c5BC5593022f4b8dE121AE",
           "0x7Fb00286be9C3A893D9EF89fB3269eBb057bc04b",
-          "0xC63Cc019Bb47A948131891407d1371849B757714",
+          "0x7B3225ADc5D908668FaA050246680CBE4e75A93f",
           "0x3848517bDC40821f56eb546d53AF61FB80bE6762",
           "0xe1b712e16Be1Eb098D0b2B846e2f547F9E292851",
           "0x5ddcf494A8b6EeE4904934E829109cCF584EAF80",
           "0x2E8a03820c77312FE1B189a78963e94553f11b6F",
+          "0xC63Cc019Bb47A948131891407d1371849B757714",
+          "0x4660cf1d89C31C07C2b405b05a1024ad44c4Aca0",
           "0x8ECF028Cd647379E580DaA6701A11154750fcd3c",
-          "0xbDeE962137373A755a71C716E01B9946B1a27686"
+          "0x5d3a0eB74Fd2937F4D292b043FBcDF117D6b05a7",
+          "0xc931c3C4feBa2b91127bEC5c64c11d78221eD7B7"
         ],
         "VAULT_REWARD_GAS_LIMIT": 100000,
         "version": "1.0.1"
@@ -451,6 +454,8 @@
     "0x420000000000000000000000000000000000000A",
     "0x42a4f1958A5d99A62C50eb24a80d1D8b142ea3A1",
     "0x4576481b914FE9FCA4Bbe6A85aB1A409124Ef9A7",
+    "0x4660cf1d89C31C07C2b405b05a1024ad44c4Aca0",
+    "0x5d3a0eB74Fd2937F4D292b043FBcDF117D6b05a7",
     "0x5da6d9675f6929A144c22d5Aa5Df6B8f05DcD839",
     "0x5ddcf494A8b6EeE4904934E829109cCF584EAF80",
     "0x7B3225ADc5D908668FaA050246680CBE4e75A93f",
@@ -473,6 +478,7 @@
     "0xcfBA39c653cae1C2d8271Ca17752a557335eba3B",
     "0xe1b712e16Be1Eb098D0b2B846e2f547F9E292851",
     "0xECe4AAf6A41aa81A164363Ec6C420510617Fc998",
+    "0xeFe674F55d86468b69EA2Fe40DE8C3b09C378548",
     "0xfC3867F19161b8981d8B9c9fa3D7360c9Cee9733"
   ],
   "abis": {


### PR DESCRIPTION
There is a change in the order of the SecurityCouncilToken owners. Before this update, the discovered.json had an incorrect order because of a known bug that has been fixed.
There is no diffHistory file, which is not consistent with the update-monitor behaviour - update-monitor refactoring is planned for the future to handle this case.

Resolves L2B-3264