### PR TITLE
Update Staked Frax Ether min timestamp

### DIFF
--- a/packages/config/src/tokens/tokenList.json
+++ b/packages/config/src/tokens/tokenList.json
@@ -2485,7 +2485,7 @@
       "address": "0xac3E018457B222d93114458476f3E3416Abbe38F",
       "symbol": "sfrxETH",
       "decimals": 18,
-      "sinceTimestamp": 1665022895,
+      "sinceTimestamp": 1669860000,
       "category": "other",
       "chainId": 1,
       "iconUrl": "https://assets.coingecko.com/coins/images/28285/large/sfrxETH_icon.png?1696527285",


### PR DESCRIPTION
The first coingecko data points are later than token deployment