### PR TITLE
Liveness caching

### DIFF
--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -44,6 +44,7 @@ export interface ApiConfig {
   readonly port: number
   readonly cache: {
     readonly tvl: boolean
+    readonly liveness: boolean
   }
 }
 

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -76,6 +76,7 @@ export function makeConfig(
       port: env.integer('PORT', isLocal ? 3000 : undefined),
       cache: {
         tvl: flags.isEnabled('cache', 'tvl'),
+        liveness: flags.isEnabled('cache', 'liveness'),
       },
     },
     health: {

--- a/packages/backend/src/modules/liveness/LivenessModule.ts
+++ b/packages/backend/src/modules/liveness/LivenessModule.ts
@@ -65,12 +65,17 @@ export function createLivenessModule(
     indexerStateRepository,
     config.projects,
     clock,
+    logger,
   )
-  const livenessRouter = createLivenessRouter(livenessController)
+  const livenessRouter = createLivenessRouter(livenessController, config)
 
   const start = async () => {
     logger = logger.for('LivenessModule')
     logger.info('Starting...')
+
+    if (config.api.cache.liveness) {
+      livenessController.start()
+    }
 
     await hourlyIndexer.start()
     await liveness.start()

--- a/packages/backend/src/modules/liveness/api/LivenessController.ts
+++ b/packages/backend/src/modules/liveness/api/LivenessController.ts
@@ -77,10 +77,12 @@ export class LivenessController {
 
   start() {
     this.taskQueue.addToFront()
+    this.logger.info('Caching: initial caching scheduled')
 
     const tenMinutes = 10 * 60 * 1000
     setInterval(() => {
       this.taskQueue.addIfEmpty()
+      this.logger.info('Caching: refetch scheduled')
     }, tenMinutes)
   }
 

--- a/packages/backend/src/modules/liveness/api/LivenessController.ts
+++ b/packages/backend/src/modules/liveness/api/LivenessController.ts
@@ -100,7 +100,8 @@ export class LivenessController {
 
     const projects: LivenessApiResponse['projects'] = {}
 
-    for (const project of this.projects.filter((p) => !p.isArchived)) {
+    const activeProjects = this.projects.filter((p) => !p.isArchived)
+    for (const project of activeProjects) {
       if (project.livenessConfig === undefined) {
         continue
       }

--- a/packages/backend/src/modules/liveness/api/LivenessRouter.ts
+++ b/packages/backend/src/modules/liveness/api/LivenessRouter.ts
@@ -3,13 +3,19 @@ import { branded, LivenessType, ProjectId } from '@l2beat/shared-pure'
 import { z } from 'zod'
 
 import { withTypedContext } from '../../../api/types'
+import { Config } from '../../../config'
 import { LivenessController } from './LivenessController'
 
-export function createLivenessRouter(livenessController: LivenessController) {
+export function createLivenessRouter(
+  livenessController: LivenessController,
+  config: Config,
+) {
   const router = new Router()
 
   router.get('/api/liveness', async (ctx) => {
-    const result = await livenessController.getLiveness()
+    const result = config.api.cache.liveness
+      ? await livenessController.getCachedLivenessApiResponse()
+      : await livenessController.getLiveness()
 
     if (result.type === 'error') {
       ctx.status = 404


### PR DESCRIPTION
This is the first step into the process of fixing liveness endpoint performance. Two high level steps we need to take:

1) Stop request timeouts when querying this endpoint
2) Change liveness logic to offload work from Controller to Indexer

Description of those two steps:

1) "Ugly solution" - hide our problems by caching the response: I have decreased the memory usage of the `.getLiveness` to make it possible to cache it every 10 minutes in our Controller's memory. Now, the endpoint response is almost instant, but still we have deep underlying performance issues that need revisiting

2) Offload work to Indexer - liveness statistics such as min, max, avg, anomalies could be calculated in the Indexer that will be dependent on LivenessIndexer. When LivenessIndexer syncs to certain timestamp the results of liveness calculations will be stored to the database and then the Controller will only perform one simple and lightweight query to the DB to expose the Liveness data for frontend

Resolves L2B-3903