### PR TITLE
Filter out CREATED and DELETED from Changelog

### DIFF
--- a/packages/frontend/src/pages/scaling/diff-history/props/diffHistoryToMarkdown.ts
+++ b/packages/frontend/src/pages/scaling/diff-history/props/diffHistoryToMarkdown.ts
@@ -41,10 +41,23 @@ function discoveryDiffToMarkdown(diffs: DiscoveryDiff[]): string {
   return result.join('\n\n')
 }
 
+function removeCreationAndDeletionDiffs(
+  diffs: DiscoveryDiff[],
+): DiscoveryDiff[] {
+  return diffs.filter(
+    (diff) => diff.type !== 'created' && diff.type !== 'deleted',
+  )
+}
+
 export function diffHistoryToMarkdown(
   changes: DiffHistoryApiResponse[0]['changes'],
 ): string {
   return changes
+    .map((change) => ({
+      ...change,
+      diffs: removeCreationAndDeletionDiffs(change.diffs),
+    }))
+    .filter((c) => c.diffs.length > 0)
     .map((change) => {
       return `## ${new UnixTime(
         +change.timestamp,


### PR DESCRIPTION
Small improvement, filter out CREATED and DELETED diff entries, since it does not provide any information.