### PR TITLE
Add TVL fallback for projects without data

### DIFF
--- a/packages/frontend/src/components/table/TotalCell.tsx
+++ b/packages/frontend/src/components/table/TotalCell.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { ScalingL2SummaryViewEntry } from '../../pages/scaling/summary/types'
 import { getSentimentFillColor } from '../../utils/sentimentFillColor'
+import { Badge } from '../badge/Badge'
 import { RoundedWarningIcon } from '../icons'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../tooltip/Tooltip'
 import { NumberCell } from './NumberCell'
@@ -11,7 +12,7 @@ export interface TotalCellProps {
 }
 
 export function TotalCell({ project }: TotalCellProps) {
-  const content = (
+  const content = project.tvl ? (
     <>
       <NumberCell className="font-bold" tooltip={project.tvlTooltip}>
         {project.tvl?.displayValue}
@@ -20,6 +21,10 @@ export function TotalCell({ project }: TotalCellProps) {
         {project.sevenDayChange}
       </NumberCell>
     </>
+  ) : (
+    <Badge type="gray" className="mx-auto translate-x-[11.5px]">
+      Coming soon
+    </Badge>
   )
 
   if (project.tvlWarning) {

--- a/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
+++ b/packages/frontend/src/components/table/props/getScalingTableColumnsConfig.tsx
@@ -97,10 +97,12 @@ export function getActiveScalingSummaryColumnsConfig() {
       minimalWidth: true,
       headClassName: '!pr-4',
       getValue: (project) =>
-        project.tvlBreakdown && (
+        project.tvlBreakdown ? (
           <NumberCell className="pr-4">
             {project.marketShare?.displayValue}
           </NumberCell>
+        ) : (
+          <span className="pr-4">—</span>
         ),
       sorting: {
         getOrderValue: (project) => project.marketShare?.value,

--- a/packages/frontend/src/utils/orderByTvl.ts
+++ b/packages/frontend/src/utils/orderByTvl.ts
@@ -17,14 +17,10 @@ export function orderByTvl<
     const tvl =
       tvlApiResponse.projects[project.id.toString()]?.charts.hourly.data.at(
         -1,
-      )?.[1] ?? 0
+      )?.[1]
 
     if (tvl) {
-      return (
-        tvlApiResponse.projects[project.id.toString()]?.charts.hourly.data.at(
-          -1,
-        )?.[1] ?? 0
-      )
+      return tvl ?? 0
     }
 
     const useTvlFrom = useTvlFromMap[project.id.toString()]

--- a/packages/frontend/src/utils/orderByTvl.ts
+++ b/packages/frontend/src/utils/orderByTvl.ts
@@ -1,5 +1,9 @@
 import { ProjectId, TvlApiResponse } from '@l2beat/shared-pure'
 
+const useTvlFromMap: Record<string, string> = {
+  astarzkevm: 'polygonzkevm',
+}
+
 export function orderByTvl<
   T extends { id: ProjectId; isArchived?: boolean; isUpcoming?: boolean },
 >(projects: T[], tvlApiResponse: Pick<TvlApiResponse, 'projects'>): T[] {
@@ -9,10 +13,25 @@ export function orderByTvl<
   const archived = projects.filter((project) => project.isArchived)
   const upcoming = projects.filter((project) => project.isUpcoming)
 
-  const getTvl = (project: T) =>
-    tvlApiResponse.projects[project.id.toString()]?.charts.hourly.data.at(
-      -1,
-    )?.[1] ?? 0
+  const getTvl = (project: T) => {
+    const tvl =
+      tvlApiResponse.projects[project.id.toString()]?.charts.hourly.data.at(
+        -1,
+      )?.[1] ?? 0
+
+    if (tvl) {
+      return (
+        tvlApiResponse.projects[project.id.toString()]?.charts.hourly.data.at(
+          -1,
+        )?.[1] ?? 0
+      )
+    }
+
+    const useTvlFrom = useTvlFromMap[project.id.toString()]
+    const useTvlFromValue =
+      tvlApiResponse.projects[useTvlFrom]?.charts.hourly.data.at(-1)?.[1]
+    return useTvlFromValue ? useTvlFromValue - 1 : 0
+  }
 
   const sortByTvl = (a: T, b: T) => getTvl(b) - getTvl(a)
 


### PR DESCRIPTION
Resolves L2B-4263, L2B-4253

This pull request adds a fallback mechanism for projects that do not have TVL data available. It displays a "Coming soon" badge for these projects instead of showing a blank value. Additionally, it includes a fix for sorting projects by TVL to handle cases where TVL data is missing.