### PR TITLE
Update Blast

### DIFF
--- a/packages/backend/discovery/blast/ethereum/diffHistory.md
+++ b/packages/backend/discovery/blast/ethereum/diffHistory.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Change in the Bridge implementation. A 24h timelock is introduced on Admin Proxy updates and Bridge Transition updates. The update proposals can be created by the owner and cancelled by the owner if not executed yet. Updates that do not go through the timelock will now revert.
+Change in the Bridge implementation. A 24h timelock is introduced on Admin Proxy updates and Bridge Transition updates. The update proposals can be created by the owner and canceled by the owner if not executed yet. Updates that do not go through the timelock will now revert.
 
 Users can now withdraw in two cases:
 

--- a/packages/backend/discovery/blast/ethereum/diffHistory.md
+++ b/packages/backend/discovery/blast/ethereum/diffHistory.md
@@ -1,3 +1,48 @@
+# Diff at Tue, 12 Dec 2023 16:53:48 GMT:
+
+- author: Radina Talanova (<nt.radina@gmail.com>)
+- comparing to: master@695bd005662e55af5dd20ff984779cea92a8a968
+
+## Description
+
+Change in the Bridge implementation. A 24h timelock is introduced on Admin Proxy updates and Bridge Transition updates. The update proposals can be created by the owner and cancelled by the owner if not executed yet. Updates that do not go through the timelock will now revert.
+
+Users can now withdraw in two cases:
+
+- While there is an active proposal for upgrade/transition. In that case users will lose their points.
+- After the contract has expired (currently set to 1 June 2024)
+
+Other changes: The \_moveETH and \_moveUSD functions are refactored to return the assets value (previously executing the transfer), the actual transfer to the new bridge is now done within the transition function.
+
+## Watched changes
+
+```diff
+    contract Bridge (0x5F6AE08B8AeB7078cf2F96AFb089D7c9f51DA47d) {
+      upgradeability.implementation:
+-        "0xa01Def05A37850b2e13C8c839AA268845Df14276"
++        "0x829e8Bf84569A0B2da7B27f975F026fDb6e0a774"
+      implementations.0:
+-        "0xa01Def05A37850b2e13C8c839AA268845Df14276"
++        "0x829e8Bf84569A0B2da7B27f975F026fDb6e0a774"
+      values.proposedBridgeReadyAt:
++        0
+      values.proposedMainnetBridge:
++        ["0x0000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000000000000000000000000000"]
+      values.proposedUpgrade:
++        ["0x0000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000000000000000000000000000"]
+      values.proposedUpgradeReadyAt:
++        0
+    }
+```
+
+## Source code changes
+
+```diff
+.../Bridge/implementation/meta.txt                 |   2 +-
+ .../src/launch-bridge}/LaunchBridge.sol            | 178 ++++++++++++++++++---
+ 2 files changed, 161 insertions(+), 19 deletions(-)
+```
+
 # Diff at Mon, 04 Dec 2023 15:05:33 GMT:
 
 - author: Radina Talanova (<nt.radina@gmail.com>)

--- a/packages/backend/discovery/blast/ethereum/discovered.json
+++ b/packages/backend/discovery/blast/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "blast",
   "chain": "ethereum",
-  "blockNumber": 18713779,
+  "blockNumber": 18771421,
   "configHash": "0xda2a0607814971e6460ec8d2cfb3952fffbb6d66163fb34eba09eadc1adb0fca",
   "version": 3,
   "contracts": [
@@ -10,10 +10,10 @@
       "address": "0x5F6AE08B8AeB7078cf2F96AFb089D7c9f51DA47d",
       "upgradeability": {
         "type": "EIP1967 proxy",
-        "implementation": "0xa01Def05A37850b2e13C8c839AA268845Df14276",
+        "implementation": "0x829e8Bf84569A0B2da7B27f975F026fDb6e0a774",
         "admin": "0x0000000000000000000000000000000000000000"
       },
-      "implementations": ["0xa01Def05A37850b2e13C8c839AA268845Df14276"],
+      "implementations": ["0x829e8Bf84569A0B2da7B27f975F026fDb6e0a774"],
       "sinceTimestamp": 1700359187,
       "values": {
         "CURVE_3POOL": "0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7",
@@ -24,12 +24,22 @@
         "owner": "0x67CA7Ca75b69711cfd48B44eC3F64E469BaF608C",
         "paused": false,
         "pendingOwner": "0x0000000000000000000000000000000000000000",
+        "proposedBridgeReadyAt": 0,
+        "proposedMainnetBridge": [
+          "0x0000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ],
+        "proposedUpgrade": [
+          "0x0000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+        ],
+        "proposedUpgradeReadyAt": 0,
         "PSM": "0x89B78CfA322F6C5dE0aBcEecab66Aee45393cC5A",
         "staker": "0x9eDFc192fC4d29b8f2b18f484211161b6Fc8063E",
-        "totalETHBalance": "286395065405752297873364",
-        "totalETHShares": "285989722046565587161831",
-        "totalUSDBalanceNoUpdate": "90091490395226940198432923",
-        "totalUSDShares": "89930253867303394596970752",
+        "totalETHBalance": "326551911902768732774701",
+        "totalETHShares": "325810312923678335669485",
+        "totalUSDBalanceNoUpdate": "99782852838814615562176348",
+        "totalUSDShares": "99496855398121481403916834",
         "USDC": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
         "USDT": "0xdAC17F958D2ee523a2206206994597C13D831ec7"
       },
@@ -56,7 +66,7 @@
           "0x46e31F27Df5047D7Fad9b1E8DFFec635cF6efAcF"
         ],
         "getThreshold": 3,
-        "nonce": 5,
+        "nonce": 6,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -80,11 +90,12 @@
     "0x67CA7Ca75b69711cfd48B44eC3F64E469BaF608C": [
       "constructor(address _singleton)"
     ],
-    "0xa01Def05A37850b2e13C8c839AA268845Df14276": [
+    "0x829e8Bf84569A0B2da7B27f975F026fDb6e0a774": [
       "constructor()",
       "error BridgeIsNotSet()",
       "error CallerIsNotStaker()",
       "error InsufficientFunds()",
+      "error InvalidDepositor()",
       "error SharesNotInitiated()",
       "error TransitionIsEnabled()",
       "error TransitionNotEnabled()",
@@ -98,9 +109,14 @@
       "event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)",
       "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
       "event Paused(address account)",
+      "event ProposeTransition(address mainnetBridge)",
+      "event ProposeUpgrade(address upgradeTo)",
+      "event ResetProposedTransition()",
+      "event ResetProposedUpgrade()",
       "event USDDeposited(address indexed user, uint256 shares, uint256 amount, uint256 daiAmount)",
       "event Unpaused(address account)",
       "event Upgraded(address indexed implementation)",
+      "event Withdraw(address indexed user, uint256 ethAmount, uint256 stETHAmount, uint256 daiAmount)",
       "function CURVE_3POOL() view returns (address)",
       "function DAI() view returns (address)",
       "function DSR_MANAGER() view returns (address)",
@@ -110,6 +126,8 @@
       "function USDT() view returns (address)",
       "function acceptOwnership()",
       "function balanceOf(address user) view returns (uint256 ethBalance, uint256 usdBalance)",
+      "function cancelProposeTransition()",
+      "function cancelProposedUpgrade()",
       "function depositDAI(uint256 daiAmount)",
       "function depositDAIWithPermit(uint256 daiAmount, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s)",
       "function depositETH() payable",
@@ -118,6 +136,7 @@
       "function depositUSDC(uint256 usdcAmount)",
       "function depositUSDCWithPermit(uint256 usdcAmount, uint256 allowance, uint256 deadline, uint8 v, bytes32 r, bytes32 s)",
       "function depositUSDT(uint256 usdtAmount, uint256 minDAIAmount)",
+      "function emergencyWithdraw()",
       "function enableTransition(address mainnetBridge)",
       "function ethShares(address) view returns (uint256)",
       "function getMainnetBridge() view returns (address mainnetBridge)",
@@ -128,6 +147,12 @@
       "function pause()",
       "function paused() view returns (bool)",
       "function pendingOwner() view returns (address)",
+      "function proposeTransition(address proposedBridge)",
+      "function proposeUpgrade(address upgradeTo)",
+      "function proposedBridgeReadyAt() view returns (uint256)",
+      "function proposedMainnetBridge() view returns (address to, bytes32 codehash)",
+      "function proposedUpgrade() view returns (address to, bytes32 codehash)",
+      "function proposedUpgradeReadyAt() view returns (uint256)",
       "function proxiableUUID() view returns (bytes32)",
       "function renounceOwnership()",
       "function setStaker(address _staker)",
@@ -145,7 +170,8 @@
       "function unpause()",
       "function upgradeTo(address newImplementation)",
       "function upgradeToAndCall(address newImplementation, bytes data) payable",
-      "function usdShares(address) view returns (uint256)"
+      "function usdShares(address) view returns (uint256)",
+      "function withdrawAndLosePoints()"
     ],
     "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552": [
       "constructor()",


### PR DESCRIPTION
Change in the Bridge implementation.
The biggest change is that a 24h timelock mechanism is introduced on Admin Proxy updates and Bridge Transition updates. The update proposals can be created by the owner and canceled by the owner if not executed yet. Updates that do not go through the timelock will now revert. 

Users can now withdraw in two cases:
- While there is an active proposal for upgrade/transition. In that case, users will lose their points.
- After the contract has expired (currently set to 1 June 2024)

Other changes: The `_moveETH` and `_moveUSD` functions are refactored to return the assets value (previously executing the transfer), and the actual transfer to the new bridge is now done within the `transition` function.

Resolves L2B-3314