### PR TITLE
Refactor OP stack template, support back references

### DIFF
--- a/packages/config/src/discovery/OpStackTypes.ts
+++ b/packages/config/src/discovery/OpStackTypes.ts
@@ -11,13 +11,17 @@ export interface OPStackContractTemplate {
   coreDescription: string
 }
 
-export type OpStackTag = 'admin' | 'owner' | 'owned'
-
-export const OpStackTagDescription: Record<OpStackTag, string> = {
-  admin: 'Admin of {0}.',
-  owner: 'Owner of {0}.',
-  owned: 'Owned by {0}.',
+export type OpStackTag = 'admin' | 'owner'
+export interface OpStackTagDescription {
+  direct: string
+  referenced?: string
 }
+
+export const OpStackTagDescriptions: Record<OpStackTag, OpStackTagDescription> =
+  {
+    admin: { direct: 'Admin of {0}.' },
+    owner: { direct: 'Owner of {0}.', referenced: 'Owned by {0}.' },
+  }
 
 export interface OPStackPermissionTemplate {
   role: { value: string; contract: string }

--- a/packages/config/src/discovery/PermissionedContract.ts
+++ b/packages/config/src/discovery/PermissionedContract.ts
@@ -1,0 +1,61 @@
+import { EthereumAddress } from '@l2beat/shared-pure'
+
+import { OpStackTag, OpStackTagDescriptions } from './OpStackTypes'
+import { stringFormat } from './values/templateUtils'
+
+export class PermissionedContract {
+  constructor(
+    readonly name: string,
+    readonly address: EthereumAddress,
+    private readonly roleDescriptions: string[] = [],
+    private readonly tags: Record<string, string[]> = {},
+    private readonly referencedByTags: Record<string, string[]> = {},
+  ) {}
+
+  addTag(tag: string, name: string): void {
+    this.tags[tag] ??= []
+    this.tags[tag].push(name)
+  }
+
+  addTagReference(tag: string, name: string): void {
+    this.referencedByTags[tag] ??= []
+    this.referencedByTags[tag].push(name)
+  }
+
+  addDescription(description: string): void {
+    this.roleDescriptions.push(description)
+  }
+
+  formatDescriptions(): string {
+    return this.roleDescriptions.join(' ')
+  }
+
+  formatTags(): string {
+    return Object.entries(this.tags)
+      .map(([tag, contracts]) => {
+        const description = OpStackTagDescriptions[tag as OpStackTag]
+        return stringFormat(description.direct, contracts.join(', '))
+      })
+      .join(' ')
+  }
+
+  formatTagReferences(): string {
+    return Object.entries(this.referencedByTags)
+      .map(([tag, contracts]) => {
+        const description = OpStackTagDescriptions[tag as OpStackTag]
+        if (description.referenced) {
+          return stringFormat(description.referenced, contracts.join(', '))
+        }
+      })
+      .filter((x) => !!x)
+      .join(' ')
+  }
+
+  generateDescription(): string {
+    return [
+      ...this.formatDescriptions(),
+      ...this.formatTags(),
+      ...this.formatTagReferences(),
+    ].join('')
+  }
+}

--- a/packages/config/src/discovery/values/templateUtils.ts
+++ b/packages/config/src/discovery/values/templateUtils.ts
@@ -1,0 +1,23 @@
+import { AddressDetails, Role } from '@l2beat/discovery'
+
+import { OPStackPermissionTemplate } from '../OpStackTypes'
+
+export function stringFormat(str: string, ...val: string[]) {
+  for (let index = 0; index < val.length; index++) {
+    str = str.replaceAll(`{${index}}`, val[index])
+  }
+  return str
+}
+
+export function findRoleMatchingTemplate(
+  contract: AddressDetails,
+  template: OPStackPermissionTemplate,
+  contractOverrides?: Record<string, string>,
+): Role | undefined {
+  return contract.roles.find(
+    (r) =>
+      r.name === template.role.value &&
+      r.atName ===
+        (contractOverrides?.[template.role.contract] ?? template.role.contract),
+  )
+}


### PR DESCRIPTION
Resolves L2B-3039

Code is broken down into smaller pieces. Also back references are supported, e.g. "owned by" is automatically added.