### PR TITLE
Add logic to remove historical data from TVL module

### DIFF
--- a/packages/backend/src/core/Clock.test.ts
+++ b/packages/backend/src/core/Clock.test.ts
@@ -124,10 +124,10 @@ describe(Clock.name, () => {
       stop()
     })
 
-    it('ticks only daily for timestamps older than 7D', () => {
+    it('ticks six hourly after 7D and daily after 90D', () => {
       setTime('00:00:00')
       const now = UnixTime.now()
-      const start = now.add(-14, 'days')
+      const start = now.add(-180, 'days')
 
       const clock = new Clock(start, 0)
 
@@ -135,32 +135,23 @@ describe(Clock.name, () => {
       const stop = clock.onEveryHour((timestamp) => calls.push(timestamp))
       stop()
 
-      // timestamps older than 7D should be ticked daily
-      const dailyCalls = calls.slice(0, 7)
+      const DAILY = 90
+      const SIX_HOURLY = 83 * 4
+
+      // timestamps older than 90D should be ticked daily
+      const dailyCalls = calls.slice(0, DAILY)
       expect(dailyCalls.every((x) => x.isFull('day'))).toEqual(true)
 
-      // timestamps newer than 7D should be ticked hourly
-      const hourlyCalls = calls.slice(7)
+      // timestamps older than 7D & earlier than 90D should be ticked six hourly
+      const sixHourly = calls.slice(DAILY, DAILY + SIX_HOURLY)
+      expect(sixHourly.every((x) => x.isFull('six hours'))).toEqual(true)
+
+      const hourlyCalls = calls.slice(DAILY + SIX_HOURLY)
       for (let i = 0; i < hourlyCalls.length - 1; i++) {
         const call = hourlyCalls[i]
         const nextCall = hourlyCalls[i + 1]
         expect(nextCall).toEqual(call.add(1, 'hours'))
       }
-
-      // straightforward test case to better visualize the functionality
-      expect(calls.slice(0, 10)).toEqual([
-        toTimestamp('00:00:00').add(-14, 'days'),
-        toTimestamp('00:00:00').add(-13, 'days'),
-        toTimestamp('00:00:00').add(-12, 'days'),
-        toTimestamp('00:00:00').add(-11, 'days'),
-        toTimestamp('00:00:00').add(-10, 'days'),
-        toTimestamp('00:00:00').add(-9, 'days'),
-        toTimestamp('00:00:00').add(-8, 'days'),
-        toTimestamp('00:00:00').add(-7, 'days'),
-        toTimestamp('00:00:00').add(-7, 'days').add(1, 'hours'),
-        toTimestamp('00:00:00').add(-7, 'days').add(2, 'hours'),
-        // hourly granularity...
-      ])
     })
   })
 

--- a/packages/backend/src/core/Clock.ts
+++ b/packages/backend/src/core/Clock.ts
@@ -46,7 +46,13 @@ export class Clock {
     const onNewTimestamps = () => {
       const last = this.getLastHour()
       while (next.lte(last)) {
-        callback(next)
+        if (next.add(7, 'days').gte(last)) {
+          callback(next)
+        } else {
+          if (next.isFull('day')) {
+            callback(next)
+          }
+        }
         next = next.add(1, 'hours')
       }
     }

--- a/packages/backend/src/core/Clock.ts
+++ b/packages/backend/src/core/Clock.ts
@@ -48,6 +48,10 @@ export class Clock {
       while (next.lte(last)) {
         if (next.add(7, 'days').gte(last)) {
           callback(next)
+        } else if (next.add(90, 'days').gte(last)) {
+          if (next.isFull('six hours')) {
+            callback(next)
+          }
         } else {
           if (next.isFull('day')) {
             callback(next)

--- a/packages/backend/src/core/activity/DailyTransactionCountViewRefresher.ts
+++ b/packages/backend/src/core/activity/DailyTransactionCountViewRefresher.ts
@@ -35,7 +35,7 @@ export class DailyTransactionCountViewRefresher {
         this.refreshQueue.addIfEmpty()
       }),
     )
-    this.clock.onEveryHour(() => this.refreshQueue.addIfEmpty())
     this.refreshQueue.addIfEmpty()
+    this.clock.onNewHour(() => this.refreshQueue.addIfEmpty())
   }
 }

--- a/packages/backend/src/core/assets/CBVUpdater.ts
+++ b/packages/backend/src/core/assets/CBVUpdater.ts
@@ -95,6 +95,13 @@ export class CBVUpdater implements ReportUpdater {
       'Timestamp cannot be smaller than minTimestamp',
     )
 
+    if (timestamp.equals(this.clock.getLastHour())) {
+      await this.reportRepository.deleteHourlyUntil(timestamp.add(-7, 'days'))
+      await this.reportRepository.deleteSixHourlyUntil(
+        timestamp.add(-90, 'days'),
+      )
+    }
+
     this.logger.debug('Update started', { timestamp: timestamp.toNumber() })
     const [prices, balances] = await Promise.all([
       this.priceUpdater.getPricesWhenReady(timestamp),

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -77,6 +77,60 @@ describe(ReportRepository.name, () => {
     })
   })
 
+  describe(ReportRepository.prototype.deleteHourlyUntil.name, () => {
+    it('deletes hourly reports', async () => {
+      const start = UnixTime.now().toStartOf('day')
+
+      const reports = []
+
+      const end = 25
+
+      for (let i = 0; i <= end; i++) {
+        reports.push(fakeReport({ timestamp: start.add(i, 'hours') }))
+      }
+
+      await Promise.all(reports.map((r) => repository.addOrUpdateMany([r])))
+      await repository.deleteHourlyUntil(start.add(end, 'hours'))
+      const results = await repository.getAll()
+      expect(results).toEqualUnsorted([
+        fakeReport({ timestamp: start }),
+        fakeReport({ timestamp: start.add(6, 'hours') }),
+        fakeReport({ timestamp: start.add(12, 'hours') }),
+        fakeReport({ timestamp: start.add(18, 'hours') }),
+        fakeReport({ timestamp: start.add(24, 'hours') }),
+        fakeReport({ timestamp: start.add(25, 'hours') }),
+      ])
+    })
+  })
+
+  describe(ReportRepository.prototype.deleteSixHourlyUntil.name, () => {
+    it('deletes six hourly reports', async () => {
+      const start = UnixTime.now().toStartOf('day')
+      const end = 25
+
+      const reports = [
+        fakeReport({ timestamp: start }),
+        fakeReport({ timestamp: start.add(1, 'hours') }),
+        fakeReport({ timestamp: start.add(6, 'hours') }),
+        fakeReport({ timestamp: start.add(12, 'hours') }),
+        fakeReport({ timestamp: start.add(18, 'hours') }),
+        fakeReport({ timestamp: start.add(24, 'hours') }),
+        fakeReport({ timestamp: start.add(25, 'hours') }),
+      ]
+
+      await Promise.all(reports.map((r) => repository.addOrUpdateMany([r])))
+      await repository.deleteSixHourlyUntil(start.add(end, 'hours'))
+      const results = await repository.getAll()
+      expect(results).toEqualUnsorted([
+        fakeReport({ timestamp: start }),
+        // keeps hourly
+        fakeReport({ timestamp: start.add(1, 'hours') }),
+        fakeReport({ timestamp: start.add(24, 'hours') }),
+        fakeReport({ timestamp: start.add(25, 'hours') }),
+      ])
+    })
+  })
+
   describe(ReportRepository.prototype.getAll.name, () => {
     it('returns all reports', async () => {
       const reports = [


### PR DESCRIPTION
Context:
There is an ongoing issue with our DB size, specifically reports and balances tables:
- our postgres instance will soon reach the capacity
- per-token requests are timing out

Currently reports table has ~300M records which translates to around 120GB disk space (with indexes)

Solution:
We store data with hourly granularity for all the historical timestamps (from 2019). If we remove hourly data for timestamp older than 7D and six hourly data for timestamp older than 90D we should reduce the size to `5%` of what we currently have. This should be step in the right direction, and the next should be to get rid of zeroes (which currently constitutes 92% of reports table)

Needed changes:
- change the Clock tick behaviour
- add method to remove historical data if it goes out of range (7D, 90D) - every repository & updater keeping TVL data should have it
- update hardcoded config hash, so the reports will recalculate 


Resolves L2B-2296