### PR TITLE
Delete unifra     'https://scroll.unifra.xyz/' because it is unavailable

### DIFF
--- a/packages/config/src/layer2s/scroll.ts
+++ b/packages/config/src/layer2s/scroll.ts
@@ -62,7 +62,6 @@ export const scroll: Layer2 = {
       explorers: [
         'https://scrollscan.com/',
         'https://blockscout.scroll.io',
-        'https://scroll.unifra.xyz/',
         'https://ondora.xyz/network/scroll',
         'https://scroll.l2scan.co/',
       ],


### PR DESCRIPTION
![image](https://github.com/l2beat/l2beat/assets/20639676/d5fd9c79-5ff8-483e-ba3b-c68165a5e757)

We (Unifra) remove the old domain, and https://scroll.l2scan.co/ is already in the list.