### PR TITLE
Filter out Layer 3 projects on bridges page

### DIFF
--- a/packages/frontend/src/pages/bridges/risk/getProps.ts
+++ b/packages/frontend/src/pages/bridges/risk/getProps.ts
@@ -18,7 +18,7 @@ export function getProps(
   const included = getIncludedProjects(
     [...config.bridges, ...config.layer2s],
     tvlApiResponse,
-  )
+  ).filter((project) => project.type === 'bridge' || !project.isLayer3)
   const ordering = orderByTvl(included, tvlApiResponse)
 
   return {

--- a/packages/frontend/src/pages/bridges/tvl/props/getProps.ts
+++ b/packages/frontend/src/pages/bridges/tvl/props/getProps.ts
@@ -21,7 +21,7 @@ export function getProps(
   const included = getIncludedProjects(
     [...config.bridges, ...config.layer2s],
     tvlApiResponse,
-  )
+  ).filter((project) => project.type === 'bridge' || !project.isLayer3)
   const ordering = orderByTvl(included, tvlApiResponse)
 
   return {


### PR DESCRIPTION
This pull request updates the getProps function to filter out Layer 3 projects from the included projects list. This ensures that only bridge projects or projects that are not Layer 3 are included.