### PR TITLE
Update L2BEAT-starkware

### DIFF
--- a/packages/backend/discovery/l2beat-starkware/ethereum/diffHistory.md
+++ b/packages/backend/discovery/l2beat-starkware/ethereum/diffHistory.md
@@ -1,3 +1,34 @@
+Generated with discovered.json: 0x8f966e62bd027d2c699e581a404494171a98fecc
+
+# Diff at Wed, 13 Mar 2024 12:07:03 GMT:
+
+- author: Mateusz Radomski (<radomski.main@protonmail.com>)
+- comparing to: main@4f6a54f5fa748334d34176673b2c233534ce2fbc block: 19376058
+- current block number: 19426040
+
+## Description
+
+This value always should've been `false`.
+If it was `true` it would mean that no upgrades can be happen in the SHARPVerifier.
+But that is not the case, there were upgrades happening while this was set to "`true`" in our discovered.json.
+The reason for this mistake is that in the StarkWare Proxy handler the wrong slot was copied for the FINALIZATION flag.
+So this is the value that is actually correct.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19376058 (main branch discovery), not current.
+
+```diff
+    contract SHARPVerifierProxy (0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60) {
+    +++ description: None
+      upgradeability.isFinal:
+-        true
++        false
+    }
+```
+
 Generated with discovered.json: 0xa365edf645a8b7c07fb86981c0293b69f7b70d1d
 
 # Diff at Wed, 06 Mar 2024 12:15:21 GMT:

--- a/packages/backend/discovery/l2beat-starkware/ethereum/discovered.json
+++ b/packages/backend/discovery/l2beat-starkware/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "l2beat-starkware",
   "chain": "ethereum",
-  "blockNumber": 19376058,
+  "blockNumber": 19426040,
   "configHash": "0x241bdfda840313580acee44fbf45b93f45cefcefc409f5ff924031d57270726a",
   "version": 3,
   "contracts": [
@@ -148,7 +148,7 @@
         "implementation": "0xD4C4044ACa68ebBcB81B13cC2699e1Bca2d3F458",
         "callImplementation": "0xd51A3D50d4D2f99a345a66971E650EEA064DD8dF",
         "upgradeDelay": 0,
-        "isFinal": true,
+        "isFinal": false,
         "proxyGovernance": [
           "0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
           "0x21F9eC47b19d95b5C2DDFB6Ae5D4F92fAdacAEc4"

--- a/packages/backend/discovery/l2beat-starkware/ethereum/meta.json
+++ b/packages/backend/discovery/l2beat-starkware/ethereum/meta.json
@@ -87,6 +87,61 @@
       }
     },
     {
+      "name": "GpsStatementVerifier",
+      "values": {
+        "getBootloaderConfig": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "hasRegisteredFact": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "identify": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_ADDRESS_OFFSET": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_HASH_OFFSET": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_SIZE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_SIZE_IN_BYTES": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_SIZE_OFFSET": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "referenceFactRegistry": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "referralExpirationTime": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
       "name": "SHARPVerifier",
       "values": {
         "getBootloaderConfig": {
@@ -217,39 +272,9 @@
       }
     },
     {
-      "name": "CpuFrilessVerifier",
+      "name": "MemoryPageFactRegistry",
       "values": {
-        "getLayoutInfo": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "PAGE_INFO_ADDRESS_OFFSET": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "PAGE_INFO_HASH_OFFSET": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "PAGE_INFO_SIZE": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "PAGE_INFO_SIZE_IN_BYTES": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "PAGE_INFO_SIZE_OFFSET": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "constructorArgs": {
+        "hasRegisteredFact": {
           "description": null,
           "severity": null,
           "type": null
@@ -387,16 +412,6 @@
       }
     },
     {
-      "name": "MemoryPageFactRegistry",
-      "values": {
-        "hasRegisteredFact": {
-          "description": null,
-          "severity": null,
-          "type": null
-        }
-      }
-    },
-    {
       "name": "CpuFrilessVerifier",
       "values": {
         "getLayoutInfo": {
@@ -477,7 +492,63 @@
       }
     },
     {
-      "name": "CpuOods",
+      "name": "CpuFrilessVerifier",
+      "values": {
+        "getLayoutInfo": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_ADDRESS_OFFSET": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_HASH_OFFSET": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_SIZE": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_SIZE_IN_BYTES": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "PAGE_INFO_SIZE_OFFSET": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "constructorArgs": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
+      "name": "PoseidonPoseidonPartialRoundKey1Column",
+      "values": {}
+    },
+    {
+      "name": "CpuConstraintPoly",
+      "values": {}
+    },
+    {
+      "name": "CpuConstraintPoly",
+      "values": {}
+    },
+    {
+      "name": "PoseidonPoseidonFullRoundKey0Column",
+      "values": {}
+    },
+    {
+      "name": "EcdsaPointsYColumn",
       "values": {}
     },
     {
@@ -489,7 +560,15 @@
       "values": {}
     },
     {
-      "name": "CpuConstraintPoly",
+      "name": "CpuOods",
+      "values": {}
+    },
+    {
+      "name": "CpuOods",
+      "values": {}
+    },
+    {
+      "name": "CpuOods",
       "values": {}
     },
     {
@@ -497,7 +576,11 @@
       "values": {}
     },
     {
-      "name": "CpuConstraintPoly",
+      "name": "PoseidonPoseidonFullRoundKey2Column",
+      "values": {}
+    },
+    {
+      "name": "CpuOods",
       "values": {}
     },
     {
@@ -509,15 +592,19 @@
       "values": {}
     },
     {
-      "name": "CpuOods",
+      "name": "CpuConstraintPoly",
+      "values": {}
+    },
+    {
+      "name": "CpuConstraintPoly",
+      "values": {}
+    },
+    {
+      "name": "CpuConstraintPoly",
       "values": {}
     },
     {
       "name": "CpuOods",
-      "values": {}
-    },
-    {
-      "name": "PoseidonPoseidonFullRoundKey2Column",
       "values": {}
     },
     {
@@ -525,15 +612,15 @@
       "values": {}
     },
     {
+      "name": "CpuOods",
+      "values": {}
+    },
+    {
       "name": "PedersenHashPointsYColumn",
       "values": {}
     },
     {
-      "name": "CpuOods",
-      "values": {}
-    },
-    {
-      "name": "PoseidonPoseidonFullRoundKey0Column",
+      "name": "EcdsaPointsXColumn",
       "values": {}
     },
     {
@@ -541,25 +628,7 @@
       "values": {}
     },
     {
-      "name": "PoseidonPoseidonPartialRoundKey1Column",
-      "values": {}
-    },
-    {
       "name": "CpuOods",
-      "values": {}
-    },
-    {
-      "name": "FriStatementContract",
-      "values": {
-        "hasRegisteredFact": {
-          "description": null,
-          "severity": null,
-          "type": null
-        }
-      }
-    },
-    {
-      "name": "CpuConstraintPoly",
       "values": {}
     },
     {
@@ -573,28 +642,14 @@
       }
     },
     {
-      "name": "CpuConstraintPoly",
-      "values": {}
-    },
-    {
-      "name": "CpuOods",
-      "values": {}
-    },
-    {
-      "name": "CpuConstraintPoly",
-      "values": {}
-    },
-    {
-      "name": "CpuOods",
-      "values": {}
-    },
-    {
-      "name": "EcdsaPointsXColumn",
-      "values": {}
-    },
-    {
-      "name": "EcdsaPointsYColumn",
-      "values": {}
+      "name": "FriStatementContract",
+      "values": {
+        "hasRegisteredFact": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Resolves L2B-4393

## Description

This value always should've been `false`.
If it was `true` it would mean that no upgrades can be happen in the SHARPVerifier.
But that is not the case, there were upgrades happening while this was set to "`true`" in our discovered.json.
The reason for this mistake is that in the StarkWare Proxy handler the wrong slot was copied for the FINALIZATION flag.
So this is the value that is actually correct.