### PR TITLE
Add Missing zkSync Era Explorer Link

### DIFF
--- a/packages/config/src/layer2s/zksyncera.ts
+++ b/packages/config/src/layer2s/zksyncera.ts
@@ -58,6 +58,7 @@ export const zksyncera: Layer2 = {
       documentation: ['https://era.zksync.io/docs/'],
       explorers: [
         'https://explorer.zksync.io/',
+        'https://era.zksync.network/',
         'https://zksync-era.l2scan.co/',
       ],
       repositories: ['https://github.com/matter-labs/zksync-era'],


### PR DESCRIPTION
This PR adds the link to the zkSync Era Etherscan explorer.