### PR TITLE
Update discovery version and Polygon ZKEVM

### DIFF
--- a/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
+++ b/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
@@ -23,11 +23,11 @@
     "0x4A27aC91c5cD3768F140ECabDe3FC2B2d92eDb98": "daiBridge",
     "0xf694C9e3a34f5Fa48b6f3a0Ff186C1c6c4FcE904": "EscrowsAdmin",
     "0x519E42c24163192Dca44CD3fBDCEBF6be9130987": "PolygonZkEVMExistentEtrog",
-    "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80": "PolygonValidiumEtrog",
     "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6": "PolygonEcosystemToken",
-    "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0": "PolygonValidiumDAC",
-    "0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d": "PolygonValidiumAdmin",
-    "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E": "PolygonValidiumMultisig"
+    "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80": "AstarValidiumEtrog",
+    "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0": "AstarValidiumDAC",
+    "0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d": "AstarValidiumAdmin",
+    "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E": "AstarValidiumMultisig"
   },
   "overrides": {
     "PolygonRollupManager": {
@@ -152,8 +152,17 @@
     "PolygonZkEVMExistentEtrog": {
       "ignoreInWatchMode": ["lastAccInputHash"]
     },
-    "PolygonValidiumEtrog": {
+    "AstarValidiumEtrog": {
       "ignoreInWatchMode": ["lastAccInputHash"]
+    },
+    "AstarValidiumDAC": {
+      "fields": {
+        "members": {
+          "type": "array",
+          "method": "members",
+          "maxLength": 50
+        }
+      }
     },
     "PolygonEcosystemToken": {
       "ignoreInWatchMode": ["lastMint", "totalSupply"]

--- a/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
+++ b/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
@@ -22,7 +22,12 @@
     "0x70E70e58ed7B1Cec0D8ef7464072ED8A52d755eB": "usdcBridge",
     "0x4A27aC91c5cD3768F140ECabDe3FC2B2d92eDb98": "daiBridge",
     "0xf694C9e3a34f5Fa48b6f3a0Ff186C1c6c4FcE904": "EscrowsAdmin",
-    "0x519E42c24163192Dca44CD3fBDCEBF6be9130987": "PolygonZkEVMExistentEtrog"
+    "0x519E42c24163192Dca44CD3fBDCEBF6be9130987": "PolygonZkEVMExistentEtrog",
+    "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80": "PolygonValidiumEtrog",
+    "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6": "PolygonEcosystemToken",
+    "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0": "PolygonValidiumDAC",
+    "0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d": "PolygonValidiumAdmin",
+    "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E": "PolygonValidiumMultisig"
   },
   "overrides": {
     "PolygonRollupManager": {
@@ -62,6 +67,7 @@
           "type": "array",
           "method": "rollupIDToRollupData",
           "startIndex": 1,
+          "filter": ["rollupContract", "verifier"],
           "length": "{{ rollupCount }}"
         },
         "accessControl": {
@@ -145,6 +151,12 @@
     "MaticToken": { "ignoreDiscovery": true },
     "PolygonZkEVMExistentEtrog": {
       "ignoreInWatchMode": ["lastAccInputHash"]
+    },
+    "PolygonValidiumEtrog": {
+      "ignoreInWatchMode": ["lastAccInputHash"]
+    },
+    "PolygonEcosystemToken": {
+      "ignoreInWatchMode": ["lastMint", "totalSupply"]
     }
   }
 }

--- a/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
@@ -1,3 +1,246 @@
+Generated with discovered.json: 0x3ae13547b426e2661f5e8d8b9af4244b6cbc7520
+
+# Diff at Wed, 13 Mar 2024 11:44:56 GMT:
+
+- author: Mateusz Radomski (<radomski.main@protonmail.com>)
+- comparing to: main@4f6a54f5fa748334d34176673b2c233534ce2fbc block: 19282832
+- current block number: 19425934
+
+## Description
+
+Added a new rollup type: Validium.
+The rollup is owned by PolygonValidiumAdmin that itself is owned by PolygonValidiumMultisig.
+
+A trusted aggregator has been added that is an [EOA](https://etherscan.io/address/0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE).
+On 2024-02-29 [willbutton.eth](https://etherscan.io/tx/0x760fd86f9453477e23df16def04777fb6282dda9f8546e93b2f7b866467b2e49) sent some eth to that address.
+A day later it was given 5ETH by a [multisig](https://etherscan.io/address/0xc984295ad7a950fb5031154bcfc0b6267b948706) and 20ETH a week later by the same multisig.
+The account has been calling `verifyBatchesTrustedAggregator()` starting from 2024-03-04 and does so around once an hour.
+We don't have that multisig in any discovery.
+The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePendingState()` as well as `consolidatePendingState()` skipping all timeout restrictions.
+
+## Watched changes
+
+```diff
+    contract PolygonRollupManager (0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2) {
+    +++ description: None
+      values.accessControl.TRUSTED_AGGREGATOR.members.1:
++        "0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE"
+      values.rollupCount:
+-        1
++        2
+      values.rollupsData.1:
++        ["0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80","0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"]
+      values.rollupTypeCount:
+-        0
++        1
+    }
+```
+
+```diff
++   Status: CREATED
+    contract PolygonValidiumAdmin (0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract PolygonValidiumEtrog (0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract GnosisSafe (0x6c4876Ecb5de33f76700f44d547C593065806dAC)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract PolygonValidiumDAC (0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract PolygonValidiumMultisig (0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E)
+    +++ description: None
+```
+
+## Source code changes
+
+```diff
+.../implementation/contracts/GnosisSafe.sol        |  422 +++++
+ .../implementation/contracts/base/Executor.sol     |   27 +
+ .../contracts/base/FallbackManager.sol             |   53 +
+ .../implementation/contracts/base/GuardManager.sol |   50 +
+ .../contracts/base/ModuleManager.sol               |  133 ++
+ .../implementation/contracts/base/OwnerManager.sol |  149 ++
+ .../implementation/contracts/common/Enum.sol       |    8 +
+ .../contracts/common/EtherPaymentFallback.sol      |   13 +
+ .../contracts/common/SecuredTokenTransfer.sol      |   35 +
+ .../contracts/common/SelfAuthorized.sol            |   16 +
+ .../contracts/common/SignatureDecoder.sol          |   36 +
+ .../implementation/contracts/common/Singleton.sol  |   11 +
+ .../contracts/common/StorageAccessible.sol         |   47 +
+ .../contracts/external/GnosisSafeMath.sol          |   54 +
+ .../contracts/interfaces/ISignatureValidator.sol   |   20 +
+ .../.code/GnosisSafe/implementation/meta.txt       |    2 +
+ .../.code/GnosisSafe/proxy/GnosisSafeProxy.sol     |  155 ++
+ .../ethereum/.code/GnosisSafe/proxy/meta.txt       |    2 +
+ .../@openzeppelin/contracts/access/Ownable.sol     |   83 +
+ .../contracts/interfaces/IERC1967.sol              |   26 +
+ .../contracts/interfaces/draft-IERC1822.sol        |   20 +
+ .../contracts/proxy/ERC1967/ERC1967Proxy.sol       |   32 +
+ .../contracts/proxy/ERC1967/ERC1967Upgrade.sol     |  171 ++
+ .../@openzeppelin/contracts/proxy/Proxy.sol        |   86 +
+ .../contracts/proxy/beacon/BeaconProxy.sol         |   61 +
+ .../contracts/proxy/beacon/IBeacon.sol             |   16 +
+ .../contracts/proxy/beacon/UpgradeableBeacon.sol   |   65 +
+ .../contracts/proxy/transparent/ProxyAdmin.sol     |   81 +
+ .../transparent/TransparentUpgradeableProxy.sol    |  193 ++
+ .../@openzeppelin/contracts/utils/Address.sol      |  244 +++
+ .../@openzeppelin/contracts/utils/Context.sol      |   24 +
+ .../@openzeppelin/contracts/utils/StorageSlot.sol  |   88 +
+ .../ethereum/.code/PolygonValidiumAdmin/meta.txt   |    2 +
+ .../@openzeppelin/contracts/utils/Strings.sol      |   70 +
+ .../contracts/utils/cryptography/ECDSA.sol         |  213 +++
+ .../@openzeppelin/contracts/utils/math/Math.sol    |  345 ++++
+ .../access/OwnableUpgradeable.sol                  |   95 +
+ .../proxy/utils/Initializable.sol                  |  165 ++
+ .../utils/AddressUpgradeable.sol                   |  219 +++
+ .../utils/ContextUpgradeable.sol                   |   37 +
+ .../v2/consensus/validium/PolygonDataCommittee.sol |  197 ++
+ .../v2/interfaces/IDataAvailabilityProtocol.sol    |   12 +
+ .../v2/interfaces/IPolygonDataCommitteeErrors.sol  |   40 +
+ .../PolygonValidiumDAC/implementation/meta.txt     |    2 +
+ .../@openzeppelin/contracts/access/Ownable.sol     |   83 +
+ .../contracts/interfaces/IERC1967.sol              |   26 +
+ .../contracts/interfaces/draft-IERC1822.sol        |   20 +
+ .../contracts/proxy/ERC1967/ERC1967Proxy.sol       |   32 +
+ .../contracts/proxy/ERC1967/ERC1967Upgrade.sol     |  171 ++
+ .../proxy/@openzeppelin/contracts/proxy/Proxy.sol  |   86 +
+ .../contracts/proxy/beacon/BeaconProxy.sol         |   61 +
+ .../contracts/proxy/beacon/IBeacon.sol             |   16 +
+ .../contracts/proxy/beacon/UpgradeableBeacon.sol   |   65 +
+ .../contracts/proxy/transparent/ProxyAdmin.sol     |   81 +
+ .../transparent/TransparentUpgradeableProxy.sol    |  193 ++
+ .../@openzeppelin/contracts/utils/Address.sol      |  244 +++
+ .../@openzeppelin/contracts/utils/Context.sol      |   24 +
+ .../@openzeppelin/contracts/utils/StorageSlot.sol  |   88 +
+ .../.code/PolygonValidiumDAC/proxy/meta.txt        |    2 +
+ .../access/IAccessControlUpgradeable.sol           |   88 +
+ .../proxy/utils/Initializable.sol                  |  165 ++
+ .../token/ERC20/IERC20Upgradeable.sol              |   82 +
+ .../ERC20/extensions/IERC20MetadataUpgradeable.sol |   28 +
+ .../extensions/draft-IERC20PermitUpgradeable.sol   |   60 +
+ .../token/ERC20/utils/SafeERC20Upgradeable.sol     |  116 ++
+ .../utils/AddressUpgradeable.sol                   |  219 +++
+ .../utils/ContextUpgradeable.sol                   |   37 +
+ .../utils/StringsUpgradeable.sol                   |   70 +
+ .../utils/introspection/ERC165Upgradeable.sol      |   42 +
+ .../utils/introspection/IERC165Upgradeable.sol     |   25 +
+ .../utils/math/MathUpgradeable.sol                 |  345 ++++
+ .../@openzeppelin/contracts5/access/Ownable.sol    |  100 +
+ .../contracts5/interfaces/IERC1967.sol             |   24 +
+ .../contracts5/proxy/ERC1967/ERC1967Proxy.sol      |   40 +
+ .../contracts5/proxy/ERC1967/ERC1967Utils.sol      |  193 ++
+ .../@openzeppelin/contracts5/proxy/Proxy.sol       |   69 +
+ .../contracts5/proxy/beacon/IBeacon.sol            |   16 +
+ .../contracts5/proxy/transparent/ProxyAdmin.sol    |   45 +
+ .../transparent/TransparentUpgradeableProxy.sol    |  116 ++
+ .../@openzeppelin/contracts5/utils/Address.sol     |  159 ++
+ .../@openzeppelin/contracts5/utils/Context.sol     |   24 +
+ .../@openzeppelin/contracts5/utils/StorageSlot.sol |  135 ++
+ .../interfaces/IBasePolygonZkEVMGlobalExitRoot.sol |   16 +
+ .../contracts/interfaces/IPolygonZkEVMBridge.sol   |  118 ++
+ .../contracts/interfaces/IPolygonZkEVMErrors.sol   |  211 +++
+ .../contracts/interfaces/IVerifierRollup.sol       |   13 +
+ .../contracts/lib/EmergencyManager.sol             |   73 +
+ .../contracts/v2/PolygonRollupManager.sol          | 1911 ++++++++++++++++++++
+ .../v2/consensus/validium/PolygonValidiumEtrog.sol |  279 +++
+ .../consensus/zkEVM/PolygonZkEVMExistentEtrog.sol  |  134 ++
+ .../v2/interfaces/IDataAvailabilityProtocol.sol    |   12 +
+ .../contracts/v2/interfaces/IPolygonRollupBase.sol |   20 +
+ .../v2/interfaces/IPolygonRollupManager.sol        |  170 ++
+ .../contracts/v2/interfaces/IPolygonValidium.sol   |   15 +
+ .../v2/interfaces/IPolygonZkEVMBridgeV2.sol        |  166 ++
+ .../interfaces/IPolygonZkEVMGlobalExitRootV2.sol   |   10 +
+ .../v2/interfaces/IPolygonZkEVMVEtrogErrors.sol    |   46 +
+ .../contracts/v2/lib/LegacyZKEVMStateVariables.sol |  153 ++
+ .../v2/lib/PolygonAccessControlUpgradeable.sol     |  245 +++
+ .../contracts/v2/lib/PolygonConstantsBase.sol      |   14 +
+ .../contracts/v2/lib/PolygonRollupBaseEtrog.sol    |  923 ++++++++++
+ .../contracts/v2/lib/PolygonTransparentProxy.sol   |   79 +
+ .../PolygonValidiumEtrog/implementation/meta.txt   |    2 +
+ .../@openzeppelin/contracts5/access/Ownable.sol    |  100 +
+ .../contracts5/interfaces/IERC1967.sol             |   24 +
+ .../contracts5/proxy/ERC1967/ERC1967Proxy.sol      |   40 +
+ .../contracts5/proxy/ERC1967/ERC1967Utils.sol      |  193 ++
+ .../proxy/@openzeppelin/contracts5/proxy/Proxy.sol |   69 +
+ .../contracts5/proxy/beacon/IBeacon.sol            |   16 +
+ .../contracts5/proxy/transparent/ProxyAdmin.sol    |   45 +
+ .../transparent/TransparentUpgradeableProxy.sol    |  116 ++
+ .../@openzeppelin/contracts5/utils/Address.sol     |  159 ++
+ .../@openzeppelin/contracts5/utils/Context.sol     |   24 +
+ .../@openzeppelin/contracts5/utils/StorageSlot.sol |  135 ++
+ .../contracts/v2/lib/PolygonTransparentProxy.sol   |   79 +
+ .../.code/PolygonValidiumEtrog/proxy/meta.txt      |    2 +
+ .../implementation/contracts/GnosisSafe.sol        |  422 +++++
+ .../implementation/contracts/base/Executor.sol     |   27 +
+ .../contracts/base/FallbackManager.sol             |   53 +
+ .../implementation/contracts/base/GuardManager.sol |   50 +
+ .../contracts/base/ModuleManager.sol               |  133 ++
+ .../implementation/contracts/base/OwnerManager.sol |  149 ++
+ .../implementation/contracts/common/Enum.sol       |    8 +
+ .../contracts/common/EtherPaymentFallback.sol      |   13 +
+ .../contracts/common/SecuredTokenTransfer.sol      |   35 +
+ .../contracts/common/SelfAuthorized.sol            |   16 +
+ .../contracts/common/SignatureDecoder.sol          |   36 +
+ .../implementation/contracts/common/Singleton.sol  |   11 +
+ .../contracts/common/StorageAccessible.sol         |   47 +
+ .../contracts/external/GnosisSafeMath.sol          |   54 +
+ .../contracts/interfaces/ISignatureValidator.sol   |   20 +
+ .../implementation/meta.txt                        |    2 +
+ .../proxy/GnosisSafeProxy.sol                      |  155 ++
+ .../.code/PolygonValidiumMultisig/proxy/meta.txt   |    2 +
+ 134 files changed, 14055 insertions(+)
+```
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19282832 (main branch discovery), not current.
+
+```diff
+    contract PolygonRollupManager (0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2) {
+    +++ description: None
+      values.rollupsData.0.11:
+-        0
+      values.rollupsData.0.10:
+-        0
+      values.rollupsData.0.9:
+-        1984749
+      values.rollupsData.0.8:
+-        0
+      values.rollupsData.0.7:
+-        0
+      values.rollupsData.0.6:
+-        1991783
+      values.rollupsData.0.5:
+-        1991800
+      values.rollupsData.0.4:
+-        "0x8ad85f1e7b882d12cf6c64cf256cab8d255d6085e8109400741d82850a1d944b"
+      values.rollupsData.0.3:
+-        7
+      values.rollupsData.0.2:
+-        "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"
+      values.rollupsData.0.1:
+-        1101
++        "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"
+    }
+```
+
 Generated with discovered.json: 0xa044c3c3b7dd5811d191b9d7da48b7a243b45f1c
 
 # Diff at Thu, 22 Feb 2024 11:24:11 GMT:

--- a/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
@@ -10,6 +10,7 @@ Generated with discovered.json: 0x3ae13547b426e2661f5e8d8b9af4244b6cbc7520
 
 Added a new rollup type: Validium.
 The rollup is owned by PolygonValidiumAdmin that itself is owned by PolygonValidiumMultisig.
+The new contract is the AstarZKEVM Validum.
 
 A trusted aggregator has been added that is an [EOA](https://etherscan.io/address/0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE).
 On 2024-02-29 [willbutton.eth](https://etherscan.io/tx/0x760fd86f9453477e23df16def04777fb6282dda9f8546e93b2f7b866467b2e49) sent some eth to that address.

--- a/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
@@ -8,9 +8,8 @@ Generated with discovered.json: 0xf5c29c1b6e921c17297af2fa6650362ebbbffcb5
 
 ## Description
 
-Added a new rollup type: Validium.
-The rollup is owned by PolygonValidiumAdmin that itself is owned by PolygonValidiumMultisig.
-The new contract is the AstarZKEVM Validum.
+Added a Validium - AstarZKEVM.
+The validium is owned by AstarValidiumAdmin that itself is owned by AstarValidiumMultisig.
 
 A trusted aggregator has been added that is an [EOA](https://etherscan.io/address/0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE).
 On 2024-02-29 [willbutton.eth](https://etherscan.io/tx/0x760fd86f9453477e23df16def04777fb6282dda9f8546e93b2f7b866467b2e49) sent some eth to that address.

--- a/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
@@ -1,10 +1,10 @@
-Generated with discovered.json: 0x3ae13547b426e2661f5e8d8b9af4244b6cbc7520
+Generated with discovered.json: 0xf5c29c1b6e921c17297af2fa6650362ebbbffcb5
 
-# Diff at Wed, 13 Mar 2024 11:44:56 GMT:
+# Diff at Thu, 14 Mar 2024 11:46:46 GMT:
 
 - author: Mateusz Radomski (<radomski.main@protonmail.com>)
-- comparing to: main@4f6a54f5fa748334d34176673b2c233534ce2fbc block: 19282832
-- current block number: 19425934
+- comparing to: main@24c5721630392f8b6f59093376472db03d18b2c2 block: 19282832
+- current block number: 19433041
 
 ## Description
 
@@ -26,11 +26,20 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
     +++ description: None
       values.accessControl.TRUSTED_AGGREGATOR.members.1:
 +        "0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE"
++++ description: The number of rollups that the manager can use.
++++ type: STRUCTURE
++++ severity: LOW
       values.rollupCount:
 -        1
 +        2
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.1:
 +        ["0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80","0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"]
++++ description: The number of unique rollup types that the manager can use.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupTypeCount:
 -        0
 +        1
@@ -39,13 +48,13 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
 
 ```diff
 +   Status: CREATED
-    contract PolygonValidiumAdmin (0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d)
+    contract AstarValidiumAdmin (0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d)
     +++ description: None
 ```
 
 ```diff
 +   Status: CREATED
-    contract PolygonValidiumEtrog (0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80)
+    contract AstarValidiumEtrog (0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80)
     +++ description: None
 ```
 
@@ -57,38 +66,20 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
 
 ```diff
 +   Status: CREATED
-    contract PolygonValidiumDAC (0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0)
+    contract AstarValidiumDAC (0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0)
     +++ description: None
 ```
 
 ```diff
 +   Status: CREATED
-    contract PolygonValidiumMultisig (0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E)
+    contract AstarValidiumMultisig (0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E)
     +++ description: None
 ```
 
 ## Source code changes
 
 ```diff
-.../implementation/contracts/GnosisSafe.sol        |  422 +++++
- .../implementation/contracts/base/Executor.sol     |   27 +
- .../contracts/base/FallbackManager.sol             |   53 +
- .../implementation/contracts/base/GuardManager.sol |   50 +
- .../contracts/base/ModuleManager.sol               |  133 ++
- .../implementation/contracts/base/OwnerManager.sol |  149 ++
- .../implementation/contracts/common/Enum.sol       |    8 +
- .../contracts/common/EtherPaymentFallback.sol      |   13 +
- .../contracts/common/SecuredTokenTransfer.sol      |   35 +
- .../contracts/common/SelfAuthorized.sol            |   16 +
- .../contracts/common/SignatureDecoder.sol          |   36 +
- .../implementation/contracts/common/Singleton.sol  |   11 +
- .../contracts/common/StorageAccessible.sol         |   47 +
- .../contracts/external/GnosisSafeMath.sol          |   54 +
- .../contracts/interfaces/ISignatureValidator.sol   |   20 +
- .../.code/GnosisSafe/implementation/meta.txt       |    2 +
- .../.code/GnosisSafe/proxy/GnosisSafeProxy.sol     |  155 ++
- .../ethereum/.code/GnosisSafe/proxy/meta.txt       |    2 +
- .../@openzeppelin/contracts/access/Ownable.sol     |   83 +
+.../@openzeppelin/contracts/access/Ownable.sol     |   83 +
  .../contracts/interfaces/IERC1967.sol              |   26 +
  .../contracts/interfaces/draft-IERC1822.sol        |   20 +
  .../contracts/proxy/ERC1967/ERC1967Proxy.sol       |   32 +
@@ -102,7 +93,7 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
  .../@openzeppelin/contracts/utils/Address.sol      |  244 +++
  .../@openzeppelin/contracts/utils/Context.sol      |   24 +
  .../@openzeppelin/contracts/utils/StorageSlot.sol  |   88 +
- .../ethereum/.code/PolygonValidiumAdmin/meta.txt   |    2 +
+ .../ethereum/.code/AstarValidiumAdmin/meta.txt     |    2 +
  .../@openzeppelin/contracts/utils/Strings.sol      |   70 +
  .../contracts/utils/cryptography/ECDSA.sol         |  213 +++
  .../@openzeppelin/contracts/utils/math/Math.sol    |  345 ++++
@@ -113,7 +104,7 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
  .../v2/consensus/validium/PolygonDataCommittee.sol |  197 ++
  .../v2/interfaces/IDataAvailabilityProtocol.sol    |   12 +
  .../v2/interfaces/IPolygonDataCommitteeErrors.sol  |   40 +
- .../PolygonValidiumDAC/implementation/meta.txt     |    2 +
+ .../.code/AstarValidiumDAC/implementation/meta.txt |    2 +
  .../@openzeppelin/contracts/access/Ownable.sol     |   83 +
  .../contracts/interfaces/IERC1967.sol              |   26 +
  .../contracts/interfaces/draft-IERC1822.sol        |   20 +
@@ -128,7 +119,7 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
  .../@openzeppelin/contracts/utils/Address.sol      |  244 +++
  .../@openzeppelin/contracts/utils/Context.sol      |   24 +
  .../@openzeppelin/contracts/utils/StorageSlot.sol  |   88 +
- .../.code/PolygonValidiumDAC/proxy/meta.txt        |    2 +
+ .../ethereum/.code/AstarValidiumDAC/proxy/meta.txt |    2 +
  .../access/IAccessControlUpgradeable.sol           |   88 +
  .../proxy/utils/Initializable.sol                  |  165 ++
  .../token/ERC20/IERC20Upgradeable.sol              |   82 +
@@ -172,7 +163,7 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
  .../contracts/v2/lib/PolygonConstantsBase.sol      |   14 +
  .../contracts/v2/lib/PolygonRollupBaseEtrog.sol    |  923 ++++++++++
  .../contracts/v2/lib/PolygonTransparentProxy.sol   |   79 +
- .../PolygonValidiumEtrog/implementation/meta.txt   |    2 +
+ .../AstarValidiumEtrog/implementation/meta.txt     |    2 +
  .../@openzeppelin/contracts5/access/Ownable.sol    |  100 +
  .../contracts5/interfaces/IERC1967.sol             |   24 +
  .../contracts5/proxy/ERC1967/ERC1967Proxy.sol      |   40 +
@@ -185,7 +176,7 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
  .../@openzeppelin/contracts5/utils/Context.sol     |   24 +
  .../@openzeppelin/contracts5/utils/StorageSlot.sol |  135 ++
  .../contracts/v2/lib/PolygonTransparentProxy.sol   |   79 +
- .../.code/PolygonValidiumEtrog/proxy/meta.txt      |    2 +
+ .../.code/AstarValidiumEtrog/proxy/meta.txt        |    2 +
  .../implementation/contracts/GnosisSafe.sol        |  422 +++++
  .../implementation/contracts/base/Executor.sol     |   27 +
  .../contracts/base/FallbackManager.sol             |   53 +
@@ -201,9 +192,27 @@ The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePen
  .../contracts/common/StorageAccessible.sol         |   47 +
  .../contracts/external/GnosisSafeMath.sol          |   54 +
  .../contracts/interfaces/ISignatureValidator.sol   |   20 +
- .../implementation/meta.txt                        |    2 +
+ .../AstarValidiumMultisig/implementation/meta.txt  |    2 +
  .../proxy/GnosisSafeProxy.sol                      |  155 ++
- .../.code/PolygonValidiumMultisig/proxy/meta.txt   |    2 +
+ .../.code/AstarValidiumMultisig/proxy/meta.txt     |    2 +
+ .../implementation/contracts/GnosisSafe.sol        |  422 +++++
+ .../implementation/contracts/base/Executor.sol     |   27 +
+ .../contracts/base/FallbackManager.sol             |   53 +
+ .../implementation/contracts/base/GuardManager.sol |   50 +
+ .../contracts/base/ModuleManager.sol               |  133 ++
+ .../implementation/contracts/base/OwnerManager.sol |  149 ++
+ .../implementation/contracts/common/Enum.sol       |    8 +
+ .../contracts/common/EtherPaymentFallback.sol      |   13 +
+ .../contracts/common/SecuredTokenTransfer.sol      |   35 +
+ .../contracts/common/SelfAuthorized.sol            |   16 +
+ .../contracts/common/SignatureDecoder.sol          |   36 +
+ .../implementation/contracts/common/Singleton.sol  |   11 +
+ .../contracts/common/StorageAccessible.sol         |   47 +
+ .../contracts/external/GnosisSafeMath.sol          |   54 +
+ .../contracts/interfaces/ISignatureValidator.sol   |   20 +
+ .../.code/GnosisSafe/implementation/meta.txt       |    2 +
+ .../.code/GnosisSafe/proxy/GnosisSafeProxy.sol     |  155 ++
+ .../ethereum/.code/GnosisSafe/proxy/meta.txt       |    2 +
  134 files changed, 14055 insertions(+)
 ```
 
@@ -216,26 +225,59 @@ discovery. Values are for block 19282832 (main branch discovery), not current.
 ```diff
     contract PolygonRollupManager (0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2) {
     +++ description: None
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.11:
 -        0
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.10:
 -        0
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.9:
 -        1984749
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.8:
 -        0
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.7:
 -        0
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.6:
 -        1991783
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.5:
 -        1991800
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.4:
 -        "0x8ad85f1e7b882d12cf6c64cf256cab8d255d6085e8109400741d82850a1d944b"
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.3:
 -        7
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.2:
 -        "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"
++++ description: Addresses of the rollup backend as well as the rollup verifier.
++++ type: STRUCTURE
++++ severity: MEDIUM
       values.rollupsData.0.1:
 -        1101
 +        "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"

--- a/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "polygonzkevm",
   "chain": "ethereum",
-  "blockNumber": 19282832,
-  "configHash": "0xc1ea489f39f5094e7b1fbceacae54f17cc1eedd835beeb18c4900095fae31a75",
+  "blockNumber": 19425934,
+  "configHash": "0xd294d42368e3e63637e4e5a4d8711e46a8e121c3d807629d9f98d3b4f2bacff9",
   "version": 3,
   "contracts": [
     {
@@ -29,12 +29,69 @@
       "derivedName": "ProxyAdmin"
     },
     {
+      "name": "PolygonValidiumAdmin",
+      "address": "0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d",
+      "upgradeability": {
+        "type": "immutable"
+      },
+      "sinceTimestamp": 1708624547,
+      "values": {
+        "owner": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E"
+      },
+      "derivedName": "ProxyAdmin"
+    },
+    {
       "name": "FflonkVerifier",
       "address": "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8",
       "upgradeability": {
         "type": "immutable"
       },
       "sinceTimestamp": 1706364923
+    },
+    {
+      "name": "PolygonValidiumEtrog",
+      "address": "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80",
+      "upgradeability": {
+        "type": "EIP1967 proxy",
+        "implementation": "0x9cf80f7eB1C76ec5AE7A88b417e373449b73ac30",
+        "admin": "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
+      },
+      "implementations": ["0x9cf80f7eB1C76ec5AE7A88b417e373449b73ac30"],
+      "sinceTimestamp": 1708632059,
+      "values": {
+        "admin": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E",
+        "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
+        "calculatePolPerForceBatch": 0,
+        "dataAvailabilityProtocol": "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0",
+        "forceBatchAddress": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E",
+        "forceBatchTimeout": 432000,
+        "gasTokenAddress": "0x0000000000000000000000000000000000000000",
+        "gasTokenNetwork": 0,
+        "GLOBAL_EXIT_ROOT_MANAGER_L2": "0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA",
+        "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
+        "INITIALIZE_TX_BRIDGE_LIST_LEN_LEN": 249,
+        "INITIALIZE_TX_BRIDGE_PARAMS": "0x80808401c9c38094",
+        "INITIALIZE_TX_BRIDGE_PARAMS_AFTER_BRIDGE_ADDRESS": "0x80b9",
+        "INITIALIZE_TX_BRIDGE_PARAMS_AFTER_BRIDGE_ADDRESS_EMPTY_METADATA": "0x80b8",
+        "INITIALIZE_TX_CONSTANT_BYTES": 32,
+        "INITIALIZE_TX_CONSTANT_BYTES_EMPTY_METADATA": 31,
+        "INITIALIZE_TX_DATA_LEN_EMPTY_METADATA": 228,
+        "INITIALIZE_TX_EFFECTIVE_PERCENTAGE": "0xff",
+        "isSequenceWithDataAvailabilityAllowed": false,
+        "lastAccInputHash": "0x6ce032bbfbd1c12025f50da075e988263b8623864a7a4b851d19af086a36c1d5",
+        "lastForceBatch": 0,
+        "lastForceBatchSequenced": 0,
+        "networkName": "Astar zkEVM",
+        "pendingAdmin": "0x0000000000000000000000000000000000000000",
+        "pol": "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
+        "rollupManager": "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2",
+        "SIGNATURE_INITIALIZE_TX_R": "0x00000000000000000000000000000000000000000000000000000005ca1ab1e0",
+        "SIGNATURE_INITIALIZE_TX_S": "0x000000000000000000000000000000000000000000000000000000005ca1ab1e",
+        "SIGNATURE_INITIALIZE_TX_V": 27,
+        "trustedSequencer": "0xD49CD5f9776A54fAe89B68205F6Af69586F98203",
+        "trustedSequencerURL": "https://rpc.astar-zkevm.gelato.digital"
+      },
+      "derivedName": "PolygonValidiumEtrog"
     },
     {
       "name": "AdminMultisig",
@@ -74,7 +131,7 @@
         "gasTokenAddress": "0x0000000000000000000000000000000000000000",
         "gasTokenMetadata": "0x",
         "gasTokenNetwork": 0,
-        "getRoot": "0xd70ef26fdae205a2005eef354691977c7e836044b7c18035deeea9a0ad297eb1",
+        "getRoot": "0xfb11dbcb83337959af04d409ac405cabb5909eb3400268b4aee867640df74cfb",
         "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
         "isEmergencyState": false,
         "networkID": 0,
@@ -133,16 +190,17 @@
           []
         ],
         "EMISSION_ROLE": "0x573321b8a13c75b2702bc4b0ad9afaae98bf6985285411964a564e68bf6da1c9",
-        "lastMint": 1707890975,
+        "lastMint": 1710310247,
         "mintPerSecondCap": "13370000000000000000",
         "name": "Polygon Ecosystem Token",
         "PERMIT2": "0x000000000022D473030F116dDEE9F6B43aC78BA3",
         "PERMIT2_REVOKER_ROLE": "0xbd4c1461ef59750b24719a44d7e2a7948c57fd12c98e333541b7ea7b61f07cb7",
         "permit2Enabled": true,
         "symbol": "POL",
-        "totalSupply": "10091013227478185580000000000",
+        "totalSupply": "10113921492245423640000000000",
         "version": "1.1.0"
-      }
+      },
+      "derivedName": "PolygonEcosystemToken"
     },
     {
       "name": "daiBridge",
@@ -171,7 +229,7 @@
         ],
         "pendingDefaultAdminDelay": [0, 0],
         "sdai": "0x83F20F44975D03b1b09e64809B757c47f942BEeA",
-        "totalBridgedDAI": "62850000000000000000",
+        "totalBridgedDAI": "252815555626934742210448",
         "totalProtocolDAI": "1000000000000000000",
         "zkEvmBridge": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe"
       },
@@ -196,7 +254,10 @@
           },
           "TRUSTED_AGGREGATOR": {
             "adminRole": "TRUSTED_AGGREGATOR_ADMIN",
-            "members": ["0x6329Fe417621925C81c16F9F9a18c203C21Af7ab"]
+            "members": [
+              "0x6329Fe417621925C81c16F9F9a18c203C21Af7ab",
+              "0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE"
+            ]
           },
           "ADD_ROLLUP_TYPE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -246,34 +307,28 @@
         "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "getBatchFee": "100000000000000000",
-        "getRollupExitRoot": "0xe5fff67927180b54d65c809ec59cf145fb867341223f8ea770c1bbf7cbaa4065",
+        "getRollupExitRoot": "0x5bbe036e33f5ec881ad526b9c9001cfe970e75797070bd545a778ca9b3728fee",
         "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
         "isEmergencyState": false,
-        "lastAggregationTimestamp": 1708598195,
+        "lastAggregationTimestamp": 1710329975,
         "lastDeactivatedEmergencyStateTimestamp": 0,
         "nondeterminsiticPendingState": [],
         "pendingStateTimeout": 432000,
         "pol": "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6",
-        "rollupCount": 1,
+        "rollupCount": 2,
         "rollupsData": [
           [
             "0x519E42c24163192Dca44CD3fBDCEBF6be9130987",
-            1101,
-            "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8",
-            7,
-            "0x8ad85f1e7b882d12cf6c64cf256cab8d255d6085e8109400741d82850a1d944b",
-            1991800,
-            1991783,
-            0,
-            0,
-            1984749,
-            0,
-            0
+            "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"
+          ],
+          [
+            "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80",
+            "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8"
           ]
         ],
-        "rollupTypeCount": 0,
-        "totalSequencedBatches": 7051,
-        "totalVerifiedBatches": 7034,
+        "rollupTypeCount": 1,
+        "totalSequencedBatches": 15620,
+        "totalVerifiedBatches": 15518,
         "trustedAggregatorTimeout": 432000,
         "verifyBatchTimeTarget": 1800
       },
@@ -307,7 +362,7 @@
         "INITIALIZE_TX_CONSTANT_BYTES_EMPTY_METADATA": 31,
         "INITIALIZE_TX_DATA_LEN_EMPTY_METADATA": 228,
         "INITIALIZE_TX_EFFECTIVE_PERCENTAGE": "0xff",
-        "lastAccInputHash": "0x32c4d9649fa9fd5d443d165be04d1428c0f38919933fbca1eab2367beafdc974",
+        "lastAccInputHash": "0xd4918ec03da716176ebd982a9595494b41b4527b2852b42bc1c6dedd617f111c",
         "lastForceBatch": 0,
         "lastForceBatchSequenced": 0,
         "networkName": "polygon zkEVM",
@@ -335,11 +390,34 @@
       "sinceTimestamp": 1679653151,
       "values": {
         "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
-        "depositCount": 1351,
-        "getRoot": "0x1bd1cd9522b0046fca0176dc565d9c898b662d3939d05bab0b3992a2a643f6a8",
+        "depositCount": 3546,
+        "getRoot": "0x263f4a5fea4d642b508e8605b17cac0de54811c9c0b9fee14e917d6e893a5d98",
         "rollupManager": "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
       },
       "derivedName": "PolygonZkEVMGlobalExitRootV2"
+    },
+    {
+      "name": "GnosisSafe",
+      "address": "0x6c4876Ecb5de33f76700f44d547C593065806dAC",
+      "upgradeability": {
+        "type": "gnosis safe",
+        "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+        "modules": []
+      },
+      "implementations": ["0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"],
+      "sinceTimestamp": 1708443503,
+      "values": {
+        "domainSeparator": "0x441d2a12799495cc46b37e56d46fc0f7f724dc7414f16f665f284d32eac972e0",
+        "getChainId": 1,
+        "getOwners": [
+          "0xEc33045FA66cF43E9b5b9F332dc124dbc71c0917",
+          "0x33f9b8ac59814E1A0a59e5d1a6125E5E7AF58BA8",
+          "0x2b3Aa0Dc0622eFb9426F5A44015aE9151Bd8224C"
+        ],
+        "getThreshold": 1,
+        "nonce": 2,
+        "VERSION": "1.3.0"
+      }
     },
     {
       "name": "usdcBridge",
@@ -360,6 +438,50 @@
         "zkNetworkId": 1
       },
       "derivedName": "L1Escrow"
+    },
+    {
+      "name": "PolygonValidiumDAC",
+      "address": "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0",
+      "upgradeability": {
+        "type": "EIP1967 proxy",
+        "implementation": "0xF4e87685e323818E0aE35dCdFc3B65106002E456",
+        "admin": "0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d"
+      },
+      "implementations": ["0xF4e87685e323818E0aE35dCdFc3B65106002E456"],
+      "sinceTimestamp": 1708624559,
+      "values": {
+        "committeeHash": "0xf3b713b9d34dd6c8f99950e7f622937def5d1044471824b807c8b9dbedf75d2f",
+        "getAmountOfMembers": 5,
+        "getProcotolName": "DataAvailabilityCommittee",
+        "members": [
+          [
+            "http://cdk-validium-dac-5-prod-6d3f0-port1.cdk-validium-deployment-6d3f0.svc.cluster.local:8444",
+            "0x08EbBdFf8cB6d1336515A89641e899bc8ce91F2C"
+          ],
+          [
+            "http://cdk-validium-dac-4-prod-6d3f0-port1.cdk-validium-deployment-6d3f0.svc.cluster.local:8444",
+            "0x37f0B74e0Fc72aDAAb1Fd39Ec6d779F596866aB8"
+          ],
+          [
+            "http://cdk-validium-dac-3-prod-6d3f0-port1.cdk-validium-deployment-6d3f0.svc.cluster.local:8444",
+            "0x8FB3cb4777EE1c2C35C48aC69a650026d18aFF08"
+          ],
+          [
+            "http://cdk-validium-dac-2-prod-6d3f0-port1.cdk-validium-deployment-6d3f0.svc.cluster.local:8444",
+            "0xCFb77B6abb27e04cE0DB347cCCd5544f51A98CBc"
+          ],
+          [
+            "http://cdk-validium-dac-1-prod-6d3f0-port1.cdk-validium-deployment-6d3f0.svc.cluster.local:8444",
+            "0xF54b295a221B5d3510D03d9B16E23BA151da012A"
+          ]
+        ],
+        "owner": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E",
+        "requiredAmountOfSignatures": 3
+      },
+      "errors": {
+        "members": "Too many values. Update configuration to explore fully"
+      },
+      "derivedName": "PolygonDataCommittee"
     },
     {
       "name": "Timelock",
@@ -469,18 +591,54 @@
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
+    },
+    {
+      "name": "PolygonValidiumMultisig",
+      "address": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E",
+      "upgradeability": {
+        "type": "gnosis safe",
+        "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+        "modules": []
+      },
+      "implementations": ["0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552"],
+      "sinceTimestamp": 1708444367,
+      "values": {
+        "domainSeparator": "0x9eb12473e8e7bb9cf5c92b4b3effda22cbfcab7b4fb961127d7b5c3c54d2c943",
+        "getChainId": 1,
+        "getOwners": [
+          "0xe4D4fBC6e27B3AE9D881BD9400071FB6c62E4dfa",
+          "0xEc24369A1269171e3cb0A323DD920F99Cb528Fb0",
+          "0x127Bae6Fc751dC92111a359500ae91EB437f3dCb",
+          "0x83cC8195856b0463dEd5f052021009b7985FDa2C",
+          "0x4324c3960c7B2567D0C13ba17493bb364c407937",
+          "0x6c4876Ecb5de33f76700f44d547C593065806dAC"
+        ],
+        "getThreshold": 3,
+        "nonce": 5,
+        "VERSION": "1.3.0"
+      },
+      "derivedName": "GnosisSafe"
     }
   ],
   "eoas": [
+    "0x08EbBdFf8cB6d1336515A89641e899bc8ce91F2C",
     "0x099198353446A9E3a20672eDC1Bd461E978842c3",
+    "0x127Bae6Fc751dC92111a359500ae91EB437f3dCb",
     "0x148Ee7dAF16574cD020aFa34CC658f8F3fbd2800",
+    "0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE",
     "0x21887c89368bf918346c62460e0c339113801C28",
+    "0x2b3Aa0Dc0622eFb9426F5A44015aE9151Bd8224C",
+    "0x33f9b8ac59814E1A0a59e5d1a6125E5E7AF58BA8",
+    "0x37f0B74e0Fc72aDAAb1Fd39Ec6d779F596866aB8",
     "0x3ab9f4b964eE665F7CDf1d65f1cEEc6196B0D622",
+    "0x4324c3960c7B2567D0C13ba17493bb364c407937",
     "0x49c15936864690bCd6af0ecaca8E874adFF30E86",
     "0x4c1665d6651ecEfa59B9B3041951608468b18891",
     "0x4DE44Aa0Ef9DB64DF3eB3465d35D73d0409d44ed",
     "0x4E83124eD15b13265240B61EC9627797CCE1032E",
     "0x6329Fe417621925C81c16F9F9a18c203C21Af7ab",
+    "0x83cC8195856b0463dEd5f052021009b7985FDa2C",
+    "0x8FB3cb4777EE1c2C35C48aC69a650026d18aFF08",
     "0x9F7dfAb2222A473284205cdDF08a677726d786A0",
     "0xA0B02B28920812324f1cC3255bd8840867d3f227",
     "0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA",
@@ -489,12 +647,18 @@
     "0xBDa0B27f93B2FD3f076725b89cf02e48609bC189",
     "0xBDc235cC9d6Baa641c5ae306bc83962475A5FEFf",
     "0xc4591c41e01a7a654B5427f39Bbd1dEe5bD45D1D",
+    "0xCFb77B6abb27e04cE0DB347cCCd5544f51A98CBc",
     "0xD09971D8ed6C6a5e57581e90d593ee5B94e348D4",
     "0xd1B856ee12Bd00922cae8DD86ab068f8c0F95224",
+    "0xD49CD5f9776A54fAe89B68205F6Af69586F98203",
     "0xDB5D9c10FD2a92692DB51853e06058EE0436d69B",
+    "0xe4D4fBC6e27B3AE9D881BD9400071FB6c62E4dfa",
     "0xE6Ee0F8D81170160d50ed77b9C91E6219473d43a",
     "0xEad77b01ea770839F7f576Cd1516Ff6A298d9dB2",
+    "0xEc24369A1269171e3cb0A323DD920F99Cb528Fb0",
+    "0xEc33045FA66cF43E9b5b9F332dc124dbc71c0917",
     "0xF53D1fB2EeD22Cf1E8f7E90Da7f1CAe88344065F",
+    "0xF54b295a221B5d3510D03d9B16E23BA151da012A",
     "0xf56AE6520776934127AB68438d1b4652BCe07F8f",
     "0xFe45baf0F18c207152A807c1b05926583CFE2e4b"
   ],
@@ -656,8 +820,29 @@
       "function upgradeToAndCall(address newImplementation, bytes data) payable",
       "function wrappedTokenAddress() view returns (address)"
     ],
+    "0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d": [
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "function changeProxyAdmin(address proxy, address newAdmin)",
+      "function getProxyAdmin(address proxy) view returns (address)",
+      "function getProxyImplementation(address proxy) view returns (address)",
+      "function owner() view returns (address)",
+      "function renounceOwnership()",
+      "function transferOwnership(address newOwner)",
+      "function upgrade(address proxy, address implementation)",
+      "function upgradeAndCall(address proxy, address implementation, bytes data) payable"
+    ],
     "0x1C3A3da552b8662CD69538356b1E7c2E9CC1EBD8": [
       "function verifyProof(bytes32[24] proof, uint256[1] pubSignals) view returns (bool)"
+    ],
+    "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80": [
+      "constructor(address _logic, address admin, bytes _data) payable",
+      "error AddressEmptyCode(address target)",
+      "error ERC1967InvalidAdmin(address admin)",
+      "error ERC1967InvalidImplementation(address implementation)",
+      "error ERC1967NonPayable()",
+      "error FailedInnerCall()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event Upgraded(address indexed implementation)"
     ],
     "0x242daE44F5d8fb54B198D03a94dA45B5a4413e21": [
       "constructor(address _singleton)"
@@ -898,6 +1083,9 @@
       "function upgradeTo(address newImplementation)",
       "function upgradeToAndCall(address newImplementation, bytes data) payable"
     ],
+    "0x6c4876Ecb5de33f76700f44d547C593065806dAC": [
+      "constructor(address _singleton)"
+    ],
     "0x70E70e58ed7B1Cec0D8ef7464072ED8A52d755eB": [
       "constructor(address impl_, bytes data_) payable",
       "event AdminChanged(address previousAdmin, address newAdmin)",
@@ -1009,6 +1197,127 @@
       "function setForceBatchTimeout(uint64 newforceBatchTimeout)",
       "function setTrustedSequencer(address newTrustedSequencer)",
       "function setTrustedSequencerURL(string newTrustedSequencerURL)",
+      "function transferAdminRole(address newPendingAdmin)",
+      "function trustedSequencer() view returns (address)",
+      "function trustedSequencerURL() view returns (string)"
+    ],
+    "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0": [
+      "constructor(address _logic, address admin_, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "0x9cf80f7eB1C76ec5AE7A88b417e373449b73ac30": [
+      "constructor(address _globalExitRootManager, address _pol, address _bridgeAddress, address _rollupManager)",
+      "error BatchAlreadyVerified()",
+      "error BatchNotSequencedOrNotSequenceEnd()",
+      "error ExceedMaxVerifyBatches()",
+      "error FinalNumBatchBelowLastVerifiedBatch()",
+      "error FinalNumBatchDoesNotMatchPendingState()",
+      "error FinalPendingStateNumInvalid()",
+      "error ForceBatchNotAllowed()",
+      "error ForceBatchTimeoutNotExpired()",
+      "error ForceBatchesAlreadyActive()",
+      "error ForceBatchesDecentralized()",
+      "error ForceBatchesNotAllowedOnEmergencyState()",
+      "error ForceBatchesOverflow()",
+      "error ForcedDataDoesNotMatch()",
+      "error GasTokenNetworkMustBeZeroOnEther()",
+      "error GlobalExitRootNotExist()",
+      "error HaltTimeoutNotExpired()",
+      "error HaltTimeoutNotExpiredAfterEmergencyState()",
+      "error HugeTokenMetadataNotSupported()",
+      "error InitNumBatchAboveLastVerifiedBatch()",
+      "error InitNumBatchDoesNotMatchPendingState()",
+      "error InvalidInitializeTransaction()",
+      "error InvalidProof()",
+      "error InvalidRangeBatchTimeTarget()",
+      "error InvalidRangeForceBatchTimeout()",
+      "error InvalidRangeMultiplierBatchFee()",
+      "error NewAccInputHashDoesNotExist()",
+      "error NewPendingStateTimeoutMustBeLower()",
+      "error NewStateRootNotInsidePrime()",
+      "error NewTrustedAggregatorTimeoutMustBeLower()",
+      "error NotEnoughMaticAmount()",
+      "error NotEnoughPOLAmount()",
+      "error OldAccInputHashDoesNotExist()",
+      "error OldStateRootDoesNotExist()",
+      "error OnlyAdmin()",
+      "error OnlyPendingAdmin()",
+      "error OnlyRollupManager()",
+      "error OnlyTrustedAggregator()",
+      "error OnlyTrustedSequencer()",
+      "error PendingStateDoesNotExist()",
+      "error PendingStateInvalid()",
+      "error PendingStateNotConsolidable()",
+      "error PendingStateTimeoutExceedHaltAggregationTimeout()",
+      "error SequenceWithDataAvailabilityNotAllowed()",
+      "error SequenceZeroBatches()",
+      "error SequencedTimestampBelowForcedTimestamp()",
+      "error SequencedTimestampInvalid()",
+      "error StoredRootMustBeDifferentThanNewRoot()",
+      "error SwitchToSameValue()",
+      "error TransactionsLengthAboveMax()",
+      "error TrustedAggregatorTimeoutExceedHaltAggregationTimeout()",
+      "error TrustedAggregatorTimeoutNotExpired()",
+      "event AcceptAdminRole(address newAdmin)",
+      "event ForceBatch(uint64 indexed forceBatchNum, bytes32 lastGlobalExitRoot, address sequencer, bytes transactions)",
+      "event InitialSequenceBatches(bytes transactions, bytes32 lastGlobalExitRoot, address sequencer)",
+      "event Initialized(uint8 version)",
+      "event SequenceBatches(uint64 indexed numBatch, bytes32 l1InfoRoot)",
+      "event SequenceForceBatches(uint64 indexed numBatch)",
+      "event SetDataAvailabilityProtocol(address newDataAvailabilityProtocol)",
+      "event SetForceBatchAddress(address newForceBatchAddress)",
+      "event SetForceBatchTimeout(uint64 newforceBatchTimeout)",
+      "event SetTrustedSequencer(address newTrustedSequencer)",
+      "event SetTrustedSequencerURL(string newTrustedSequencerURL)",
+      "event SwitchSequenceWithDataAvailability()",
+      "event TransferAdminRole(address newPendingAdmin)",
+      "event VerifyBatches(uint64 indexed numBatch, bytes32 stateRoot, address indexed aggregator)",
+      "function GLOBAL_EXIT_ROOT_MANAGER_L2() view returns (address)",
+      "function INITIALIZE_TX_BRIDGE_LIST_LEN_LEN() view returns (uint8)",
+      "function INITIALIZE_TX_BRIDGE_PARAMS() view returns (bytes)",
+      "function INITIALIZE_TX_BRIDGE_PARAMS_AFTER_BRIDGE_ADDRESS() view returns (bytes)",
+      "function INITIALIZE_TX_BRIDGE_PARAMS_AFTER_BRIDGE_ADDRESS_EMPTY_METADATA() view returns (bytes)",
+      "function INITIALIZE_TX_CONSTANT_BYTES() view returns (uint16)",
+      "function INITIALIZE_TX_CONSTANT_BYTES_EMPTY_METADATA() view returns (uint16)",
+      "function INITIALIZE_TX_DATA_LEN_EMPTY_METADATA() view returns (uint8)",
+      "function INITIALIZE_TX_EFFECTIVE_PERCENTAGE() view returns (bytes1)",
+      "function SIGNATURE_INITIALIZE_TX_R() view returns (bytes32)",
+      "function SIGNATURE_INITIALIZE_TX_S() view returns (bytes32)",
+      "function SIGNATURE_INITIALIZE_TX_V() view returns (uint8)",
+      "function acceptAdminRole()",
+      "function admin() view returns (address)",
+      "function bridgeAddress() view returns (address)",
+      "function calculatePolPerForceBatch() view returns (uint256)",
+      "function dataAvailabilityProtocol() view returns (address)",
+      "function forceBatch(bytes transactions, uint256 polAmount)",
+      "function forceBatchAddress() view returns (address)",
+      "function forceBatchTimeout() view returns (uint64)",
+      "function forcedBatches(uint64) view returns (bytes32)",
+      "function gasTokenAddress() view returns (address)",
+      "function gasTokenNetwork() view returns (uint32)",
+      "function generateInitializeTransaction(uint32 networkID, address _gasTokenAddress, uint32 _gasTokenNetwork, bytes _gasTokenMetadata) view returns (bytes)",
+      "function globalExitRootManager() view returns (address)",
+      "function initialize(address _admin, address sequencer, uint32 networkID, address _gasTokenAddress, string sequencerURL, string _networkName)",
+      "function isSequenceWithDataAvailabilityAllowed() view returns (bool)",
+      "function lastAccInputHash() view returns (bytes32)",
+      "function lastForceBatch() view returns (uint64)",
+      "function lastForceBatchSequenced() view returns (uint64)",
+      "function networkName() view returns (string)",
+      "function onVerifyBatches(uint64 lastVerifiedBatch, bytes32 newStateRoot, address aggregator)",
+      "function pendingAdmin() view returns (address)",
+      "function pol() view returns (address)",
+      "function rollupManager() view returns (address)",
+      "function sequenceBatches(tuple(bytes transactions, bytes32 forcedGlobalExitRoot, uint64 forcedTimestamp, bytes32 forcedBlockHashL1)[] batches, address l2Coinbase)",
+      "function sequenceBatchesValidium(tuple(bytes32 transactionsHash, bytes32 forcedGlobalExitRoot, uint64 forcedTimestamp, bytes32 forcedBlockHashL1)[] batches, address l2Coinbase, bytes dataAvailabilityMessage)",
+      "function sequenceForceBatches(tuple(bytes transactions, bytes32 forcedGlobalExitRoot, uint64 forcedTimestamp, bytes32 forcedBlockHashL1)[] batches)",
+      "function setDataAvailabilityProtocol(address newDataAvailabilityProtocol)",
+      "function setForceBatchAddress(address newForceBatchAddress)",
+      "function setForceBatchTimeout(uint64 newforceBatchTimeout)",
+      "function setTrustedSequencer(address newTrustedSequencer)",
+      "function setTrustedSequencerURL(string newTrustedSequencerURL)",
+      "function switchSequenceWithDataAvailability(bool newIsSequenceWithDataAvailabilityAllowed)",
       "function transferAdminRole(address newPendingAdmin)",
       "function trustedSequencer() view returns (address)",
       "function trustedSequencerURL() view returns (string)"
@@ -1140,6 +1449,30 @@
       "event BeaconUpgraded(address indexed beacon)",
       "event Upgraded(address indexed implementation)"
     ],
+    "0xF4e87685e323818E0aE35dCdFc3B65106002E456": [
+      "constructor()",
+      "error CommitteeAddressDoesNotExist()",
+      "error EmptyURLNotAllowed()",
+      "error TooManyRequiredSignatures()",
+      "error UnexpectedAddrsAndSignaturesSize()",
+      "error UnexpectedAddrsBytesLength()",
+      "error UnexpectedCommitteeHash()",
+      "error WrongAddrOrder()",
+      "event CommitteeUpdated(bytes32 committeeHash)",
+      "event Initialized(uint8 version)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "function committeeHash() view returns (bytes32)",
+      "function getAmountOfMembers() view returns (uint256)",
+      "function getProcotolName() pure returns (string)",
+      "function initialize()",
+      "function members(uint256) view returns (string url, address addr)",
+      "function owner() view returns (address)",
+      "function renounceOwnership()",
+      "function requiredAmountOfSignatures() view returns (uint256)",
+      "function setupCommittee(uint256 _requiredAmountOfSignatures, string[] urls, bytes addrsBytes)",
+      "function transferOwnership(address newOwner)",
+      "function verifyMessage(bytes32 signedHash, bytes signaturesAndAddrs) view"
+    ],
     "0xF684f2CB299cCDaAB483ffc1573B82f40C6b775b": [
       "constructor()",
       "error BeneficiaryInvalid(address newBeneficiary)",
@@ -1201,6 +1534,9 @@
       "function zkEvmBridge() view returns (address)"
     ],
     "0xf694C9e3a34f5Fa48b6f3a0Ff186C1c6c4FcE904": [
+      "constructor(address _singleton)"
+    ],
+    "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E": [
       "constructor(address _singleton)"
     ]
   }

--- a/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "polygonzkevm",
   "chain": "ethereum",
-  "blockNumber": 19425934,
-  "configHash": "0xd294d42368e3e63637e4e5a4d8711e46a8e121c3d807629d9f98d3b4f2bacff9",
+  "blockNumber": 19433041,
+  "configHash": "0xc0c3d0c45a89fcc13d0efceae0616aaa893e0f5ac1278282ade4efc093d710dd",
   "version": 3,
   "contracts": [
     {
@@ -29,7 +29,7 @@
       "derivedName": "ProxyAdmin"
     },
     {
-      "name": "PolygonValidiumAdmin",
+      "name": "AstarValidiumAdmin",
       "address": "0x1963D7b78e75A5eDfF9e5376E7A07A935Fb3d50d",
       "upgradeability": {
         "type": "immutable"
@@ -49,7 +49,7 @@
       "sinceTimestamp": 1706364923
     },
     {
-      "name": "PolygonValidiumEtrog",
+      "name": "AstarValidiumEtrog",
       "address": "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80",
       "upgradeability": {
         "type": "EIP1967 proxy",
@@ -78,7 +78,7 @@
         "INITIALIZE_TX_DATA_LEN_EMPTY_METADATA": 228,
         "INITIALIZE_TX_EFFECTIVE_PERCENTAGE": "0xff",
         "isSequenceWithDataAvailabilityAllowed": false,
-        "lastAccInputHash": "0x6ce032bbfbd1c12025f50da075e988263b8623864a7a4b851d19af086a36c1d5",
+        "lastAccInputHash": "0xc679d5f004da847ca75829c22bcd1ed71ae14ade63e5e7b72e99c29d7ffa98f4",
         "lastForceBatch": 0,
         "lastForceBatchSequenced": 0,
         "networkName": "Astar zkEVM",
@@ -131,7 +131,7 @@
         "gasTokenAddress": "0x0000000000000000000000000000000000000000",
         "gasTokenMetadata": "0x",
         "gasTokenNetwork": 0,
-        "getRoot": "0xfb11dbcb83337959af04d409ac405cabb5909eb3400268b4aee867640df74cfb",
+        "getRoot": "0xae3b9cb3d22fff3b95385be0c0f2c90a4d506eec4689a92414949e71e2a6cf15",
         "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
         "isEmergencyState": false,
         "networkID": 0,
@@ -307,10 +307,10 @@
         "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "getBatchFee": "100000000000000000",
-        "getRollupExitRoot": "0x5bbe036e33f5ec881ad526b9c9001cfe970e75797070bd545a778ca9b3728fee",
+        "getRollupExitRoot": "0xa9e39414579e6d0b5f1fefabae67b9b1d6072d42900ad07d6ea9433a687e4887",
         "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
         "isEmergencyState": false,
-        "lastAggregationTimestamp": 1710329975,
+        "lastAggregationTimestamp": 1710415847,
         "lastDeactivatedEmergencyStateTimestamp": 0,
         "nondeterminsiticPendingState": [],
         "pendingStateTimeout": 432000,
@@ -327,8 +327,8 @@
           ]
         ],
         "rollupTypeCount": 1,
-        "totalSequencedBatches": 15620,
-        "totalVerifiedBatches": 15518,
+        "totalSequencedBatches": 16057,
+        "totalVerifiedBatches": 16037,
         "trustedAggregatorTimeout": 432000,
         "verifyBatchTimeTarget": 1800
       },
@@ -362,7 +362,7 @@
         "INITIALIZE_TX_CONSTANT_BYTES_EMPTY_METADATA": 31,
         "INITIALIZE_TX_DATA_LEN_EMPTY_METADATA": 228,
         "INITIALIZE_TX_EFFECTIVE_PERCENTAGE": "0xff",
-        "lastAccInputHash": "0xd4918ec03da716176ebd982a9595494b41b4527b2852b42bc1c6dedd617f111c",
+        "lastAccInputHash": "0x9e0fd722c6fae5c4096432688187ede63ac825e00ba00822d32c3532f3533ab2",
         "lastForceBatch": 0,
         "lastForceBatchSequenced": 0,
         "networkName": "polygon zkEVM",
@@ -390,8 +390,8 @@
       "sinceTimestamp": 1679653151,
       "values": {
         "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
-        "depositCount": 3546,
-        "getRoot": "0x263f4a5fea4d642b508e8605b17cac0de54811c9c0b9fee14e917d6e893a5d98",
+        "depositCount": 3685,
+        "getRoot": "0x31fa6cbd18b2dac33a73f82684b0bee61b1cef6796e3b17e88acb9630cded384",
         "rollupManager": "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
       },
       "derivedName": "PolygonZkEVMGlobalExitRootV2"
@@ -440,7 +440,7 @@
       "derivedName": "L1Escrow"
     },
     {
-      "name": "PolygonValidiumDAC",
+      "name": "AstarValidiumDAC",
       "address": "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0",
       "upgradeability": {
         "type": "EIP1967 proxy",
@@ -477,9 +477,6 @@
         ],
         "owner": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E",
         "requiredAmountOfSignatures": 3
-      },
-      "errors": {
-        "members": "Too many values. Update configuration to explore fully"
       },
       "derivedName": "PolygonDataCommittee"
     },
@@ -593,7 +590,7 @@
       "derivedName": "GnosisSafe"
     },
     {
-      "name": "PolygonValidiumMultisig",
+      "name": "AstarValidiumMultisig",
       "address": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E",
       "upgradeability": {
         "type": "gnosis safe",

--- a/packages/backend/discovery/polygonzkevm/ethereum/meta.json
+++ b/packages/backend/discovery/polygonzkevm/ethereum/meta.json
@@ -1,0 +1,763 @@
+{
+  "$schema": "https://raw.githubusercontent.com/l2beat/tools/main/schemas/meta.schema.json",
+  "contracts": [
+    {
+      "name": "wstETHBridge",
+      "values": {
+        "counterpartContract": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "counterpartNetwork": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "DEFAULT_ADMIN_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdmin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdminDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdminDelayIncreaseWait": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "EMERGENCY_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "originTokenAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "originTokenNetwork": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "owner": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "paused": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingDefaultAdmin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingDefaultAdminDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "polygonZkEVMBridge": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "wrappedTokenAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "usdcBridge",
+      "values": {
+        "bridge": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "l1USDC": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "owner": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "paused": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "zkMinterBurner": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "zkNetworkId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "daiBridge",
+      "values": {
+        "beneficiary": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "dai": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "DEFAULT_ADMIN_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdmin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdminDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdminDelayIncreaseWait": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "destAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "destId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "MAKER_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "owner": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingDefaultAdmin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingDefaultAdminDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "sdai": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "totalBridgedDAI": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "totalProtocolDAI": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "zkEvmBridge": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "PolygonRollupManager",
+      "values": {
+        "bridgeAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "DEFAULT_ADMIN_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getBatchFee": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getRollupExitRoot": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "globalExitRootManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "isEmergencyState": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "lastAggregationTimestamp": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "lastDeactivatedEmergencyStateTimestamp": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingStateTimeout": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pol": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "rollupCount": {
+          "description": "The number of rollups that the manager can use.",
+          "severity": "LOW",
+          "type": "STRUCTURE"
+        },
+        "rollupTypeCount": {
+          "description": "The number of unique rollup types that the manager can use.",
+          "severity": "MEDIUM",
+          "type": "STRUCTURE"
+        },
+        "totalSequencedBatches": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "totalVerifiedBatches": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "trustedAggregatorTimeout": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "verifyBatchTimeTarget": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "_HALT_AGGREGATION_TIMEOUT": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "accessControl": {
+          "description": null,
+          "severity": "MEDIUM",
+          "type": "PERMISSION"
+        },
+        "nondeterminsiticPendingState": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "rollupsData": {
+          "description": "Addresses of the rollup backend as well as the rollup verifier.",
+          "severity": "MEDIUM",
+          "type": "STRUCTURE"
+        }
+      }
+    },
+    {
+      "name": "FflonkVerifier",
+      "values": {}
+    },
+    {
+      "name": "PolygonEcosystemToken",
+      "values": {
+        "CAP_MANAGER_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "decimals": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "DEFAULT_ADMIN_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "DOMAIN_SEPARATOR": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "eip712Domain": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "EMISSION_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "lastMint": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "mintPerSecondCap": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "name": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PERMIT2": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PERMIT2_REVOKER_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "permit2Enabled": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "symbol": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "totalSupply": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "version": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "ProxyAdmin",
+      "values": {
+        "owner": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "SecurityCouncil",
+      "values": {
+        "domainSeparator": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getChainId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getOwners": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getThreshold": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "VERSION": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "Bridge",
+      "values": {
+        "BASE_INIT_BYTECODE_WRAPPED_TOKEN": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "gasTokenAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "gasTokenMetadata": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "gasTokenNetwork": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getRoot": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "globalExitRootManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "isEmergencyState": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "networkID": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "polygonRollupManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "WETHToken": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "EscrowsAdmin",
+      "values": {
+        "domainSeparator": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getChainId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getOwners": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getThreshold": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "VERSION": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "GlobalExitRootV2",
+      "values": {
+        "bridgeAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "depositCount": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getRoot": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "rollupManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "AdminMultisig",
+      "values": {
+        "domainSeparator": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getChainId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getOwners": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getThreshold": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "VERSION": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "Timelock",
+      "values": {
+        "getMinDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "polygonZkEVM": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "accessControl": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "PolygonZkEVMExistentEtrog",
+      "values": {
+        "admin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "bridgeAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "calculatePolPerForceBatch": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "forceBatchAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "forceBatchTimeout": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "gasTokenAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "gasTokenNetwork": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "GLOBAL_EXIT_ROOT_MANAGER_L2": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "globalExitRootManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_BRIDGE_LIST_LEN_LEN": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_BRIDGE_PARAMS": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_BRIDGE_PARAMS_AFTER_BRIDGE_ADDRESS": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_BRIDGE_PARAMS_AFTER_BRIDGE_ADDRESS_EMPTY_METADATA": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_CONSTANT_BYTES": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_CONSTANT_BYTES_EMPTY_METADATA": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_DATA_LEN_EMPTY_METADATA": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "INITIALIZE_TX_EFFECTIVE_PERCENTAGE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "lastAccInputHash": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "lastForceBatch": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "lastForceBatchSequenced": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "networkName": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingAdmin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pol": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "rollupManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "SET_UP_ETROG_TX": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "SIGNATURE_INITIALIZE_TX_R": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "SIGNATURE_INITIALIZE_TX_S": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "SIGNATURE_INITIALIZE_TX_V": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "trustedSequencer": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "trustedSequencerURL": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "",
+      "values": {}
+    },
+    {
+      "name": "Permit2",
+      "values": {
+        "DOMAIN_SEPARATOR": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    }
+  ]
+}

--- a/packages/backend/discovery/polygonzkevm/ethereum/meta.json
+++ b/packages/backend/discovery/polygonzkevm/ethereum/meta.json
@@ -2,6 +2,91 @@
   "$schema": "https://raw.githubusercontent.com/l2beat/tools/main/schemas/meta.schema.json",
   "contracts": [
     {
+      "name": "daiBridge",
+      "values": {
+        "beneficiary": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "dai": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "DEFAULT_ADMIN_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdmin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdminDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "defaultAdminDelayIncreaseWait": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "destAddress": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "destId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "MAKER_ROLE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "owner": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingDefaultAdmin": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "pendingDefaultAdminDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "sdai": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "totalBridgedDAI": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "totalProtocolDAI": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "zkEvmBridge": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
       "name": "wstETHBridge",
       "values": {
         "counterpartContract": {
@@ -110,91 +195,6 @@
           "type": null
         },
         "zkNetworkId": {
-          "description": null,
-          "severity": null,
-          "type": null
-        }
-      }
-    },
-    {
-      "name": "daiBridge",
-      "values": {
-        "beneficiary": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "dai": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "DEFAULT_ADMIN_ROLE": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "defaultAdmin": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "defaultAdminDelay": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "defaultAdminDelayIncreaseWait": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "destAddress": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "destId": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "MAKER_ROLE": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "owner": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "pendingDefaultAdmin": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "pendingDefaultAdminDelay": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "sdai": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "totalBridgedDAI": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "totalProtocolDAI": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "zkEvmBridge": {
           "description": null,
           "severity": null,
           "type": null
@@ -311,6 +311,16 @@
       "values": {}
     },
     {
+      "name": "ProxyAdmin",
+      "values": {
+        "owner": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
       "name": "PolygonEcosystemToken",
       "values": {
         "CAP_MANAGER_ROLE": {
@@ -391,46 +401,6 @@
       }
     },
     {
-      "name": "ProxyAdmin",
-      "values": {
-        "owner": {
-          "description": null,
-          "severity": null,
-          "type": null
-        }
-      }
-    },
-    {
-      "name": "SecurityCouncil",
-      "values": {
-        "domainSeparator": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "getChainId": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "getOwners": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "getThreshold": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "VERSION": {
-          "description": null,
-          "severity": null,
-          "type": null
-        }
-      }
-    },
-    {
       "name": "Bridge",
       "values": {
         "BASE_INIT_BYTECODE_WRAPPED_TOKEN": {
@@ -486,6 +456,36 @@
       }
     },
     {
+      "name": "AdminMultisig",
+      "values": {
+        "domainSeparator": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getChainId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getOwners": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getThreshold": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "VERSION": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
       "name": "EscrowsAdmin",
       "values": {
         "domainSeparator": {
@@ -534,56 +534,6 @@
           "type": null
         },
         "rollupManager": {
-          "description": null,
-          "severity": null,
-          "type": null
-        }
-      }
-    },
-    {
-      "name": "AdminMultisig",
-      "values": {
-        "domainSeparator": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "getChainId": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "getOwners": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "getThreshold": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "VERSION": {
-          "description": null,
-          "severity": null,
-          "type": null
-        }
-      }
-    },
-    {
-      "name": "Timelock",
-      "values": {
-        "getMinDelay": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "polygonZkEVM": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "accessControl": {
           "description": null,
           "severity": null,
           "type": null
@@ -739,6 +689,56 @@
           "type": null
         },
         "trustedSequencerURL": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "SecurityCouncil",
+      "values": {
+        "domainSeparator": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getChainId": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getOwners": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "getThreshold": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "VERSION": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "Timelock",
+      "values": {
+        "getMinDelay": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "polygonZkEVM": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "accessControl": {
           "description": null,
           "severity": null,
           "type": null

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -36,7 +36,7 @@
     "@koa/router": "^12.0.0",
     "@l2beat/backend-tools": "^0.5.0",
     "@l2beat/config": "*",
-    "@l2beat/discovery": "0.45.1",
+    "@l2beat/discovery": "0.45.4",
     "@l2beat/discovery-types": "0.8.0",
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,7 +26,7 @@
     "@l2beat/discovery-types": "0.8.0",
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
-    "@l2beat/discovery": "0.45.1",
+    "@l2beat/discovery": "0.45.4",
     "chalk": "^4.1.2",
     "cheerio": "^1.0.0-rc.11",
     "ethers": "^5.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,10 +2205,10 @@
   dependencies:
     zod "^3.22.2"
 
-"@l2beat/discovery@0.45.1":
-  version "0.45.1"
-  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.45.1.tgz#809fb34149378406c6e0983bd5df6a1c98f1fee6"
-  integrity sha512-ax3Bn4lPiwYXwXtqSowoZ2e6ETxYQbGIHHveSI+bJ3xucRDzoMTM1lMDl4TKTUEgpHlNvWB1SHBE5m4m8JSj1Q==
+"@l2beat/discovery@0.45.4":
+  version "0.45.4"
+  resolved "https://registry.yarnpkg.com/@l2beat/discovery/-/discovery-0.45.4.tgz#99ba94d430965b7142aa972d5cb076254e634f23"
+  integrity sha512-WQ3HzOs3IOc+jVLP8uGHrYKEnMXOS2ZjZ7x6WVSUqz2OSQHZLbCMH/XoxIHHQWkTniGMuAq9KoMnnTJhp5NmRg==
   dependencies:
     "@l2beat/backend-tools" "^0.5.1"
     "@l2beat/discovery-types" "^0.8.0"


### PR DESCRIPTION
Resolves L2B-4125

## Description

Added a Validium - AstarZKEVM.
The validium is owned by AstarValidiumAdmin that itself is owned by AstarValidiumMultisig.

A trusted aggregator has been added that is an [EOA](https://etherscan.io/address/0x20A53dCb196cD2bcc14Ece01F358f1C849aA51dE).
On 2024-02-29 [willbutton.eth](https://etherscan.io/tx/0x760fd86f9453477e23df16def04777fb6282dda9f8546e93b2f7b866467b2e49) sent some eth to that address.
A day later it was given 5ETH by a [multisig](https://etherscan.io/address/0xc984295ad7a950fb5031154bcfc0b6267b948706) and 20ETH a week later by the same multisig.
The account has been calling `verifyBatchesTrustedAggregator()` starting from 2024-03-04 and does so around once an hour.
We don't have that multisig in any discovery.
The trusted aggregator can call `verifyBatchesTrustedAggregator()`, `overridePendingState()` as well as `consolidatePendingState()` skipping all timeout restrictions.