### PR TITLE
Import assert from @l2beat/shared-pure

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,6 +52,10 @@
           {
             "group": ["ethers/*"],
             "message": "Do not import from ethers submodules. For example instead of importing getAddress from ethers/lib/utils, import utils from ethers and use utils.getAddress"
+          },
+          {
+            "group": ["console"],
+            "message": "Do not import assert from console. You probably wanted to import from @l2beat/shared-pure."
           }
         ]
       }

--- a/packages/backend/src/core/discovery/DiscoveryRunner.ts
+++ b/packages/backend/src/core/discovery/DiscoveryRunner.ts
@@ -9,8 +9,7 @@ import {
   UnixTime as DiscoveryUnixTime,
 } from '@l2beat/discovery'
 import type { DiscoveryOutput } from '@l2beat/discovery-types'
-import { ChainId, UnixTime } from '@l2beat/shared-pure'
-import { assert } from 'console'
+import { assert, ChainId, UnixTime } from '@l2beat/shared-pure'
 import { isEqual, isError } from 'lodash'
 import { Gauge, Histogram } from 'prom-client'
 

--- a/packages/config/scripts/tokens/add/index.ts
+++ b/packages/config/scripts/tokens/add/index.ts
@@ -1,8 +1,7 @@
 import { getEnv } from '@l2beat/backend-tools'
 import { CoingeckoClient, HttpClient } from '@l2beat/shared'
-import { EthereumAddress, Token } from '@l2beat/shared-pure'
+import { assert, EthereumAddress, Token } from '@l2beat/shared-pure'
 import chalk from 'chalk'
-import { assert } from 'console'
 import { providers } from 'ethers'
 import { writeFileSync } from 'fs'
 

--- a/packages/config/src/layer2s/aztecconnect.ts
+++ b/packages/config/src/layer2s/aztecconnect.ts
@@ -1,5 +1,9 @@
-import { EthereumAddress, ProjectId, UnixTime } from '@l2beat/shared-pure'
-import { assert } from 'console'
+import {
+  assert,
+  EthereumAddress,
+  ProjectId,
+  UnixTime,
+} from '@l2beat/shared-pure'
 
 import {
   CONTRACTS,


### PR DESCRIPTION
There was a bug (3 occurrences) that we import assert from `console` instead of `@l2beat/shared-pure`. This PR fixes the bug and adds an eslint rule banning importing from console.