### PR TITLE
Update token amount tooltip

### DIFF
--- a/packages/frontend/src/components/tvl-breakdown/table/TokenAmountCell.tsx
+++ b/packages/frontend/src/components/tvl-breakdown/table/TokenAmountCell.tsx
@@ -20,7 +20,7 @@ export function TokenAmountCell(props: TokenAmountCellProps) {
     token?.formula === 'totalSupply'
       ? 'Total supply'
       : token?.formula === 'circulatingSupply'
-      ? 'Circulating supply'
+      ? 'Circulating supply (Market Cap/Price)'
       : ''
 
   return props.forCanonical && props.escrows ? (


### PR DESCRIPTION
Updates the tooltip for the token amount on the TVL Breakdown page, as sometimes there are small differences between the Circulating supply shown by Coingecko and the one derived by Market cap/Price.