### PR TITLE
fix: duplicated milestone

### DIFF
--- a/packages/config/src/layer2s/zksyncera.ts
+++ b/packages/config/src/layer2s/zksyncera.ts
@@ -6,7 +6,6 @@ import {
   EXITS,
   FORCE_TRANSACTIONS,
   makeBridgeCompatible,
-  MILESTONES,
   NEW_CRYPTOGRAPHY,
   NUGGETS,
   OPERATOR,
@@ -374,13 +373,6 @@ export const zksyncera: Layer2 = {
       link: 'https://zksync.mirror.xyz/HJ2Pj45EJkRdt5Pau-ZXwkV2ctPx8qFL19STM5jdYhc',
       date: '2023-07-17T00:00:00Z',
       description: 'Deployment of Boojum - new high-performance proof system.',
-    },
-    {
-      ...MILESTONES.MAINNET_OPEN,
-      link: 'https://blog.matter-labs.io/gm-zkevm-171b12a26b36',
-      date: '2022-03-24T00:00:00Z',
-      description:
-        'Whitelist got removed, there are no restrictions on who can transact with the network.',
     },
     {
       name: 'zkSync 2.0 baby alpha launch',


### PR DESCRIPTION
There's a duplicated milestone in the zkSync Era page. Mainnet launch is included twice, the first one as the "zkSync 2.0 baby alpha launch" and the second one as the default "Mainnet for all", which even has a wrong date (March 2022). This PR removes the default one.