### PR TITLE
Add build:without-frontend script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "turbo run build",
     "build:backend": "turbo run build --filter=backend",
     "build:frontend": "turbo run build --filter=frontend",
+    "build:without-frontend": "turbo run build --filter=!frontend",
     "clean": "turbo run clean",
     "fix": "yarn lint:fix && yarn format:fix",
     "format": "turbo run format",


### PR DESCRIPTION
This PR is aimed to make people not working on frontend life easier by adding a script that omits the frontend build process which takes the most time and is not necessary for everyone.