### PR TITLE
Exclude package json of non-dependent packages from Chromatic

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -29,4 +29,15 @@ jobs:
         run: yarn storybook:build
 
       - name: Publish to Chromatic
-        run: npx chromatic --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} --storybook-build-dir ./storybook-static --only-changed --exit-once-uploaded --exit-zero-on-changes --externals packages/frontend/tailwind.config.js --externals packages/frontend/src/styles --externals packages/frontend/src/static/fonts
+        run: >
+          npx chromatic 
+          --project-token ${{ secrets.CHROMATIC_PROJECT_TOKEN }} 
+          --storybook-build-dir ./storybook-static 
+          --only-changed 
+          --exit-once-uploaded 
+          --exit-zero-on-changes 
+          --externals packages/frontend/tailwind.config.js 
+          --externals packages/frontend/src/styles 
+          --externals packages/frontend/src/static/fonts 
+          --untraced packages/backend/package.json
+          --untraced packages/shared/package.json


### PR DESCRIPTION
This pull request excludes the package.json files of non-dependent packages from the Chromatic build process. This ensures that only the necessary package.json files are included, improving turbo snap efficiency.