### PR TITLE
fix: update zksync Lite links

### DIFF
--- a/packages/config/src/layer2s/zksynclite.ts
+++ b/packages/config/src/layer2s/zksynclite.ts
@@ -62,7 +62,7 @@ export const zksynclite: Layer2 = {
     links: {
       websites: ['https://zksync.io/'],
       apps: ['https://lite.zksync.io/'],
-      documentation: ['https://docs.zksync.io/dev/'],
+      documentation: ['https://docs.lite.zksync.io/dev/'],
       explorers: ['https://zkscan.io/'],
       repositories: ['https://github.com/matter-labs/zksync'],
       socialMedia: [
@@ -297,7 +297,7 @@ export const zksynclite: Layer2 = {
         references: [
           {
             text: 'Withdrawing funds - zkSync documentation',
-            href: 'https://docs.zksync.io/dev/payments/basic/#withdrawing-funds',
+            href: 'https://docs.lite.zksync.io/dev/payments/basic/#withdrawing-funds',
           },
         ],
       },
@@ -306,7 +306,7 @@ export const zksynclite: Layer2 = {
         references: [
           {
             text: 'Withdrawing funds - zkSync documentation',
-            href: 'https://docs.zksync.io/dev/payments/basic/#withdrawing-funds',
+            href: 'https://docs.lite.zksync.io/dev/payments/basic/#withdrawing-funds',
           },
           {
             text: 'ZkSync.sol#L325 - Etherscan source code, requestFullExit function',
@@ -323,7 +323,7 @@ export const zksynclite: Layer2 = {
         references: [
           {
             text: 'Withdrawing funds - zkSync documentation',
-            href: 'https://docs.zksync.io/dev/payments/basic/#withdrawing-funds',
+            href: 'https://docs.lite.zksync.io/dev/payments/basic/#withdrawing-funds',
           },
           {
             text: 'README.md - zkSync Exit Tool',


### PR DESCRIPTION
Hello,
I've found that some of the links inside the `zkSync Lite` page need to be updated to explicitly match Lite docs instead of `zkSync Era` docs. Hope it helps.
