### PR TITLE
fixed broken link of immutablex

### DIFF
--- a/packages/config/src/layer2s/immutablex.ts
+++ b/packages/config/src/layer2s/immutablex.ts
@@ -58,7 +58,7 @@ export const immutablex: Layer2 = {
     dataAvailabilityMode: 'NotApplicable',
     links: {
       websites: ['https://immutable.com/'],
-      apps: ['https://market.x.immutable.com/'],
+      apps: ['https://market.immutable.com/'],
       documentation: ['https://docs.starkware.co/starkex-docs-v2/'],
       explorers: ['https://immutascan.io/'],
       repositories: ['https://github.com/starkware-libs/starkex-contracts'],


### PR DESCRIPTION
The link "https://market.x.immutable.com/" was giving 404 error as it was not updated, fixed and updated the url in the source code.