### PR TITLE
Fix block search in BlockscoutClient

### DIFF
--- a/packages/shared/src/services/blockscout/BlockscoutLikeClient.test.ts
+++ b/packages/shared/src/services/blockscout/BlockscoutLikeClient.test.ts
@@ -158,7 +158,7 @@ describe(BlockscoutLikeClient.name, () => {
               JSON.stringify({
                 status: '1',
                 message: 'NOTOK',
-                result: `Error! No closest block found`,
+                result: `Error! Block does not exist`,
               }),
             ),
           )
@@ -215,7 +215,7 @@ describe(BlockscoutLikeClient.name, () => {
               JSON.stringify({
                 status: '1',
                 message: 'NOTOK',
-                result: `Error! No closest block found`,
+                result: `Error! Block does not exist`,
               }),
             ),
           )
@@ -258,7 +258,7 @@ describe(BlockscoutLikeClient.name, () => {
               JSON.stringify({
                 status: '1',
                 message: 'NOTOK',
-                result: `Error! No closest block found`,
+                result: `Error! Block does not exist`,
               }),
             ),
           )
@@ -300,7 +300,7 @@ describe(BlockscoutLikeClient.name, () => {
               JSON.stringify({
                 status: '1',
                 message: 'NOTOK',
-                result: `Error! No closest block found`,
+                result: `Error! Block does not exist`,
               }),
             ),
           )
@@ -343,7 +343,7 @@ describe(BlockscoutLikeClient.name, () => {
               JSON.stringify({
                 status: '1',
                 message: 'NOTOK',
-                result: `Error! No closest block found`,
+                result: `Error! Block does not exist`,
               }),
             ),
           )
@@ -352,7 +352,7 @@ describe(BlockscoutLikeClient.name, () => {
               JSON.stringify({
                 status: '1',
                 message: 'NOTOK',
-                result: `Error! No closest block found`,
+                result: `Error! Block does not exist`,
               }),
             ),
           )
@@ -361,7 +361,7 @@ describe(BlockscoutLikeClient.name, () => {
               JSON.stringify({
                 status: '1',
                 message: 'NOTOK',
-                result: `Error! No closest block found`,
+                result: `Error! Block does not exist`,
               }),
             ),
           )

--- a/packages/shared/src/services/blockscout/BlockscoutLikeClient.ts
+++ b/packages/shared/src/services/blockscout/BlockscoutLikeClient.ts
@@ -40,7 +40,7 @@ export class BlockscoutLikeClient {
         }
 
         const errorObject = error as BlockscoutError
-        if (!errorObject.message.includes('No closest block found')) {
+        if (!errorObject.message.includes('Block does not exist')) {
           throw new Error(errorObject.message)
         }
 


### PR DESCRIPTION
Resolves L2B-3748

Blockscout returns `Block does not exist` when the bucket range is too small instead of `No closest block found`.