### PR TITLE
Do not rely on error piping to determine master/main

### DIFF
--- a/packages/backend/src/tools/updateDiffHistory.ts
+++ b/packages/backend/src/tools/updateDiffHistory.ts
@@ -157,11 +157,6 @@ function getMainBranchName(): 'main' | 'master' {
     // If error, it means 'master' doesn't exist, so we'll stick with 'main'
     return 'main'
   }
-
-  assert(
-    false,
-    "This should never happen, see in git's history how this place looked at the time of writing this comment.",
-  )
 }
 
 function compareFolders(path1: string, path2: string): string {

--- a/packages/backend/src/tools/updateDiffHistory.ts
+++ b/packages/backend/src/tools/updateDiffHistory.ts
@@ -149,13 +149,10 @@ async function performDiscoveryOnPreviousBlock(
 
 function getMainBranchName(): 'main' | 'master' {
   try {
-    if (
-      execSync('git show-ref --verify refs/heads/master > /dev/null 2>&1')
-        .toString()
-        .trim()
-    ) {
-      return 'master'
-    }
+    execSync('git show-ref --verify refs/heads/master', {
+      stdio: 'ignore',
+    })
+    return 'master'
   } catch (error) {
     // If error, it means 'master' doesn't exist, so we'll stick with 'main'
     return 'main'


### PR DESCRIPTION
This PR uses `stdio: "ignore"` to divert the command output instead of direct piping.
We observed this differnce between some systems

```
# System1
git show-ref --verify refs/heads/master # error code = 128
git show-ref --verify refs/heads/master > /dev/null 2>&1 # error code = 0

# System2
git show-ref --verify refs/heads/master # error code = 128
git show-ref --verify refs/heads/master > /dev/null 2>&1 # error code = 128
```

This in turn brakes updateDiffHistory because it relies on the fact that this command will throw when master branch is not present.