### PR TITLE
Update LayerZero discovery across supported chains

### DIFF
--- a/packages/backend/discovery/lzomnichain/arbitrum/diffHistory.md
+++ b/packages/backend/discovery/lzomnichain/arbitrum/diffHistory.md
@@ -1,4 +1,88 @@
-# Diff at Tue, 09 Jan 2024 16:43:12 GMT:
+# Diff at Mon, 22 Jan 2024 17:01:57 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@f58cc44bf923844f52038487bcd5a563329f4b43 block: 168740974
+- current block number: 173078316
+
+## Description
+
+Default lib switched to FPValidator.
+New path-ways added.
+
+## Watched changes
+
+```diff
+    contract UltraLightNodeV2 (0x4D73AdB72bC3DD368966edD0f0b2148401A178E2) {
+      values.chainAddressSizeMap.234:
++        20
+      values.defaultAdapterParams.234:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAppConfig.101.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.101.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.102.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.102.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.106.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.106.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.109.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.109.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.110.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.110.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.111.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.111.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.112.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.112.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.115.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.115.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.126.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.126.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.234:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":20,"oracle":"0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f","relayer":"0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"}
+      values.inboundProofLibrary.234:
++        ["0x462F7eC57C6492B983a8C8322B4369a7f149B859","0x87794d2f64e076694a153aFdb12cA62eb9C2ea5B"]
+      values.supportedOutboundProof.234:
++        2
+      values.ulnLookup.234:
++        "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+    }
+```
+
+# Diff at Tue, 09 Jan 2024 16:43:12 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@0b578574e6a64020b5157f700c09de14e6b3eed3 block: 117399533

--- a/packages/backend/discovery/lzomnichain/arbitrum/discovered.json
+++ b/packages/backend/discovery/lzomnichain/arbitrum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "arbitrum",
-  "blockNumber": 168740974,
+  "blockNumber": 173078316,
   "configHash": "0xf37daaaf27ec77fdb946c02ca9019835c772c6e432488b33c3ab795160c6f89d",
   "version": 3,
   "contracts": [
@@ -147,7 +147,8 @@
           "216": 20,
           "217": 20,
           "218": 20,
-          "230": 20
+          "230": 20,
+          "234": 20
         },
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -359,29 +360,33 @@
           "230": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "234": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           }
         },
         "defaultAppConfig": {
           "101": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 15,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "102": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "106": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 12,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
@@ -395,33 +400,33 @@
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "109": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 512,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "110": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "111": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "112": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
@@ -435,9 +440,9 @@
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "115": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
@@ -459,9 +464,9 @@
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           },
           "126": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
@@ -769,6 +774,14 @@
             "outboundBlockConfirm": 20,
             "oracle": "0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f",
             "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
+          },
+          "234": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 20,
+            "oracle": "0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f",
+            "relayer": "0x177d36dBE2271A4DdB2Ad8304d82628eb921d790"
           }
         },
         "endpoint": "0x3c2269811836af69497E5F486A85D7316753cf62",
@@ -970,6 +983,10 @@
           "230": [
             "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
             "0x87794d2f64e076694a153aFdb12cA62eb9C2ea5B"
+          ],
+          "234": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x87794d2f64e076694a153aFdb12cA62eb9C2ea5B"
           ]
         },
         "layerZeroToken": "0x0000000000000000000000000000000000000000",
@@ -1027,7 +1044,8 @@
           "216": [1, 2],
           "217": [1, 2],
           "218": [1, 2],
-          "230": 2
+          "230": 2,
+          "234": 2
         },
         "treasuryContract": "0x3773E1E9Deb273fCdf9f80bc88bB387B1e6Ce34d",
         "treasuryZROFees": 0,
@@ -1082,7 +1100,8 @@
           "216": "0x000000000000000000000000fe7c30860d01e28371d40434806f4a8fcdd3a098",
           "217": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "218": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
-          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981",
+          "234": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
         }
       },
       "derivedName": "UltraLightNodeV2"
@@ -1207,7 +1226,7 @@
           "0xf1f5E3777a3ADBe6f3289AD6b21eae6427dfb553"
         ],
         "getThreshold": 2,
-        "nonce": 58,
+        "nonce": 64,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafeL2"

--- a/packages/backend/discovery/lzomnichain/base/diffHistory.md
+++ b/packages/backend/discovery/lzomnichain/base/diffHistory.md
@@ -1,4 +1,58 @@
-# Diff at Tue, 09 Jan 2024 16:44:11 GMT:
+# Diff at Mon, 22 Jan 2024 17:18:02 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@f58cc44bf923844f52038487bcd5a563329f4b43 block: 9014644
+- current block number: 9577249
+
+## Description
+
+Default lib switched to FPValidator.
+New path-ways added.
+
+## Watched changes
+
+```diff
+    contract UltraLightNodeV2 (0x38dE71124f7a447a01D67945a51eDcE9FF491251) {
+      values.chainAddressSizeMap.150:
++        20
+      values.chainAddressSizeMap.159:
++        20
+      values.chainAddressSizeMap.234:
++        20
+      values.defaultAdapterParams.150:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAdapterParams.159:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAdapterParams.234:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAppConfig.150:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":10,"oracle":"0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4","relayer":"0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"}
+      values.defaultAppConfig.159:
++        {"inboundProofLib":2,"inboundBlockConfirm":2,"outboundProofType":2,"outboundBlockConfirm":10,"oracle":"0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4","relayer":"0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"}
+      values.defaultAppConfig.234:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":10,"oracle":"0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4","relayer":"0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"}
+      values.inboundProofLibrary.150:
++        ["0x2D61DCDD36F10b22176E0433B86F74567d529aAa","0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"]
+      values.inboundProofLibrary.159:
++        ["0x2D61DCDD36F10b22176E0433B86F74567d529aAa","0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"]
+      values.inboundProofLibrary.234:
++        ["0x2D61DCDD36F10b22176E0433B86F74567d529aAa","0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"]
+      values.supportedOutboundProof.150:
++        2
+      values.supportedOutboundProof.159:
++        2
+      values.supportedOutboundProof.234:
++        2
+      values.ulnLookup.150:
++        "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251"
+      values.ulnLookup.159:
++        "0x000000000000000000000000c1b15d3b262beec0e3565c11c9e0f6134bdacb36"
+      values.ulnLookup.234:
++        "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+    }
+```
+
+# Diff at Tue, 09 Jan 2024 16:44:11 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@0b578574e6a64020b5157f700c09de14e6b3eed3 block: 2177243

--- a/packages/backend/discovery/lzomnichain/base/discovered.json
+++ b/packages/backend/discovery/lzomnichain/base/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "base",
-  "blockNumber": 9014644,
+  "blockNumber": 9577249,
   "configHash": "0xb10db71148a6e70fb9842f7963d90fe33bd5b70b59ac9ee789fefbb8f9207db3",
   "version": 3,
   "contracts": [
@@ -26,7 +26,7 @@
           "0x67FC8c432448f9a8d541C17579EF7a142378d5aD"
         ],
         "getThreshold": 2,
-        "nonce": 25,
+        "nonce": 27,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafeL2"
@@ -67,8 +67,10 @@
           "112": 20,
           "126": 20,
           "145": 20,
+          "150": 20,
           "151": 20,
           "158": 20,
+          "159": 20,
           "165": 20,
           "167": 20,
           "175": 20,
@@ -83,7 +85,8 @@
           "210": 20,
           "212": 20,
           "214": 20,
-          "230": 20
+          "230": 20,
+          "234": 20
         },
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -132,11 +135,19 @@
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
+          "150": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
           "151": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
           "158": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "159": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
@@ -197,6 +208,10 @@
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
           "230": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "234": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           }
@@ -282,6 +297,14 @@
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"
           },
+          "150": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 10,
+            "oracle": "0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4",
+            "relayer": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"
+          },
           "151": {
             "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
@@ -293,6 +316,14 @@
           "158": {
             "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 10,
+            "oracle": "0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4",
+            "relayer": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"
+          },
+          "159": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 2,
             "outboundProofType": 2,
             "outboundBlockConfirm": 10,
             "oracle": "0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4",
@@ -417,6 +448,14 @@
             "outboundBlockConfirm": 10,
             "oracle": "0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4",
             "relayer": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"
+          },
+          "234": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 10,
+            "oracle": "0xAaB5A48CFC03Efa9cC34A2C1aAcCCB84b4b770e4",
+            "relayer": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa"
           }
         },
         "endpoint": "0xb6319cC6c8c27A8F5dAF0dD3DF91EA35C4720dd7",
@@ -458,11 +497,19 @@
             "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
             "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
           ],
+          "150": [
+            "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
+            "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
+          ],
           "151": [
             "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
             "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
           ],
           "158": [
+            "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
+            "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
+          ],
+          "159": [
             "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
             "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
           ],
@@ -522,6 +569,10 @@
           "230": [
             "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
             "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
+          ],
+          "234": [
+            "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
+            "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
           ]
         },
         "layerZeroToken": "0x0000000000000000000000000000000000000000",
@@ -539,8 +590,10 @@
           "112": 2,
           "126": 2,
           "145": 2,
+          "150": 2,
           "151": 2,
           "158": 2,
+          "159": 2,
           "165": 2,
           "167": 2,
           "175": 2,
@@ -555,7 +608,8 @@
           "210": 2,
           "212": 2,
           "214": 2,
-          "230": 2
+          "230": 2,
+          "234": 2
         },
         "treasuryContract": "0x980205D352F198748B626f6f7C38A8a5663Ec981",
         "treasuryZROFees": 0,
@@ -570,8 +624,10 @@
           "112": "0x0000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e2",
           "126": "0x0000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e2",
           "145": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
+          "150": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "151": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "158": "0x000000000000000000000000fe7c30860d01e28371d40434806f4a8fcdd3a098",
+          "159": "0x000000000000000000000000c1b15d3b262beec0e3565c11c9e0f6134bdacb36",
           "165": "0x000000000000000000000000042b8289c97896529ec2fe49ba1a8b9c956a86cc",
           "167": "0x000000000000000000000000e9ba4c1e76d874a43942718dafc96009ec9d9917",
           "175": "0x0000000000000000000000002d61dcdd36f10b22176e0433b86f74567d529aaa",
@@ -586,7 +642,8 @@
           "210": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "212": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "214": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
-          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981",
+          "234": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
         }
       },
       "derivedName": "UltraLightNodeV2"

--- a/packages/backend/discovery/lzomnichain/bsc/diffHistory.md
+++ b/packages/backend/discovery/lzomnichain/bsc/diffHistory.md
@@ -1,4 +1,88 @@
-# Diff at Tue, 09 Jan 2024 16:42:57 GMT:
+# Diff at Mon, 22 Jan 2024 17:50:53 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@f58cc44bf923844f52038487bcd5a563329f4b43 block: 35098616
+- current block number: 35473523
+
+## Description
+
+Default lib switched to FPValidator.
+New path-ways added.
+
+## Watched changes
+
+```diff
+    contract UltraLightNodeV2 (0x4D73AdB72bC3DD368966edD0f0b2148401A178E2) {
+      values.chainAddressSizeMap.234:
++        20
+      values.defaultAdapterParams.234:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAppConfig.101.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.101.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.102.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.102.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.106.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.106.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.109.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.109.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.110.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.110.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.111.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.111.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.112.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.112.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.115.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.115.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.126.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.126.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.234:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":20,"oracle":"0x5a54fe5234E811466D5366846283323c954310B2","relayer":"0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"}
+      values.inboundProofLibrary.234:
++        ["0x462F7eC57C6492B983a8C8322B4369a7f149B859","0x28A5536cA9F36c45A9d2AC8d2B62Fc46Fde024B6"]
+      values.supportedOutboundProof.234:
++        2
+      values.ulnLookup.234:
++        "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+    }
+```
+
+# Diff at Tue, 09 Jan 2024 16:42:57 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@0b578574e6a64020b5157f700c09de14e6b3eed3 block: 30528470

--- a/packages/backend/discovery/lzomnichain/bsc/discovered.json
+++ b/packages/backend/discovery/lzomnichain/bsc/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "bsc",
-  "blockNumber": 35098616,
+  "blockNumber": 35473523,
   "configHash": "0x98a11a7a5bd0b5ef463a25161512ce578955c1febfd51029bf63564bb3b3bf29",
   "version": 3,
   "contracts": [
@@ -150,7 +150,8 @@
           "216": 20,
           "217": 20,
           "218": 20,
-          "230": 20
+          "230": 20,
+          "234": 20
         },
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -354,6 +355,10 @@
           "230": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "234": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           }
         },
         "defaultAppConfig": {
@@ -374,25 +379,25 @@
             "relayer": "0xde19274c009A22921E3966a1Ec868cEba40A5DaC"
           },
           "101": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 15,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "102": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "106": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 12,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
@@ -406,33 +411,33 @@
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "109": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 512,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "110": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "111": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "112": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
@@ -446,9 +451,9 @@
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "115": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
@@ -470,9 +475,9 @@
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           },
           "126": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
@@ -764,6 +769,14 @@
             "outboundBlockConfirm": 20,
             "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
             "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
+          },
+          "234": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 20,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
+            "relayer": "0xA27A2cA24DD28Ce14Fb5f5844b59851F03DCf182"
           }
         },
         "endpoint": "0x3c2269811836af69497E5F486A85D7316753cf62",
@@ -959,6 +972,10 @@
           "230": [
             "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
             "0x28A5536cA9F36c45A9d2AC8d2B62Fc46Fde024B6"
+          ],
+          "234": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x28A5536cA9F36c45A9d2AC8d2B62Fc46Fde024B6"
           ]
         },
         "layerZeroToken": "0x0000000000000000000000000000000000000000",
@@ -1016,7 +1033,8 @@
           "216": [1, 2],
           "217": [1, 2],
           "218": [1, 2],
-          "230": 2
+          "230": 2,
+          "234": 2
         },
         "treasuryContract": "0x3773E1E9Deb273fCdf9f80bc88bB387B1e6Ce34d",
         "treasuryZROFees": 0,
@@ -1069,7 +1087,8 @@
           "216": "0x000000000000000000000000fe7c30860d01e28371d40434806f4a8fcdd3a098",
           "217": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "218": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
-          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981",
+          "234": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
         }
       },
       "derivedName": "UltraLightNodeV2"
@@ -1152,7 +1171,7 @@
           "0xf1f5E3777a3ADBe6f3289AD6b21eae6427dfb553"
         ],
         "getThreshold": 2,
-        "nonce": 56,
+        "nonce": 62,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafeL2"

--- a/packages/backend/discovery/lzomnichain/ethereum/diffHistory.md
+++ b/packages/backend/discovery/lzomnichain/ethereum/diffHistory.md
@@ -1,4 +1,94 @@
-# Diff at Fri, 05 Jan 2024 13:32:55 GMT:
+# Diff at Mon, 22 Jan 2024 16:58:34 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@f58cc44bf923844f52038487bcd5a563329f4b43 block: 18941390
+- current block number: 19063596
+
+## Description
+
+Default lib switched to FPValidator.
+New path-ways added.
+
+## Watched changes
+
+```diff
+    contract UltraLightNodeV2 (0x4D73AdB72bC3DD368966edD0f0b2148401A178E2) {
+      values.chainAddressSizeMap.234:
++        20
+      values.defaultAdapterParams.234:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAppConfig.101.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.101.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.102.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.102.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.106.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.106.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.109.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.109.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.110.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.110.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.111.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.111.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.112.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.112.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.115.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.115.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.116.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.116.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.126.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.126.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.234:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":15,"oracle":"0x5a54fe5234E811466D5366846283323c954310B2","relayer":"0x902F09715B6303d4173037652FA7377e5b98089E"}
+      values.inboundProofLibrary.234:
++        ["0x462F7eC57C6492B983a8C8322B4369a7f149B859","0x07245eEa05826F5984c7c3C8F478b04892e4df89"]
+      values.supportedOutboundProof.234:
++        2
+      values.ulnLookup.234:
++        "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+    }
+```
+
+# Diff at Fri, 05 Jan 2024 13:32:55 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@9b1911b38ffdc811ae8c1518aae762bfe4831370 block: 18671199
@@ -45,7 +135,7 @@ for block 18671199 (main branch discovery), not current.
     }
 ```
 
-# Diff at Tue, 28 Nov 2023 16:07:09 GMT:
+# Diff at Tue, 28 Nov 2023 16:07:09 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@049dc0679d8762dc52199c99e9e62ba7cb396a7b
@@ -111,7 +201,7 @@ New remote chains added: 217, 218, 230. One of the owners in the Stargate Multis
     }
 ```
 
-# Diff at Tue, 07 Nov 2023 10:45:37 GMT:
+# Diff at Tue, 07 Nov 2023 10:45:37 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@1272f95e37268203d1aa19a319b3dff48af9c73c

--- a/packages/backend/discovery/lzomnichain/ethereum/discovered.json
+++ b/packages/backend/discovery/lzomnichain/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "ethereum",
-  "blockNumber": 18941390,
+  "blockNumber": 19063596,
   "configHash": "0x9d93123d45c6abd2bad013a50a1f7826f27652e7c043ba0567d7f7ca2541b725",
   "version": 3,
   "contracts": [
@@ -127,7 +127,8 @@
           "216": 20,
           "217": 20,
           "218": 20,
-          "230": 20
+          "230": 20,
+          "234": 20
         },
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -347,6 +348,10 @@
           "230": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "234": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           }
         },
         "defaultAppConfig": {
@@ -367,25 +372,25 @@
             "relayer": "0x6BD792911F4B3714E88FbDf32B351632e7d22c70"
           },
           "101": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 15,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "102": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "106": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 12,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
@@ -399,33 +404,33 @@
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "109": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 512,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "110": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "111": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "112": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
@@ -439,17 +444,17 @@
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "115": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "116": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
@@ -463,9 +468,9 @@
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           },
           "126": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 15,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
@@ -789,6 +794,14 @@
             "outboundBlockConfirm": 15,
             "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
             "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
+          },
+          "234": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 15,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
+            "relayer": "0x902F09715B6303d4173037652FA7377e5b98089E"
           }
         },
         "endpoint": "0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675",
@@ -1000,6 +1013,10 @@
           "230": [
             "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
             "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
+          ],
+          "234": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x07245eEa05826F5984c7c3C8F478b04892e4df89"
           ]
         },
         "layerZeroToken": "0x0000000000000000000000000000000000000000",
@@ -1061,7 +1078,8 @@
           "216": [1, 2],
           "217": [1, 2],
           "218": [1, 2],
-          "230": 2
+          "230": 2,
+          "234": 2
         },
         "treasuryContract": "0x3773E1E9Deb273fCdf9f80bc88bB387B1e6Ce34d",
         "treasuryZROFees": 0,
@@ -1118,7 +1136,8 @@
           "216": "0x000000000000000000000000fe7c30860d01e28371d40434806f4a8fcdd3a098",
           "217": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "218": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
-          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981",
+          "234": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
         }
       },
       "derivedName": "UltraLightNodeV2"
@@ -1264,7 +1283,7 @@
           "0x67FC8c432448f9a8d541C17579EF7a142378d5aD"
         ],
         "getThreshold": 2,
-        "nonce": 57,
+        "nonce": 60,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"

--- a/packages/backend/discovery/lzomnichain/linea/diffHistory.md
+++ b/packages/backend/discovery/lzomnichain/linea/diffHistory.md
@@ -1,4 +1,46 @@
-# Diff at Tue, 09 Jan 2024 16:44:29 GMT:
+# Diff at Mon, 22 Jan 2024 17:09:10 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@f58cc44bf923844f52038487bcd5a563329f4b43 block: 1584748
+- current block number: 1773788
+
+## Description
+
+Default lib switched to FPValidator.
+New path-ways added.
+
+## Watched changes
+
+```diff
+    contract UltraLightNodeV2 (0x38dE71124f7a447a01D67945a51eDcE9FF491251) {
+      values.chainAddressSizeMap.150:
++        20
+      values.chainAddressSizeMap.159:
++        20
+      values.defaultAdapterParams.150:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAdapterParams.159:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAppConfig.150:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":10,"oracle":"0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa","relayer":"0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9"}
+      values.defaultAppConfig.159:
++        {"inboundProofLib":2,"inboundBlockConfirm":2,"outboundProofType":2,"outboundBlockConfirm":10,"oracle":"0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa","relayer":"0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9"}
+      values.inboundProofLibrary.150:
++        ["0x2D61DCDD36F10b22176E0433B86F74567d529aAa","0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"]
+      values.inboundProofLibrary.159:
++        ["0x2D61DCDD36F10b22176E0433B86F74567d529aAa","0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"]
+      values.supportedOutboundProof.150:
++        2
+      values.supportedOutboundProof.159:
++        2
+      values.ulnLookup.150:
++        "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251"
+      values.ulnLookup.159:
++        "0x000000000000000000000000c1b15d3b262beec0e3565c11c9e0f6134bdacb36"
+    }
+```
+
+# Diff at Tue, 09 Jan 2024 16:44:29 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@0b578574e6a64020b5157f700c09de14e6b3eed3 block: 117054

--- a/packages/backend/discovery/lzomnichain/linea/discovered.json
+++ b/packages/backend/discovery/lzomnichain/linea/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "linea",
-  "blockNumber": 1584748,
+  "blockNumber": 1773788,
   "configHash": "0xe3ce2593bf49b29d9093aa1c84b1e7224a27912b49497d4d58b50972bc063519",
   "version": 3,
   "contracts": [
@@ -42,8 +42,10 @@
           "125": 20,
           "126": 20,
           "145": 20,
+          "150": 20,
           "151": 20,
           "158": 20,
+          "159": 20,
           "165": 20,
           "167": 20,
           "175": 20,
@@ -109,11 +111,19 @@
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
+          "150": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
           "151": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
           "158": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "159": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           },
@@ -259,6 +269,14 @@
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9"
           },
+          "150": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 10,
+            "oracle": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa",
+            "relayer": "0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9"
+          },
           "151": {
             "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
@@ -270,6 +288,14 @@
           "158": {
             "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 10,
+            "oracle": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa",
+            "relayer": "0xA658742d33ebd2ce2F0bdFf73515Aa797Fd161D9"
+          },
+          "159": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 2,
             "outboundProofType": 2,
             "outboundBlockConfirm": 10,
             "oracle": "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa",
@@ -426,11 +452,19 @@
             "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
             "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
           ],
+          "150": [
+            "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
+            "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
+          ],
           "151": [
             "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
             "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
           ],
           "158": [
+            "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
+            "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
+          ],
+          "159": [
             "0x2D61DCDD36F10b22176E0433B86F74567d529aAa",
             "0xC1b15d3B262bEeC0e3565C11C9e0F6134BdaCB36"
           ],
@@ -500,8 +534,10 @@
           "125": 2,
           "126": 2,
           "145": 2,
+          "150": 2,
           "151": 2,
           "158": 2,
+          "159": 2,
           "165": 2,
           "167": 2,
           "175": 2,
@@ -530,8 +566,10 @@
           "125": "0x000000000000000000000000377530cda84dfb2673bf4d145dcf0c4d7fdcb5b6",
           "126": "0x0000000000000000000000004d73adb72bc3dd368966edd0f0b2148401a178e2",
           "145": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
+          "150": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "151": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "158": "0x000000000000000000000000fe7c30860d01e28371d40434806f4a8fcdd3a098",
+          "159": "0x000000000000000000000000c1b15d3b262beec0e3565c11c9e0f6134bdacb36",
           "165": "0x000000000000000000000000042b8289c97896529ec2fe49ba1a8b9c956a86cc",
           "167": "0x000000000000000000000000e9ba4c1e76d874a43942718dafc96009ec9d9917",
           "175": "0x0000000000000000000000002d61dcdd36f10b22176e0433b86f74567d529aaa",

--- a/packages/backend/discovery/lzomnichain/optimism/diffHistory.md
+++ b/packages/backend/discovery/lzomnichain/optimism/diffHistory.md
@@ -1,4 +1,91 @@
-# Diff at Tue, 09 Jan 2024 16:40:02 GMT:
+# Diff at Mon, 22 Jan 2024 17:08:21 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@f58cc44bf923844f52038487bcd5a563329f4b43 block: 114609805
+- current block number: 115172250
+
+## Description
+
+Default lib switched to FPValidator.
+New path-ways added.
+
+## Watched changes
+
+```diff
+    contract UltraLightNodeV2 (0x4D73AdB72bC3DD368966edD0f0b2148401A178E2) {
+      values.chainAddressSizeMap.234:
++        20
+      values.defaultAdapterParams.234:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAppConfig.101.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.101.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.102.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.102.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.106.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.106.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.109.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.110.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.110.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.111.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.111.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.112.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.112.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.115.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.115.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.116.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.116.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.126.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.126.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.234:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":20,"oracle":"0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f","relayer":"0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"}
+      values.inboundProofLibrary.234:
++        ["0x462F7eC57C6492B983a8C8322B4369a7f149B859","0x23ec43e2b8f9aE21D895eEa5a1a9c444fe301044"]
+      values.supportedOutboundProof.234:
++        2
+      values.ulnLookup.234:
++        "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+    }
+```
+
+# Diff at Tue, 09 Jan 2024 16:40:02 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@0b578574e6a64020b5157f700c09de14e6b3eed3 block: 107689171

--- a/packages/backend/discovery/lzomnichain/optimism/discovered.json
+++ b/packages/backend/discovery/lzomnichain/optimism/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "optimism",
-  "blockNumber": 114609805,
+  "blockNumber": 115172250,
   "configHash": "0xa8f686361ee8e8c728e230c02b54dd92327df396d95339429826b82b9ff685d2",
   "version": 3,
   "contracts": [
@@ -43,7 +43,7 @@
           "0xf1f5E3777a3ADBe6f3289AD6b21eae6427dfb553"
         ],
         "getThreshold": 2,
-        "nonce": 58,
+        "nonce": 62,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafeL2"
@@ -186,7 +186,8 @@
           "216": 20,
           "217": 20,
           "218": 20,
-          "230": 20
+          "230": 20,
+          "234": 20
         },
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -394,29 +395,33 @@
           "230": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "234": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           }
         },
         "defaultAppConfig": {
           "101": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 15,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "102": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "106": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 12,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
@@ -432,31 +437,31 @@
           "109": {
             "inboundProofLib": 2,
             "inboundBlockConfirm": 512,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "110": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "111": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "112": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
@@ -470,17 +475,17 @@
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "115": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "116": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
@@ -494,9 +499,9 @@
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           },
           "126": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 20,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
@@ -796,6 +801,14 @@
             "outboundBlockConfirm": 20,
             "oracle": "0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f",
             "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
+          },
+          "234": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 20,
+            "oracle": "0xA0Cc33Dd6f4819D473226257792AFe230EC3c67f",
+            "relayer": "0x81E792e5a9003CC1C8BF5569A00f34b65d75b017"
           }
         },
         "endpoint": "0x3c2269811836af69497E5F486A85D7316753cf62",
@@ -993,6 +1006,10 @@
           "230": [
             "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
             "0x23ec43e2b8f9aE21D895eEa5a1a9c444fe301044"
+          ],
+          "234": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x23ec43e2b8f9aE21D895eEa5a1a9c444fe301044"
           ]
         },
         "layerZeroToken": "0x0000000000000000000000000000000000000000",
@@ -1049,7 +1066,8 @@
           "216": [1, 2],
           "217": [1, 2],
           "218": [1, 2],
-          "230": 2
+          "230": 2,
+          "234": 2
         },
         "treasuryContract": "0x3773E1E9Deb273fCdf9f80bc88bB387B1e6Ce34d",
         "treasuryZROFees": 0,
@@ -1103,7 +1121,8 @@
           "216": "0x000000000000000000000000fe7c30860d01e28371d40434806f4a8fcdd3a098",
           "217": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "218": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
-          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981",
+          "234": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
         }
       },
       "derivedName": "UltraLightNodeV2"

--- a/packages/backend/discovery/lzomnichain/polygonpos/diffHistory.md
+++ b/packages/backend/discovery/lzomnichain/polygonpos/diffHistory.md
@@ -1,4 +1,91 @@
-# Diff at Tue, 09 Jan 2024 16:43:54 GMT:
+# Diff at Mon, 22 Jan 2024 17:10:47 GMT
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: master@f58cc44bf923844f52038487bcd5a563329f4b43 block: 52128611
+- current block number: 52626877
+
+## Description
+
+Default lib switched to FPValidator.
+New path-ways added.
+
+## Watched changes
+
+```diff
+    contract UltraLightNodeV2 (0x4D73AdB72bC3DD368966edD0f0b2148401A178E2) {
+      values.chainAddressSizeMap.234:
++        20
+      values.defaultAdapterParams.234:
++        {"proofType":2,"adapterParams":"0x00010000000000000000000000000000000000000000000000000000000000030d40"}
+      values.defaultAppConfig.101.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.101.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.102.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.102.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.106.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.106.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.109.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.109.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.110.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.110.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.111.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.112.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.112.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.115.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.115.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.116.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.116.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.126.inboundProofLib:
+-        1
++        2
+      values.defaultAppConfig.126.outboundProofType:
+-        1
++        2
+      values.defaultAppConfig.234:
++        {"inboundProofLib":2,"inboundBlockConfirm":5,"outboundProofType":2,"outboundBlockConfirm":512,"oracle":"0x5a54fe5234E811466D5366846283323c954310B2","relayer":"0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"}
+      values.inboundProofLibrary.234:
++        ["0x462F7eC57C6492B983a8C8322B4369a7f149B859","0x86Bb63148d17d445Ed5398ef26Aa05Bf76dD5b59"]
+      values.supportedOutboundProof.234:
++        2
+      values.ulnLookup.234:
++        "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+    }
+```
+
+# Diff at Tue, 09 Jan 2024 16:43:54 GMT
 
 - author: Michał Sobieraj-Jakubiec (<michalsidzej@gmail.com>)
 - comparing to: master@0b578574e6a64020b5157f700c09de14e6b3eed3 block: 45856553

--- a/packages/backend/discovery/lzomnichain/polygonpos/discovered.json
+++ b/packages/backend/discovery/lzomnichain/polygonpos/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "lzomnichain",
   "chain": "polygonpos",
-  "blockNumber": 52128611,
+  "blockNumber": 52626877,
   "configHash": "0xf24b1156546067fc8c243a38bb4785ac804a569e6c18c0669f92f0a8aa72a9a0",
   "version": 3,
   "contracts": [
@@ -129,7 +129,8 @@
           "216": 20,
           "217": 20,
           "218": 20,
-          "230": 20
+          "230": 20,
+          "234": 20
         },
         "CONFIG_TYPE_INBOUND_BLOCK_CONFIRMATIONS": 2,
         "CONFIG_TYPE_INBOUND_PROOF_LIBRARY_VERSION": 1,
@@ -333,29 +334,33 @@
           "230": {
             "proofType": 2,
             "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
+          },
+          "234": {
+            "proofType": 2,
+            "adapterParams": "0x00010000000000000000000000000000000000000000000000000000000000030d40"
           }
         },
         "defaultAppConfig": {
           "101": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 15,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "102": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "106": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 12,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
@@ -369,23 +374,23 @@
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "109": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 512,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "110": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "111": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 20,
             "outboundProofType": 2,
             "outboundBlockConfirm": 512,
@@ -393,9 +398,9 @@
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "112": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
@@ -409,17 +414,17 @@
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "115": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "116": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 5,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
@@ -433,9 +438,9 @@
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           },
           "126": {
-            "inboundProofLib": 1,
+            "inboundProofLib": 2,
             "inboundBlockConfirm": 10,
-            "outboundProofType": 1,
+            "outboundProofType": 2,
             "outboundBlockConfirm": 512,
             "oracle": "0xD56e4eAb23cb81f43168F9F45211Eb027b9aC7cc",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
@@ -727,6 +732,14 @@
             "outboundBlockConfirm": 512,
             "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
             "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
+          },
+          "234": {
+            "inboundProofLib": 2,
+            "inboundBlockConfirm": 5,
+            "outboundProofType": 2,
+            "outboundBlockConfirm": 512,
+            "oracle": "0x5a54fe5234E811466D5366846283323c954310B2",
+            "relayer": "0x75dC8e5F50C8221a82CA6aF64aF811caA983B65f"
           }
         },
         "endpoint": "0x3c2269811836af69497E5F486A85D7316753cf62",
@@ -920,6 +933,10 @@
           "230": [
             "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
             "0x86Bb63148d17d445Ed5398ef26Aa05Bf76dD5b59"
+          ],
+          "234": [
+            "0x462F7eC57C6492B983a8C8322B4369a7f149B859",
+            "0x86Bb63148d17d445Ed5398ef26Aa05Bf76dD5b59"
           ]
         },
         "layerZeroToken": "0x0000000000000000000000000000000000000000",
@@ -975,7 +992,8 @@
           "216": [1, 2],
           "217": [1, 2],
           "218": [1, 2],
-          "230": 2
+          "230": 2,
+          "234": 2
         },
         "treasuryContract": "0x5f3481F45A3926A136D3dEE078e14D5353C13f2D",
         "treasuryZROFees": 0,
@@ -1028,7 +1046,8 @@
           "216": "0x000000000000000000000000fe7c30860d01e28371d40434806f4a8fcdd3a098",
           "217": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
           "218": "0x00000000000000000000000038de71124f7a447a01d67945a51edce9ff491251",
-          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
+          "230": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981",
+          "234": "0x000000000000000000000000980205d352f198748b626f6f7c38a8a5663ec981"
         }
       },
       "derivedName": "UltraLightNodeV2"
@@ -1169,7 +1188,7 @@
           "0xf1f5E3777a3ADBe6f3289AD6b21eae6427dfb553"
         ],
         "getThreshold": 2,
-        "nonce": 53,
+        "nonce": 57,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafeL2"


### PR DESCRIPTION
Resolves L2B-3620

Default lib switched to FPValidator.
New path-ways added.
No breaking changes.