### PR TITLE
Remove staked frax ether

### DIFF
--- a/packages/config/src/tokens/tokenList.json
+++ b/packages/config/src/tokens/tokenList.json
@@ -2479,20 +2479,6 @@
       "formula": "locked"
     },
     {
-      "id": "sfrxeth-staked-frax-ether",
-      "name": "Staked Frax Ether",
-      "coingeckoId": "staked-frax-ether",
-      "address": "0xac3E018457B222d93114458476f3E3416Abbe38F",
-      "symbol": "sfrxETH",
-      "decimals": 18,
-      "sinceTimestamp": 1665022895,
-      "category": "other",
-      "chainId": 1,
-      "iconUrl": "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1696527285",
-      "type": "CBV",
-      "formula": "locked"
-    },
-    {
       "id": "stg-stargatetoken",
       "name": "StargateToken",
       "coingeckoId": "stargate-finance",


### PR DESCRIPTION
This coin is problematic with our TVL. This coin is important for Starknet, but removing it will give us some more time to resolve the issue.