### PR TITLE
fix: update outdated links

### DIFF
--- a/packages/config/src/bridges/hyphen.ts
+++ b/packages/config/src/bridges/hyphen.ts
@@ -17,10 +17,10 @@ export const hyphen: Bridge = {
     links: {
       websites: ['https://hyphen.biconomy.io/'],
       documentation: [
-        'https://docs.biconomy.io/products/hyphen-instant-cross-chain-transfers',
+        'https://docs-gasless.biconomy.io/products/hyphen-instant-cross-chain-transfers',
       ],
       explorers: ['https://hyphen-stats.biconomy.io/'],
-      repositories: ['https://github.com/bcnmy'],
+      repositories: ['https://github.com/bcnmy/hyphen-sdk'],
       socialMedia: [
         'https://discord.gg/yuxXPqu82F',
         'https://twitter.com/biconomy',

--- a/packages/config/src/layer2s/myria.ts
+++ b/packages/config/src/layer2s/myria.ts
@@ -60,7 +60,7 @@ export const myria: Layer2 = {
     links: {
       websites: ['https://myria.com/'],
       apps: ['https://market.x.immutable.com/'],
-      documentation: ['https://docs.starkware.co/starkex-docs-v2/'],
+      documentation: ['https://docs.starkware.co/starkex/index.html'],
       explorers: [],
       repositories: ['https://github.com/starkware-libs/starkex-contracts'],
       socialMedia: [


### PR DESCRIPTION
Hello,
I'm fixing two issues:

1. Outdated link inside Myria page pointing to Starkex docs.
2. Outdated links to Biconomy Hyphen library. The Biconomy is maintaining multiple products, and the bridge related docs were moved into different subdomain. The same holds for the hyphen github repo.

