### PR TITLE
Exclude L3s from TVL

### DIFF
--- a/packages/backend/src/api/controllers/tvl/TvlController.ts
+++ b/packages/backend/src/api/controllers/tvl/TvlController.ts
@@ -149,6 +149,9 @@ export class TvlController {
 
     const projectIdsFilter = [...layer2s, ...bridges]
       .filter((project) => !project.isUpcoming)
+      .filter((project) =>
+        project.type === 'layer2' ? !project.isLayer3 : true,
+      )
       .filter((project) => slugs.includes(project.display.slug))
       .map((project) => project.id)
 

--- a/packages/backend/src/core/reports/ReportProject.ts
+++ b/packages/backend/src/core/reports/ReportProject.ts
@@ -2,5 +2,5 @@ import { Project } from '../../model'
 
 export type ReportProject = Pick<
   Project,
-  'projectId' | 'type' | 'escrows' | 'isUpcoming'
+  'projectId' | 'type' | 'escrows' | 'isUpcoming' | 'isLayer3'
 >

--- a/packages/backend/src/core/reports/aggregateReports.test.ts
+++ b/packages/backend/src/core/reports/aggregateReports.test.ts
@@ -181,6 +181,45 @@ describe(aggregateReports.name, () => {
     expect(totalTvl?.usdValue).toEqual(sum.usdValue)
   })
 
+  it('filters out layer 3 projects', () => {
+    const result = aggregateReports(
+      [
+        report(ARBITRUM, 'eth', 30n, 'CBV'),
+        report(ARBITRUM, 'dai', 5_000n, 'CBV'),
+        report(OPTIMISM, 'dai', 1_000n, 'CBV'),
+        report(ProjectId('other'), 'eth', 40n, 'CBV'),
+      ],
+      [
+        project(ARBITRUM, 'layer2'),
+        project(OPTIMISM, 'layer2'),
+        project(ProjectId('other'), 'layer2', false, true),
+      ],
+      NOW,
+    )
+    const sum = result
+      .filter(
+        (x) =>
+          (x.projectId === ARBITRUM || x.projectId === OPTIMISM) &&
+          x.reportType === 'TVL',
+      )
+      .reduce(
+        (acc, next) => ({
+          ethValue: acc.ethValue + next.ethValue,
+          usdValue: acc.usdValue + next.usdValue,
+        }),
+        {
+          ethValue: 0n,
+          usdValue: 0n,
+        },
+      )
+    const totalTvl = result.find(
+      (x) => x.projectId === ProjectId.ALL && x.reportType === 'TVL',
+    )
+
+    expect(totalTvl?.ethValue).toEqual(sum.ethValue)
+    expect(totalTvl?.usdValue).toEqual(sum.usdValue)
+  })
+
   function report(
     projectId: ProjectId,
     asset: 'eth' | 'dai',
@@ -204,8 +243,9 @@ describe(aggregateReports.name, () => {
     projectId: ProjectId,
     type: ReportProject['type'],
     isUpcoming = false,
+    isLayer3 = false,
   ): ReportProject {
-    return { projectId, type, escrows: [], isUpcoming }
+    return { projectId, type, escrows: [], isUpcoming, isLayer3 }
   }
 
   function record(

--- a/packages/backend/src/core/reports/aggregateReports.ts
+++ b/packages/backend/src/core/reports/aggregateReports.ts
@@ -136,7 +136,7 @@ export function deriveCategoryTree(
   )
 
   for (const [project, valueMap] of tree) {
-    if (project.isUpcoming) {
+    if (project.isUpcoming || project.isLayer3) {
       continue
     }
 

--- a/packages/backend/src/core/reports/getReportConfigHash.ts
+++ b/packages/backend/src/core/reports/getReportConfigHash.ts
@@ -14,7 +14,7 @@ export function getReportConfigHash(projects: ReportProject[]) {
 
 export function getEntries(projects: ReportProject[]) {
   const entries = []
-  for (const { projectId, escrows, type, isUpcoming } of projects) {
+  for (const { projectId, escrows, type, isUpcoming, isLayer3 } of projects) {
     for (const { tokens, address, sinceTimestamp } of escrows) {
       for (const token of tokens) {
         entries.push({
@@ -25,6 +25,7 @@ export function getEntries(projects: ReportProject[]) {
           assetId: token.id.toString(),
           assetSinceTimestamp: token.sinceTimestamp.toNumber(),
           isUpcoming: Boolean(isUpcoming),
+          isLayer3: Boolean(isLayer3),
         })
       }
     }

--- a/packages/backend/src/model/Project.ts
+++ b/packages/backend/src/model/Project.ts
@@ -38,6 +38,7 @@ export interface Project {
   isArchived?: boolean
   type: 'layer2' | 'bridge'
   isUpcoming?: boolean
+  isLayer3?: boolean
   escrows: ProjectEscrow[]
   transactionApi?: Layer2TransactionApi
   livenessConfig?: LivenessConfig
@@ -54,6 +55,7 @@ export function layer2ToProject(layer2: Layer2): Project {
     projectId: layer2.id,
     type: 'layer2',
     isUpcoming: layer2.isUpcoming,
+    isLayer3: layer2.isLayer3,
     isArchived: layer2.isArchived,
     escrows: layer2.config.escrows.map((escrow) => ({
       address: escrow.address,

--- a/packages/config/src/common/ProjectEscrow.ts
+++ b/packages/config/src/common/ProjectEscrow.ts
@@ -16,6 +16,8 @@ interface OldProjectEscrow {
   newVersion?: false
   /** Upcoming projects needs upcoming escrows (needed for TVL) */
   isUpcoming?: boolean
+  /** If project is Layer 3 */
+  isLayer3?: boolean
 }
 
 interface NewProjectEscrow {
@@ -33,4 +35,6 @@ interface NewProjectEscrow {
   newVersion?: true
   /** Upcoming projects needs upcoming escrows (needed for TVL) */
   isUpcoming?: boolean
+  /** If project is Layer 3 */
+  isLayer3?: boolean
 }

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -110,6 +110,7 @@ export class ProjectDiscovery {
     upgradableBy,
     upgradeDelay,
     isUpcoming,
+    isLayer3,
   }: {
     address: EthereumAddress
     name?: string
@@ -119,6 +120,7 @@ export class ProjectDiscovery {
     upgradableBy?: string[]
     upgradeDelay?: string
     isUpcoming?: boolean
+    isLayer3?: boolean
   }): ProjectEscrow {
     const contract = this.getContractByAddress(address.toString())
     const timestamp = sinceTimestamp?.toNumber() ?? contract.sinceTimestamp
@@ -140,6 +142,7 @@ export class ProjectDiscovery {
         upgradeDelay,
       },
       isUpcoming,
+      isLayer3,
     }
   }
 

--- a/packages/frontend/src/build/api/sanityCheck.ts
+++ b/packages/frontend/src/build/api/sanityCheck.ts
@@ -14,6 +14,7 @@ const bridges = allBridges
 const layer2s = allLayer2s
   .filter((x) => !x.isUpcoming)
   .filter((x) => !x.isArchived)
+  .filter((x) => !x.isLayer3)
 
 export type TvlProjectData = [string, TvlApiCharts]
 


### PR DESCRIPTION
This PR fixes sanity check for Layer 3 projects which are active but we do not track TVL