### PR TITLE
Add MAGIC token to token list

### DIFF
--- a/packages/config/src/tokens/tokenList.json
+++ b/packages/config/src/tokens/tokenList.json
@@ -1611,6 +1611,20 @@
       "formula": "locked"
     },
     {
+      "id": "magic-magic",
+      "name": "MAGIC",
+      "coingeckoId": "magic",
+      "address": "0xB0c7a3Ba49C7a6EaBa6cD4a96C55a1391070Ac9A",
+      "symbol": "MAGIC",
+      "decimals": 18,
+      "sinceTimestamp": 1630989984,
+      "category": "other",
+      "chainId": 1,
+      "iconUrl": "https://assets.coingecko.com/coins/images/18623/large/magic.png?1696518095",
+      "type": "CBV",
+      "formula": "locked"
+    },
+    {
       "id": "mim-magic-internet-money",
       "name": "Magic Internet Money",
       "coingeckoId": "magic-internet-money",


### PR DESCRIPTION
This PR adds the MAGIC token to the L2Beat token list with the goal of it showing up in L2 TVL calculations.

It was added by calling `yarn tokens:add 0xB0c7a3Ba49C7a6EaBa6cD4a96C55a1391070Ac9A other` as commended from the comment at the top of the token list file

Let me know if this doesn't make sense or if there's any other info I can provide. The token has a $331m USD circulating supply according to Arbiscan so seems definitely worth tracking and it was natively bridged so my impression is that the proper route is to just add it's L1 address

L1 token: https://etherscan.io/token/0xB0c7a3Ba49C7a6EaBa6cD4a96C55a1391070Ac9A
L2 token: https://arbiscan.io/token/0x539bdE0d7Dbd336b79148AA742883198BBF60342