### PR TITLE
fix: broken polynetwork link

### DIFF
--- a/packages/config/src/bridges/polynetwork.ts
+++ b/packages/config/src/bridges/polynetwork.ts
@@ -33,7 +33,7 @@ export const polynetwork: Bridge = {
       documentation: [
         'https://dev-docs.poly.network/',
         'https://github.com/PolygonNetwork/docs',
-        'https://github.com/PolygonNetwork/docs/tree/master/eth',
+        'https://github.com/PolygonNetwork/docs/tree/master/eth/README.md',
       ],
     },
     description:

--- a/packages/config/src/bridges/polynetwork.ts
+++ b/packages/config/src/bridges/polynetwork.ts
@@ -32,8 +32,8 @@ export const polynetwork: Bridge = {
       repositories: ['https://github.com/polynetwork'],
       documentation: [
         'https://dev-docs.poly.network/',
-        'https://github.com/polynetwork/docs',
-        'https://github.com/polynetwork/docs/blob/master/eth/README.md',
+        'https://github.com/PolygonNetwork/docs',
+        'https://github.com/PolygonNetwork/docs/tree/master/eth',
       ],
     },
     description:

--- a/packages/config/src/bridges/polynetwork.ts
+++ b/packages/config/src/bridges/polynetwork.ts
@@ -33,7 +33,7 @@ export const polynetwork: Bridge = {
       documentation: [
         'https://dev-docs.poly.network/',
         'https://github.com/PolygonNetwork/docs',
-        'https://github.com/PolygonNetwork/docs/tree/master/eth/README.md',
+        'https://github.com/PolygonNetwork/docs/blob/master/eth/README.md',
       ],
     },
     description:


### PR DESCRIPTION
I fixed broken Poly Bridge links into developer docs. The original [link](https://github.com/polynetwork/docs) is replaced by new [one](https://github.com/PolygonNetwork/docs). 

To check validity of this change I used wayback machine. I checked that (no more existing) [content](https://web.archive.org/web/20230217152746/https://github.com/polynetwork/docs) of old link is same as content of replacement.