### PR TITLE
Update Polygon zkEVM

### DIFF
--- a/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
+++ b/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
@@ -106,6 +106,9 @@
     "AdminMultisig": {
       "ignoreMethods": ["nonce"]
     },
+    "EscrowsAdmin": {
+      "ignoreMethods": ["nonce"]
+    },
     "MaticToken": { "ignoreDiscovery": true }
   }
 }

--- a/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
@@ -1,3 +1,36 @@
+# Diff at Thu, 11 Jan 2024 15:48:40 GMT:
+
+- author: Radina Talanova (<radinatalanova@Radinas-MacBook-Air.local>)
+- comparing to: master@d79128df189c297a74fb89b3a58b7e0d6edd88f4 block: 18968776
+- current block number: 18984674
+
+## Description
+
+The EscrowsAdmin multisig threshold is updated - now 5/10. Nonce is ignored.
+
+## Watched changes
+
+```diff
+    contract EscrowsAdmin (0xf694C9e3a34f5Fa48b6f3a0Ff186C1c6c4FcE904) {
+      values.getThreshold:
+-        1
++        5
+    }
+```
+
+## Config related changes
+
+Following changes come from updates made to the config file,
+not from differences found during discovery. Values are
+for block 18968776 (main branch discovery), not current.
+
+```diff
+    contract EscrowsAdmin (0xf694C9e3a34f5Fa48b6f3a0Ff186C1c6c4FcE904) {
+      values.nonce:
+-        0
+    }
+```
+
 # Diff at Fri, 10 Nov 2023 10:41:51 GMT:
 
 - author: Mateusz Radomski (<radomski.main@protonmail.com>)

--- a/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
@@ -1,6 +1,6 @@
 # Diff at Thu, 11 Jan 2024 15:48:40 GMT:
 
-- author: Radina Talanova (<radinatalanova@Radinas-MacBook-Air.local>)
+- author: Radina Talanova (<nt.radina@gmail.com>)
 - comparing to: master@d79128df189c297a74fb89b3a58b7e0d6edd88f4 block: 18968776
 - current block number: 18984674
 

--- a/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "polygonzkevm",
   "chain": "ethereum",
-  "blockNumber": 18968776,
-  "configHash": "0xdcc57498fdfc78cbaafe06569c130434bee15b10e7b7d6a51c916b20dfee1406",
+  "blockNumber": 18984674,
+  "configHash": "0x90c6e7d7015fe5fb8b0a9ef15df7da6896bc0bd52716d88a3d21c5e42f0b94ae",
   "version": 3,
   "contracts": [
     {
@@ -305,8 +305,7 @@
           "0x4DE44Aa0Ef9DB64DF3eB3465d35D73d0409d44ed",
           "0x4E83124eD15b13265240B61EC9627797CCE1032E"
         ],
-        "getThreshold": 1,
-        "nonce": 0,
+        "getThreshold": 5,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"


### PR DESCRIPTION
The EscrowsAdmin multisig threshold is updated - now 5/10. `nonce` is ignored.

Resolves L2B-3543