### PR TITLE
Remove unnecessary information from liveness type  tooltip

### DIFF
--- a/packages/frontend/src/components/table/LivenessDurationCell.tsx
+++ b/packages/frontend/src/components/table/LivenessDurationCell.tsx
@@ -3,14 +3,12 @@ import classNames from 'classnames'
 import React from 'react'
 
 import { ScalingLivenessViewEntry } from '../../pages/scaling/liveness/types'
-import { RoundedWarningIcon } from '../icons/symbols/RoundedWarningIcon'
 
 export function LivenessDurationCell(props: {
   durationInSeconds: number | undefined
   dataType?: Exclude<keyof LivenessApiProject, 'anomalies'>
   project?: ScalingLivenessViewEntry
   tooltip?: string
-  warning?: string
 }) {
   if (
     !props.durationInSeconds &&
@@ -71,19 +69,11 @@ export function LivenessDurationCell(props: {
 
   return (
     <span
-      className={classNames(
-        'inline-flex items-center gap-1.5',
-        props.tooltip && 'Tooltip',
-      )}
+      className={classNames(props.tooltip && 'Tooltip')}
       title={props.tooltip}
       data-tooltip-big={true}
     >
       {duration}
-      {props.warning && (
-        <div className="Tooltip" title={props.warning}>
-          <RoundedWarningIcon className="h-5 w-5 fill-yellow-700 dark:fill-yellow-300" />
-        </div>
-      )}
     </span>
   )
 }

--- a/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
+++ b/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
@@ -739,7 +739,7 @@ export function getScalingLivenessColumnsConfig() {
     {
       name: 'Type',
       tooltip:
-        'Type of this project. Determines data availability and proof system used.<br>ZK Rollups = Validity Proofs + onchain data<br>Optimistic Rollups = Fraud Proofs + onchain data<br>Validiums = Validity Proofs + offchain data<br>Optimiums = Fraud Proofs + offchain data',
+        'Type of this project. Determines data availability and proof system used.<br>ZK Rollups = Validity Proofs + onchain data<br>Optimistic Rollups = Fraud Proofs + onchain data',
       shortName: 'Type',
       getValue: (project) => (
         <TypeCell provider={project.provider} disableColors>

--- a/packages/frontend/src/pages/scaling/liveness/view/LivenessDurationTimeRangeCell.tsx
+++ b/packages/frontend/src/pages/scaling/liveness/view/LivenessDurationTimeRangeCell.tsx
@@ -2,6 +2,7 @@ import { LivenessApiProject, LivenessDataPoint } from '@l2beat/shared-pure'
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
+import { RoundedWarningIcon } from '../../../../components/icons'
 import { LivenessDurationCell } from '../../../../components/table/LivenessDurationCell'
 import { LivenessDetailsWithWarning, ScalingLivenessViewEntry } from '../types'
 import { LivenessTimeRangeCell } from './LivenessTimeRangeCell'
@@ -21,37 +22,55 @@ export function LivenessDurationTimeRangeCell({
     <div>
       <LivenessTimeRangeCell
         last30Days={
-          <LivenessDurationCell
-            durationInSeconds={data?.last30Days?.averageInSeconds}
-            project={project}
-            tooltip={renderToStaticMarkup(
-              <Tooltip label="30-day intervals" data={data?.last30Days} />,
+          <div className="flex items-center gap-1.5">
+            <LivenessDurationCell
+              durationInSeconds={data?.last30Days?.averageInSeconds}
+              project={project}
+              tooltip={renderToStaticMarkup(
+                <Tooltip label="30-day intervals" data={data?.last30Days} />,
+              )}
+              dataType={dataType}
+            />
+            {data?.warning && (
+              <div className="Tooltip" title={data.warning}>
+                <RoundedWarningIcon className="h-5 w-5 fill-yellow-700 dark:fill-yellow-300" />
+              </div>
             )}
-            warning={data?.warning}
-            dataType={dataType}
-          />
+          </div>
         }
         last90Days={
-          <LivenessDurationCell
-            durationInSeconds={data?.last90Days?.averageInSeconds}
-            project={project}
-            tooltip={renderToStaticMarkup(
-              <Tooltip label="90-day intervals" data={data?.last90Days} />,
+          <div className="flex items-center gap-1.5">
+            <LivenessDurationCell
+              durationInSeconds={data?.last90Days?.averageInSeconds}
+              project={project}
+              tooltip={renderToStaticMarkup(
+                <Tooltip label="90-day intervals" data={data?.last90Days} />,
+              )}
+              dataType={dataType}
+            />
+            {data?.warning && (
+              <div className="Tooltip" title={data.warning}>
+                <RoundedWarningIcon className="h-5 w-5 fill-yellow-700 dark:fill-yellow-300" />
+              </div>
             )}
-            warning={data?.warning}
-            dataType={dataType}
-          />
+          </div>
         }
         max={
-          <LivenessDurationCell
-            durationInSeconds={data?.allTime?.averageInSeconds}
-            project={project}
-            tooltip={renderToStaticMarkup(
-              <Tooltip label="All-time intervals" data={data?.allTime} />,
+          <div className="flex items-center gap-1.5">
+            <LivenessDurationCell
+              durationInSeconds={data?.allTime?.averageInSeconds}
+              project={project}
+              tooltip={renderToStaticMarkup(
+                <Tooltip label="All-time intervals" data={data?.allTime} />,
+              )}
+              dataType={dataType}
+            />
+            {data?.warning && (
+              <div className="Tooltip" title={data.warning}>
+                <RoundedWarningIcon className="h-5 w-5 fill-yellow-700 dark:fill-yellow-300" />
+              </div>
             )}
-            warning={data?.warning}
-            dataType={dataType}
-          />
+          </div>
         }
       />
     </div>

--- a/packages/frontend/src/scripts/configureTooltips.ts
+++ b/packages/frontend/src/scripts/configureTooltips.ts
@@ -71,13 +71,9 @@ export function configureTooltips() {
 
   window.addEventListener('resize', hide)
   document
-    .querySelectorAll('.TableView')
-    .forEach((x) => x.addEventListener('scroll', hide))
-  document
     .querySelectorAll('[data-role="table"]')
     .forEach((x) => x.addEventListener('scroll', hide))
   document.body.addEventListener('scroll', hide)
-  window.addEventListener('scroll', hide)
   window.addEventListener('scroll', hide)
   document.body.addEventListener('click', (e) => {
     if (e.currentTarget !== tooltip) {


### PR DESCRIPTION
The tooltip previously included details about different types of projects, but it has been simplified to only include information about the rollups.

This PR also fixes the tooltip interactions on liveness