### PR TITLE
Fix chart type on control

### DIFF
--- a/packages/frontend/src/components/chart/RadioChartTypeControl.tsx
+++ b/packages/frontend/src/components/chart/RadioChartTypeControl.tsx
@@ -20,7 +20,7 @@ export function RadioChartTypeControl({
     hasTvl && {
       fullName: 'Value Locked',
       shortName: 'Value',
-      value: 'tvl',
+      value: 'detailedTvl',
       checked: true,
     },
     hasActivity && {


### PR DESCRIPTION
This pull request fixes the chart type in the RadioChartTypeControl component. The value property in the Value Locked option has been changed from 'tvl' to 'detailedTvl'.