### PR TITLE
Expose LZ OApps

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -10,6 +10,7 @@ import { createFinalityModule } from './modules/finality/FinalityModule'
 import { createHealthModule } from './modules/health/HealthModule'
 import { LivenessIndexer } from './modules/liveness/LivenessIndexer'
 import { createLivenessModule } from './modules/liveness/LivenessModule'
+import { createLzOAppsModule } from './modules/lz-oapps/createLzOAppsModule'
 import { createMetricsModule } from './modules/metrics/MetricsModule'
 import { createStatusModule } from './modules/status/StatusModule'
 import { createTvlModule } from './modules/tvl/modules/TvlModule'
@@ -62,6 +63,7 @@ export class Application {
         clock,
         livenessModule?.indexer as LivenessIndexer,
       ),
+      createLzOAppsModule(config, logger),
     ]
 
     const apiServer = new ApiServer(

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -26,6 +26,7 @@ export interface Config {
   readonly activity: ActivityConfig | false
   readonly updateMonitor: UpdateMonitorConfig | false
   readonly diffHistory: DiffHistoryConfig | false
+  readonly lzOAppsEnabled: boolean
   readonly statusEnabled: boolean
   readonly chains: { name: string; chainId: ChainId }[]
   readonly flags: ResolvedFeatureFlag[]

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -136,6 +136,7 @@ export function makeConfig(
         .filter((x) => flags.isEnabled('activity', x.id.toString()))
         .map((x) => ({ id: x.id, config: getChainActivityConfig(env, x) })),
     },
+    lzOAppsEnabled: flags.isEnabled('lzOApps'),
     statusEnabled: flags.isEnabled('status'),
     updateMonitor: flags.isEnabled('updateMonitor') && {
       runOnStart: isLocal

--- a/packages/backend/src/modules/lz-oapps/api/LzOappsController.ts
+++ b/packages/backend/src/modules/lz-oapps/api/LzOappsController.ts
@@ -1,0 +1,44 @@
+import { assert, Logger } from '@l2beat/backend-tools'
+import { bridges, tokenList } from '@l2beat/config'
+import { ProjectId } from '@l2beat/shared-pure'
+
+export class LzOAppsController {
+  constructor(private readonly logger: Logger) {}
+
+  public getOApps() {
+    const layerzeroBridge = bridges.find(
+      (bridge) => bridge.id === ProjectId('lzomnichain'),
+    )
+
+    assert(layerzeroBridge, 'LayerZero bridge not found')
+
+    const oApps = layerzeroBridge.config.escrows.flatMap((escrow) =>
+      escrow.tokens === '*'
+        ? []
+        : escrow.tokens.map((token) => ({ address: escrow.address, token })),
+    )
+
+    const resolvedOApps = oApps.flatMap((oApp) => {
+      const token = tokenList.find((token) => token.symbol === oApp.token)
+
+      if (!token) {
+        this.logger.warn(
+          `Could not find token for oApp escrow remap: ${
+            oApp.token
+          } on ${oApp.address.toString()}`,
+        )
+        return []
+      }
+
+      return {
+        address: oApp.address,
+        name: token.name,
+        symbol: token.symbol,
+        iconUrl: token.iconUrl,
+        chainId: token.chainId,
+      }
+    })
+
+    return resolvedOApps
+  }
+}

--- a/packages/backend/src/modules/lz-oapps/api/LzOappsRouter.ts
+++ b/packages/backend/src/modules/lz-oapps/api/LzOappsRouter.ts
@@ -5,7 +5,7 @@ import { LzOAppsController } from './LzOappsController'
 export function createLzOAppsRouter(controller: LzOAppsController) {
   const router = new Router()
 
-  router.get('/layerzero-oapps', (ctx) => {
+  router.get('/api/integrations/layerzero-oapps', (ctx) => {
     ctx.body = controller.getOApps()
   })
 

--- a/packages/backend/src/modules/lz-oapps/api/LzOappsRouter.ts
+++ b/packages/backend/src/modules/lz-oapps/api/LzOappsRouter.ts
@@ -1,0 +1,13 @@
+import Router from '@koa/router'
+
+import { LzOAppsController } from './LzOappsController'
+
+export function createLzOAppsRouter(controller: LzOAppsController) {
+  const router = new Router()
+
+  router.get('/layerzero-oapps', (ctx) => {
+    ctx.body = controller.getOApps()
+  })
+
+  return router
+}

--- a/packages/backend/src/modules/lz-oapps/createLzOAppsModule.ts
+++ b/packages/backend/src/modules/lz-oapps/createLzOAppsModule.ts
@@ -1,0 +1,29 @@
+import { Logger } from '@l2beat/backend-tools'
+
+import { Config } from '../../config'
+import { ApplicationModule } from '../ApplicationModule'
+import { LzOAppsController } from './api/LzOappsController'
+import { createLzOAppsRouter } from './api/LzOappsRouter'
+
+export function createLzOAppsModule(
+  config: Config,
+  logger: Logger,
+): ApplicationModule | undefined {
+  if (!config.lzOAppsEnabled) {
+    logger.info('LayerZero OApps module disabled')
+    return
+  }
+
+  const controller = new LzOAppsController(logger)
+  const routers = [createLzOAppsRouter(controller)]
+
+  const start = () => {
+    logger = logger.for('LzOAppsModule')
+    logger.info('Started')
+  }
+
+  return {
+    start,
+    routers,
+  }
+}


### PR DESCRIPTION
Part of L2B-4083

Part of PoC effort to link dashboard and L2Beat site. The ultimate goal will be to keep the OApps list in sync with the L2Beat config, track them on the LZ Dashboard side, and expose information on whether a given OApp has defaults set or uses custom configuration.