### PR TITLE
Refactor LineaFinalityAnalyzer

### DIFF
--- a/packages/backend/src/modules/finality/FinalityIndexer.test.ts
+++ b/packages/backend/src/modules/finality/FinalityIndexer.test.ts
@@ -41,12 +41,6 @@ describe(FinalityIndexer.name, () => {
     })
 
     it('correctly syncs not synced projects', async () => {
-      const project2Results = {
-        averageTimeToInclusion: 4,
-        minimumTimeToInclusion: 1,
-        maximumTimeToInclusion: 7,
-      }
-
       const finalityRepository = mockObject<FinalityRepository>({
         getProjectsSyncedOnTimestamp: mockFn().resolvesToOnce([
           ProjectId('project-1'),
@@ -55,7 +49,7 @@ describe(FinalityIndexer.name, () => {
       })
       const runtimeConfigurations = getMockFinalityRuntimeConfigurations([
         undefined,
-        project2Results,
+        [2, 4],
       ])
 
       const finalityIndexer = getMockFinalityIndexer({
@@ -71,7 +65,9 @@ describe(FinalityIndexer.name, () => {
         {
           projectId: ProjectId('project-2'),
           timestamp: MIN_TIMESTAMP.add(1, 'days'),
-          ...project2Results,
+          averageTimeToInclusion: 3,
+          minimumTimeToInclusion: 2,
+          maximumTimeToInclusion: 4,
         },
       ])
     })
@@ -93,8 +89,8 @@ describe(FinalityIndexer.name, () => {
         addMany: mockFn().resolvesToOnce(1),
       })
       const runtimeConfigurations = getMockFinalityRuntimeConfigurations([
-        project1Results,
-        project2Results,
+        [1, 2, 3],
+        [1, 7],
       ])
 
       const finalityIndexer = getMockFinalityIndexer({
@@ -164,8 +160,8 @@ describe(FinalityIndexer.name, () => {
       }
 
       const configurations = getMockFinalityRuntimeConfigurations([
-        project1Results,
-        project2Results,
+        [1, 2, 3],
+        [1, 7],
       ])
       const finalityIndexer = getMockFinalityIndexer({})
 
@@ -197,7 +193,7 @@ describe(FinalityIndexer.name, () => {
       const project2Results = undefined
 
       const configurations = getMockFinalityRuntimeConfigurations([
-        project1Results,
+        [1, 3],
         project2Results,
       ])
       const finalityIndexer = getMockFinalityIndexer({})
@@ -356,14 +352,7 @@ function getMockStateRepository(
 }
 
 function getMockFinalityRuntimeConfigurations(
-  results: (
-    | {
-        averageTimeToInclusion: number
-        minimumTimeToInclusion: number
-        maximumTimeToInclusion: number
-      }
-    | undefined
-  )[],
+  results: (number[] | undefined)[],
 ): FinalityConfig[] {
   return results.map((r, i) => ({
     projectId: ProjectId(`project-${i + 1}`),

--- a/packages/backend/src/modules/finality/FinalityModule.ts
+++ b/packages/backend/src/modules/finality/FinalityModule.ts
@@ -51,17 +51,17 @@ export function createFinalityModule(
   )
   const ethereumRPC = new RpcClient(ethereumProvider, logger)
 
-  const lineaAnalyzer = new LineaFinalityAnalyzer(
-    ethereumRPC,
-    livenessRepository,
-  )
-
   const runtimeConfigurations = config.projects
     .map((p) => {
       if (p.finalityConfig?.type === 'Linea') {
         return {
           projectId: p.projectId,
-          analyzer: lineaAnalyzer,
+          analyzer: new LineaFinalityAnalyzer(
+            ethereumRPC,
+            livenessRepository,
+            p.projectId,
+            'STATE',
+          ),
         }
       }
     })

--- a/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.test.ts
+++ b/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.test.ts
@@ -14,7 +14,12 @@ describe(LineaFinalityAnalyzer.name, () => {
 
       const l1Timestamp = 1705407431
 
-      const calculator = new LineaFinalityAnalyzer(provider, livenessRepository)
+      const calculator = new LineaFinalityAnalyzer(
+        provider,
+        livenessRepository,
+        ProjectId('linea'),
+        LivenessType('STATE'),
+      )
       const results = await calculator.getFinality({
         txHash: '0x121',
         timestamp: new UnixTime(l1Timestamp),
@@ -36,6 +41,8 @@ describe(LineaFinalityAnalyzer.name, () => {
         const calculator = new LineaFinalityAnalyzer(
           provider,
           livenessRepository,
+          ProjectId('linea'),
+          LivenessType('STATE'),
         )
 
         await calculator.getFinalityWithGranularity(
@@ -101,6 +108,8 @@ describe(LineaFinalityAnalyzer.name, () => {
         const calculator = new LineaFinalityAnalyzer(
           provider,
           livenessRepository,
+          ProjectId('linea'),
+          LivenessType('STATE'),
         )
         const results = await calculator.getFinalityWithGranularity(
           start.add(-1, 'hours'),

--- a/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.ts
@@ -1,4 +1,4 @@
-import { LivenessType, ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { UnixTime } from '@l2beat/shared-pure'
 import { utils } from 'ethers'
 
 import { BaseAnalyzer } from './types/BaseAnalyzer'
@@ -11,14 +11,6 @@ type LineaDecoded = [
 ]
 
 export class LineaFinalityAnalyzer extends BaseAnalyzer {
-  getProjectId(): ProjectId {
-    return ProjectId('linea')
-  }
-
-  getLivenessType(): LivenessType {
-    return LivenessType('STATE')
-  }
-
   async getFinality(transaction: {
     txHash: string
     timestamp: UnixTime
@@ -26,20 +18,20 @@ export class LineaFinalityAnalyzer extends BaseAnalyzer {
     const tx = await this.provider.getTransaction(transaction.txHash)
     const l1Timestamp = transaction.timestamp
 
-    const decodedInput = decodeInput(tx.data)
+    const decodedInput = this.decodeInput(tx.data)
     const timestamps = decodedInput[0].map((x) => x[1])
 
     return timestamps.map((l2Timestamp) => l1Timestamp.toNumber() - l2Timestamp)
   }
-}
 
-function decodeInput(data: string) {
-  const fnSignature =
-    'finalizeBlocks((bytes32,uint32,bytes[],bytes32[],bytes,uint16[])[], bytes, uint256, bytes32)'
-  const iface = new utils.Interface([`function ${fnSignature}`])
-  const decodedInput = iface.decodeFunctionData(
-    fnSignature,
-    data,
-  ) as LineaDecoded
-  return decodedInput
+  private decodeInput(data: string) {
+    const fnSignature =
+      'finalizeBlocks((bytes32,uint32,bytes[],bytes32[],bytes,uint16[])[], bytes, uint256, bytes32)'
+    const iface = new utils.Interface([`function ${fnSignature}`])
+    const decodedInput = iface.decodeFunctionData(
+      fnSignature,
+      data,
+    ) as LineaDecoded
+    return decodedInput
+  }
 }

--- a/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.ts
@@ -1,14 +1,6 @@
-import {
-  assert,
-  LivenessType,
-  notUndefined,
-  ProjectId,
-  UnixTime,
-} from '@l2beat/shared-pure'
+import { LivenessType, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { utils } from 'ethers'
 
-import { RpcClient } from '../../../peripherals/rpcclient/RpcClient'
-import { LivenessRepository } from '../../liveness/repositories/LivenessRepository'
 import { BaseAnalyzer } from './types/BaseAnalyzer'
 
 type LineaDecoded = [
@@ -18,49 +10,13 @@ type LineaDecoded = [
   string,
 ]
 
-export class LineaFinalityAnalyzer implements BaseAnalyzer {
-  constructor(
-    private readonly provider: RpcClient,
-    private readonly livenessRepository: LivenessRepository,
-  ) {}
+export class LineaFinalityAnalyzer extends BaseAnalyzer {
+  getProjectId(): ProjectId {
+    return ProjectId('linea')
+  }
 
-  async getFinalityWithGranularity(
-    from: UnixTime,
-    to: UnixTime,
-    granularity: number,
-  ) {
-    assert(to.toNumber() > from.toNumber())
-    const interval = (to.toNumber() - from.toNumber()) / granularity
-
-    const transactions = (
-      await Promise.all(
-        Array.from({ length: granularity }).map(async (_, i) => {
-          const targetTimestamp = to.add(-interval * i, 'seconds')
-          const lowerBound = targetTimestamp.add(-interval, 'seconds')
-
-          return this.livenessRepository.findTransactionWithinTimeRange(
-            ProjectId('linea'),
-            LivenessType('STATE'),
-            targetTimestamp,
-            lowerBound,
-          )
-        }),
-      )
-    ).filter(notUndefined)
-
-    if (!transactions.length) {
-      return undefined
-    }
-
-    const finalityDelays = (
-      await Promise.all(
-        transactions.map(async (transaction) => {
-          return this.getFinality(transaction)
-        }),
-      )
-    ).flat()
-
-    return finalityDelays
+  getLivenessType(): LivenessType {
+    return LivenessType('STATE')
   }
 
   async getFinality(transaction: {

--- a/packages/backend/src/modules/finality/analyzers/types/BaseAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/types/BaseAnalyzer.ts
@@ -1,9 +1,63 @@
-import { UnixTime } from '@l2beat/shared-pure'
+import {
+  assert,
+  LivenessType,
+  notUndefined,
+  ProjectId,
+  UnixTime,
+} from '@l2beat/shared-pure'
 
-export interface BaseAnalyzer {
-  getFinalityWithGranularity(
+import { RpcClient } from '../../../../peripherals/rpcclient/RpcClient'
+import { LivenessRepository } from '../../../liveness/repositories/LivenessRepository'
+
+export abstract class BaseAnalyzer {
+  constructor(
+    protected readonly provider: RpcClient,
+    protected readonly livenessRepository: LivenessRepository,
+  ) {}
+
+  async getFinalityWithGranularity(
     from: UnixTime,
     to: UnixTime,
     granularity: number,
-  ): Promise<number[] | undefined>
+  ) {
+    assert(to.toNumber() > from.toNumber())
+    const interval = (to.toNumber() - from.toNumber()) / granularity
+
+    const transactions = (
+      await Promise.all(
+        Array.from({ length: granularity }).map(async (_, i) => {
+          const targetTimestamp = to.add(-interval * i, 'seconds')
+          const lowerBound = targetTimestamp.add(-interval, 'seconds')
+
+          return this.livenessRepository.findTransactionWithinTimeRange(
+            this.getProjectId(),
+            this.getLivenessType(),
+            targetTimestamp,
+            lowerBound,
+          )
+        }),
+      )
+    ).filter(notUndefined)
+
+    if (!transactions.length) {
+      return undefined
+    }
+
+    const finalityDelays = (
+      await Promise.all(
+        transactions.map(async (transaction) => {
+          return this.getFinality(transaction)
+        }),
+      )
+    ).flat()
+
+    return finalityDelays
+  }
+
+  abstract getProjectId(): ProjectId
+  abstract getLivenessType(): LivenessType
+  abstract getFinality(transaction: {
+    txHash: string
+    timestamp: UnixTime
+  }): Promise<number[]>
 }

--- a/packages/backend/src/modules/finality/analyzers/types/BaseAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/types/BaseAnalyzer.ts
@@ -5,12 +5,5 @@ export interface BaseAnalyzer {
     from: UnixTime,
     to: UnixTime,
     granularity: number,
-  ): Promise<
-    | {
-        minimumTimeToInclusion: number
-        maximumTimeToInclusion: number
-        averageTimeToInclusion: number
-      }
-    | undefined
-  >
+  ): Promise<number[] | undefined>
 }


### PR DESCRIPTION
This PR refactors a little bit LineaFinalityAnalyzer, BaseAnalyzer and FinalityIndexer, to do not repeat the logic when writing new analyzers for other projects