### PR TITLE
Remove wUSDM

### DIFF
--- a/packages/config/src/tokens/tokenList.json
+++ b/packages/config/src/tokens/tokenList.json
@@ -2997,20 +2997,6 @@
       "formula": "locked"
     },
     {
-      "id": "wusdm-wrapped-mountain-protocol-usd",
-      "name": "Wrapped Mountain Protocol USD",
-      "coingeckoId": "wrapped-usdm",
-      "address": "0x57F5E098CaD7A3D1Eed53991D4d66C45C9AF7812",
-      "symbol": "wUSDM",
-      "decimals": 18,
-      "sinceTimestamp": 1696622279,
-      "category": "stablecoin",
-      "iconUrl": "https://assets.coingecko.com/coins/images/33785/large/wUSDM_PNG_240px.png?1702981552",
-      "chainId": 1,
-      "type": "CBV",
-      "formula": "locked"
-    },
-    {
       "id": "toncoin-wrapped-ton-coin",
       "name": "Wrapped TON Coin",
       "coingeckoId": "the-open-network",


### PR DESCRIPTION
The token is causing issues because its historical data is not returned from Coingecko (it has been added recently).
Will be added later once there is some data.