### PR TITLE
Preserve new lines in tooltip

### DIFF
--- a/packages/config/src/layer2s/arbitrum.ts
+++ b/packages/config/src/layer2s/arbitrum.ts
@@ -460,7 +460,7 @@ export const arbitrum: Layer2 = {
         selfSequencingDelay,
       )} to force a tx, users have only ${formatSeconds(
         l2TimelockDelay - selfSequencingDelay,
-      )} to exit. If users post a tx after that time, they would need to self propose a root with a ${formatSeconds(
+      )} to exit.\nIf users post a tx after that time, they would need to self propose a root with a ${formatSeconds(
         validatorAfkTime,
       )} delay and then wait for the ${formatSeconds(
         challengeWindowSeconds,

--- a/packages/config/src/layer2s/nova.ts
+++ b/packages/config/src/layer2s/nova.ts
@@ -125,7 +125,7 @@ export const nova: Layer2 = {
         selfSequencingDelay,
       )} to force a tx, users have only ${formatSeconds(
         l2TimelockDelay - selfSequencingDelay,
-      )} to exit. If users post a tx after that time, they would need to self propose a root with a ${formatSeconds(
+      )} to exit.\nIf users post a tx after that time, they would need to self propose a root with a ${formatSeconds(
         validatorAfkTime,
       )} delay and then wait for the ${formatSeconds(
         challengeWindowSeconds,

--- a/packages/frontend/src/components/tooltip/TooltipProvider.tsx
+++ b/packages/frontend/src/components/tooltip/TooltipProvider.tsx
@@ -17,7 +17,7 @@ export function TooltipProvider({
       data-role="tooltip-popup"
       data-testid="tooltip"
     >
-      <span />
+      <span className="whitespace-pre-line" />
       <svg
         width="16"
         height="8"


### PR DESCRIPTION
This pull request preserves new lines in the tooltip by adding the "whitespace-pre-line" class to the span element.