### PR TITLE
Allow for adding l2 contracts to project page

### DIFF
--- a/packages/config/src/common/ProjectContracts.ts
+++ b/packages/config/src/common/ProjectContracts.ts
@@ -24,6 +24,8 @@ export type ProjectContract =
 export interface ProjectContractSingleAddress {
   /** Address of the contract */
   address: EthereumAddress
+  /** Url to chain's etherscan */
+  etherscanUrl?: string
   /** Solidity name of the contract */
   name: string
   /** Description of the contract's role in the system */
@@ -60,6 +62,8 @@ export interface ProjectContractMultipleAddresses {
   /** Solidity name of the contract */
   name: string
   /** Description of the contract's role in the system */
+  /** Url to chain's etherscan */
+  etherscanUrl?: string
   description?: string
 }
 

--- a/packages/config/src/common/ProjectPermission.ts
+++ b/packages/config/src/common/ProjectPermission.ts
@@ -6,6 +6,7 @@ export interface ProjectPermission {
   accounts: ProjectPermissionedAccount[]
   name: string
   description: string
+  etherscanUrl?: string
   // list of source code permalinks and useful materials
   references?: ProjectReference[]
 }

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -54,12 +54,18 @@ const filesystem = {
 
 export class ProjectDiscovery {
   private readonly discovery: DiscoveryOutput
+  private readonly explorer: string
   constructor(
     public readonly projectName: string,
     public readonly chainId: ChainId = ChainId.ETHEREUM,
     private readonly fs: Filesystem = filesystem,
   ) {
     this.discovery = this.getDiscoveryJson(projectName)
+    this.explorer = ChainId.getExplorer(chainId)
+    assert(
+      this.explorer,
+      `No explorer found for chainId: ${chainId.toString()}`,
+    )
   }
 
   private getDiscoveryJson(project: string): DiscoveryOutput {
@@ -97,6 +103,7 @@ export class ProjectDiscovery {
       name: contract.name,
       address: contract.address,
       upgradeability: contract.upgradeability,
+      etherscanUrl: this.explorer,
       ...descriptionOrOptions,
     }
   }
@@ -138,6 +145,7 @@ export class ProjectDiscovery {
         name: name ?? contract.name,
         description,
         upgradeability: contract.upgradeability,
+        etherscanUrl: this.explorer,
         upgradableBy,
         upgradeDelay,
       },
@@ -219,6 +227,7 @@ export class ProjectDiscovery {
           ),
         )
         .join(' '),
+      etherscanUrl: this.explorer,
     }))
   }
 
@@ -245,6 +254,7 @@ export class ProjectDiscovery {
             type: 'MultiSig',
           },
         ],
+        etherscanUrl: this.explorer,
       },
       {
         name: `${identifier} participants`,
@@ -349,11 +359,11 @@ export class ProjectDiscovery {
     if (typeof descriptionOrOptions === 'string') {
       descriptionOrOptions = { description: descriptionOrOptions }
     }
-
     return {
       address: contract.address,
       name: contract.name,
       upgradeability: contract.upgradeability,
+      etherscanUrl: this.explorer,
       ...descriptionOrOptions,
     }
   }
@@ -395,6 +405,7 @@ export class ProjectDiscovery {
           type: 'Contract',
         },
       ],
+      etherscanUrl: this.explorer,
       description,
     }
   }

--- a/packages/frontend/src/components/project/ContractEntry.tsx
+++ b/packages/frontend/src/components/project/ContractEntry.tsx
@@ -22,6 +22,7 @@ export interface TechnologyContract {
   upgradeDelay?: string
   upgradeConsiderations?: string
   references?: TechnologyReference[]
+  etherscanUrl?: string
 }
 
 export interface TechnologyContractLinks {
@@ -87,6 +88,7 @@ export function ContractEntry({
             {(contract.addresses ?? []).map((address, i) => (
               <EtherscanLink
                 address={address}
+                url={contract.etherscanUrl}
                 key={i}
                 className={cx(
                   verificationStatus.contracts[address] === false

--- a/packages/frontend/src/components/project/EtherscanLink.tsx
+++ b/packages/frontend/src/components/project/EtherscanLink.tsx
@@ -4,12 +4,14 @@ import { Link } from '../Link'
 
 interface EtherscanLinkProps {
   address: string
+  url?: string
   children?: ReactNode
   className?: string
 }
 
 export function EtherscanLink(props: EtherscanLinkProps) {
-  const link = `https://etherscan.io/address/${props.address}`
+  const explorerUrl = props.url ?? 'https://etherscan.io'
+  const link = `${explorerUrl}/address/${props.address}`
   return (
     <Link href={link} className={props.className}>
       {props.address.slice(0, 6)}…{props.address.slice(38, 42)}

--- a/packages/frontend/src/utils/project/getContractSection.ts
+++ b/packages/frontend/src/utils/project/getContractSection.ts
@@ -100,6 +100,7 @@ function makeTechnologyContract(
   isEscrow?: boolean,
 ): TechnologyContract {
   const links: TechnologyContractLinks[] = []
+  const etherscanUrl = item.etherscanUrl ?? 'https://etherscan.io'
 
   if (isSingleAddress(item)) {
     if (item.upgradeability?.type) {
@@ -110,14 +111,14 @@ function makeTechnologyContract(
         case 'Eternal Storage proxy':
           links.push({
             name: 'Implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.implementation.toString()}#code`,
             address: item.upgradeability.implementation.toString(),
             isAdmin: false,
           })
           if (item.upgradeability.admin) {
             links.push({
               name: 'Admin',
-              href: `https://etherscan.io/address/${item.upgradeability.admin.toString()}#code`,
+              href: `${etherscanUrl}/address/${item.upgradeability.admin.toString()}#code`,
               address: item.upgradeability.admin.toString(),
               isAdmin: true,
             })
@@ -132,7 +133,7 @@ function makeTechnologyContract(
         case 'Polygon proxy':
           links.push({
             name: 'Implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.implementation.toString()}#code`,
             address: item.upgradeability.implementation.toString(),
             isAdmin: false,
           })
@@ -148,7 +149,7 @@ function makeTechnologyContract(
             name: `Implementation (Upgradable${
               delay ? ` ${days} days delay` : ''
             })`,
-            href: `https://etherscan.io/address/${implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${implementation.toString()}#code`,
             address: implementation.toString(),
             isAdmin: false,
           })
@@ -158,7 +159,7 @@ function makeTechnologyContract(
         case 'Reference':
           links.push({
             name: 'Code (Upgradable)',
-            href: `https://etherscan.io/address/${item.address.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.address.toString()}#code`,
             address: item.address.toString(),
             isAdmin: false,
           })
@@ -168,19 +169,19 @@ function makeTechnologyContract(
         case 'Arbitrum proxy':
           links.push({
             name: 'Admin',
-            href: `https://etherscan.io/address/${item.upgradeability.admin.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.admin.toString()}#code`,
             address: item.upgradeability.admin.toString(),
             isAdmin: true,
           })
           links.push({
             name: 'Admin logic (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.adminImplementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.adminImplementation.toString()}#code`,
             address: item.upgradeability.adminImplementation.toString(),
             isAdmin: true,
           })
           links.push({
             name: 'User logic (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.userImplementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.userImplementation.toString()}#code`,
             address: item.upgradeability.userImplementation.toString(),
             isAdmin: false,
           })
@@ -189,19 +190,19 @@ function makeTechnologyContract(
         case 'Beacon':
           links.push({
             name: 'Beacon',
-            href: `https://etherscan.io/address/${item.upgradeability.beacon.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.beacon.toString()}#code`,
             address: item.upgradeability.beacon.toString(),
             isAdmin: false,
           })
           links.push({
             name: 'Implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.implementation.toString()}#code`,
             address: item.upgradeability.implementation.toString(),
             isAdmin: false,
           })
           links.push({
             name: 'Beacon Admin',
-            href: `https://etherscan.io/address/${item.upgradeability.beaconAdmin.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.beaconAdmin.toString()}#code`,
             address: item.upgradeability.beaconAdmin.toString(),
             isAdmin: true,
           })
@@ -210,19 +211,19 @@ function makeTechnologyContract(
         case 'zkSync Lite proxy':
           links.push({
             name: 'Implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.implementation.toString()}#code`,
             address: item.upgradeability.implementation.toString(),
             isAdmin: false,
           })
           links.push({
             name: 'Additional implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.additional.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.additional.toString()}#code`,
             address: item.upgradeability.additional.toString(),
             isAdmin: false,
           })
           links.push({
             name: 'Admin',
-            href: `https://etherscan.io/address/${item.upgradeability.admin.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.admin.toString()}#code`,
             address: item.upgradeability.admin.toString(),
             isAdmin: true,
           })
@@ -231,21 +232,21 @@ function makeTechnologyContract(
         case 'zkSpace proxy':
           links.push({
             name: 'Implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.implementation.toString()}#code`,
             address: item.upgradeability.implementation.toString(),
             isAdmin: false,
           })
           links.push(
             ...item.upgradeability.additional.map((additional) => ({
               name: 'Additional implementation (Upgradable)',
-              href: `https://etherscan.io/address/${additional.toString()}#code`,
+              href: `${etherscanUrl}/address/${additional.toString()}#code`,
               address: additional.toString(),
               isAdmin: false,
             })),
           )
           links.push({
             name: 'Admin',
-            href: `https://etherscan.io/address/${item.upgradeability.admin.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.admin.toString()}#code`,
             address: item.upgradeability.admin.toString(),
             isAdmin: true,
           })
@@ -254,13 +255,13 @@ function makeTechnologyContract(
         case 'Polygon Extension proxy':
           links.push({
             name: 'Implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.implementation.toString()}#code`,
             address: item.upgradeability.implementation.toString(),
             isAdmin: false,
           }),
             links.push({
               name: 'Extension (Upgradable)',
-              href: `https://etherscan.io/address/${item.upgradeability.extension.toString()}#code`,
+              href: `${etherscanUrl}/address/${item.upgradeability.extension.toString()}#code`,
               address: item.upgradeability.extension.toString(),
               isAdmin: false,
             })
@@ -268,19 +269,19 @@ function makeTechnologyContract(
         case 'Optics Beacon proxy':
           links.push({
             name: 'Upgrade Beacon',
-            href: `https://etherscan.io/address/${item.upgradeability.upgradeBeacon.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.upgradeBeacon.toString()}#code`,
             address: item.upgradeability.upgradeBeacon.toString(),
             isAdmin: false,
           })
           links.push({
             name: 'Implementation (Upgradable)',
-            href: `https://etherscan.io/address/${item.upgradeability.implementation.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.implementation.toString()}#code`,
             address: item.upgradeability.implementation.toString(),
             isAdmin: false,
           })
           links.push({
             name: 'Beacon Controller',
-            href: `https://etherscan.io/address/${item.upgradeability.beaconController.toString()}#code`,
+            href: `${etherscanUrl}/address/${item.upgradeability.beaconController.toString()}#code`,
             address: item.upgradeability.beaconController.toString(),
             isAdmin: true,
           })
@@ -289,7 +290,7 @@ function makeTechnologyContract(
           links.push(
             ...item.upgradeability.admins.map((admin, i) => ({
               name: `Admin ${i}`,
-              href: `https://etherscan.io/address/${admin.toString()}#code`,
+              href: `${etherscanUrl}/address/${admin.toString()}#code`,
               address: admin.toString(),
               isAdmin: true,
             })),
@@ -297,7 +298,7 @@ function makeTechnologyContract(
           links.push(
             ...item.upgradeability.owners.map((owner, i) => ({
               name: `Owner ${i}`,
-              href: `https://etherscan.io/address/${owner.toString()}#code`,
+              href: `${etherscanUrl}/address/${owner.toString()}#code`,
               address: owner.toString(),
               isAdmin: true,
             })),
@@ -305,7 +306,7 @@ function makeTechnologyContract(
           links.push(
             ...item.upgradeability.operators.map((operator, i) => ({
               name: `Operator ${i}`,
-              href: `https://etherscan.io/address/${operator.toString()}#code`,
+              href: `${etherscanUrl}/address/${operator.toString()}#code`,
               address: operator.toString(),
               isAdmin: true,
             })),
@@ -386,6 +387,7 @@ function makeTechnologyContract(
     addresses,
     description,
     links,
+    etherscanUrl: item.etherscanUrl,
   }
 
   if (isSingleAddress(item)) {

--- a/packages/frontend/src/utils/project/getPermissionsSection.ts
+++ b/packages/frontend/src/utils/project/getPermissionsSection.ts
@@ -38,11 +38,12 @@ export function getPermissionsSection(
 function toTechnologyContract(
   permission: ProjectPermission,
 ): TechnologyContract {
+  const etherscanUrl = permission.etherscanUrl ?? 'https://etherscan.io'
   const links = permission.accounts.slice(1).map((account) => {
     return {
       name: `${account.address.slice(0, 6)}…${account.address.slice(38, 42)}`,
       address: account.address.toString(),
-      href: `https://etherscan.io/address/${account.address.toString()}#code`,
+      href: `${etherscanUrl}/address/${account.address.toString()}#code`,
       isAdmin: false,
     }
   })
@@ -59,5 +60,6 @@ function toTechnologyContract(
     description: permission.description,
     links,
     references: permission.references,
+    etherscanUrl: permission.etherscanUrl,
   }
 }


### PR DESCRIPTION
Resolves L2B-2602

To add contract on L2, we now need to create second instance of `ProjectDiscovery` with ChainId of this L2, and then call discovery methods on this instance