### PR TITLE
Reduce DB size

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,6 +40,7 @@
     "basic-auth": "^2.0.1",
     "chalk": "^4.1.2",
     "deep-diff": "^1.0.2",
+    "earl": "^1.1.0",
     "ethers": "^5.7.2",
     "jsonc-parser": "^3.2.0",
     "knex": "^2.4.2",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,7 +40,6 @@
     "basic-auth": "^2.0.1",
     "chalk": "^4.1.2",
     "deep-diff": "^1.0.2",
-    "earl": "^1.1.0",
     "ethers": "^5.7.2",
     "jsonc-parser": "^3.2.0",
     "knex": "^2.4.2",

--- a/packages/backend/src/api/controllers/BlocksController.test.ts
+++ b/packages/backend/src/api/controllers/BlocksController.test.ts
@@ -7,7 +7,7 @@ import { BlocksController } from './BlocksController'
 describe(BlocksController.name, () => {
   it('returns transformed blocks', async () => {
     const blockNumberRepository = mockObject<BlockNumberRepository>({
-      async getAll() {
+      async getAllByChainId() {
         return [
           {
             blockNumber: 123,

--- a/packages/backend/src/api/controllers/BlocksController.ts
+++ b/packages/backend/src/api/controllers/BlocksController.ts
@@ -6,7 +6,9 @@ export class BlocksController {
   constructor(private readonly blockNumberRepository: BlockNumberRepository) {}
 
   async getAllBlocks(): Promise<json> {
-    const all = await this.blockNumberRepository.getAll(ChainId.ETHEREUM)
+    const all = await this.blockNumberRepository.getAllByChainId(
+      ChainId.ETHEREUM,
+    )
     return all.map((x) => ({
       blockNumber: x.blockNumber.toString(),
       timestamp: x.timestamp.toDate().toISOString(),

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -28,6 +28,7 @@ export interface Config {
   readonly statusEnabled: boolean
   readonly chains: { name: string; chainId: ChainId }[]
   readonly flags: ResolvedFeatureFlag[]
+  readonly tvlCleanerEnabled: boolean
 }
 
 export type LoggerConfig = Pick<LoggerOptions, 'logLevel' | 'format'> &

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -139,8 +139,8 @@ export function makeConfig(
       chains: [getChainDiscoveryConfig(env, 'ethereum')],
     },
     chains: chains.map((x) => ({ name: x.name, chainId: ChainId(x.chainId) })),
-    flags: flags.getResolved(),
     tvlCleanerEnabled: flags.isEnabled('tvlCleaner'),
+    flags: flags.getResolved(),
   }
 }
 

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -140,6 +140,7 @@ export function makeConfig(
     },
     chains: chains.map((x) => ({ name: x.name, chainId: ChainId(x.chainId) })),
     flags: flags.getResolved(),
+    tvlCleanerEnabled: flags.isEnabled('tvlCleaner'),
   }
 }
 

--- a/packages/backend/src/core/BlockNumberUpdater.test.ts
+++ b/packages/backend/src/core/BlockNumberUpdater.test.ts
@@ -24,7 +24,7 @@ describe(BlockNumberUpdater.name, () => {
           .resolvesToOnce(1100n),
       })
       const blockNumberRepository = mockObject<BlockNumberRepository>({
-        getAll: mockFn().returns([
+        getAllByChainId: mockFn().returns([
           { timestamp: TIME_0, blockNumber: 1000n },
           { timestamp: TIME_2, blockNumber: 1200n },
         ]),

--- a/packages/backend/src/core/BlockNumberUpdater.test.ts
+++ b/packages/backend/src/core/BlockNumberUpdater.test.ts
@@ -31,7 +31,7 @@ describe(BlockNumberUpdater.name, () => {
         add: mockFn().returns([]),
       })
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(TIME_0)
           callback(TIME_1)
           callback(TIME_2)

--- a/packages/backend/src/core/BlockNumberUpdater.ts
+++ b/packages/backend/src/core/BlockNumberUpdater.ts
@@ -81,7 +81,7 @@ export class BlockNumberUpdater {
     }
 
     this.logger.info('Started')
-    return this.clock.onEveryHour((timestamp) => {
+    return this.clock._TVL_ONLY_onEveryHour((timestamp) => {
       if (!this.blocksByTimestamp.has(timestamp.toNumber())) {
         if (timestamp.gte(this.minTimestamp)) {
           // we add to front to sync from newest to oldest

--- a/packages/backend/src/core/BlockNumberUpdater.ts
+++ b/packages/backend/src/core/BlockNumberUpdater.ts
@@ -75,7 +75,7 @@ export class BlockNumberUpdater {
   }
 
   async start() {
-    const known = await this.blockNumberRepository.getAll(this.chainId)
+    const known = await this.blockNumberRepository.getAllByChainId(this.chainId)
     for (const { timestamp, blockNumber } of known) {
       this.blocksByTimestamp.set(timestamp.toNumber(), blockNumber)
     }

--- a/packages/backend/src/core/Clock.test.ts
+++ b/packages/backend/src/core/Clock.test.ts
@@ -189,4 +189,26 @@ describe(Clock.name, () => {
       stop()
     })
   })
+
+  describe(Clock.prototype._TVL_ONLY_getHourlyDeletionBoundary.name, () => {
+    it('returns timestamp 10 days before now', () => {
+      setTime('00:00:00')
+      const now = UnixTime.now()
+      const clock = new Clock(new UnixTime(0), 0)
+      const boundary = clock._TVL_ONLY_getHourlyDeletionBoundary()
+
+      expect(boundary).toEqual(now.add(-10, 'days'))
+    })
+  })
+
+  describe(Clock.prototype._TVL_ONLY_getSixHourlyDeletionBoundary.name, () => {
+    it('returns timestamp 93 days before now', () => {
+      setTime('00:00:00')
+      const now = UnixTime.now()
+      const clock = new Clock(new UnixTime(0), 0)
+      const boundary = clock._TVL_ONLY_getSixHourlyDeletionBoundary()
+
+      expect(boundary).toEqual(now.add(-93, 'days'))
+    })
+  })
 })

--- a/packages/backend/src/core/Clock.test.ts
+++ b/packages/backend/src/core/Clock.test.ts
@@ -131,8 +131,12 @@ describe(Clock.name, () => {
     it('ticks six hourly after 7D and daily after 90D', () => {
       setTime('00:00:00')
       const now = UnixTime.now()
-      const start = now.add(-180, 'days')
 
+      const TOTAL_DAYS = 183
+      const DAILY_TICK_START_DAY = 93
+      const SIX_HOURLY_TICK_START_DAY = 10
+
+      const start = now.add(-TOTAL_DAYS, 'days')
       const clock = new Clock(start, 0)
 
       const calls: UnixTime[] = []
@@ -141,18 +145,23 @@ describe(Clock.name, () => {
       )
       stop()
 
-      const DAILY = 90
-      const SIX_HOURLY = 83 * 4
-
-      // timestamps older than 90D should be ticked daily
-      const dailyCalls = calls.slice(0, DAILY)
+      const DAILY_TICKS = TOTAL_DAYS - DAILY_TICK_START_DAY
+      const dailyCalls = calls.slice(0, DAILY_TICKS)
+      expect(dailyCalls.length).toEqual(DAILY_TICKS)
       expect(dailyCalls.every((x) => x.isFull('day'))).toEqual(true)
 
-      // timestamps older than 7D & earlier than 90D should be ticked six hourly
-      const sixHourly = calls.slice(DAILY, DAILY + SIX_HOURLY)
-      expect(sixHourly.every((x) => x.isFull('six hours'))).toEqual(true)
+      const SIX_HOURLY_TICKS =
+        (DAILY_TICK_START_DAY - SIX_HOURLY_TICK_START_DAY) * 4
+      const sixHourlyCalls = calls.slice(
+        DAILY_TICKS,
+        DAILY_TICKS + SIX_HOURLY_TICKS,
+      )
+      expect(sixHourlyCalls.length).toEqual(SIX_HOURLY_TICKS)
+      expect(sixHourlyCalls.every((x) => x.isFull('six hours'))).toEqual(true)
 
-      const hourlyCalls = calls.slice(DAILY + SIX_HOURLY)
+      const HOURLY_TICKS = 10 * 24 + 1
+      const hourlyCalls = calls.slice(DAILY_TICKS + SIX_HOURLY_TICKS)
+      expect(hourlyCalls.length).toEqual(HOURLY_TICKS)
       for (let i = 0; i < hourlyCalls.length - 1; i++) {
         const call = hourlyCalls[i]
         const nextCall = hourlyCalls[i + 1]

--- a/packages/backend/src/core/Clock.test.ts
+++ b/packages/backend/src/core/Clock.test.ts
@@ -19,7 +19,9 @@ describe(Clock.name, () => {
     UnixTime.fromDate(new Date(`2022-06-29T${hhmmss}.000Z`))
 
   function setTime(hhmmss: string) {
-    time.setSystemTime(new Date(`2022-06-29T${hhmmss}.000Z`))
+    const newTime = new Date(`2022-06-29T${hhmmss}.000Z`)
+    time.setSystemTime(newTime)
+    return newTime
   }
 
   describe(Clock.prototype.getFirstHour.name, () => {
@@ -80,7 +82,7 @@ describe(Clock.name, () => {
     })
   })
 
-  describe(Clock.prototype.onEveryHour.name, () => {
+  describe(Clock.prototype._TVL_ONLY_onEveryHour.name, () => {
     it('calls the callback for every hour up to now', () => {
       setTime('13:05:48')
       const start = toTimestamp('10:00:00')
@@ -88,7 +90,9 @@ describe(Clock.name, () => {
       const clock = new Clock(start, 0)
 
       const calls: UnixTime[] = []
-      const stop = clock.onEveryHour((timestamp) => calls.push(timestamp))
+      const stop = clock._TVL_ONLY_onEveryHour((timestamp) =>
+        calls.push(timestamp),
+      )
       stop()
 
       expect(calls).toEqual([
@@ -106,7 +110,9 @@ describe(Clock.name, () => {
       const clock = new Clock(start, 0, 60 * 1000)
 
       const calls: UnixTime[] = []
-      const stop = clock.onEveryHour((timestamp) => calls.push(timestamp))
+      const stop = clock._TVL_ONLY_onEveryHour((timestamp) =>
+        calls.push(timestamp),
+      )
 
       expect(calls).toEqual([toTimestamp('12:00:00'), toTimestamp('13:00:00')])
 
@@ -120,6 +126,38 @@ describe(Clock.name, () => {
         toTimestamp('15:00:00'),
       ])
       stop()
+    })
+
+    it('ticks six hourly after 7D and daily after 90D', () => {
+      setTime('00:00:00')
+      const now = UnixTime.now()
+      const start = now.add(-180, 'days')
+
+      const clock = new Clock(start, 0)
+
+      const calls: UnixTime[] = []
+      const stop = clock._TVL_ONLY_onEveryHour((timestamp) =>
+        calls.push(timestamp),
+      )
+      stop()
+
+      const DAILY = 90
+      const SIX_HOURLY = 83 * 4
+
+      // timestamps older than 90D should be ticked daily
+      const dailyCalls = calls.slice(0, DAILY)
+      expect(dailyCalls.every((x) => x.isFull('day'))).toEqual(true)
+
+      // timestamps older than 7D & earlier than 90D should be ticked six hourly
+      const sixHourly = calls.slice(DAILY, DAILY + SIX_HOURLY)
+      expect(sixHourly.every((x) => x.isFull('six hours'))).toEqual(true)
+
+      const hourlyCalls = calls.slice(DAILY + SIX_HOURLY)
+      for (let i = 0; i < hourlyCalls.length - 1; i++) {
+        const call = hourlyCalls[i]
+        const nextCall = hourlyCalls[i + 1]
+        expect(nextCall).toEqual(call.add(1, 'hours'))
+      }
     })
   })
 

--- a/packages/backend/src/core/Clock.ts
+++ b/packages/backend/src/core/Clock.ts
@@ -1,5 +1,8 @@
 import { UnixTime } from '@l2beat/shared-pure'
 
+const SAFETY_OFFSET = 3
+const REMOVE_HOURLY_AFTER_DAYS = 7 + SAFETY_OFFSET
+const REMOVE_SIX_HOURLY_AFTER_DAYS = 90 + SAFETY_OFFSET
 export class Clock {
   constructor(
     private readonly minTimestamp: UnixTime,
@@ -49,9 +52,9 @@ export class Clock {
     const onNewTimestamps = () => {
       const last = this.getLastHour()
       while (next.lte(last)) {
-        if (next.add(7, 'days').gte(last)) {
+        if (next.add(REMOVE_HOURLY_AFTER_DAYS, 'days').gte(last)) {
           callback(next)
-        } else if (next.add(90, 'days').gte(last)) {
+        } else if (next.add(REMOVE_SIX_HOURLY_AFTER_DAYS, 'days').gte(last)) {
           if (next.isFull('six hours')) {
             callback(next)
           }

--- a/packages/backend/src/core/Clock.ts
+++ b/packages/backend/src/core/Clock.ts
@@ -116,4 +116,12 @@ export class Clock {
     const interval = setInterval(onNewTimestamps, this.refreshIntervalMs)
     return () => clearInterval(interval)
   }
+
+  _TVL_ONLY_getHourlyDeletionBoundary(): UnixTime {
+    return this.getLastHour().add(-REMOVE_HOURLY_AFTER_DAYS, 'days')
+  }
+
+  _TVL_ONLY_getSixHourlyDeletionBoundary(): UnixTime {
+    return this.getLastHour().add(-REMOVE_SIX_HOURLY_AFTER_DAYS, 'days')
+  }
 }

--- a/packages/backend/src/core/Clock.ts
+++ b/packages/backend/src/core/Clock.ts
@@ -41,12 +41,25 @@ export class Clock {
     return UnixTime.now().add(-this.delayInSeconds, 'seconds').toStartOf('day')
   }
 
-  onEveryHour(callback: (timestamp: UnixTime) => void) {
+  /**
+   * WARNING: this method should be used only in TVL module
+   */
+  _TVL_ONLY_onEveryHour(callback: (timestamp: UnixTime) => void) {
     let next = this.getFirstHour()
     const onNewTimestamps = () => {
       const last = this.getLastHour()
       while (next.lte(last)) {
-        callback(next)
+        if (next.add(7, 'days').gte(last)) {
+          callback(next)
+        } else if (next.add(90, 'days').gte(last)) {
+          if (next.isFull('six hours')) {
+            callback(next)
+          }
+        } else {
+          if (next.isFull('day')) {
+            callback(next)
+          }
+        }
         next = next.add(1, 'hours')
       }
     }

--- a/packages/backend/src/core/Clock.ts
+++ b/packages/backend/src/core/Clock.ts
@@ -3,6 +3,7 @@ import { UnixTime } from '@l2beat/shared-pure'
 const SAFETY_OFFSET = 3
 const REMOVE_HOURLY_AFTER_DAYS = 7 + SAFETY_OFFSET
 const REMOVE_SIX_HOURLY_AFTER_DAYS = 90 + SAFETY_OFFSET
+
 export class Clock {
   constructor(
     private readonly minTimestamp: UnixTime,

--- a/packages/backend/src/core/activity/DailyTransactionCountViewRefresher.ts
+++ b/packages/backend/src/core/activity/DailyTransactionCountViewRefresher.ts
@@ -35,7 +35,7 @@ export class DailyTransactionCountViewRefresher {
         this.refreshQueue.addIfEmpty()
       }),
     )
-    this.clock.onEveryHour(() => this.refreshQueue.addIfEmpty())
+    this.clock.onNewHour(() => this.refreshQueue.addIfEmpty())
     this.refreshQueue.addIfEmpty()
   }
 }

--- a/packages/backend/src/core/assets/CBVUpdater.test.ts
+++ b/packages/backend/src/core/assets/CBVUpdater.test.ts
@@ -146,7 +146,7 @@ describe(CBVUpdater.name, () => {
       })
 
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(MOCK.NOW.add(-1, 'hours'))
           callback(MOCK.NOW)
           callback(MOCK.NOW.add(1, 'hours'))
@@ -222,7 +222,7 @@ describe(CBVUpdater.name, () => {
       })
 
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(MOCK.NOW.add(-1, 'hours'))
           callback(MOCK.NOW)
           callback(MOCK.NOW.add(1, 'hours'))
@@ -315,6 +315,6 @@ function mockReport(project: ReportProject, asset: AssetId): ReportRecord {
 
 function getEmptyClock() {
   return mockObject<Clock>({
-    onEveryHour: () => () => {},
+    _TVL_ONLY_onEveryHour: () => () => {},
   })
 }

--- a/packages/backend/src/core/assets/CBVUpdater.ts
+++ b/packages/backend/src/core/assets/CBVUpdater.ts
@@ -78,7 +78,7 @@ export class CBVUpdater implements ReportUpdater {
     }
 
     this.logger.info('Started')
-    return this.clock.onEveryHour((timestamp) => {
+    return this.clock._TVL_ONLY_onEveryHour((timestamp) => {
       if (!this.knownSet.has(timestamp.toNumber())) {
         if (timestamp.gte(this.minTimestamp)) {
           // we add to front to sync from newest to oldest

--- a/packages/backend/src/core/assets/CirculatingSupplyFormulaUpdater.test.ts
+++ b/packages/backend/src/core/assets/CirculatingSupplyFormulaUpdater.test.ts
@@ -144,7 +144,7 @@ describe(CirculatingSupplyFormulaUpdater.name, () => {
       })
 
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(MOCK.NOW.add(-1, 'hours'))
           callback(MOCK.NOW)
           callback(MOCK.NOW.add(1, 'hours'))
@@ -227,7 +227,7 @@ describe(CirculatingSupplyFormulaUpdater.name, () => {
         })
 
         const clock = mockObject<Clock>({
-          onEveryHour: (callback) => {
+          _TVL_ONLY_onEveryHour: (callback) => {
             callback(MOCK.NOW.add(-1, 'hours'))
             callback(MOCK.NOW)
             callback(MOCK.NOW.add(1, 'hours'))

--- a/packages/backend/src/core/assets/CirculatingSupplyFormulaUpdater.ts
+++ b/packages/backend/src/core/assets/CirculatingSupplyFormulaUpdater.ts
@@ -94,7 +94,7 @@ export class CirculatingSupplyFormulaUpdater implements ReportUpdater {
     }
 
     this.logger.info('Started')
-    return this.clock.onEveryHour((timestamp) => {
+    return this.clock._TVL_ONLY_onEveryHour((timestamp) => {
       if (!this.knownSet.has(timestamp.toNumber())) {
         if (timestamp.gte(this.minTimestamp)) {
           // we add to front to sync from newest to oldest

--- a/packages/backend/src/core/assets/TotalSupplyFormulaUpdater.test.ts
+++ b/packages/backend/src/core/assets/TotalSupplyFormulaUpdater.test.ts
@@ -142,7 +142,7 @@ describe(TotalSupplyFormulaUpdater.name, () => {
       })
 
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(MOCK.NOW.add(-1, 'hours'))
           callback(MOCK.NOW)
           callback(MOCK.NOW.add(1, 'hours'))
@@ -223,7 +223,7 @@ describe(TotalSupplyFormulaUpdater.name, () => {
       })
 
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(MOCK.NOW.add(-1, 'hours'))
           callback(MOCK.NOW)
           callback(MOCK.NOW.add(1, 'hours'))

--- a/packages/backend/src/core/assets/TotalSupplyFormulaUpdater.ts
+++ b/packages/backend/src/core/assets/TotalSupplyFormulaUpdater.ts
@@ -93,7 +93,7 @@ export class TotalSupplyFormulaUpdater implements ReportUpdater {
     }
 
     this.logger.info('Started')
-    return this.clock.onEveryHour((timestamp) => {
+    return this.clock._TVL_ONLY_onEveryHour((timestamp) => {
       if (!this.knownSet.has(timestamp.toNumber())) {
         if (timestamp.gte(this.minTimestamp)) {
           // we add to front to sync from newest to oldest

--- a/packages/backend/src/core/balances/BalanceUpdater.test.ts
+++ b/packages/backend/src/core/balances/BalanceUpdater.test.ts
@@ -31,7 +31,7 @@ describe(BalanceUpdater.name, () => {
 
     it('skips known timestamps', async () => {
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(NOW.add(-1, 'hours'))
           callback(NOW)
           callback(NOW.add(1, 'hours'))

--- a/packages/backend/src/core/balances/BalanceUpdater.ts
+++ b/packages/backend/src/core/balances/BalanceUpdater.ts
@@ -90,7 +90,7 @@ export class BalanceUpdater {
     }
 
     this.logger.info('Started', { chainId: this.chainId.toString() })
-    return this.clock.onEveryHour((timestamp) => {
+    return this.clock._TVL_ONLY_onEveryHour((timestamp) => {
       if (!this.knownSet.has(timestamp.toNumber())) {
         if (timestamp.gte(this.minTimestamp)) {
           // we add to front to sync from newest to oldest

--- a/packages/backend/src/core/reports/AggregatedReportUpdater.test.ts
+++ b/packages/backend/src/core/reports/AggregatedReportUpdater.test.ts
@@ -139,7 +139,7 @@ describe(AggregatedReportUpdater.name, () => {
       const configHash = getAggregatedConfigHash([cbvUpdater])
 
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(MOCK.NOW.add(-1, 'hours'))
           callback(MOCK.NOW)
           callback(MOCK.NOW.add(1, 'hours'))

--- a/packages/backend/src/core/reports/AggregatedReportUpdater.ts
+++ b/packages/backend/src/core/reports/AggregatedReportUpdater.ts
@@ -58,7 +58,7 @@ export class AggregatedReportUpdater {
     }
 
     this.logger.info('Started')
-    return this.clock.onEveryHour((timestamp) => {
+    return this.clock._TVL_ONLY_onEveryHour((timestamp) => {
       if (!this.knownSet.has(timestamp.toNumber())) {
         // we add to front to sync from newest to oldest
         this.taskQueue.addToFront(timestamp)

--- a/packages/backend/src/core/totalSupply/TotalSupplyUpdater.test.ts
+++ b/packages/backend/src/core/totalSupply/TotalSupplyUpdater.test.ts
@@ -26,7 +26,7 @@ describe(TotalSupplyUpdater.name, () => {
 
     it('skips known timestamps', async () => {
       const clock = mockObject<Clock>({
-        onEveryHour: (callback) => {
+        _TVL_ONLY_onEveryHour: (callback) => {
           callback(NOW.add(-1, 'hours'))
           callback(NOW)
           callback(NOW.add(1, 'hours'))

--- a/packages/backend/src/core/totalSupply/TotalSupplyUpdater.ts
+++ b/packages/backend/src/core/totalSupply/TotalSupplyUpdater.ts
@@ -113,7 +113,7 @@ export class TotalSupplyUpdater {
     }
 
     this.logger.info('Started')
-    return this.clock.onEveryHour((timestamp) => {
+    return this.clock._TVL_ONLY_onEveryHour((timestamp) => {
       if (!this.knownSet.has(timestamp.toNumber())) {
         if (timestamp.gte(this.minTimestamp)) {
           // we add to front to sync from newest to oldest

--- a/packages/backend/src/modules/tvl/TvlCleaner.test.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.test.ts
@@ -1,0 +1,65 @@
+import { Logger } from '@l2beat/backend-tools'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockObject } from 'earl'
+import waitForExpect from 'wait-for-expect'
+
+import { Clock } from '../../core/Clock'
+import { TvlCleaner } from './TvlCleaner'
+
+describe(TvlCleaner.name, () => {
+  describe(TvlCleaner.prototype.start.name, () => {
+    it('schedules on every hour', async () => {
+      const clock = mockObject<Clock>({
+        onNewHour: () => () => {},
+        _TVL_ONLY_getHourlyDeletionBoundary: () => UnixTime.ZERO,
+        _TVL_ONLY_getSixHourlyDeletionBoundary: () => UnixTime.ZERO,
+      })
+      const tvlCleaner = new TvlCleaner(clock, Logger.SILENT, [])
+
+      tvlCleaner.start()
+
+      await waitForExpect(() => {
+        expect(clock.onNewHour).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe(TvlCleaner.prototype.clean.name, () => {
+    it('gets boundaries, iterates over tables and deletes', async () => {
+      const hourlyDeletionBoundary = new UnixTime(1000)
+      const sixHourlyDeletionBoundary = new UnixTime(2000)
+      const clock = mockObject<Clock>({
+        onNewHour: () => () => {},
+        _TVL_ONLY_getHourlyDeletionBoundary: () => hourlyDeletionBoundary,
+        _TVL_ONLY_getSixHourlyDeletionBoundary: () => sixHourlyDeletionBoundary,
+      })
+      const firstTable = mockObject({
+        deleteHourlyUntil: (_: UnixTime) => Promise.resolve(1),
+        deleteSixHourlyUntil: (_: UnixTime) => Promise.resolve(2),
+      })
+      const secondTable = mockObject({
+        deleteHourlyUntil: (_: UnixTime) => Promise.resolve(1),
+        deleteSixHourlyUntil: (_: UnixTime) => Promise.resolve(2),
+      })
+      const tvlCleaner = new TvlCleaner(clock, Logger.SILENT, [
+        firstTable,
+        secondTable,
+      ])
+
+      await tvlCleaner.clean()
+
+      expect(firstTable.deleteHourlyUntil).toHaveBeenCalledWith(
+        hourlyDeletionBoundary,
+      )
+      expect(firstTable.deleteSixHourlyUntil).toHaveBeenCalledWith(
+        sixHourlyDeletionBoundary,
+      )
+      expect(secondTable.deleteHourlyUntil).toHaveBeenCalledWith(
+        hourlyDeletionBoundary,
+      )
+      expect(secondTable.deleteSixHourlyUntil).toHaveBeenCalledWith(
+        sixHourlyDeletionBoundary,
+      )
+    })
+  })
+})

--- a/packages/backend/src/modules/tvl/TvlCleaner.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.ts
@@ -1,0 +1,49 @@
+import { Logger } from '@l2beat/backend-tools'
+import { UnixTime } from '@l2beat/shared-pure'
+
+import { Clock } from '../../core/Clock'
+import { TaskQueue } from '../../core/queue/TaskQueue'
+
+interface Table {
+  deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
+  deleteSixHourlyUntil: (timestamp: UnixTime) => Promise<number>
+}
+
+export class TvlCleaner {
+  private readonly taskQueue: TaskQueue<void>
+
+  constructor(
+    private readonly clock: Clock,
+    private readonly logger: Logger,
+    private readonly tables: Table[],
+  ) {
+    this.logger = this.logger.for(this)
+    this.taskQueue = new TaskQueue(
+      () => this.clean(),
+      this.logger.for('taskQueue'),
+      {
+        metricsId: TvlCleaner.name,
+      },
+    )
+  }
+
+  start() {
+    this.taskQueue.addToFront()
+    this.logger.info('Started')
+    return this.clock.onNewHour(() => {
+      this.taskQueue.addToFront()
+    })
+  }
+
+  async clean() {
+    const hourlyDeletionBoundary =
+      this.clock._TVL_ONLY_getHourlyDeletionBoundary()
+    const sixHourlyDeletionBoundary =
+      this.clock._TVL_ONLY_getSixHourlyDeletionBoundary()
+
+    for (const table of this.tables) {
+      await table.deleteHourlyUntil(hourlyDeletionBoundary)
+      await table.deleteSixHourlyUntil(sixHourlyDeletionBoundary)
+    }
+  }
+}

--- a/packages/backend/src/modules/tvl/TvlCleaner.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.ts
@@ -44,11 +44,11 @@ export class TvlCleaner {
     for (const table of this.repositories) {
       this.logger.info(`Cleaning ${table.constructor.name}`)
       const hourly = await table.deleteHourlyUntil(hourlyDeletionBoundary)
+      this.logger.info(`Cleaned hourly ${table.constructor.name}`, { hourly })
       const sixHourly = await table.deleteSixHourlyUntil(
         sixHourlyDeletionBoundary,
       )
-      this.logger.info(`Cleaned ${table.constructor.name}`, {
-        hourly,
+      this.logger.info(`Cleaned sixHourly ${table.constructor.name}`, {
         sixHourly,
       })
     }

--- a/packages/backend/src/modules/tvl/TvlCleaner.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.ts
@@ -44,8 +44,15 @@ export class TvlCleaner {
       this.clock._TVL_ONLY_getSixHourlyDeletionBoundary()
 
     for (const table of this.tables) {
-      await table.deleteHourlyUntil(hourlyDeletionBoundary)
-      await table.deleteSixHourlyUntil(sixHourlyDeletionBoundary)
+      this.logger.info(`Cleaning ${table.constructor.name}`)
+      const hourly = await table.deleteHourlyUntil(hourlyDeletionBoundary)
+      const sixHourly = await table.deleteSixHourlyUntil(
+        sixHourlyDeletionBoundary,
+      )
+      this.logger.info(`Cleaned ${table.constructor.name}`, {
+        hourly,
+        sixHourly,
+      })
     }
   }
 }

--- a/packages/backend/src/modules/tvl/TvlCleaner.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.ts
@@ -54,13 +54,21 @@ export function initializeTvlCleaner(
   config: Config,
   logger: Logger,
   clock: Clock,
-  database: TvlDatabase,
+  db: TvlDatabase,
 ): TvlCleaner | undefined {
   if (!config.tvlCleanerEnabled) {
     return undefined
   }
 
-  const tables = [database.reportRepository]
+  const tables = [
+    db.blockNumberRepository,
+    db.priceRepository,
+    db.balanceRepository,
+    db.totalSupplyRepository,
+    db.circulatingSupplyRepository,
+    db.reportRepository,
+    db.aggregatedReportRepository,
+  ]
 
   return new TvlCleaner(clock, logger, tables)
 }

--- a/packages/backend/src/modules/tvl/TvlCleaner.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.ts
@@ -1,10 +1,8 @@
 import { Logger } from '@l2beat/backend-tools'
 import { UnixTime } from '@l2beat/shared-pure'
 
-import { Config } from '../../config/Config'
 import { Clock } from '../../core/Clock'
 import { TaskQueue } from '../../core/queue/TaskQueue'
-import { TvlDatabase } from './types'
 
 interface Repository {
   deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
@@ -55,27 +53,4 @@ export class TvlCleaner {
       })
     }
   }
-}
-
-export function initializeTvlCleaner(
-  config: Config,
-  logger: Logger,
-  clock: Clock,
-  db: TvlDatabase,
-): TvlCleaner | undefined {
-  if (!config.tvlCleanerEnabled) {
-    return undefined
-  }
-
-  const tables = [
-    db.blockNumberRepository,
-    db.priceRepository,
-    db.balanceRepository,
-    db.totalSupplyRepository,
-    db.circulatingSupplyRepository,
-    db.reportRepository,
-    db.aggregatedReportRepository,
-  ]
-
-  return new TvlCleaner(clock, logger, tables)
 }

--- a/packages/backend/src/modules/tvl/TvlCleaner.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.ts
@@ -6,7 +6,7 @@ import { Clock } from '../../core/Clock'
 import { TaskQueue } from '../../core/queue/TaskQueue'
 import { TvlDatabase } from './types'
 
-interface Table {
+interface Repository {
   deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
   deleteSixHourlyUntil: (timestamp: UnixTime) => Promise<number>
 }
@@ -17,7 +17,7 @@ export class TvlCleaner {
   constructor(
     private readonly clock: Clock,
     private readonly logger: Logger,
-    private readonly tables: Table[],
+    private readonly repositories: Repository[],
   ) {
     this.logger = this.logger.for(this)
     this.taskQueue = new TaskQueue(
@@ -43,7 +43,7 @@ export class TvlCleaner {
     const sixHourlyDeletionBoundary =
       this.clock._TVL_ONLY_getSixHourlyDeletionBoundary()
 
-    for (const table of this.tables) {
+    for (const table of this.repositories) {
       this.logger.info(`Cleaning ${table.constructor.name}`)
       const hourly = await table.deleteHourlyUntil(hourlyDeletionBoundary)
       const sixHourly = await table.deleteSixHourlyUntil(

--- a/packages/backend/src/modules/tvl/TvlCleaner.ts
+++ b/packages/backend/src/modules/tvl/TvlCleaner.ts
@@ -1,8 +1,10 @@
 import { Logger } from '@l2beat/backend-tools'
 import { UnixTime } from '@l2beat/shared-pure'
 
+import { Config } from '../../config/Config'
 import { Clock } from '../../core/Clock'
 import { TaskQueue } from '../../core/queue/TaskQueue'
+import { TvlDatabase } from './types'
 
 interface Table {
   deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
@@ -46,4 +48,19 @@ export class TvlCleaner {
       await table.deleteSixHourlyUntil(sixHourlyDeletionBoundary)
     }
   }
+}
+
+export function initializeTvlCleaner(
+  config: Config,
+  logger: Logger,
+  clock: Clock,
+  database: TvlDatabase,
+): TvlCleaner | undefined {
+  if (!config.tvlCleanerEnabled) {
+    return undefined
+  }
+
+  const tables = [database.reportRepository]
+
+  return new TvlCleaner(clock, logger, tables)
 }

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -160,7 +160,9 @@ export function createTvlModule(
     logger.info('Starting')
 
     priceUpdater.start()
-    tvlCleaner.start()
+    if (config.tvlCleanerEnabled) {
+      tvlCleaner.start()
+    }
 
     logger.info('Starting modules...')
 

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -33,7 +33,7 @@ import { TotalSupplyStatusRepository } from '../../peripherals/database/TotalSup
 import { ApplicationModule } from '../ApplicationModule'
 import { chainTvlModule } from './ChainTvlModule'
 import { createEthereumTvlModule } from './EthereumTvlModule'
-import { TvlCleaner } from './TvlCleaner'
+import { initializeTvlCleaner } from './TvlCleaner'
 import { TvlDatabase } from './types'
 
 export function createTvlModule(
@@ -91,7 +91,8 @@ export function createTvlModule(
     config.tokens,
     logger,
   )
-  const tvlCleaner = new TvlCleaner(clock, logger, [db.reportRepository])
+
+  const tvlCleaner = initializeTvlCleaner(config, logger, clock, db)
 
   // #endregion
   // #region modules
@@ -160,9 +161,7 @@ export function createTvlModule(
     logger.info('Starting')
 
     priceUpdater.start()
-    if (config.tvlCleanerEnabled) {
-      tvlCleaner.start()
-    }
+    tvlCleaner?.start()
 
     logger.info('Starting modules...')
 

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -53,23 +53,24 @@ export function createTvlModule(
     blockNumberRepository: new BlockNumberRepository(database, logger),
     priceRepository: new PriceRepository(database, logger),
     balanceRepository: new BalanceRepository(database, logger),
+    totalSupplyRepository: new TotalSupplyRepository(database, logger),
+    circulatingSupplyRepository: new CirculatingSupplyRepository(
+      database,
+      logger,
+    ),
     reportRepository: new ReportRepository(database, logger),
     aggregatedReportRepository: new AggregatedReportRepository(
       database,
       logger,
     ),
-    reportStatusRepository: new ReportStatusRepository(database, logger),
-    aggregatedReportStatusRepository: new AggregatedReportStatusRepository(
-      database,
-      logger,
-    ),
+    // status tables
     balanceStatusRepository: new BalanceStatusRepository(database, logger),
-    totalSupplyRepository: new TotalSupplyRepository(database, logger),
     totalSupplyStatusRepository: new TotalSupplyStatusRepository(
       database,
       logger,
     ),
-    circulatingSupplyRepository: new CirculatingSupplyRepository(
+    reportStatusRepository: new ReportStatusRepository(database, logger),
+    aggregatedReportStatusRepository: new AggregatedReportStatusRepository(
       database,
       logger,
     ),

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -33,7 +33,7 @@ import { TotalSupplyStatusRepository } from '../../peripherals/database/TotalSup
 import { ApplicationModule } from '../ApplicationModule'
 import { chainTvlModule } from './ChainTvlModule'
 import { createEthereumTvlModule } from './EthereumTvlModule'
-import { initializeTvlCleaner } from './TvlCleaner'
+import { TvlCleaner } from './TvlCleaner'
 import { TvlDatabase } from './types'
 
 export function createTvlModule(
@@ -93,7 +93,16 @@ export function createTvlModule(
     logger,
   )
 
-  const tvlCleaner = initializeTvlCleaner(config, logger, clock, db)
+  const repositoriesToClean = [
+    db.blockNumberRepository,
+    db.priceRepository,
+    db.balanceRepository,
+    db.totalSupplyRepository,
+    db.circulatingSupplyRepository,
+    db.reportRepository,
+    db.aggregatedReportRepository,
+  ]
+  const tvlCleaner = new TvlCleaner(clock, logger, repositoriesToClean)
 
   // #endregion
   // #region modules
@@ -162,7 +171,10 @@ export function createTvlModule(
     logger.info('Starting')
 
     priceUpdater.start()
-    tvlCleaner?.start()
+
+    if (config.tvlCleanerEnabled) {
+      tvlCleaner.start()
+    }
 
     logger.info('Starting modules...')
 

--- a/packages/backend/src/modules/tvl/TvlModule.ts
+++ b/packages/backend/src/modules/tvl/TvlModule.ts
@@ -33,6 +33,7 @@ import { TotalSupplyStatusRepository } from '../../peripherals/database/TotalSup
 import { ApplicationModule } from '../ApplicationModule'
 import { chainTvlModule } from './ChainTvlModule'
 import { createEthereumTvlModule } from './EthereumTvlModule'
+import { TvlCleaner } from './TvlCleaner'
 import { TvlDatabase } from './types'
 
 export function createTvlModule(
@@ -73,6 +74,7 @@ export function createTvlModule(
       logger,
     ),
   }
+
   // #endregion
   // #region peripherals
 
@@ -89,6 +91,7 @@ export function createTvlModule(
     config.tokens,
     logger,
   )
+  const tvlCleaner = new TvlCleaner(clock, logger, [db.reportRepository])
 
   // #endregion
   // #region modules
@@ -157,6 +160,7 @@ export function createTvlModule(
     logger.info('Starting')
 
     priceUpdater.start()
+    tvlCleaner.start()
 
     logger.info('Starting modules...')
 

--- a/packages/backend/src/modules/tvl/types.ts
+++ b/packages/backend/src/modules/tvl/types.ts
@@ -14,12 +14,13 @@ export interface TvlDatabase {
   readonly blockNumberRepository: BlockNumberRepository
   readonly priceRepository: PriceRepository
   readonly balanceRepository: BalanceRepository
+  readonly totalSupplyRepository: TotalSupplyRepository
+  readonly circulatingSupplyRepository: CirculatingSupplyRepository
   readonly reportRepository: ReportRepository
   readonly aggregatedReportRepository: AggregatedReportRepository
-  readonly aggregatedReportStatusRepository: AggregatedReportStatusRepository
-  readonly reportStatusRepository: ReportStatusRepository
+  // status tables
   readonly balanceStatusRepository: BalanceStatusRepository
-  readonly totalSupplyRepository: TotalSupplyRepository
   readonly totalSupplyStatusRepository: TotalSupplyStatusRepository
-  readonly circulatingSupplyRepository: CirculatingSupplyRepository
+  readonly reportStatusRepository: ReportStatusRepository
+  readonly aggregatedReportStatusRepository: AggregatedReportStatusRepository
 }

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
@@ -7,6 +7,7 @@ import {
   AggregatedReportRecord,
   AggregatedReportRepository,
 } from './AggregatedReportRepository'
+import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
 
 describeDatabase(AggregatedReportRepository.name, (database) => {
   const repository = new AggregatedReportRepository(database, Logger.SILENT)
@@ -278,67 +279,7 @@ describeDatabase(AggregatedReportRepository.name, (database) => {
     })
   })
 
-  describe(AggregatedReportRepository.prototype.deleteHourlyUntil.name, () => {
-    it('deletes hourly reports', async () => {
-      const start = UnixTime.now().toStartOf('day')
-      const until = start.add(25, 'hours')
-
-      const entries = []
-      for (
-        let i = start.toNumber();
-        i <= until.toNumber();
-        i += UnixTime.HOUR
-      ) {
-        entries.push(fakeAggregateReport({ timestamp: new UnixTime(i) }))
-      }
-
-      await repository.addOrUpdateMany(entries)
-      await repository.deleteHourlyUntil(until)
-      const results = await repository.getAll()
-
-      expect(results).toEqualUnsorted([
-        fakeAggregateReport({ timestamp: start }),
-        fakeAggregateReport({ timestamp: start.add(6, 'hours') }),
-        fakeAggregateReport({ timestamp: start.add(12, 'hours') }),
-        fakeAggregateReport({ timestamp: start.add(18, 'hours') }),
-        fakeAggregateReport({ timestamp: start.add(24, 'hours') }),
-        fakeAggregateReport({ timestamp: start.add(25, 'hours') }),
-      ])
-    })
-  })
-
-  describe(
-    AggregatedReportRepository.prototype.deleteSixHourlyUntil.name,
-    () => {
-      it('deletes six hourly reports', async () => {
-        const start = UnixTime.now().toStartOf('day')
-        const until = start.add(7, 'hours')
-
-        const entries = []
-        for (
-          let i = start.toNumber();
-          i <= until.toNumber();
-          i += UnixTime.HOUR
-        ) {
-          entries.push(fakeAggregateReport({ timestamp: new UnixTime(i) }))
-        }
-
-        await repository.addOrUpdateMany(entries)
-        await repository.deleteSixHourlyUntil(until)
-        const results = await repository.getAll()
-
-        expect(results).toEqualUnsorted([
-          fakeAggregateReport({ timestamp: start }),
-          fakeAggregateReport({ timestamp: start.add(1, 'hours') }),
-          fakeAggregateReport({ timestamp: start.add(2, 'hours') }),
-          fakeAggregateReport({ timestamp: start.add(3, 'hours') }),
-          fakeAggregateReport({ timestamp: start.add(4, 'hours') }),
-          fakeAggregateReport({ timestamp: start.add(5, 'hours') }),
-          fakeAggregateReport({ timestamp: start.add(7, 'hours') }),
-        ])
-      })
-    },
-  )
+  _TVL_ONLY_deletion_test(repository, fakeAggregateReportTimestamp)
 })
 
 function getResult(
@@ -398,4 +339,10 @@ function fakeAggregateReport(
     reportType: 'TVL',
     ...report,
   }
+}
+
+function fakeAggregateReportTimestamp(
+  timestamp: UnixTime,
+): AggregatedReportRecord {
+  return fakeAggregateReport({ timestamp })
 }

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
@@ -7,7 +7,7 @@ import {
   AggregatedReportRecord,
   AggregatedReportRepository,
 } from './AggregatedReportRepository'
-import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
 
 describeDatabase(AggregatedReportRepository.name, (database) => {
   const repository = new AggregatedReportRepository(database, Logger.SILENT)
@@ -279,7 +279,7 @@ describeDatabase(AggregatedReportRepository.name, (database) => {
     })
   })
 
-  _TVL_ONLY_deletion_test(repository, fakeAggregateReportTimestamp)
+  testDeletingArchivedRecords(repository, fakeAggregateReportTimestamp)
 })
 
 function getResult(

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
@@ -13,7 +13,6 @@ describeDatabase(AggregatedReportRepository.name, (database) => {
 
   const TIME_0 = UnixTime.now().toStartOf('day')
   const TIME_1 = TIME_0.add(1, 'hours')
-  const TIME_2 = TIME_0.add(2, 'hours')
 
   const PROJECT_A = ProjectId('project-a')
   const PROJECT_B = ProjectId('project-b')

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
@@ -17,7 +17,7 @@ describeDatabase(AggregatedReportRepository.name, (database) => {
   const PROJECT_A = ProjectId('project-a')
   const PROJECT_B = ProjectId('project-b')
 
-  beforeEach(async () => {
+  afterEach(async () => {
     await repository.deleteAll()
   })
 

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
@@ -7,7 +7,7 @@ import {
   AggregatedReportRecord,
   AggregatedReportRepository,
 } from './AggregatedReportRepository'
-import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords.test'
 
 describeDatabase(AggregatedReportRepository.name, (database) => {
   const repository = new AggregatedReportRepository(database, Logger.SILENT)

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.test.ts
@@ -284,16 +284,16 @@ describeDatabase(AggregatedReportRepository.name, (database) => {
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(25, 'hours')
 
-      const reports = []
+      const entries = []
       for (
         let i = start.toNumber();
         i <= until.toNumber();
         i += UnixTime.HOUR
       ) {
-        reports.push(fakeAggregateReport({ timestamp: new UnixTime(i) }))
+        entries.push(fakeAggregateReport({ timestamp: new UnixTime(i) }))
       }
 
-      await repository.addOrUpdateMany(reports)
+      await repository.addOrUpdateMany(entries)
       await repository.deleteHourlyUntil(until)
       const results = await repository.getAll()
 
@@ -315,16 +315,16 @@ describeDatabase(AggregatedReportRepository.name, (database) => {
         const start = UnixTime.now().toStartOf('day')
         const until = start.add(7, 'hours')
 
-        const reports = []
+        const entries = []
         for (
           let i = start.toNumber();
           i <= until.toNumber();
           i += UnixTime.HOUR
         ) {
-          reports.push(fakeAggregateReport({ timestamp: new UnixTime(i) }))
+          entries.push(fakeAggregateReport({ timestamp: new UnixTime(i) }))
         }
 
-        await repository.addOrUpdateMany(reports)
+        await repository.addOrUpdateMany(entries)
         await repository.deleteSixHourlyUntil(until)
         const results = await repository.getAll()
 

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
@@ -5,8 +5,8 @@ import { AggregatedReportRow } from 'knex/types/tables'
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 import {
-  _TVL_ONLY_deleteHourlyUntil,
-  _TVL_ONLY_deleteSixHourlyUntil,
+  deleteHourlyUntil,
+  deleteSixHourlyUntil,
 } from './shared/deleteArchivedRecords'
 
 export interface AggregatedReportRecord {
@@ -207,12 +207,12 @@ export class AggregatedReportRepository extends BaseRepository {
 
   async deleteHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteHourlyUntil(knex, 'aggregated_reports', timestamp)
+    return deleteHourlyUntil(knex, 'aggregated_reports', timestamp)
   }
 
   async deleteSixHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'aggregated_reports', timestamp)
+    return deleteSixHourlyUntil(knex, 'aggregated_reports', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
@@ -193,6 +193,13 @@ export class AggregatedReportRepository extends BaseRepository {
     return rows.length
   }
 
+  async addMany(reports: AggregatedReportRecord[]) {
+    const rows = reports.map(toRow)
+    const knex = await this.knex()
+    await knex.batchInsert('aggregated_reports', rows, 10_000)
+    return rows.length
+  }
+
   async deleteAll() {
     const knex = await this.knex()
     return knex('aggregated_reports').delete()

--- a/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
+++ b/packages/backend/src/peripherals/database/AggregatedReportRepository.ts
@@ -1,10 +1,5 @@
 import { Logger } from '@l2beat/backend-tools'
-import {
-  AggregatedReportType,
-  assert,
-  ProjectId,
-  UnixTime,
-} from '@l2beat/shared-pure'
+import { AggregatedReportType, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { AggregatedReportRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'

--- a/packages/backend/src/peripherals/database/BalanceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.test.ts
@@ -250,4 +250,78 @@ describeDatabase(BalanceRepository.name, (database) => {
 
     expect(result).toEqual([])
   })
+
+  describe(BalanceRepository.prototype.deleteHourlyUntil.name, () => {
+    it('deletes hourly reports', async () => {
+      await repository.deleteAll()
+
+      const start = UnixTime.now().toStartOf('day')
+      const until = start.add(25, 'hours')
+
+      const entries = []
+      for (
+        let i = start.toNumber();
+        i <= until.toNumber();
+        i += UnixTime.HOUR
+      ) {
+        entries.push(fakeBalance({ timestamp: new UnixTime(i) }))
+      }
+
+      await repository.addOrUpdateMany(entries)
+      await repository.deleteHourlyUntil(until)
+      const results = await repository.getAll()
+
+      expect(results).toEqualUnsorted([
+        fakeBalance({ timestamp: start }),
+        fakeBalance({ timestamp: start.add(6, 'hours') }),
+        fakeBalance({ timestamp: start.add(12, 'hours') }),
+        fakeBalance({ timestamp: start.add(18, 'hours') }),
+        fakeBalance({ timestamp: start.add(24, 'hours') }),
+        fakeBalance({ timestamp: start.add(25, 'hours') }),
+      ])
+    })
+  })
+
+  describe(BalanceRepository.prototype.deleteSixHourlyUntil.name, () => {
+    it('deletes six hourly reports', async () => {
+      await repository.deleteAll()
+
+      const start = UnixTime.now().toStartOf('day')
+      const until = start.add(7, 'hours')
+
+      const entries = []
+      for (
+        let i = start.toNumber();
+        i <= until.toNumber();
+        i += UnixTime.HOUR
+      ) {
+        entries.push(fakeBalance({ timestamp: new UnixTime(i) }))
+      }
+
+      await repository.addOrUpdateMany(entries)
+      await repository.deleteSixHourlyUntil(until)
+      const results = await repository.getAll()
+
+      expect(results).toEqualUnsorted([
+        fakeBalance({ timestamp: start }),
+        fakeBalance({ timestamp: start.add(1, 'hours') }),
+        fakeBalance({ timestamp: start.add(2, 'hours') }),
+        fakeBalance({ timestamp: start.add(3, 'hours') }),
+        fakeBalance({ timestamp: start.add(4, 'hours') }),
+        fakeBalance({ timestamp: start.add(5, 'hours') }),
+        fakeBalance({ timestamp: start.add(7, 'hours') }),
+      ])
+    })
+  })
 })
+
+function fakeBalance(entry?: Partial<BalanceRecord>): BalanceRecord {
+  return {
+    timestamp: UnixTime.now(),
+    holderAddress: EthereumAddress.ZERO,
+    assetId: AssetId('fake'),
+    balance: 0n,
+    chainId: ChainId.ETHEREUM,
+    ...entry,
+  }
+}

--- a/packages/backend/src/peripherals/database/BalanceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.test.ts
@@ -42,11 +42,12 @@ describeDatabase(BalanceRepository.name, (database) => {
 
   beforeEach(async () => {
     await repository.deleteAll()
-    await repository.addOrUpdateMany(DATA)
   })
 
   describe(BalanceRepository.prototype.getByTimestamp.name, () => {
     it('known timestamp', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const additionalData = [
         mockBalance(HOLDER_A, 0, AssetId('asset-a'), BALANCE, ChainId.ETHEREUM),
         mockBalance(HOLDER_A, 0, AssetId('asset-b'), BALANCE, ChainId.ETHEREUM),
@@ -63,6 +64,8 @@ describeDatabase(BalanceRepository.name, (database) => {
     })
 
     it('unknown timestamp', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const result = await repository.getByChainAndTimestamp(
         ChainId.ETHEREUM,
         START.add(1, 'days'),
@@ -71,7 +74,6 @@ describeDatabase(BalanceRepository.name, (database) => {
     })
 
     it('one project one asset', async () => {
-      await repository.deleteAll()
       const data = [
         mockBalance(HOLDER_A, 0, ASSET_1, 1n, ChainId.ETHEREUM),
         mockBalance(HOLDER_A, 1, ASSET_1, 1n, ChainId.ETHEREUM),
@@ -96,7 +98,6 @@ describeDatabase(BalanceRepository.name, (database) => {
     })
 
     it('many projects many assets', async () => {
-      await repository.deleteAll()
       const data = [
         mockBalance(HOLDER_A, 0, ASSET_1, 1n, ChainId.ETHEREUM),
         mockBalance(HOLDER_A, 1, ASSET_1, 1n, ChainId.ETHEREUM),
@@ -142,6 +143,8 @@ describeDatabase(BalanceRepository.name, (database) => {
     })
 
     it('take chainId into consideration', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const resultEth = await repository.getByChainAndTimestamp(
         ChainId.ETHEREUM,
         START,
@@ -158,6 +161,8 @@ describeDatabase(BalanceRepository.name, (database) => {
 
   describe(BalanceRepository.prototype.addOrUpdateMany.name, () => {
     it('new rows only', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const newRows = [
         {
           timestamp: START.add(2, 'hours'),
@@ -185,6 +190,8 @@ describeDatabase(BalanceRepository.name, (database) => {
     })
 
     it('existing rows only', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const existingRows = [
         {
           timestamp: DATA[0].timestamp,
@@ -208,6 +215,8 @@ describeDatabase(BalanceRepository.name, (database) => {
     })
 
     it('mixed: existing and new rows', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const mixedRows = [
         {
           timestamp: DATA[1].timestamp,
@@ -233,17 +242,22 @@ describeDatabase(BalanceRepository.name, (database) => {
     })
 
     it('empty array', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       await expect(repository.addOrUpdateMany([])).not.toBeRejected()
     })
   })
 
   it(BalanceRepository.prototype.getAll.name, async () => {
+    await repository.addOrUpdateMany(DATA)
+
     const result = await repository.getAll()
 
     expect(result).toEqual(DATA)
   })
 
   it(BalanceRepository.prototype.deleteAll.name, async () => {
+    await repository.addOrUpdateMany(DATA)
     await repository.deleteAll()
 
     const result = await repository.getAll()
@@ -253,8 +267,6 @@ describeDatabase(BalanceRepository.name, (database) => {
 
   describe(BalanceRepository.prototype.deleteHourlyUntil.name, () => {
     it('deletes hourly reports', async () => {
-      await repository.deleteAll()
-
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(25, 'hours')
 
@@ -284,8 +296,6 @@ describeDatabase(BalanceRepository.name, (database) => {
 
   describe(BalanceRepository.prototype.deleteSixHourlyUntil.name, () => {
     it('deletes six hourly reports', async () => {
-      await repository.deleteAll()
-
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(7, 'hours')
 

--- a/packages/backend/src/peripherals/database/BalanceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
 import { BalanceRecord, BalanceRepository } from './BalanceRepository'
-import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
 const mockBalance = (
@@ -266,7 +266,7 @@ describeDatabase(BalanceRepository.name, (database) => {
     expect(result).toEqual([])
   })
 
-  _TVL_ONLY_deletion_test(repository, fakeBalance)
+  testDeletingArchivedRecords(repository, fakeBalance)
 })
 
 function fakeBalance(timestamp: UnixTime): BalanceRecord {

--- a/packages/backend/src/peripherals/database/BalanceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.test.ts
@@ -40,7 +40,7 @@ describeDatabase(BalanceRepository.name, (database) => {
     mockBalance(HOLDER_A, 1, ASSET_1, BALANCE, ChainId.ETHEREUM),
   ]
 
-  beforeEach(async () => {
+  afterEach(async () => {
     await repository.deleteAll()
   })
 

--- a/packages/backend/src/peripherals/database/BalanceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.test.ts
@@ -9,7 +9,7 @@ import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
 import { BalanceRecord, BalanceRepository } from './BalanceRepository'
-import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords.test'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
 const mockBalance = (

--- a/packages/backend/src/peripherals/database/BalanceRepository.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.ts
@@ -71,6 +71,13 @@ export class BalanceRepository extends BaseRepository {
     return rows.length
   }
 
+  async addMany(balances: BalanceRecord[]) {
+    const rows = balances.map(toRow)
+    const knex = await this.knex()
+    await knex.batchInsert('balances', rows, 10_000)
+    return rows.length
+  }
+
   async getAll(): Promise<BalanceRecord[]> {
     const knex = await this.knex()
     const rows = await knex('balances')

--- a/packages/backend/src/peripherals/database/BalanceRepository.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.ts
@@ -9,6 +9,10 @@ import { BalanceRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
+import {
+  _TVL_ONLY_deleteHourlyUntil,
+  _TVL_ONLY_deleteSixHourlyUntil,
+} from './shared/deleteArchivedRecords'
 
 export interface BalanceRecord {
   timestamp: UnixTime
@@ -76,6 +80,16 @@ export class BalanceRepository extends BaseRepository {
   async deleteAll() {
     const knex = await this.knex()
     return knex('balances').delete()
+  }
+
+  async deleteHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteHourlyUntil(knex, 'balances', timestamp)
+  }
+
+  async deleteSixHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'balances', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/BalanceRepository.ts
+++ b/packages/backend/src/peripherals/database/BalanceRepository.ts
@@ -10,8 +10,8 @@ import { BalanceRow } from 'knex/types/tables'
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 import {
-  _TVL_ONLY_deleteHourlyUntil,
-  _TVL_ONLY_deleteSixHourlyUntil,
+  deleteHourlyUntil,
+  deleteSixHourlyUntil,
 } from './shared/deleteArchivedRecords'
 
 export interface BalanceRecord {
@@ -91,12 +91,12 @@ export class BalanceRepository extends BaseRepository {
 
   async deleteHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteHourlyUntil(knex, 'balances', timestamp)
+    return deleteHourlyUntil(knex, 'balances', timestamp)
   }
 
   async deleteSixHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'balances', timestamp)
+    return deleteSixHourlyUntil(knex, 'balances', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -12,10 +12,6 @@ import { PriceRepository } from './PriceRepository'
 describeDatabase(BlockNumberRepository.name, (database) => {
   const repository = new BlockNumberRepository(database, Logger.SILENT)
 
-  beforeEach(async () => {
-    await repository.deleteAll()
-  })
-
   afterEach(async () => {
     await repository.deleteAll()
   })

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -16,6 +16,10 @@ describeDatabase(BlockNumberRepository.name, (database) => {
     await repository.deleteAll()
   })
 
+  afterEach(async () => {
+    await repository.deleteAll()
+  })
+
   it(BlockNumberRepository.prototype.add.name, async () => {
     const itemA = {
       blockNumber: 1234,

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -7,7 +7,7 @@ import {
   BlockNumberRecord,
   BlockNumberRepository,
 } from './BlockNumberRepository'
-import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords.test'
 
 describeDatabase(BlockNumberRepository.name, (database) => {
   const repository = new BlockNumberRepository(database, Logger.SILENT)

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.test.ts
@@ -7,7 +7,7 @@ import {
   BlockNumberRecord,
   BlockNumberRepository,
 } from './BlockNumberRepository'
-import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
 
 describeDatabase(BlockNumberRepository.name, (database) => {
   const repository = new BlockNumberRepository(database, Logger.SILENT)
@@ -112,7 +112,7 @@ describeDatabase(BlockNumberRepository.name, (database) => {
     expect(results).toEqual([])
   })
 
-  _TVL_ONLY_deletion_test(repository, fakeBlockRecord)
+  testDeletingArchivedRecords(repository, fakeBlockRecord)
 })
 
 function fakeBlockRecord(timestamp: UnixTime): BlockNumberRecord {

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -5,8 +5,8 @@ import { BlockNumberRow } from 'knex/types/tables'
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 import {
-  _TVL_ONLY_deleteHourlyUntil,
-  _TVL_ONLY_deleteSixHourlyUntil,
+  deleteHourlyUntil,
+  deleteSixHourlyUntil,
 } from './shared/deleteArchivedRecords'
 
 export interface BlockNumberRecord {
@@ -69,12 +69,12 @@ export class BlockNumberRepository extends BaseRepository {
   }
   async deleteHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteHourlyUntil(knex, 'block_numbers', timestamp)
+    return deleteHourlyUntil(knex, 'block_numbers', timestamp)
   }
 
   async deleteSixHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'block_numbers', timestamp)
+    return deleteSixHourlyUntil(knex, 'block_numbers', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -4,6 +4,10 @@ import { BlockNumberRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
+import {
+  _TVL_ONLY_deleteHourlyUntil,
+  _TVL_ONLY_deleteSixHourlyUntil,
+} from './shared/deleteArchivedRecords'
 
 export interface BlockNumberRecord {
   timestamp: UnixTime
@@ -49,6 +53,15 @@ export class BlockNumberRepository extends BaseRepository {
   async deleteAll() {
     const knex = await this.knex()
     return knex('block_numbers').delete()
+  }
+  async deleteHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteHourlyUntil(knex, 'block_numbers', timestamp)
+  }
+
+  async deleteSixHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'block_numbers', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/BlockNumberRepository.ts
+++ b/packages/backend/src/peripherals/database/BlockNumberRepository.ts
@@ -30,7 +30,20 @@ export class BlockNumberRepository extends BaseRepository {
     )}`
   }
 
-  async getAll(chainId: ChainId): Promise<BlockNumberRecord[]> {
+  async addMany(records: BlockNumberRecord[]) {
+    const rows = records.map(toRow)
+    const knex = await this.knex()
+    await knex.batchInsert('block_numbers', rows, 10_000)
+    return rows.length
+  }
+
+  async getAll(): Promise<BlockNumberRecord[]> {
+    const knex = await this.knex()
+    const rows = await knex('block_numbers')
+    return rows.map(toRecord)
+  }
+
+  async getAllByChainId(chainId: ChainId): Promise<BlockNumberRecord[]> {
     const knex = await this.knex()
     const rows = await knex('block_numbers')
       .where('chain_id', '=', Number(chainId))

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -7,6 +7,7 @@ import {
   CirculatingSupplyRecord,
   CirculatingSupplyRepository,
 } from './CirculatingSupplyRepository'
+import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
 
@@ -244,77 +245,14 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     expect(result).toEqual([])
   })
 
-  describe(CirculatingSupplyRepository.prototype.deleteHourlyUntil.name, () => {
-    it('deletes hourly reports', async () => {
-      const start = UnixTime.now().toStartOf('day')
-      const until = start.add(25, 'hours')
-
-      const entries = []
-      for (
-        let i = start.toNumber();
-        i <= until.toNumber();
-        i += UnixTime.HOUR
-      ) {
-        entries.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
-      }
-
-      await repository.addMany(entries)
-      await repository.deleteHourlyUntil(until)
-      const results = await repository.getAll()
-
-      expect(results).toEqualUnsorted([
-        fakeCirculatingSupply({ timestamp: start }),
-        fakeCirculatingSupply({ timestamp: start.add(6, 'hours') }),
-        fakeCirculatingSupply({ timestamp: start.add(12, 'hours') }),
-        fakeCirculatingSupply({ timestamp: start.add(18, 'hours') }),
-        fakeCirculatingSupply({ timestamp: start.add(24, 'hours') }),
-        fakeCirculatingSupply({ timestamp: start.add(25, 'hours') }),
-      ])
-    })
-  })
-
-  describe(
-    CirculatingSupplyRepository.prototype.deleteSixHourlyUntil.name,
-    () => {
-      it('deletes six hourly reports', async () => {
-        const start = UnixTime.now().toStartOf('day')
-        const until = start.add(7, 'hours')
-
-        const entries = []
-        for (
-          let i = start.toNumber();
-          i <= until.toNumber();
-          i += UnixTime.HOUR
-        ) {
-          entries.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
-        }
-
-        await repository.addMany(entries)
-        await repository.deleteSixHourlyUntil(until)
-        const results = await repository.getAll()
-
-        expect(results).toEqualUnsorted([
-          fakeCirculatingSupply({ timestamp: start }),
-          fakeCirculatingSupply({ timestamp: start.add(1, 'hours') }),
-          fakeCirculatingSupply({ timestamp: start.add(2, 'hours') }),
-          fakeCirculatingSupply({ timestamp: start.add(3, 'hours') }),
-          fakeCirculatingSupply({ timestamp: start.add(4, 'hours') }),
-          fakeCirculatingSupply({ timestamp: start.add(5, 'hours') }),
-          fakeCirculatingSupply({ timestamp: start.add(7, 'hours') }),
-        ])
-      })
-    },
-  )
+  _TVL_ONLY_deletion_test(repository, fakeCirculatingSupply)
 })
 
-function fakeCirculatingSupply(
-  entry?: Partial<CirculatingSupplyRecord>,
-): CirculatingSupplyRecord {
+function fakeCirculatingSupply(timestamp: UnixTime): CirculatingSupplyRecord {
   return {
-    timestamp: UnixTime.ZERO,
+    timestamp,
     circulatingSupply: 0,
     assetId: AssetId('fake'),
     chainId: ChainId.ARBITRUM,
-    ...entry,
   }
 }

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -7,7 +7,7 @@ import {
   CirculatingSupplyRecord,
   CirculatingSupplyRepository,
 } from './CirculatingSupplyRepository'
-import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords.test'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
 

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -250,16 +250,16 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(25, 'hours')
 
-      const reports = []
+      const entries = []
       for (
         let i = start.toNumber();
         i <= until.toNumber();
         i += UnixTime.HOUR
       ) {
-        reports.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
+        entries.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
       }
 
-      await repository.addMany(reports)
+      await repository.addMany(entries)
       await repository.deleteHourlyUntil(until)
       const results = await repository.getAll()
 
@@ -283,16 +283,16 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
         const start = UnixTime.now().toStartOf('day')
         const until = start.add(7, 'hours')
 
-        const reports = []
+        const entries = []
         for (
           let i = start.toNumber();
           i <= until.toNumber();
           i += UnixTime.HOUR
         ) {
-          reports.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
+          entries.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
         }
 
-        await repository.addMany(reports)
+        await repository.addMany(entries)
         await repository.deleteSixHourlyUntil(until)
         const results = await repository.getAll()
 
@@ -311,13 +311,13 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
 })
 
 function fakeCirculatingSupply(
-  report?: Partial<CirculatingSupplyRecord>,
+  entry?: Partial<CirculatingSupplyRecord>,
 ): CirculatingSupplyRecord {
   return {
     timestamp: UnixTime.ZERO,
     circulatingSupply: 0,
     assetId: AssetId('fake'),
     chainId: ChainId.ARBITRUM,
-    ...report,
+    ...entry,
   }
 }

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -35,17 +35,14 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     mockCirculatingSupply(C_SUPPLY, 1, ASSET_2, ChainId.ETHEREUM),
   ]
 
-  beforeEach(async () => {
-    // TODO: get rid of this, adding new tests is tricky because of it
-    await repository.addMany(DATA)
-  })
-
   afterEach(async () => {
     await repository.deleteAll()
   })
 
   describe(CirculatingSupplyRepository.prototype.getByTimestamp.name, () => {
     it('returns matching data for given timestamp', async () => {
+      await repository.addMany(DATA)
+
       const additionalData = [
         mockCirculatingSupply(
           C_SUPPLY,
@@ -74,6 +71,8 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     })
 
     it('returns empty list if no data exists for given timestamp', async () => {
+      await repository.addMany(DATA)
+
       const result = await repository.getByTimestamp(
         ChainId.ETHEREUM,
         START.add(1, 'days'),
@@ -82,7 +81,6 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     })
 
     it('one project one asset', async () => {
-      await repository.deleteAll()
       const data = [
         mockCirculatingSupply(C_SUPPLY, 0, ASSET_1, ChainId.ETHEREUM),
         mockCirculatingSupply(C_SUPPLY, 1, ASSET_1, ChainId.ETHEREUM),
@@ -103,7 +101,6 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     })
 
     it('many projects many assets', async () => {
-      await repository.deleteAll()
       const data = [
         mockCirculatingSupply(C_SUPPLY, 0, ASSET_1, ChainId.ETHEREUM),
         mockCirculatingSupply(C_SUPPLY, 1, ASSET_1, ChainId.ETHEREUM),
@@ -134,6 +131,8 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     })
 
     it('take chainId into consideration', async () => {
+      await repository.addMany(DATA)
+
       const resultEth = await repository.getByTimestamp(ChainId.ETHEREUM, START)
       expect(resultEth).toEqual([DATA[0]])
 
@@ -146,8 +145,6 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     CirculatingSupplyRepository.prototype.findDataBoundaries.name,
     () => {
       it('boundary of single and multi row data', async () => {
-        await repository.deleteAll()
-
         const DATA: CirculatingSupplyRecord[] = [
           mockCirculatingSupply(C_SUPPLY, 0, ASSET_1, ChainId.ETHEREUM),
           mockCirculatingSupply(C_SUPPLY, 1, ASSET_1, ChainId.ETHEREUM),
@@ -190,6 +187,8 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
 
   describe(CirculatingSupplyRepository.prototype.addMany.name, () => {
     it('new rows only', async () => {
+      await repository.addMany(DATA)
+
       const newRows: CirculatingSupplyRecord[] = [
         {
           circulatingSupply: C_SUPPLY,
@@ -230,12 +229,14 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
   })
 
   it(CirculatingSupplyRepository.prototype.getAll.name, async () => {
+    await repository.addMany(DATA)
     const result = await repository.getAll()
 
     expect(result).toEqual(DATA)
   })
 
   it(CirculatingSupplyRepository.prototype.deleteAll.name, async () => {
+    await repository.addMany(DATA)
     await repository.deleteAll()
 
     const result = await repository.getAll()
@@ -245,8 +246,6 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
 
   describe(CirculatingSupplyRepository.prototype.deleteHourlyUntil.name, () => {
     it('deletes hourly reports', async () => {
-      await repository.deleteAll()
-
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(25, 'hours')
 
@@ -278,8 +277,6 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     CirculatingSupplyRepository.prototype.deleteSixHourlyUntil.name,
     () => {
       it('deletes six hourly reports', async () => {
-        await repository.deleteAll()
-
         const start = UnixTime.now().toStartOf('day')
         const until = start.add(7, 'hours')
 

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -9,6 +9,7 @@ import {
 } from './CirculatingSupplyRepository'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
+
 const mockCirculatingSupply = (
   circulatingSupply: number,
   offset: number,
@@ -35,6 +36,7 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
   ]
 
   beforeEach(async () => {
+    // TODO: get rid of this, adding new tests is tricky because of it
     await repository.addMany(DATA)
   })
 
@@ -240,4 +242,82 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
 
     expect(result).toEqual([])
   })
+
+  describe(CirculatingSupplyRepository.prototype.deleteHourlyUntil.name, () => {
+    it('deletes hourly reports', async () => {
+      await repository.deleteAll()
+
+      const start = UnixTime.now().toStartOf('day')
+      const until = start.add(25, 'hours')
+
+      const reports = []
+      for (
+        let i = start.toNumber();
+        i <= until.toNumber();
+        i += UnixTime.HOUR
+      ) {
+        reports.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
+      }
+
+      await repository.addMany(reports)
+      await repository.deleteHourlyUntil(until)
+      const results = await repository.getAll()
+
+      expect(results).toEqualUnsorted([
+        fakeCirculatingSupply({ timestamp: start }),
+        fakeCirculatingSupply({ timestamp: start.add(6, 'hours') }),
+        fakeCirculatingSupply({ timestamp: start.add(12, 'hours') }),
+        fakeCirculatingSupply({ timestamp: start.add(18, 'hours') }),
+        fakeCirculatingSupply({ timestamp: start.add(24, 'hours') }),
+        fakeCirculatingSupply({ timestamp: start.add(25, 'hours') }),
+      ])
+    })
+  })
+
+  describe(
+    CirculatingSupplyRepository.prototype.deleteSixHourlyUntil.name,
+    () => {
+      it('deletes six hourly reports', async () => {
+        await repository.deleteAll()
+
+        const start = UnixTime.now().toStartOf('day')
+        const until = start.add(7, 'hours')
+
+        const reports = []
+        for (
+          let i = start.toNumber();
+          i <= until.toNumber();
+          i += UnixTime.HOUR
+        ) {
+          reports.push(fakeCirculatingSupply({ timestamp: new UnixTime(i) }))
+        }
+
+        await repository.addMany(reports)
+        await repository.deleteSixHourlyUntil(until)
+        const results = await repository.getAll()
+
+        expect(results).toEqualUnsorted([
+          fakeCirculatingSupply({ timestamp: start }),
+          fakeCirculatingSupply({ timestamp: start.add(1, 'hours') }),
+          fakeCirculatingSupply({ timestamp: start.add(2, 'hours') }),
+          fakeCirculatingSupply({ timestamp: start.add(3, 'hours') }),
+          fakeCirculatingSupply({ timestamp: start.add(4, 'hours') }),
+          fakeCirculatingSupply({ timestamp: start.add(5, 'hours') }),
+          fakeCirculatingSupply({ timestamp: start.add(7, 'hours') }),
+        ])
+      })
+    },
+  )
 })
+
+function fakeCirculatingSupply(
+  report?: Partial<CirculatingSupplyRecord>,
+): CirculatingSupplyRecord {
+  return {
+    timestamp: UnixTime.ZERO,
+    circulatingSupply: 0,
+    assetId: AssetId('fake'),
+    chainId: ChainId.ARBITRUM,
+    ...report,
+  }
+}

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.test.ts
@@ -7,7 +7,7 @@ import {
   CirculatingSupplyRecord,
   CirculatingSupplyRepository,
 } from './CirculatingSupplyRepository'
-import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
 
 const START = UnixTime.fromDate(new Date('2022-05-17'))
 
@@ -245,7 +245,7 @@ describeDatabase(CirculatingSupplyRepository.name, (database) => {
     expect(result).toEqual([])
   })
 
-  _TVL_ONLY_deletion_test(repository, fakeCirculatingSupply)
+  testDeletingArchivedRecords(repository, fakeCirculatingSupply)
 })
 
 function fakeCirculatingSupply(timestamp: UnixTime): CirculatingSupplyRecord {

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
@@ -4,6 +4,10 @@ import { CirculatingSupplyRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
+import {
+  _TVL_ONLY_deleteHourlyUntil,
+  _TVL_ONLY_deleteSixHourlyUntil,
+} from './shared/deleteArchivedRecords'
 
 export interface CirculatingSupplyRecord {
   timestamp: UnixTime
@@ -72,6 +76,20 @@ export class CirculatingSupplyRepository extends BaseRepository {
   async deleteAll() {
     const knex = await this.knex()
     return knex('circulating_supplies').delete()
+  }
+
+  async deleteHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteHourlyUntil(knex, 'circulating_supplies', timestamp)
+  }
+
+  async deleteSixHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteSixHourlyUntil(
+      knex,
+      'circulating_supplies',
+      timestamp,
+    )
   }
 }
 

--- a/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
+++ b/packages/backend/src/peripherals/database/CirculatingSupplyRepository.ts
@@ -5,8 +5,8 @@ import { CirculatingSupplyRow } from 'knex/types/tables'
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 import {
-  _TVL_ONLY_deleteHourlyUntil,
-  _TVL_ONLY_deleteSixHourlyUntil,
+  deleteHourlyUntil,
+  deleteSixHourlyUntil,
 } from './shared/deleteArchivedRecords'
 
 export interface CirculatingSupplyRecord {
@@ -80,16 +80,12 @@ export class CirculatingSupplyRepository extends BaseRepository {
 
   async deleteHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteHourlyUntil(knex, 'circulating_supplies', timestamp)
+    return deleteHourlyUntil(knex, 'circulating_supplies', timestamp)
   }
 
   async deleteSixHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteSixHourlyUntil(
-      knex,
-      'circulating_supplies',
-      timestamp,
-    )
+    return deleteSixHourlyUntil(knex, 'circulating_supplies', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -4,6 +4,7 @@ import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
 import { PriceRecord, PriceRepository } from './PriceRepository'
+import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
 
 describeDatabase(PriceRepository.name, (database) => {
   const repository = new PriceRepository(database, Logger.SILENT)
@@ -193,71 +194,13 @@ describeDatabase(PriceRepository.name, (database) => {
     })
   })
 
-  describe(PriceRepository.prototype.deleteHourlyUntil.name, () => {
-    it('deletes hourly reports', async () => {
-      const start = UnixTime.now().toStartOf('day')
-      const until = start.add(25, 'hours')
-
-      const entries = []
-      for (
-        let i = start.toNumber();
-        i <= until.toNumber();
-        i += UnixTime.HOUR
-      ) {
-        entries.push(fakePriceRecord({ timestamp: new UnixTime(i) }))
-      }
-
-      await repository.addMany(entries)
-      await repository.deleteHourlyUntil(until)
-      const results = await repository.getAll()
-
-      expect(results).toEqualUnsorted([
-        fakePriceRecord({ timestamp: start }),
-        fakePriceRecord({ timestamp: start.add(6, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(12, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(18, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(24, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(25, 'hours') }),
-      ])
-    })
-  })
-
-  describe(PriceRepository.prototype.deleteSixHourlyUntil.name, () => {
-    it('deletes six hourly reports', async () => {
-      const start = UnixTime.now().toStartOf('day')
-      const until = start.add(7, 'hours')
-
-      const entries = []
-      for (
-        let i = start.toNumber();
-        i <= until.toNumber();
-        i += UnixTime.HOUR
-      ) {
-        entries.push(fakePriceRecord({ timestamp: new UnixTime(i) }))
-      }
-
-      await repository.addMany(entries)
-      await repository.deleteSixHourlyUntil(until)
-      const results = await repository.getAll()
-
-      expect(results).toEqualUnsorted([
-        fakePriceRecord({ timestamp: start }),
-        fakePriceRecord({ timestamp: start.add(1, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(2, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(3, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(4, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(5, 'hours') }),
-        fakePriceRecord({ timestamp: start.add(7, 'hours') }),
-      ])
-    })
-  })
+  _TVL_ONLY_deletion_test(repository, fakePriceRecord)
 })
 
-function fakePriceRecord(report?: Partial<PriceRecord>): PriceRecord {
+function fakePriceRecord(timestamp: UnixTime): PriceRecord {
   return {
-    timestamp: UnixTime.ZERO,
+    timestamp,
     assetId: AssetId.ETH,
     priceUsd: 0,
-    ...report,
   }
 }

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -187,4 +187,76 @@ describeDatabase(PriceRepository.name, (database) => {
       expect(result).toEqual(new Map())
     })
   })
+
+  describe(PriceRepository.prototype.deleteHourlyUntil.name, () => {
+    it('deletes hourly reports', async () => {
+      await repository.deleteAll()
+
+      const start = UnixTime.now().toStartOf('day')
+      const until = start.add(25, 'hours')
+
+      const entries = []
+      for (
+        let i = start.toNumber();
+        i <= until.toNumber();
+        i += UnixTime.HOUR
+      ) {
+        entries.push(fakePriceRecord({ timestamp: new UnixTime(i) }))
+      }
+
+      await repository.addMany(entries)
+      await repository.deleteHourlyUntil(until)
+      const results = await repository.getAll()
+
+      expect(results).toEqualUnsorted([
+        fakePriceRecord({ timestamp: start }),
+        fakePriceRecord({ timestamp: start.add(6, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(12, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(18, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(24, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(25, 'hours') }),
+      ])
+    })
+  })
+
+  describe(PriceRepository.prototype.deleteSixHourlyUntil.name, () => {
+    it('deletes six hourly reports', async () => {
+      await repository.deleteAll()
+
+      const start = UnixTime.now().toStartOf('day')
+      const until = start.add(7, 'hours')
+
+      const entries = []
+      for (
+        let i = start.toNumber();
+        i <= until.toNumber();
+        i += UnixTime.HOUR
+      ) {
+        entries.push(fakePriceRecord({ timestamp: new UnixTime(i) }))
+      }
+
+      await repository.addMany(entries)
+      await repository.deleteSixHourlyUntil(until)
+      const results = await repository.getAll()
+
+      expect(results).toEqualUnsorted([
+        fakePriceRecord({ timestamp: start }),
+        fakePriceRecord({ timestamp: start.add(1, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(2, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(3, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(4, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(5, 'hours') }),
+        fakePriceRecord({ timestamp: start.add(7, 'hours') }),
+      ])
+    })
+  })
 })
+
+function fakePriceRecord(report?: Partial<PriceRecord>): PriceRecord {
+  return {
+    timestamp: UnixTime.ZERO,
+    assetId: AssetId.ETH,
+    priceUsd: 0,
+    ...report,
+  }
+}

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
 import { PriceRecord, PriceRepository } from './PriceRepository'
-import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
 
 describeDatabase(PriceRepository.name, (database) => {
   const repository = new PriceRepository(database, Logger.SILENT)
@@ -194,7 +194,7 @@ describeDatabase(PriceRepository.name, (database) => {
     })
   })
 
-  _TVL_ONLY_deletion_test(repository, fakePriceRecord)
+  testDeletingArchivedRecords(repository, fakePriceRecord)
 })
 
 function fakePriceRecord(timestamp: UnixTime): PriceRecord {

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -37,16 +37,14 @@ describeDatabase(PriceRepository.name, (database) => {
     },
   ]
 
-  beforeEach(async () => {
-    await repository.addMany(DATA)
-  })
-
   afterEach(async () => {
     await repository.deleteAll()
   })
 
   describe(PriceRepository.prototype.addMany.name, () => {
     it('only new rows', async () => {
+      await repository.addMany(DATA)
+
       const newRows = [
         {
           priceUsd: 3300,
@@ -84,12 +82,16 @@ describeDatabase(PriceRepository.name, (database) => {
   })
 
   it(PriceRepository.prototype.getAll.name, async () => {
+    await repository.addMany(DATA)
+
     const results = await repository.getAll()
 
     expect(results).toEqualUnsorted(DATA)
   })
 
   it(PriceRepository.prototype.getByTimestamp.name, async () => {
+    await repository.addMany(DATA)
+
     const timestamp = START.add(-1, 'hours')
 
     const results = await repository.getByTimestamp(timestamp)
@@ -98,6 +100,8 @@ describeDatabase(PriceRepository.name, (database) => {
   })
 
   it(PriceRepository.prototype.getByToken.name, async () => {
+    await repository.addMany(DATA)
+
     const token = AssetId('uni-uniswap')
     const results = await repository.getByToken(token)
 
@@ -105,6 +109,8 @@ describeDatabase(PriceRepository.name, (database) => {
   })
 
   it(PriceRepository.prototype.deleteAll.name, async () => {
+    await repository.addMany(DATA)
+
     await repository.deleteAll()
 
     const results = await repository.getAll()
@@ -114,6 +120,8 @@ describeDatabase(PriceRepository.name, (database) => {
 
   describe(PriceRepository.prototype.findDataBoundaries.name, () => {
     it('boundary of single and multi row data', async () => {
+      await repository.addMany(DATA)
+
       const result = await repository.findDataBoundaries()
 
       expect(result).toEqual(
@@ -154,7 +162,6 @@ describeDatabase(PriceRepository.name, (database) => {
 
   describe(PriceRepository.prototype.findLatestByTokenBetween.name, () => {
     it('gets most recent record of each token', async () => {
-      await repository.deleteAll()
       await repository.addMany([
         {
           priceUsd: 3000,
@@ -177,8 +184,6 @@ describeDatabase(PriceRepository.name, (database) => {
     })
 
     it('works with empty database', async () => {
-      await repository.deleteAll()
-
       const result = await repository.findLatestByTokenBetween(
         START.add(-1, 'days'),
         START.add(-1, 'hours'),
@@ -190,8 +195,6 @@ describeDatabase(PriceRepository.name, (database) => {
 
   describe(PriceRepository.prototype.deleteHourlyUntil.name, () => {
     it('deletes hourly reports', async () => {
-      await repository.deleteAll()
-
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(25, 'hours')
 
@@ -221,8 +224,6 @@ describeDatabase(PriceRepository.name, (database) => {
 
   describe(PriceRepository.prototype.deleteSixHourlyUntil.name, () => {
     it('deletes six hourly reports', async () => {
-      await repository.deleteAll()
-
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(7, 'hours')
 

--- a/packages/backend/src/peripherals/database/PriceRepository.test.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
 import { PriceRecord, PriceRepository } from './PriceRepository'
-import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords.test'
 
 describeDatabase(PriceRepository.name, (database) => {
   const repository = new PriceRepository(database, Logger.SILENT)

--- a/packages/backend/src/peripherals/database/PriceRepository.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.ts
@@ -4,6 +4,10 @@ import { PriceRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
+import {
+  _TVL_ONLY_deleteHourlyUntil,
+  _TVL_ONLY_deleteSixHourlyUntil,
+} from './shared/deleteArchivedRecords'
 
 export interface PriceRecord {
   assetId: AssetId
@@ -104,6 +108,16 @@ export class PriceRepository extends BaseRepository {
     return new Map(
       rows.map((row) => [AssetId(row.asset_id), UnixTime.fromDate(row.max)]),
     )
+  }
+
+  async deleteHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteHourlyUntil(knex, 'coingecko_prices', timestamp)
+  }
+
+  async deleteSixHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'coingecko_prices', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/PriceRepository.ts
+++ b/packages/backend/src/peripherals/database/PriceRepository.ts
@@ -5,8 +5,8 @@ import { PriceRow } from 'knex/types/tables'
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 import {
-  _TVL_ONLY_deleteHourlyUntil,
-  _TVL_ONLY_deleteSixHourlyUntil,
+  deleteHourlyUntil,
+  deleteSixHourlyUntil,
 } from './shared/deleteArchivedRecords'
 
 export interface PriceRecord {
@@ -112,12 +112,12 @@ export class PriceRepository extends BaseRepository {
 
   async deleteHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteHourlyUntil(knex, 'coingecko_prices', timestamp)
+    return deleteHourlyUntil(knex, 'coingecko_prices', timestamp)
   }
 
   async deleteSixHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'coingecko_prices', timestamp)
+    return deleteSixHourlyUntil(knex, 'coingecko_prices', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -95,16 +95,16 @@ describeDatabase(ReportRepository.name, (database) => {
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(25, 'hours')
 
-      const reports = []
+      const entries = []
       for (
         let i = start.toNumber();
         i <= until.toNumber();
         i += UnixTime.HOUR
       ) {
-        reports.push(fakeReport({ timestamp: new UnixTime(i) }))
+        entries.push(fakeReport({ timestamp: new UnixTime(i) }))
       }
 
-      await repository.addOrUpdateMany(reports)
+      await repository.addOrUpdateMany(entries)
       await repository.deleteHourlyUntil(until)
       const results = await repository.getAll()
 
@@ -124,16 +124,16 @@ describeDatabase(ReportRepository.name, (database) => {
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(7, 'hours')
 
-      const reports = []
+      const entries = []
       for (
         let i = start.toNumber();
         i <= until.toNumber();
         i += UnixTime.HOUR
       ) {
-        reports.push(fakeReport({ timestamp: new UnixTime(i) }))
+        entries.push(fakeReport({ timestamp: new UnixTime(i) }))
       }
 
-      await repository.addOrUpdateMany(reports)
+      await repository.addOrUpdateMany(entries)
       await repository.deleteSixHourlyUntil(until)
       const results = await repository.getAll()
 

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -93,18 +93,21 @@ describeDatabase(ReportRepository.name, (database) => {
   describe(ReportRepository.prototype.deleteHourlyUntil.name, () => {
     it('deletes hourly reports', async () => {
       const start = UnixTime.now().toStartOf('day')
+      const until = start.add(25, 'hours')
 
       const reports = []
-
-      const end = 25
-
-      for (let i = 0; i <= end; i++) {
-        reports.push(fakeReport({ timestamp: start.add(i, 'hours') }))
+      for (
+        let i = start.toNumber();
+        i <= until.toNumber();
+        i += UnixTime.HOUR
+      ) {
+        reports.push(fakeReport({ timestamp: new UnixTime(i) }))
       }
 
       await repository.addOrUpdateMany(reports)
-      await repository.deleteHourlyUntil(start.add(end, 'hours'))
+      await repository.deleteHourlyUntil(until)
       const results = await repository.getAll()
+
       expect(results).toEqualUnsorted([
         fakeReport({ timestamp: start }),
         fakeReport({ timestamp: start.add(6, 'hours') }),
@@ -119,27 +122,29 @@ describeDatabase(ReportRepository.name, (database) => {
   describe(ReportRepository.prototype.deleteSixHourlyUntil.name, () => {
     it('deletes six hourly reports', async () => {
       const start = UnixTime.now().toStartOf('day')
-      const end = 25
+      const until = start.add(7, 'hours')
 
-      const reports = [
-        fakeReport({ timestamp: start }),
-        fakeReport({ timestamp: start.add(1, 'hours') }),
-        fakeReport({ timestamp: start.add(6, 'hours') }),
-        fakeReport({ timestamp: start.add(12, 'hours') }),
-        fakeReport({ timestamp: start.add(18, 'hours') }),
-        fakeReport({ timestamp: start.add(24, 'hours') }),
-        fakeReport({ timestamp: start.add(25, 'hours') }),
-      ]
+      const reports = []
+      for (
+        let i = start.toNumber();
+        i <= until.toNumber();
+        i += UnixTime.HOUR
+      ) {
+        reports.push(fakeReport({ timestamp: new UnixTime(i) }))
+      }
+
       await repository.addOrUpdateMany(reports)
-
-      await repository.deleteSixHourlyUntil(start.add(end, 'hours'))
+      await repository.deleteSixHourlyUntil(until)
       const results = await repository.getAll()
+
       expect(results).toEqualUnsorted([
         fakeReport({ timestamp: start }),
-        // keeps hourly
         fakeReport({ timestamp: start.add(1, 'hours') }),
-        fakeReport({ timestamp: start.add(24, 'hours') }),
-        fakeReport({ timestamp: start.add(25, 'hours') }),
+        fakeReport({ timestamp: start.add(2, 'hours') }),
+        fakeReport({ timestamp: start.add(3, 'hours') }),
+        fakeReport({ timestamp: start.add(4, 'hours') }),
+        fakeReport({ timestamp: start.add(5, 'hours') }),
+        fakeReport({ timestamp: start.add(7, 'hours') }),
       ])
     })
   })

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -13,7 +13,6 @@ describeDatabase(ReportRepository.name, (database) => {
 
   const PROJECT_A = ProjectId('project-a')
   const PROJECT_B = ProjectId('project-b')
-  const PROJECT_C = ProjectId('project-c')
 
   beforeEach(async () => {
     await repository.deleteAll()
@@ -46,16 +45,6 @@ describeDatabase(ReportRepository.name, (database) => {
 
     it('handles empty array', async () => {
       await expect(repository.addOrUpdateMany([])).not.toBeRejected()
-    })
-
-    it('throws if timestamps do not match', async () => {
-      await expect(
-        repository.addOrUpdateMany([
-          fakeReport({ projectId: PROJECT_A, timestamp: TIME_0 }),
-          fakeReport({ projectId: PROJECT_B, timestamp: TIME_0 }),
-          fakeReport({ projectId: PROJECT_C, timestamp: TIME_1 }),
-        ]),
-      ).toBeRejectedWith('Assertion Error: Timestamps must match')
     })
 
     it('batches insert', async () => {
@@ -113,7 +102,7 @@ describeDatabase(ReportRepository.name, (database) => {
         reports.push(fakeReport({ timestamp: start.add(i, 'hours') }))
       }
 
-      await Promise.all(reports.map((r) => repository.addOrUpdateMany([r])))
+      await repository.addOrUpdateMany(reports)
       await repository.deleteHourlyUntil(start.add(end, 'hours'))
       const results = await repository.getAll()
       expect(results).toEqualUnsorted([
@@ -141,8 +130,8 @@ describeDatabase(ReportRepository.name, (database) => {
         fakeReport({ timestamp: start.add(24, 'hours') }),
         fakeReport({ timestamp: start.add(25, 'hours') }),
       ]
+      await repository.addOrUpdateMany(reports)
 
-      await Promise.all(reports.map((r) => repository.addOrUpdateMany([r])))
       await repository.deleteSixHourlyUntil(start.add(end, 'hours'))
       const results = await repository.getAll()
       expect(results).toEqualUnsorted([

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -109,14 +109,5 @@ function fakeReport(report?: Partial<ReportRecord>): ReportRecord {
 }
 
 function fakeReportTimestamp(timestamp: UnixTime): ReportRecord {
-  return {
-    timestamp,
-    projectId: ProjectId('fake-project'),
-    asset: AssetId('fake-asset'),
-    reportType: 'CBV',
-    chainId: ChainId.ETHEREUM,
-    amount: 1234n,
-    usdValue: 1234n,
-    ethValue: 1234n,
-  }
+  return fakeReport({ timestamp })
 }

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
 import { ReportRecord, ReportRepository } from './ReportRepository'
-import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords.test'
 
 describeDatabase(ReportRepository.name, (database) => {
   const repository = new ReportRepository(database, Logger.SILENT)

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
 import { ReportRecord, ReportRepository } from './ReportRepository'
-import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
 
 describeDatabase(ReportRepository.name, (database) => {
   const repository = new ReportRepository(database, Logger.SILENT)
@@ -91,7 +91,7 @@ describeDatabase(ReportRepository.name, (database) => {
     })
   })
 
-  _TVL_ONLY_deletion_test(repository, fakeReportTimestamp)
+  testDeletingArchivedRecords(repository, fakeReportTimestamp)
 })
 
 function fakeReport(report?: Partial<ReportRecord>): ReportRecord {

--- a/packages/backend/src/peripherals/database/ReportRepository.test.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.test.ts
@@ -14,7 +14,7 @@ describeDatabase(ReportRepository.name, (database) => {
   const PROJECT_A = ProjectId('project-a')
   const PROJECT_B = ProjectId('project-b')
 
-  beforeEach(async () => {
+  afterEach(async () => {
     await repository.deleteAll()
   })
 

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -13,8 +13,8 @@ import { ReportRow } from 'knex/types/tables'
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 import {
-  _TVL_ONLY_deleteHourlyUntil,
-  _TVL_ONLY_deleteSixHourlyUntil,
+  deleteHourlyUntil,
+  deleteSixHourlyUntil,
 } from './shared/deleteArchivedRecords'
 
 export interface ReportRecord {
@@ -173,12 +173,12 @@ export class ReportRepository extends BaseRepository {
 
   async deleteHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteHourlyUntil(knex, 'reports', timestamp)
+    return deleteHourlyUntil(knex, 'reports', timestamp)
   }
 
   async deleteSixHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'reports', timestamp)
+    return deleteSixHourlyUntil(knex, 'reports', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -79,6 +79,14 @@ export class ReportRepository extends BaseRepository {
     return reports.length
   }
 
+  async addMany(reports: ReportRecord[]) {
+    const rows = reports.map(toRow)
+    const knex = await this.knex()
+    await knex.batchInsert('reports', rows, 10_000)
+
+    return rows.length
+  }
+
   private async _addOrUpdateMany(
     reports: ReportRecord[],
     trx: Knex.Transaction,

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -18,8 +18,6 @@ export interface ReportRecord {
   projectId: ProjectId
   asset: AssetId
   chainId: ChainId
-  // TODO: Index this column when we start querying by it.
-  // TODO: Rename
   reportType: ReportType
   amount: bigint
   usdValue: bigint
@@ -74,7 +72,6 @@ export class ReportRepository extends BaseRepository {
 
     await this.runInTransaction(async (trx) => {
       for (let i = 0; i < reports.length; i += BATCH_SIZE) {
-        // Can't be two or more updaters on the chain because it will break the logic
         await this._addOrUpdateMany(reports.slice(i, i + BATCH_SIZE), trx)
       }
     })
@@ -164,17 +161,6 @@ export class ReportRepository extends BaseRepository {
       .orderBy('unix_timestamp')
 
     return rows.map(toRecord)
-  }
-
-  private _getByProjectAndAssetQuery(
-    knex: Knex,
-    projectId: ProjectId,
-    assetId: AssetId,
-  ) {
-    return knex('reports')
-      .where('asset_id', assetId.toString())
-      .andWhere('project_id', projectId.toString())
-      .orderBy('unix_timestamp')
   }
 }
 

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -12,6 +12,10 @@ import { ReportRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
+import {
+  _TVL_ONLY_deleteHourlyUntil,
+  _TVL_ONLY_deleteSixHourlyUntil,
+} from './shared/deleteArchivedRecords'
 
 export interface ReportRecord {
   timestamp: UnixTime
@@ -161,6 +165,16 @@ export class ReportRepository extends BaseRepository {
       .orderBy('unix_timestamp')
 
     return rows.map(toRecord)
+  }
+
+  async deleteHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteHourlyUntil(knex, 'reports', timestamp)
+  }
+
+  async deleteSixHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'reports', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/ReportRepository.ts
+++ b/packages/backend/src/peripherals/database/ReportRepository.ts
@@ -67,11 +67,7 @@ export class ReportRepository extends BaseRepository {
   }
 
   async addOrUpdateMany(reports: ReportRecord[]) {
-    const timestampsMatch = reports.every((r) =>
-      r.timestamp.equals(reports[0].timestamp),
-    )
     const chainIdsMatch = reports.every((r) => r.chainId === reports[0].chainId)
-    assert(timestampsMatch, 'Timestamps must match')
     assert(chainIdsMatch, 'Chain Ids must match')
 
     await this.runInTransaction(async (trx) => {

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
@@ -36,12 +36,12 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
 
   beforeEach(async () => {
     await repository.deleteAll()
-    // TODO: get rid of this, adding new tests is tricky because of it
-    await repository.addOrUpdateMany(DATA)
   })
 
   describe(TotalSupplyRepository.prototype.getByTimestamp.name, () => {
     it('returns matching data for given timestamp', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const additionalData = [
         mockTotalSupply(TOTAL_SUPPLY, 0, AssetId('asset-a'), ChainId.ETHEREUM),
         mockTotalSupply(TOTAL_SUPPLY, 0, AssetId('asset-b'), ChainId.ETHEREUM),
@@ -55,6 +55,8 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     })
 
     it('returns empty list if no data exists for given timestamp', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const result = await repository.getByTimestamp(
         ChainId.ETHEREUM,
         START.add(1, 'days'),
@@ -115,6 +117,8 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     })
 
     it('take chainId into consideration', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const resultEth = await repository.getByTimestamp(ChainId.ETHEREUM, START)
       expect(resultEth).toEqual([DATA[0]])
 
@@ -125,6 +129,8 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
 
   describe(TotalSupplyRepository.prototype.addOrUpdateMany.name, () => {
     it('new rows only', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const newRows: TotalSupplyRecord[] = [
         {
           totalSupply: TOTAL_SUPPLY,
@@ -146,6 +152,8 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     })
 
     it('existing rows only', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const existingRows: TotalSupplyRecord[] = [
         {
           timestamp: DATA[0].timestamp,
@@ -167,6 +175,8 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     })
 
     it('mixed: existing and new rows', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       const mixedRows: TotalSupplyRecord[] = [
         {
           timestamp: DATA[1].timestamp,
@@ -188,11 +198,15 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     })
 
     it('skips empty row modification', async () => {
+      await repository.addOrUpdateMany(DATA)
+
       await expect(repository.addOrUpdateMany([])).not.toBeRejected()
     })
   })
 
   it(TotalSupplyRepository.prototype.getAll.name, async () => {
+    await repository.addOrUpdateMany(DATA)
+
     const result = await repository.getAll()
 
     expect(result).toEqual(DATA)

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
@@ -34,7 +34,7 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     mockTotalSupply(TOTAL_SUPPLY, 1, ASSET_2, ChainId.ETHEREUM),
   ]
 
-  beforeEach(async () => {
+  afterEach(async () => {
     await repository.deleteAll()
   })
 
@@ -65,7 +65,6 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     })
 
     it('one project one asset', async () => {
-      await repository.deleteAll()
       const data = [
         mockTotalSupply(TOTAL_SUPPLY, 0, ASSET_1, ChainId.ETHEREUM),
         mockTotalSupply(TOTAL_SUPPLY, 1, ASSET_1, ChainId.ETHEREUM),
@@ -86,7 +85,6 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     })
 
     it('many projects many assets', async () => {
-      await repository.deleteAll()
       const data = [
         mockTotalSupply(TOTAL_SUPPLY, 0, ASSET_1, ChainId.ETHEREUM),
         mockTotalSupply(TOTAL_SUPPLY, 1, ASSET_1, ChainId.ETHEREUM),
@@ -213,6 +211,7 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
   })
 
   it(TotalSupplyRepository.prototype.deleteAll.name, async () => {
+    await repository.addOrUpdateMany(DATA)
     await repository.deleteAll()
 
     const result = await repository.getAll()
@@ -222,8 +221,6 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
 
   describe(TotalSupplyRepository.prototype.deleteHourlyUntil.name, () => {
     it('deletes hourly reports', async () => {
-      await repository.deleteAll()
-
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(25, 'hours')
 
@@ -253,8 +250,6 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
 
   describe(TotalSupplyRepository.prototype.deleteSixHourlyUntil.name, () => {
     it('deletes six hourly reports', async () => {
-      await repository.deleteAll()
-
       const start = UnixTime.now().toStartOf('day')
       const until = start.add(7, 'hours')
 

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
@@ -3,6 +3,7 @@ import { AssetId, ChainId, UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
+import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
 import {
   TotalSupplyRecord,
   TotalSupplyRepository,
@@ -219,74 +220,14 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     expect(result).toEqual([])
   })
 
-  describe(TotalSupplyRepository.prototype.deleteHourlyUntil.name, () => {
-    it('deletes hourly reports', async () => {
-      const start = UnixTime.now().toStartOf('day')
-      const until = start.add(25, 'hours')
-
-      const entries = []
-      for (
-        let i = start.toNumber();
-        i <= until.toNumber();
-        i += UnixTime.HOUR
-      ) {
-        entries.push(fakeTotalSupply({ timestamp: new UnixTime(i) }))
-      }
-
-      await repository.addOrUpdateMany(entries)
-      await repository.deleteHourlyUntil(until)
-      const results = await repository.getAll()
-
-      expect(results).toEqualUnsorted([
-        fakeTotalSupply({ timestamp: start }),
-        fakeTotalSupply({ timestamp: start.add(6, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(12, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(18, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(24, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(25, 'hours') }),
-      ])
-    })
-  })
-
-  describe(TotalSupplyRepository.prototype.deleteSixHourlyUntil.name, () => {
-    it('deletes six hourly reports', async () => {
-      const start = UnixTime.now().toStartOf('day')
-      const until = start.add(7, 'hours')
-
-      const entries = []
-      for (
-        let i = start.toNumber();
-        i <= until.toNumber();
-        i += UnixTime.HOUR
-      ) {
-        entries.push(fakeTotalSupply({ timestamp: new UnixTime(i) }))
-      }
-
-      await repository.addOrUpdateMany(entries)
-      await repository.deleteSixHourlyUntil(until)
-      const results = await repository.getAll()
-
-      expect(results).toEqualUnsorted([
-        fakeTotalSupply({ timestamp: start }),
-        fakeTotalSupply({ timestamp: start.add(1, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(2, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(3, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(4, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(5, 'hours') }),
-        fakeTotalSupply({ timestamp: start.add(7, 'hours') }),
-      ])
-    })
-  })
+  _TVL_ONLY_deletion_test(repository, fakeTotalSupply)
 })
 
-function fakeTotalSupply(
-  entry?: Partial<TotalSupplyRecord>,
-): TotalSupplyRecord {
+function fakeTotalSupply(timestamp: UnixTime): TotalSupplyRecord {
   return {
-    timestamp: UnixTime.ZERO,
+    timestamp,
     totalSupply: 0n,
     assetId: AssetId('fake'),
     chainId: ChainId.ARBITRUM,
-    ...entry,
   }
 }

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
@@ -3,7 +3,7 @@ import { AssetId, ChainId, UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
-import { _TVL_ONLY_deletion_test } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
 import {
   TotalSupplyRecord,
   TotalSupplyRepository,
@@ -220,7 +220,7 @@ describeDatabase(TotalSupplyRepository.name, (database) => {
     expect(result).toEqual([])
   })
 
-  _TVL_ONLY_deletion_test(repository, fakeTotalSupply)
+  testDeletingArchivedRecords(repository, fakeTotalSupply)
 })
 
 function fakeTotalSupply(timestamp: UnixTime): TotalSupplyRecord {

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.test.ts
@@ -3,7 +3,7 @@ import { AssetId, ChainId, UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 
 import { describeDatabase } from '../../test/database'
-import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords'
+import { testDeletingArchivedRecords } from './shared/deleteArchivedRecords.test'
 import {
   TotalSupplyRecord,
   TotalSupplyRepository,

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.ts
@@ -5,8 +5,8 @@ import { TotalSupplyRow } from 'knex/types/tables'
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
 import {
-  _TVL_ONLY_deleteHourlyUntil,
-  _TVL_ONLY_deleteSixHourlyUntil,
+  deleteHourlyUntil,
+  deleteSixHourlyUntil,
 } from './shared/deleteArchivedRecords'
 
 export interface TotalSupplyRecord {
@@ -65,12 +65,12 @@ export class TotalSupplyRepository extends BaseRepository {
 
   async deleteHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteHourlyUntil(knex, 'total_supplies', timestamp)
+    return deleteHourlyUntil(knex, 'total_supplies', timestamp)
   }
 
   async deleteSixHourlyUntil(timestamp: UnixTime) {
     const knex = await this.knex()
-    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'total_supplies', timestamp)
+    return deleteSixHourlyUntil(knex, 'total_supplies', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.ts
@@ -4,6 +4,10 @@ import { TotalSupplyRow } from 'knex/types/tables'
 
 import { BaseRepository, CheckConvention } from './shared/BaseRepository'
 import { Database } from './shared/Database'
+import {
+  _TVL_ONLY_deleteHourlyUntil,
+  _TVL_ONLY_deleteSixHourlyUntil,
+} from './shared/deleteArchivedRecords'
 
 export interface TotalSupplyRecord {
   timestamp: UnixTime
@@ -55,6 +59,16 @@ export class TotalSupplyRepository extends BaseRepository {
   async deleteAll() {
     const knex = await this.knex()
     return knex('total_supplies').delete()
+  }
+
+  async deleteHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteHourlyUntil(knex, 'total_supplies', timestamp)
+  }
+
+  async deleteSixHourlyUntil(timestamp: UnixTime) {
+    const knex = await this.knex()
+    return _TVL_ONLY_deleteSixHourlyUntil(knex, 'total_supplies', timestamp)
   }
 }
 

--- a/packages/backend/src/peripherals/database/TotalSupplyRepository.ts
+++ b/packages/backend/src/peripherals/database/TotalSupplyRepository.ts
@@ -36,17 +36,19 @@ export class TotalSupplyRepository extends BaseRepository {
   }
 
   async addOrUpdateMany(totalSupplies: TotalSupplyRecord[]) {
-    this.logger.info('addOrUpdateMany', {
-      chainId: totalSupplies[0].chainId.toString(),
-      rows: totalSupplies.length,
-    })
-
     const rows = totalSupplies.map(toRow)
     const knex = await this.knex()
     await knex('total_supplies')
       .insert(rows)
       .onConflict(['chain_id', 'unix_timestamp', 'asset_id'])
       .merge()
+    return rows.length
+  }
+
+  async addMany(totalSupplies: TotalSupplyRecord[]) {
+    const rows = totalSupplies.map(toRow)
+    const knex = await this.knex()
+    await knex.batchInsert('total_supplies', rows, 10_000)
     return rows.length
   }
 

--- a/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.test.ts
+++ b/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.test.ts
@@ -1,0 +1,61 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+
+interface TestedRepository<T> {
+  deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
+  deleteSixHourlyUntil: (timestamp: UnixTime) => Promise<number>
+  addMany: (records: T[]) => Promise<number>
+  getAll: () => Promise<T[]>
+}
+
+export function testDeletingArchivedRecords<T>(
+  repository: TestedRepository<T>,
+  fakeRecord: (timestamp: UnixTime) => T,
+) {
+  it('deletes hourly records', async () => {
+    const start = UnixTime.now().toStartOf('day')
+    const until = start.add(25, 'hours')
+
+    const entries = []
+    for (let i = start.toNumber(); i <= until.toNumber(); i += UnixTime.HOUR) {
+      entries.push(fakeRecord(new UnixTime(i)))
+    }
+
+    await repository.addMany(entries)
+    await repository.deleteHourlyUntil(until)
+    const results = await repository.getAll()
+
+    expect(results).toEqualUnsorted([
+      fakeRecord(start),
+      fakeRecord(start.add(6, 'hours')),
+      fakeRecord(start.add(12, 'hours')),
+      fakeRecord(start.add(18, 'hours')),
+      fakeRecord(start.add(24, 'hours')),
+      fakeRecord(start.add(25, 'hours')),
+    ])
+  })
+
+  it('deletes six hourly records', async () => {
+    const start = UnixTime.now().toStartOf('day')
+    const until = start.add(7, 'hours')
+
+    const entries = []
+    for (let i = start.toNumber(); i <= until.toNumber(); i += UnixTime.HOUR) {
+      entries.push(fakeRecord(new UnixTime(i)))
+    }
+
+    await repository.addMany(entries)
+    await repository.deleteSixHourlyUntil(until)
+    const results = await repository.getAll()
+
+    expect(results).toEqualUnsorted([
+      fakeRecord(start),
+      fakeRecord(start.add(1, 'hours')),
+      fakeRecord(start.add(2, 'hours')),
+      fakeRecord(start.add(3, 'hours')),
+      fakeRecord(start.add(4, 'hours')),
+      fakeRecord(start.add(5, 'hours')),
+      fakeRecord(start.add(7, 'hours')),
+    ])
+  })
+}

--- a/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
+++ b/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
@@ -43,8 +43,8 @@ export function _TVL_ONLY_deleteSixHourlyUntil(
 interface Repository {
   deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
   deleteSixHourlyUntil: (timestamp: UnixTime) => Promise<number>
-  addMany: (records: any[]) => Promise<number>
-  getAll: () => Promise<any[]>
+  addMany: (records: unknown[]) => Promise<number>
+  getAll: () => Promise<unknown[]>
 }
 
 export function _TVL_ONLY_deletion_test<T>(

--- a/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
+++ b/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
@@ -1,5 +1,4 @@
 import { UnixTime } from '@l2beat/shared-pure'
-import { expect } from 'earl'
 import { Knex } from 'knex'
 
 /**
@@ -38,63 +37,4 @@ export function deleteSixHourlyUntil(
       .andWhereRaw(`extract(hour from "unix_timestamp") % 6 = 0`)
       .delete()
   )
-}
-
-interface Repository<T> {
-  deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
-  deleteSixHourlyUntil: (timestamp: UnixTime) => Promise<number>
-  addMany: (records: T[]) => Promise<number>
-  getAll: () => Promise<T[]>
-}
-
-export function testDeletingArchivedRecords<T>(
-  repository: Repository<T>,
-  fakeRecord: (timestamp: UnixTime) => T,
-) {
-  it('deletes hourly records', async () => {
-    const start = UnixTime.now().toStartOf('day')
-    const until = start.add(25, 'hours')
-
-    const entries = []
-    for (let i = start.toNumber(); i <= until.toNumber(); i += UnixTime.HOUR) {
-      entries.push(fakeRecord(new UnixTime(i)))
-    }
-
-    await repository.addMany(entries)
-    await repository.deleteHourlyUntil(until)
-    const results = await repository.getAll()
-
-    expect(results).toEqualUnsorted([
-      fakeRecord(start),
-      fakeRecord(start.add(6, 'hours')),
-      fakeRecord(start.add(12, 'hours')),
-      fakeRecord(start.add(18, 'hours')),
-      fakeRecord(start.add(24, 'hours')),
-      fakeRecord(start.add(25, 'hours')),
-    ])
-  })
-
-  it('deletes six hourly records', async () => {
-    const start = UnixTime.now().toStartOf('day')
-    const until = start.add(7, 'hours')
-
-    const entries = []
-    for (let i = start.toNumber(); i <= until.toNumber(); i += UnixTime.HOUR) {
-      entries.push(fakeRecord(new UnixTime(i)))
-    }
-
-    await repository.addMany(entries)
-    await repository.deleteSixHourlyUntil(until)
-    const results = await repository.getAll()
-
-    expect(results).toEqualUnsorted([
-      fakeRecord(start),
-      fakeRecord(start.add(1, 'hours')),
-      fakeRecord(start.add(2, 'hours')),
-      fakeRecord(start.add(3, 'hours')),
-      fakeRecord(start.add(4, 'hours')),
-      fakeRecord(start.add(5, 'hours')),
-      fakeRecord(start.add(7, 'hours')),
-    ])
-  })
 }

--- a/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
+++ b/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
@@ -1,4 +1,5 @@
 import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
 import { Knex } from 'knex'
 
 /**
@@ -37,4 +38,63 @@ export function _TVL_ONLY_deleteSixHourlyUntil(
       .andWhereRaw(`extract(hour from "unix_timestamp") % 6 = 0`)
       .delete()
   )
+}
+
+interface Repository {
+  deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
+  deleteSixHourlyUntil: (timestamp: UnixTime) => Promise<number>
+  addMany: (records: any[]) => Promise<number>
+  getAll: () => Promise<any[]>
+}
+
+export function _TVL_ONLY_deletion_test<T>(
+  repository: Repository,
+  fakeRecord: (timestamp: UnixTime) => T,
+) {
+  it('deletes hourly records', async () => {
+    const start = UnixTime.now().toStartOf('day')
+    const until = start.add(25, 'hours')
+
+    const entries = []
+    for (let i = start.toNumber(); i <= until.toNumber(); i += UnixTime.HOUR) {
+      entries.push(fakeRecord(new UnixTime(i)))
+    }
+
+    await repository.addMany(entries)
+    await repository.deleteHourlyUntil(until)
+    const results = await repository.getAll()
+
+    expect(results).toEqualUnsorted([
+      fakeRecord(start),
+      fakeRecord(start.add(6, 'hours')),
+      fakeRecord(start.add(12, 'hours')),
+      fakeRecord(start.add(18, 'hours')),
+      fakeRecord(start.add(24, 'hours')),
+      fakeRecord(start.add(25, 'hours')),
+    ])
+  })
+
+  it('deletes six hourly records', async () => {
+    const start = UnixTime.now().toStartOf('day')
+    const until = start.add(7, 'hours')
+
+    const entries = []
+    for (let i = start.toNumber(); i <= until.toNumber(); i += UnixTime.HOUR) {
+      entries.push(fakeRecord(new UnixTime(i)))
+    }
+
+    await repository.addMany(entries)
+    await repository.deleteSixHourlyUntil(until)
+    const results = await repository.getAll()
+
+    expect(results).toEqualUnsorted([
+      fakeRecord(start),
+      fakeRecord(start.add(1, 'hours')),
+      fakeRecord(start.add(2, 'hours')),
+      fakeRecord(start.add(3, 'hours')),
+      fakeRecord(start.add(4, 'hours')),
+      fakeRecord(start.add(5, 'hours')),
+      fakeRecord(start.add(7, 'hours')),
+    ])
+  })
 }

--- a/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
+++ b/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
@@ -5,7 +5,7 @@ import { Knex } from 'knex'
 /**
  * WARNING: this method requires table to have unix_timestamp column
  */
-export function _TVL_ONLY_deleteHourlyUntil(
+export function deleteHourlyUntil(
   knex: Knex,
   tableName: string,
   timestamp: UnixTime,
@@ -24,7 +24,7 @@ export function _TVL_ONLY_deleteHourlyUntil(
 /**
  * WARNING: this method requires table to have unix_timestamp column
  */
-export function _TVL_ONLY_deleteSixHourlyUntil(
+export function deleteSixHourlyUntil(
   knex: Knex,
   tableName: string,
   timestamp: UnixTime,
@@ -47,7 +47,7 @@ interface Repository<T> {
   getAll: () => Promise<T[]>
 }
 
-export function _TVL_ONLY_deletion_test<T>(
+export function testDeletingArchivedRecords<T>(
   repository: Repository<T>,
   fakeRecord: (timestamp: UnixTime) => T,
 ) {

--- a/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
+++ b/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
@@ -1,0 +1,40 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { Knex } from 'knex'
+
+/**
+ * WARNING: this method requires table to have unix_timestamp column
+ */
+export function _TVL_ONLY_deleteHourlyUntil(
+  knex: Knex,
+  tableName: string,
+  timestamp: UnixTime,
+) {
+  return (
+    knex(tableName)
+      .where('unix_timestamp', '<', timestamp.toDate())
+      // do not delete daily
+      .andWhereRaw(`extract(hour from "unix_timestamp") != 0`)
+      // do not delete six hourly
+      .andWhereRaw(`extract(hour from "unix_timestamp") % 6 != 0`)
+      .delete()
+  )
+}
+
+/**
+ * WARNING: this method requires table to have unix_timestamp column
+ */
+export function _TVL_ONLY_deleteSixHourlyUntil(
+  knex: Knex,
+  tableName: string,
+  timestamp: UnixTime,
+) {
+  return (
+    knex(tableName)
+      .where('unix_timestamp', '<', timestamp.toDate())
+      // do not delete daily
+      .andWhereRaw(`extract(hour from "unix_timestamp") != 0`)
+      // delete only six hourly
+      .andWhereRaw(`extract(hour from "unix_timestamp") % 6 = 0`)
+      .delete()
+  )
+}

--- a/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
+++ b/packages/backend/src/peripherals/database/shared/deleteArchivedRecords.ts
@@ -40,15 +40,15 @@ export function _TVL_ONLY_deleteSixHourlyUntil(
   )
 }
 
-interface Repository {
+interface Repository<T> {
   deleteHourlyUntil: (timestamp: UnixTime) => Promise<number>
   deleteSixHourlyUntil: (timestamp: UnixTime) => Promise<number>
-  addMany: (records: unknown[]) => Promise<number>
-  getAll: () => Promise<unknown[]>
+  addMany: (records: T[]) => Promise<number>
+  getAll: () => Promise<T[]>
 }
 
 export function _TVL_ONLY_deletion_test<T>(
-  repository: Repository,
+  repository: Repository<T>,
   fakeRecord: (timestamp: UnixTime) => T,
 ) {
   it('deletes hourly records', async () => {

--- a/packages/shared-pure/src/types/UnixTime.ts
+++ b/packages/shared-pure/src/types/UnixTime.ts
@@ -19,6 +19,11 @@ export class UnixTime {
 
   static SIX_HOURS = 6 * this.HOUR
 
+  /**
+   * Static instance for test purposes, in most cases indicates that the timestamp is not important in this test case.
+   */
+  static ZERO = new UnixTime(0)
+
   static now() {
     return UnixTime.fromDate(new Date())
   }


### PR DESCRIPTION
STATS:
- it took ~30 mins to run locally

We only need to store:
- hourly data for last 7D
- sixHourly data for last 90D
- daily data for whole time range

This is why we can get rid of the earlier hourly and sixHourly data that is no longer being used by the chart. 

**How?**
- add to every tvl repository method to remove such historical data
- add TvlCleaner class that will function as a scheduler of deletion
- change the way the clock ticks

Resolve L2B-2296

15:17:32.798 INFO [ TvlCleaner ] Cleaning BlockNumberRepository
15:17:32.800 INFO [ AggregatedReportUpdater ] Started
15:17:32.800 INFO [ TvlModule ] Started
15:17:32.800 INFO [ StatusModule ] Started
15:17:32.821 INFO [ TvlCleaner ] Cleaned BlockNumberRepository
    { hourly: 0, sixHourly: 0 }
15:17:32.821 INFO [ TvlCleaner ] Cleaning PriceRepository
15:17:33.952 INFO [ PriceUpdater ] Update completed
    { timestamp: 1706706000 }
15:17:34.373 INFO [ TvlCleaner ] Cleaned PriceRepository
    { hourly: 0, sixHourly: 0 }
15:17:34.374 INFO [ TvlCleaner ] Cleaning BalanceRepository
15:36:43.724 INFO [ TvlCleaner ] Cleaned BalanceRepository
    { hourly: 168731500, sixHourly: 22354522 }
15:36:43.728 INFO [ TvlCleaner ] Cleaning TotalSupplyRepository
15:36:43.811 INFO [ TvlCleaner ] Cleaned TotalSupplyRepository
    { hourly: 74303, sixHourly: 8049 }
15:36:43.812 INFO [ TvlCleaner ] Cleaning CirculatingSupplyRepository
15:36:43.909 INFO [ TvlCleaner ] Cleaned CirculatingSupplyRepository
    { hourly: 76274, sixHourly: 9360 }
15:36:43.909 INFO [ TvlCleaner ] Cleaning ReportRepository
15:52:57.163 INFO [ ApiServer ]
    { type: 'request', method: 'GET', url: '/api/tvl/' }
15:53:01.854 INFO [ ApiServer ]
    {
      type: 'response',
      status: 200,
      timeMs: 4692,
      method: 'GET',
      url: '/api/tvl/'
    }
15:53:06.313 INFO [ TvlCleaner ] Cleaned ReportRepository
    { hourly: 287522756, sixHourly: 40654186 }
15:53:06.313 INFO [ TvlCleaner ] Cleaning AggregatedReportRepository
15:53:19.377 INFO [ TvlCleaner ] Cleaned AggregatedReportRepository
    { hourly: 15417360, sixHourly: 2187360 }