### PR TITLE
Update Starknet

### DIFF
--- a/packages/backend/discovery/starknet/ethereum/diffHistory.md
+++ b/packages/backend/discovery/starknet/ethereum/diffHistory.md
@@ -1,3 +1,36 @@
+# Diff at Mon, 15 Jan 2024 12:19:39 GMT:
+
+- author: Radina Talanova (<nt.radina@gmail.com>)
+- comparing to: master@7146ff49765d6596dfb78aa68e5c4cee6f5f4642 block: 18940875
+- current block number: 19012236
+
+## Description
+
+The program hash and config hash are updated (with transactions 0xd15e25aaac8f634fcbe599fe0f47959d087dac5674091e12fc5a5a9808899f46 and 0x28a355fcc9228ed719110e075a3071d20446cfaff5ece324839429680fc87cf4). One of the USDC Bridge proxy governors has been removed.
+
+## Watched changes
+
+```diff
+    contract Starknet (0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4) {
+      values.configHash:
+-        "671483050609816861429812414688707376174032882875357307847551691140236175837"
++        "2590421891839256512113614983194993186457498815986333310670788206383913888162"
+      values.programHash:
+-        "54878256403880350656938046611252303365750679698042371543935159963667935317"
++        "2479841346739966073527450029179698923866252973805981504232089731754042431018"
+    }
+```
+
+```diff
+    contract USDC Bridge (0xF6080D9fbEEbcd44D89aFfBFd42F098cbFf92816) {
+      upgradeability.proxyGovernance[1]:
+-        "0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"
+      upgradeability.proxyGovernance.0:
+-        "0xf5EF70bb0975cAF85461523e0cB3910c35cb30b4"
++        "0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"
+    }
+```
+
 # Diff at Tue, 19 Dec 2023 15:34:07 GMT:
 
 - author: Radina Talanova (<nt.radina@gmail.com>)

--- a/packages/backend/discovery/starknet/ethereum/discovered.json
+++ b/packages/backend/discovery/starknet/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "starknet",
   "chain": "ethereum",
-  "blockNumber": 18940875,
+  "blockNumber": 19012236,
   "configHash": "0x64cde34ba05a69f506b3565a9280c5b600a9a07e4f672890cfa0bbe0b6001a67",
   "version": 3,
   "contracts": [
@@ -25,7 +25,7 @@
           "0x64F4396bb0669C72858Cc50C779b48EB25F45770"
         ],
         "getThreshold": 2,
-        "nonce": 5,
+        "nonce": 6,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -180,7 +180,7 @@
           "0xCe958D997F4a5824D4d503A128216322C6C223a0"
         ],
         "getThreshold": 2,
-        "nonce": 17,
+        "nonce": 19,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -320,7 +320,7 @@
       "implementations": ["0x16938E4b59297060484Fa56a12594d8D6F4177e8"],
       "sinceTimestamp": 1636978914,
       "values": {
-        "configHash": "671483050609816861429812414688707376174032882875357307847551691140236175837",
+        "configHash": "2590421891839256512113614983194993186457498815986333310670788206383913888162",
         "getMaxL1MsgFee": "1000000000000000000",
         "getUpgradeActivationDelay": 0,
         "governedFinalized": 0,
@@ -333,18 +333,18 @@
         "isFinalized": false,
         "isFrozen": false,
         "isNotFinalized": true,
-        "l1ToL2MessageNonce": 1612141,
+        "l1ToL2MessageNonce": 1615773,
         "messageCancellationDelay": 432100,
         "operators": [
           "0xFf6B2185E357b6e9136A1b2ca5d7C45765D5c591",
           "0x2C169DFe5fBbA12957Bdd0Ba47d9CEDbFE260CA7"
         ],
-        "programHash": "54878256403880350656938046611252303365750679698042371543935159963667935317",
+        "programHash": "2479841346739966073527450029179698923866252973805981504232089731754042431018",
         "PROXY_GOVERNANCE_TAG": "StarkEx.Proxy.2019.GovernorsInformation",
         "PROXY_VERSION": "3.0.0",
-        "stateBlockHash": "2263931808097414694782640345303634435574998748669661090796416266480593434572",
-        "stateBlockNumber": 495348,
-        "stateRoot": "885176065540924691680130036876997393196928050990788284792311644159344083517",
+        "stateBlockHash": "3477422271958119284482204678455752518076861184569368551088694938000562590910",
+        "stateBlockNumber": 506744,
+        "stateRoot": "1907077908166114592051071516510318670795872632299043023012173611380932534824",
         "UPGRADE_DELAY_SLOT": "0xc21dbb3089fcb2c4f4c6a67854ab4db2b0f233ea4b21b21f912d52d18fc5db1f",
         "verifier": "0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60"
       },
@@ -473,10 +473,7 @@
         "implementation": "0x6Fa346c1e77C17d7976Bf1EFE2b121E845f15FEB",
         "upgradeDelay": 604800,
         "isFinal": false,
-        "proxyGovernance": [
-          "0xf5EF70bb0975cAF85461523e0cB3910c35cb30b4",
-          "0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"
-        ]
+        "proxyGovernance": ["0x015277f49d5dD035A5F3Ce34aD5eBfDBaCA0C6Ec"]
       },
       "implementations": ["0x6Fa346c1e77C17d7976Bf1EFE2b121E845f15FEB"],
       "sinceTimestamp": 1657137639,
@@ -547,7 +544,6 @@
     "0xD5fB66CaEE881367Df4409B17Fd53a2Ef0D9B263",
     "0xdc29f0F7742ec462Af475AceeCECC57601991D23",
     "0xe8e9E69511BaaFC826953fC93cdf1ED6d3B63c53",
-    "0xf5EF70bb0975cAF85461523e0cB3910c35cb30b4",
     "0xfdF3E24BD26368512C5F65959BBB668d3338f994",
     "0xFf6B2185E357b6e9136A1b2ca5d7C45765D5c591"
   ],

--- a/packages/config/src/layer2s/starknet.ts
+++ b/packages/config/src/layer2s/starknet.ts
@@ -361,8 +361,16 @@ export const starknet: Layer2 = {
         {
           formula: 'sharpSubmission',
           sinceTimestamp: new UnixTime(1702921247),
+          untilTimestamp: new UnixTime(1704898931),
           programHashes: [
             '54878256403880350656938046611252303365750679698042371543935159963667935317',
+          ],
+        },
+        {
+          formula: 'sharpSubmission',
+          sinceTimestamp: new UnixTime(1704898931),
+          programHashes: [
+            '2590421891839256512113614983194993186457498815986333310670788206383913888162',
           ],
         },
       ],


### PR DESCRIPTION
Could not find what exactly the config hash is used for, but it’s validated on a state update and used when initializing contract state. The change is probably related to Starknet v0.13. Apart from that, one proxy governor is removed from the USDC bridge escrow and the program hash is updated, so is the liveness config. 

Resolves L2B-3542