### PR TITLE
Update Polygon Plasma

### DIFF
--- a/packages/backend/discovery/polygon-plasma/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygon-plasma/ethereum/diffHistory.md
@@ -1,3 +1,37 @@
+# Diff at Mon, 22 Jan 2024 11:48:25 GMT:
+
+- author: Mateusz Radomski (<radomski.main@protonmail.com>)
+- comparing to: master@7755f153438c1f16773ba6733cfa3a8c8bc0a394 block: 18769796
+- current block number: 19062081
+
+## Description
+
+Last checkpoint that had the old hash: 0x9b2c468c4ec0c6758e6918697490eb41ce9c90eaed3d243c93b27359d36672ae
+Transaction that changed the stateRoot: 0x57e1fc189829809677179955a38eab74311309c872c995834e93fd153efa31ba
+
+Changed the Merkle Root that allows for withdrawing the Heimdall fee.
+This root is not used in any other place, it's just for claiming the Heimdall fee.
+Nobody in the history of this contract nobody ever claimed any Heimdall fee.
+See `function claimFee(uint256 accumFeeAmount, uint256 index, bytes memory proof)` for how the claiming works.
+
+## Watched changes
+
+```diff
+    contract StakeManager (0x5e3Ef299fDDf15eAa0432E6e66473ace8c13D908) {
+      values.accountStateRoot:
+-        "0x85d7a8f1697e2a84910d571af5875abfdb954c6050766f6866a6bb9fc7c660ca"
++        "0x008cac7abbedf34deff1dedf34b09ccab63cc457993151a7f50e54c12174ad25"
+    }
+```
+
+```diff
+    contract StakingInfo (0xa59C847Bd5aC0172Ff4FE912C5d29E5A71A7512B) {
+      values.getAccountStateRoot:
+-        "0x85d7a8f1697e2a84910d571af5875abfdb954c6050766f6866a6bb9fc7c660ca"
++        "0x008cac7abbedf34deff1dedf34b09ccab63cc457993151a7f50e54c12174ad25"
+    }
+```
+
 # Diff at Tue, 12 Dec 2023 11:26:42 GMT:
 
 - author: Radina Talanova (<nt.radina@gmail.com>)

--- a/packages/backend/discovery/polygon-plasma/ethereum/discovered.json
+++ b/packages/backend/discovery/polygon-plasma/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "polygon-plasma",
   "chain": "ethereum",
-  "blockNumber": 18769796,
+  "blockNumber": 19062081,
   "configHash": "0xa6a26ac439c39e55635de77dc8b7d61f6879f86db46a10d9a9931ac93a2b3111",
   "version": 3,
   "contracts": [
@@ -35,7 +35,7 @@
       },
       "sinceTimestamp": 1590850580,
       "values": {
-        "counter": 2823319,
+        "counter": 2850337,
         "isOwner": false,
         "owner": "0xFa7D2a996aC6350f4b56C043112Da0366a59b74c",
         "REGISTRATIONS": [
@@ -149,18 +149,18 @@
       ],
       "sinceTimestamp": 1593189690,
       "values": {
-        "accountStateRoot": "0x85d7a8f1697e2a84910d571af5875abfdb954c6050766f6866a6bb9fc7c660ca",
+        "accountStateRoot": "0x008cac7abbedf34deff1dedf34b09ccab63cc457993151a7f50e54c12174ad25",
         "auctionPeriod": 20,
         "CHECKPOINT_REWARD": "71795000000000000000000",
         "checkPointBlockInterval": 5120,
         "checkpointRewardDelta": 10,
-        "currentEpoch": 54880,
+        "currentEpoch": 56772,
         "currentValidatorSetSize": 105,
-        "currentValidatorSetTotalStake": "3529491870751941286665987341",
+        "currentValidatorSetTotalStake": "3528079732543138653529987257",
         "delegationEnabled": true,
         "delegatorsReward": [],
         "dynasty": 80,
-        "epoch": 54880,
+        "epoch": 56772,
         "eventsHub": "0x6dF5CB08d3f0193C768C8A01f42ac4424DC5086b",
         "extensionCode": "0xef49Ea6996073752b6840CDA34773FFA78F78166",
         "getRegistry": "0x33a02E6cC863D393d6Bf231B697b82F6e499cA71",
@@ -173,7 +173,7 @@
         "minDeposit": "1000000000000000000",
         "minHeimdallFee": "1000000000000000000",
         "NFTContract": "0x47Cbe25BbDB40a774cC37E1dA92d10C2C7Ec897F",
-        "NFTCounter": 167,
+        "NFTCounter": 170,
         "owner": "0xCaf0aa768A3AE1297DF20072419Db8Bb8b5C8cEf",
         "ownerOf": [],
         "prevBlockInterval": 1,
@@ -185,13 +185,13 @@
         "rootChain": "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287",
         "signerUpdateLimit": 100,
         "token": "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0",
-        "totalHeimdallFee": "9574939209428901681108",
+        "totalHeimdallFee": "9657939209428901681108",
         "totalRewards": "201179489204211582010647007",
-        "totalRewardsLiquidated": "90501832465153508299231926",
-        "totalStaked": "18484300565665726949947902",
+        "totalRewardsLiquidated": "93582628789935965535713629",
+        "totalStaked": "16853706463170572679011317",
         "validatorReward": [],
         "validatorShareFactory": "0xc4FA447A0e77Eff9717b09C057B40570813bb642",
-        "validatorState": ["3529491870751941286665987341", 105],
+        "validatorState": ["3528079732543138653529987257", 105],
         "validatorThreshold": 105,
         "WITHDRAWAL_DELAY": 80,
         "withdrawalDelay": 80
@@ -258,10 +258,10 @@
       "implementations": ["0x536c55cFe4892E581806e10b38dFE8083551bd03"],
       "sinceTimestamp": 1590849960,
       "values": {
-        "_nextHeaderBlock": 548800000,
+        "_nextHeaderBlock": 567720000,
         "CHAINID": 137,
-        "currentHeaderBlock": 548790000,
-        "getLastChildBlock": 51042213,
+        "currentHeaderBlock": 567710000,
+        "getLastChildBlock": 52617893,
         "heimdallId": "0x7e10229e6df5851dc336f813dde0cf6559cd517f9ff1980e2e57e192ba3a2329",
         "implementation": "0x536c55cFe4892E581806e10b38dFE8083551bd03",
         "isOwner": false,
@@ -283,7 +283,7 @@
         "decimals": 18,
         "name": "Wrapped Ether",
         "symbol": "WETH",
-        "totalSupply": "105423211356009474889"
+        "totalSupply": "104924536332009474889"
       },
       "derivedName": "MaticWETH"
     },
@@ -295,7 +295,7 @@
       },
       "sinceTimestamp": 1593189612,
       "values": {
-        "getAccountStateRoot": "0x85d7a8f1697e2a84910d571af5875abfdb954c6050766f6866a6bb9fc7c660ca",
+        "getAccountStateRoot": "0x008cac7abbedf34deff1dedf34b09ccab63cc457993151a7f50e54c12174ad25",
         "getStakerDetails": [
           [0, 0, 0, 0, "0x0000000000000000000000000000000000000000", 0]
         ],


### PR DESCRIPTION
Resolves L2B-3375

Last checkpoint that had the old hash: `0x9b2c468c4ec0c6758e6918697490eb41ce9c90eaed3d243c93b27359d36672ae`
Transaction that changed the stateRoot: `0x57e1fc189829809677179955a38eab74311309c872c995834e93fd153efa31ba`

Changed the Merkle Root that allows for withdrawing the Heimdall fee.
This root is not used in any other place, it's just for claiming the Heimdall fee.
Nobody in the history of this contract nobody ever claimed any Heimdall fee.
See `function claimFee(uint256 accumFeeAmount, uint256 index, bytes memory proof)` for how the claiming works.

