### PR TITLE
Add chain name to discovery status project page

### DIFF
--- a/packages/backend/src/modules/status/api/StatusController.ts
+++ b/packages/backend/src/modules/status/api/StatusController.ts
@@ -79,6 +79,7 @@ export class StatusController {
     )
 
     return renderDashboardProjectPage({
+      chain,
       projectName: project,
       contracts,
       diff,

--- a/packages/backend/src/modules/status/api/discovery/view/DashboardProjectPage.tsx
+++ b/packages/backend/src/modules/status/api/discovery/view/DashboardProjectPage.tsx
@@ -9,6 +9,7 @@ import { Diff } from './components/Diff'
 import { UnverifiedContract } from './components/UnverifiedContract'
 
 interface ConfigPageProps {
+  chain: string
   projectName: string
   contracts: DashboardContract[]
   diff?: DiscoveryDiff[]
@@ -16,7 +17,7 @@ interface ConfigPageProps {
 
 export function DashboardProjectPage(props: ConfigPageProps) {
   return (
-    <Page title={props.projectName}>
+    <Page title={props.projectName + '@' + props.chain}>
       <a href="/status/discovery">⬅ Back</a>
 
       {props.diff && (


### PR DESCRIPTION
Before:
<img width="1800" alt="Screenshot 2024-02-08 at 14 53 19" src="https://github.com/l2beat/l2beat/assets/38423054/89e9d755-f58b-4263-afdc-3f748e72c7a2">
After:
<img width="1820" alt="Screenshot 2024-02-08 at 14 52 58" src="https://github.com/l2beat/l2beat/assets/38423054/1d00fa6c-abe7-491d-a55f-383d87f889d1">
