### PR TITLE
Fix touch event handling in configureSlideCard function

### DIFF
--- a/packages/frontend/src/scripts/configureRichSelect.ts
+++ b/packages/frontend/src/scripts/configureRichSelect.ts
@@ -129,12 +129,12 @@ function configureSlideCard(
   function onTouchEnd(e: TouchEvent) {
     const touchEndY = e.changedTouches[0].clientY
     const diff = touchEndY - touchStartY
-    content.style.transform = ''
-    background.style.opacity = ''
     if (diff > CLOSE_GESTURE_Y_DIFF) {
       setState(null)
     }
     background.classList.add('transition-opacity')
+    background.style.opacity = ''
+    content.style.transform = ''
   }
 
   function close() {


### PR DESCRIPTION
This pull request fixes the touch event handling in the configureSlideCard function. The issue was that the background opacity and content transform were not being reset correctly after the touch end event. This caused incorrect behavior when closing the slide card (opacity went 100% and then to 0% after the touch end) . The fix ensures that the background opacity and content transform are reset properly, resolving the issue.