### PR TITLE
Update Loopring node requirement

### DIFF
--- a/packages/config/src/layer2s/loopring.ts
+++ b/packages/config/src/layer2s/loopring.ts
@@ -170,7 +170,7 @@ export const loopring: Layer2 = {
       callsItselfRollup: true,
       stateRootsPostedToL1: true,
       dataAvailabilityOnL1: true,
-      rollupNodeSourceAvailable: 'UnderReview',
+      rollupNodeSourceAvailable: false,
     },
     stage1: {
       stateVerificationOnL1: true,


### PR DESCRIPTION
Resolves L2B-3484

Loopring responded in October that they were going to answer our queries regarding the node requirement, and after pinging we got no response. Assuming here that the software doesn't exist.