### PR TITLE
Update Linea

### DIFF
--- a/packages/backend/discovery/linea/ethereum/diffHistory.md
+++ b/packages/backend/discovery/linea/ethereum/diffHistory.md
@@ -1,4 +1,34 @@
-# Diff at Thu, 23 Nov 2023 15:07:23 GMT:
+# Diff at Mon, 15 Jan 2024 14:53:19 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@51b4576752b780b70ed977cf2d54041a7eb81039 block: 18618865
+- current block number: 19012997
+
+## Description
+
+New role has been configured (`1`).
+One and only member has been assigned (`0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8`).
+
+Assigned member can now invoke:
+
+- `pauseByType(bytes32)` on ZkEVM/MessageService (`0xd19d4B5d358258f05D7B411E21A1460D11B0876F`)
+- `pause()` on ERC20Bridge (`0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319`)
+- `pause()` on USDCBridge (`0x504A330327A089d8364C4ab3811Ee26976d388ce`)
+
+## The member of this role can now invoke
+
+## Watched changes
+
+```diff
+    contract Roles (0xF24f1DC519d88246809B660eb56D94048575d083) {
+      upgradeability.modules[0]:
++        "0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8"
+      values.roles.roles.1:
++        {"members":{"0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8":true},"targets":{"0xd19d4B5d358258f05D7B411E21A1460D11B0876F":{"clearance":"Function","options":"None"},"0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319":{"clearance":"Function","options":"None"},"0x504A330327A089d8364C4ab3811Ee26976d388ce":{"clearance":"Function","options":"None"}},"functions":{"0xd19d4B5d358258f05D7B411E21A1460D11B0876F":{"pauseByType(bytes32)":{"options":"None","wildcarded":true,"parameters":[]}},"0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319":{"pause()":{"options":"None","wildcarded":true,"parameters":[]}},"0x504A330327A089d8364C4ab3811Ee26976d388ce":{"pause()":{"options":"None","wildcarded":true,"parameters":[]}}},"compValues":{},"compValuesOneOf":{}}
+    }
+```
+
+# Diff at Thu, 23 Nov 2023 15:07:23 GMT
 
 - author: Mateusz Radomski (<radomski.main@protonmail.com>)
 - comparing to: master@2ff45714640abe4c50d283967078888d4af81d78
@@ -65,7 +95,7 @@ AccessControl in Scroll.
  17 files changed, 2055 insertions(+)
 ```
 
-# Diff at Mon, 16 Oct 2023 07:14:10 GMT:
+# Diff at Mon, 16 Oct 2023 07:14:10 GMT
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: master@a2d21b0282f36d2369596c2fe3bb3e7746063abe

--- a/packages/backend/discovery/linea/ethereum/discovered.json
+++ b/packages/backend/discovery/linea/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "linea",
   "chain": "ethereum",
-  "blockNumber": 18618865,
+  "blockNumber": 19012997,
   "configHash": "0x32afc6b115e3f460d66d7650302ece2ff7e5dd478565b934dc21e0e75963d04c",
   "version": 3,
   "contracts": [
@@ -84,7 +84,7 @@
       "implementations": ["0x0eC393209674090368C592A591B25811e490BF36"],
       "sinceTimestamp": 1691086271,
       "values": {
-        "balance": 14311940294779,
+        "balance": 17243586431371,
         "messageService": "0xd19d4B5d358258f05D7B411E21A1460D11B0876F",
         "owner": "0x892bb7EeD71efB060ab90140e7825d8127991DD3",
         "paused": false,
@@ -137,7 +137,7 @@
           "0xB4dAebe4D01f467701F95f0196fc29033c54dBcb"
         ],
         "getThreshold": 4,
-        "nonce": 33,
+        "nonce": 34,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -192,7 +192,7 @@
             "members": ["0x892bb7EeD71efB060ab90140e7825d8127991DD3"]
           }
         },
-        "currentPeriodAmountInWei": "83287000000000000",
+        "currentPeriodAmountInWei": "2364709172824000000",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "GENERAL_PAUSE_TYPE": "0x06193bb948d6b7a6fcbe51c193ccf2183bb5d979b6ae5d3a6971b8851461d3b0",
         "generalPause": false,
@@ -274,7 +274,7 @@
         "avatar": "0x892bb7EeD71efB060ab90140e7825d8127991DD3",
         "target": "0x892bb7EeD71efB060ab90140e7825d8127991DD3",
         "guard": "0x0000000000000000000000000000000000000000",
-        "modules": []
+        "modules": ["0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8"]
       },
       "sinceTimestamp": 1700506439,
       "values": {
@@ -285,7 +285,52 @@
         "owner": "0x892bb7EeD71efB060ab90140e7825d8127991DD3",
         "roles": {
           "defaultRoles": {},
-          "roles": {}
+          "roles": {
+            "1": {
+              "members": {
+                "0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8": true
+              },
+              "targets": {
+                "0xd19d4B5d358258f05D7B411E21A1460D11B0876F": {
+                  "clearance": "Function",
+                  "options": "None"
+                },
+                "0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319": {
+                  "clearance": "Function",
+                  "options": "None"
+                },
+                "0x504A330327A089d8364C4ab3811Ee26976d388ce": {
+                  "clearance": "Function",
+                  "options": "None"
+                }
+              },
+              "functions": {
+                "0xd19d4B5d358258f05D7B411E21A1460D11B0876F": {
+                  "pauseByType(bytes32)": {
+                    "options": "None",
+                    "wildcarded": true,
+                    "parameters": []
+                  }
+                },
+                "0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319": {
+                  "pause()": {
+                    "options": "None",
+                    "wildcarded": true,
+                    "parameters": []
+                  }
+                },
+                "0x504A330327A089d8364C4ab3811Ee26976d388ce": {
+                  "pause()": {
+                    "options": "None",
+                    "wildcarded": true,
+                    "parameters": []
+                  }
+                }
+              },
+              "compValues": {},
+              "compValuesOneOf": {}
+            }
+          }
         },
         "target": "0x892bb7EeD71efB060ab90140e7825d8127991DD3"
       },
@@ -310,6 +355,7 @@
     "0x239d9B860399366F8d25F6e2962Fb2B9D070aEFE",
     "0x353012dc4a9A6cF55c941bADC267f82004A8ceB9",
     "0x36a0b60162d7F407d74bd1def01410D20437F87B",
+    "0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8",
     "0x497515578b0BE54d2f0f32cF3F08B85Bf8cEB6aB",
     "0x4CB4da1D1C198E506031C0Aa8480BA8b57C0fAD4",
     "0x5822D8457c00FB82203918ED92907b935B9D40AE",

--- a/packages/config/src/layer2s/linea.ts
+++ b/packages/config/src/layer2s/linea.ts
@@ -296,7 +296,7 @@ export const linea: Layer2 = {
     ),
     discovery.contractAsPermissioned(
       discovery.getContract('Roles'),
-      `Module to the AdminMultisig. Allows to add additional members to the multisig via permissions to call functions specified by roles. 0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8 is able to invoke pause() on ERC20Bridge and USDCBridge. Also given address is able to invoke pauseByType() on ZkEvm contract`,
+      `Module to the AdminMultisig. Allows to add additional members to the multisig via permissions to call functions specified by roles.`,
     ),
     {
       accounts: operators,

--- a/packages/config/src/layer2s/linea.ts
+++ b/packages/config/src/layer2s/linea.ts
@@ -54,10 +54,7 @@ const zodiacRoles = discovery.getContractValue<{
 const zodiacPauserRole = '1'
 const zodiacPausers: ScalingProjectPermissionedAccount[] = Object.keys(
   zodiacRoles.roles[zodiacPauserRole].members,
-).map((zodiacPauser) => ({
-  address: EthereumAddress(zodiacPauser),
-  type: 'EOA',
-}))
+).map((zodiacPauser) => discovery.formatPermissionedAccount(zodiacPauser))
 
 const operators: ScalingProjectPermissionedAccount[] =
   roles.OPERATOR_ROLE.members.map((address) => ({

--- a/packages/config/src/layer2s/linea.ts
+++ b/packages/config/src/layer2s/linea.ts
@@ -1,6 +1,4 @@
-import { ContractValue } from '@l2beat/discovery-types'
 import {
-  assert,
   AssetId,
   ChainId,
   CoingeckoId,
@@ -298,22 +296,27 @@ export const linea: Layer2 = {
     ),
     discovery.contractAsPermissioned(
       discovery.getContract('Roles'),
-      `Module to the AdminMultisig. Allows to add additional members to the multisig via permissions to call functions specified by roles. ${(() => {
-        const roles = discovery.getContract('Roles')
-        assert(roles.values !== undefined)
-        const rolesCount = Object.entries(
-          roles.values.roles['roles' as keyof ContractValue],
-        ).length
-        assert(rolesCount === 0)
-
-        return 'Currently there are no additional members.'
-      })()}`,
+      `Module to the AdminMultisig. Allows to add additional members to the multisig via permissions to call functions specified by roles. 0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8 is able to invoke pause() on ERC20Bridge and USDCBridge. Also given address is able to invoke pauseByType() on ZkEvm contract`,
     ),
     {
       accounts: operators,
       name: 'Operators',
       description:
         'The operators are allowed to prove blocks and post the corresponding transaction data.',
+    },
+    // FIXME: Add value transformer
+    {
+      accounts: [
+        {
+          address: EthereumAddress(
+            '0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8',
+          ),
+          type: 'EOA',
+        },
+      ],
+      name: 'Members of Role 1',
+      description:
+        'Allowed to invoke pause() on ERC20Bridge and USDCBridge. Allowed to invoke pauseByType() on zkEVM contract.',
     },
   ],
   contracts: {

--- a/packages/config/src/layer2s/linea.ts
+++ b/packages/config/src/layer2s/linea.ts
@@ -48,6 +48,17 @@ const roles = discovery.getContractValue<{
   PAUSE_MANAGER_ROLE: { members: string[] }
 }>('zkEVM', 'accessControl')
 
+const zodiacRoles = discovery.getContractValue<{
+  roles: Record<string, Record<string, boolean>>
+}>('Roles', 'roles')
+const zodiacPauserRole = '1'
+const zodiacPausers: ScalingProjectPermissionedAccount[] = Object.keys(
+  zodiacRoles.roles[zodiacPauserRole].members,
+).map((zodiacPauser) => ({
+  address: EthereumAddress(zodiacPauser),
+  type: 'EOA',
+}))
+
 const operators: ScalingProjectPermissionedAccount[] =
   roles.OPERATOR_ROLE.members.map((address) => ({
     address: EthereumAddress(address),
@@ -304,19 +315,12 @@ export const linea: Layer2 = {
       description:
         'The operators are allowed to prove blocks and post the corresponding transaction data.',
     },
-    // FIXME: Add value transformer
+
     {
-      accounts: [
-        {
-          address: EthereumAddress(
-            '0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8',
-          ),
-          type: 'EOA',
-        },
-      ],
-      name: 'Members of Role 1',
+      accounts: zodiacPausers,
+      name: 'Pauser',
       description:
-        'Allowed to invoke pause() on ERC20Bridge and USDCBridge. Allowed to invoke pauseByType() on zkEVM contract.',
+        'Address allowed to pause the ERC20Bridge, the USDCBridge and the core functionalities of the project.',
     },
   ],
   contracts: {


### PR DESCRIPTION
Resolves L2B-3469

## Changes

New role has been configured (`1`).
One and only member has been assigned ([0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8](https://etherscan.io/address/0x453B3A4b4d64B4E6f472A306c3D4Fc318C34bbA8)).

Assigned member can now invoke:

- `pauseByType(bytes32)` on ZkEVM/MessageService ([0xd19d4B5d358258f05D7B411E21A1460D11B0876F](https://etherscan.io/address/0xd19d4B5d358258f05D7B411E21A1460D11B0876F))
- `pause()` on ERC20Bridge ([0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319](https://etherscan.io/address/0x051F1D88f0aF5763fB888eC4378b4D8B29ea3319))
- `pause()` on USDCBridge ([0x504A330327A089d8364C4ab3811Ee26976d388ce](https://etherscan.io/address/0x504A330327A089d8364C4ab3811Ee26976d388ce))

## Notes

- [Role configuration transaction](https://etherscan.io/tx/0x713fbc3ad326969596c6d7fb38e76081a971036333b3807f2302242d87b53134)
- Tenderly stack
![image](https://github.com/l2beat/l2beat/assets/67391475/b08e77f3-5bc0-4432-a3bc-67a4227a1d6e)

I'm not into the topic much yet, so I have to sync my understanding of zodiac Roles w/ somebody.
I presume this one member cannot pause the bridge without owners signing the transactions first ;p

I'll write the extractor for roles to be displayed on the page once I get confirmation.
