### PR TITLE
Fix DAC risk wording

### DIFF
--- a/packages/config/src/common/dataAvailability.ts
+++ b/packages/config/src/common/dataAvailability.ts
@@ -66,7 +66,7 @@ function ANYTRUST_OFF_CHAIN(
   const threshold = DAC.keyCount - DAC.threshold + 1
   return {
     ...GENERIC_OFF_CHAIN,
-    description: `Users transactions are not published on-chain, but rather sent to several well known and trusted parties, also known as committee members (DAC). Members of the DAC collectively produce a Data Availability Certificate (comprising BLS signatures from a quorum) guaranteeing that the data behind the new transaction batch will be available until the expiry period elapses (currently a minimum of two weeks). This signature is not verified by L1, however external Validators will skip the batch if BLS signature is not valid resulting. This will result in a fraud proof challenge if this batch is included in a consecutive state update. It is assumed that at least one honest DAC member that signed the batch will reveal tx data to the Validators if Sequencer decides to act maliciously and withhold the data. If the Sequencer cannot gather enough signatures from the DAC, it will "fall back to rollup" mode and by posting the full data directly to the L1 chain. The current DAC threshold is ${threshold} out of ${DAC.keyCount}.`,
+    description: `Users transactions are not published on-chain, but rather sent to several trusted parties, also known as committee members (DAC). Members of the DAC collectively produce a Data Availability Certificate (comprising BLS signatures from a quorum) guaranteeing that the data behind the new transaction batch will be available until the expiry period elapses (currently a minimum of two weeks). This signature is not verified by L1, however external Validators will skip the batch if BLS signature is not valid resulting. This will result in a fraud proof challenge if this batch is included in a consecutive state update. It is assumed that at least one honest DAC member that signed the batch will reveal tx data to the Validators if Sequencer decides to act maliciously and withhold the data. If the Sequencer cannot gather enough signatures from the DAC, it will "fall back to rollup" mode and by posting the full data directly to the L1 chain. The current DAC threshold is ${threshold} out of ${DAC.keyCount}.`,
     risks: [
       ...GENERIC_OFF_CHAIN.risks,
       {
@@ -86,7 +86,7 @@ function ANYTRUST_OFF_CHAIN(
 const STARKEX_OFF_CHAIN: ScalingProjectTechnologyChoice = {
   ...GENERIC_OFF_CHAIN,
   description:
-    'The balances of the users are not published on-chain, but rather sent to several well known and trusted parties, also known as committee members. A state update is valid and accepted on-chain only if at least a quorum of the committee members sign a state update.',
+    'The balances of the users are not published on-chain, but rather sent to several trusted parties, also known as committee members. A state update is valid and accepted on-chain only if at least a quorum of the committee members sign a state update.',
   risks: [
     ...GENERIC_OFF_CHAIN.risks,
     {

--- a/packages/config/src/common/dataAvailability.ts
+++ b/packages/config/src/common/dataAvailability.ts
@@ -66,7 +66,7 @@ function ANYTRUST_OFF_CHAIN(
   const threshold = DAC.keyCount - DAC.threshold + 1
   return {
     ...GENERIC_OFF_CHAIN,
-    description: `Users transactions are not published on-chain, but rather sent to several trusted parties, also known as committee members (DAC). Members of the DAC collectively produce a Data Availability Certificate (comprising BLS signatures from a quorum) guaranteeing that the data behind the new transaction batch will be available until the expiry period elapses (currently a minimum of two weeks). This signature is not verified by L1, however external Validators will skip the batch if BLS signature is not valid resulting. This will result in a fraud proof challenge if this batch is included in a consecutive state update. It is assumed that at least one honest DAC member that signed the batch will reveal tx data to the Validators if Sequencer decides to act maliciously and withhold the data. If the Sequencer cannot gather enough signatures from the DAC, it will "fall back to rollup" mode and by posting the full data directly to the L1 chain. The current DAC threshold is ${threshold} out of ${DAC.keyCount}.`,
+    description: `Users transactions are not published on-chain, but rather sent to external trusted parties, also known as committee members (DAC). Members of the DAC collectively produce a Data Availability Certificate (comprising BLS signatures from a quorum) guaranteeing that the data behind the new transaction batch will be available until the expiry period elapses (currently a minimum of two weeks). This signature is not verified by L1, however external Validators will skip the batch if BLS signature is not valid resulting. This will result in a fraud proof challenge if this batch is included in a consecutive state update. It is assumed that at least one honest DAC member that signed the batch will reveal tx data to the Validators if Sequencer decides to act maliciously and withhold the data. If the Sequencer cannot gather enough signatures from the DAC, it will "fall back to rollup" mode and by posting the full data directly to the L1 chain. The current DAC threshold is ${threshold} out of ${DAC.keyCount}.`,
     risks: [
       ...GENERIC_OFF_CHAIN.risks,
       {
@@ -86,7 +86,7 @@ function ANYTRUST_OFF_CHAIN(
 const STARKEX_OFF_CHAIN: ScalingProjectTechnologyChoice = {
   ...GENERIC_OFF_CHAIN,
   description:
-    'The balances of the users are not published on-chain, but rather sent to several trusted parties, also known as committee members. A state update is valid and accepted on-chain only if at least a quorum of the committee members sign a state update.',
+    'The balances of the users are not published on-chain, but rather sent to external trusted parties, also known as committee members. A state update is valid and accepted on-chain only if at least a quorum of the committee members sign a state update.',
   risks: [
     ...GENERIC_OFF_CHAIN.risks,
     {


### PR DESCRIPTION
Not every DAC is public or big.

> ...rather sent to several well known and trusted parties

changed to

> ...rather sent to external trusted parties