### PR TITLE
Add conditional generation of meta images in build process

### DIFF
--- a/packages/frontend/gulpfile.js
+++ b/packages/frontend/gulpfile.js
@@ -111,7 +111,7 @@ function serve() {
 const build = gulp.series(
   clean,
   gulp.parallel(buildScripts, buildSass, buildStyles, buildContent, copyStatic),
-  generateMetaImages,
+  ...(process.env.GENERATE_METAIMAGES ? [generateMetaImages] : []),
 )
 
 const watch = gulp.series(

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production gulp build",
+    "build:metaimages": "NODE_ENV=production GENERATE_METAIMAGES=true gulp build",
     "build:dependencies": "cd ../.. && yarn build:dependencies",
     "clean": "rm -rf build",
     "format:fix": "prettier --write .",

--- a/packages/frontend/src/build/caching/JsonHttpClient.ts
+++ b/packages/frontend/src/build/caching/JsonHttpClient.ts
@@ -6,7 +6,7 @@ import { HttpClient } from '../../../../shared/build'
 export class JsonHttpClient {
   constructor(
     private readonly http: HttpClient,
-    private readonly skipCache: boolean | undefined,
+    private readonly skipCache: boolean,
   ) {}
 
   async fetchJson(url: string): Promise<unknown> {

--- a/packages/frontend/src/build/caching/JsonHttpClient.ts
+++ b/packages/frontend/src/build/caching/JsonHttpClient.ts
@@ -6,7 +6,7 @@ import { HttpClient } from '../../../../shared/build'
 export class JsonHttpClient {
   constructor(
     private readonly http: HttpClient,
-    private readonly skipCache: boolean,
+    private readonly skipCache: boolean | undefined,
   ) {}
 
   async fetchJson(url: string): Promise<unknown> {


### PR DESCRIPTION
This pull request adds a conditional generation of meta images in the build process. Previously, the generation of meta images was always performed during the build. With this change, the generation of meta images will only occur if the environment variable `GENERATE_METAIMAGES` is set to `true`. This allows for more flexibility and control over the build process.