### PR TITLE
Fix incorrect attribute name in svgShape

### DIFF
--- a/packages/frontend/src/scripts/charts/styles.ts
+++ b/packages/frontend/src/scripts/charts/styles.ts
@@ -39,7 +39,7 @@ export const POINT_CLASS_NAMES: Record<string, PointShapeDef> = {
     height: 9,
     width: 9,
     svgViewBox: '0 0 9 9',
-    svgShape: '<circle cn="4.5" cy="4.5" r="3.5" fill="#A64EFF" />',
+    svgShape: '<circle cx="4.5" cy="4.5" r="3.5" fill="#A64EFF" />',
   },
   pinkSquare: {
     type: 'svg',


### PR DESCRIPTION
This pull request fixes an issue where the attribute name "cn" was used instead of "cx" in the svgShape of the POINT_CLASS_NAMES object. The correct attribute name has been updated to "cx" to ensure proper rendering of the circle shape.