### PR TITLE
Fix rosette label placement

### DIFF
--- a/packages/frontend/src/components/rosette/Rosette.tsx
+++ b/packages/frontend/src/components/rosette/Rosette.tsx
@@ -189,7 +189,7 @@ export function BigRosette({
         Data availability
       </span>
       <span
-        className="absolute left-[207px] top-[72px] rotate-[64deg] text-center text-xs font-medium uppercase leading-tight"
+        className="absolute left-[205px] top-[86px] w-[10ch] rotate-[69deg] text-center text-xs font-medium uppercase leading-tight"
         data-role="rosette-text"
         data-rosette="exit-window"
       >


### PR DESCRIPTION
Before: 
<img width="424" alt="Screenshot 2024-02-09 at 09 35 37" src="https://github.com/l2beat/l2beat/assets/38423054/4af524ee-2ddf-43c5-bbb3-bfe089d7c620">
After: 
<img width="418" alt="Screenshot 2024-02-09 at 09 39 42" src="https://github.com/l2beat/l2beat/assets/38423054/828bbfb2-8a8f-41e4-b28d-6681c99d2595">

