### PR TITLE
Fix bullet icon placement

### DIFF
--- a/packages/frontend/src/components/project/ContractEntry.tsx
+++ b/packages/frontend/src/components/project/ContractEntry.tsx
@@ -64,7 +64,7 @@ export function ContractEntry({
         tooltip="Source code is not verified"
       />
     ) : (
-      <BulletIcon className="h-6 md:h-[27px]" />
+      <BulletIcon className="h-[1em]" />
     )
 
   addresses.forEach((address) => {

--- a/packages/frontend/src/components/project/TokenEntry.tsx
+++ b/packages/frontend/src/components/project/TokenEntry.tsx
@@ -13,7 +13,7 @@ export function TokenEntry({ className, l2Tokens }: TokenEntryProps) {
   return (
     <Callout
       className={cx('px-4', className)}
-      icon={<BulletIcon className="h-6 md:h-[27px]" />}
+      icon={<BulletIcon className="h-[1em]" />}
       body={
         <>
           <div className="flex flex-wrap gap-x-2">


### PR DESCRIPTION
Fixing the bullet icon being placed a bit too low.

Before: 
<img width="473" alt="Screenshot 2023-12-20 at 15 48 11" src="https://github.com/l2beat/l2beat/assets/38423054/8c103634-d818-4794-b02f-a90b876f2b9d">
<img width="974" alt="Screenshot 2023-12-20 at 15 47 47" src="https://github.com/l2beat/l2beat/assets/38423054/6456ee57-c26a-46ce-9a34-bfd226fd40fd">

After: 
<img width="465" alt="Screenshot 2023-12-20 at 15 47 03" src="https://github.com/l2beat/l2beat/assets/38423054/d06f86bd-2728-4ffc-b321-5f347b1fd64f">
<img width="923" alt="Screenshot 2023-12-20 at 15 47 23" src="https://github.com/l2beat/l2beat/assets/38423054/a4b6c674-330e-4bb5-a885-3082543ce70e">
