### PR TITLE
Update Starknet delegation URL

### DIFF
--- a/packages/frontend/src/content/delegatedProjects/starknet.json
+++ b/packages/frontend/src/content/delegatedProjects/starknet.json
@@ -1,4 +1,4 @@
 {
   "name": "Starknet",
-  "delegateTokensUrl": "https://starknet.karmahq.xyz/profile/l2beatcom.eth#overview"
+  "delegateTokensUrl": "https://governance.starknet.io/delegates/profile/750dadd4-0187-41f8-9107-b19620029f9a"
 }

--- a/packages/frontend/src/pages/governance/index/props/getProps.ts
+++ b/packages/frontend/src/pages/governance/index/props/getProps.ts
@@ -19,7 +19,7 @@ export function getProps(config: Config): Wrapped<GovernancePageProps> {
   const publications = getCollection('publications')
   const events = getCollection('events')
   const delegatedProjects = getCollection('delegatedProjects')
-  console.log(getEvents(events))
+
   return {
     props: {
       publications: getPublications(publications),


### PR DESCRIPTION
This pull request updates the delegateTokensUrl in the Starknet configuration to point to the new URL: "https://governance.starknet.io/delegates/profile/750dadd4-0187-41f8-9107-b19620029f9a". It also removes a console.log statement from the code.