### PR TITLE
Remove stale daily discoveries

### DIFF
--- a/packages/backend/src/core/discovery/ProjectDiscoverer.ts
+++ b/packages/backend/src/core/discovery/ProjectDiscoverer.ts
@@ -41,14 +41,20 @@ export class ProjectDiscoverer {
       ChainId.fromName(this.chain),
     )
 
-    for (const timestamp of known) {
-      this.knownSet.add(timestamp.toStartOf('day').toNumber())
-    }
-
     this.projectConfig = await this.configReader.readConfig(
       this.projectName,
       this.chain,
     )
+
+    await this.repository.deleteStaleProjectDiscoveries(
+      this.projectName,
+      ChainId.fromName(this.chain),
+      this.projectConfig.hash,
+    )
+
+    for (const timestamp of known) {
+      this.knownSet.add(timestamp.toStartOf('day').toNumber())
+    }
 
     return this.clock.onEveryDay((timestamp) => {
       if (!this.knownSet.has(timestamp.toStartOf('day').toNumber())) {

--- a/packages/backend/src/peripherals/database/discovery/DiscoveryHistoryRepository.ts
+++ b/packages/backend/src/peripherals/database/discovery/DiscoveryHistoryRepository.ts
@@ -81,6 +81,22 @@ export class DiscoveryHistoryRepository extends BaseRepository {
     }))
   }
 
+  async deleteStaleProjectDiscoveries(
+    projectName: string,
+    chainId: ChainId,
+    configHash: Hash256,
+  ): Promise<number> {
+    const knex = await this.knex()
+
+    return await knex('daily_discovery')
+      .where({
+        project_name: projectName,
+        chain_id: +chainId,
+      })
+      .andWhere('config_hash', '!=', configHash.toString())
+      .delete()
+  }
+
   async getProject(
     projectName: string,
     chainId: ChainId,


### PR DESCRIPTION
Resolves L2B-3677

This mechanism rediscovers on new config because we are going to have an empty database for a given project. Only entries with the matching config hash will be left untouched.