### PR TITLE
Immutable zkEVM disc update: ignore withdrawal queue in watch mode, add withdrawalDelay to .ts file

### DIFF
--- a/packages/backend/discovery/immutablezkevm/ethereum/config.jsonc
+++ b/packages/backend/discovery/immutablezkevm/ethereum/config.jsonc
@@ -9,7 +9,8 @@
   },
   "overrides": {
     "Bridge": {
-      "ignoreRelatives": ["rootWETHToken", "rootIMXToken"]
+      "ignoreRelatives": ["rootWETHToken", "rootIMXToken"],
+      "ignoreInWatchMode": ["withdrawalQueueActivated"]
     },
     "OwnerMultisig": {
       "ignoreInWatchMode": ["nonce"]

--- a/packages/backend/discovery/immutablezkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/immutablezkevm/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xd2a4ba631aba948423bcbbd39d7eb0084cacd4da
+Generated with discovered.json: 0x2535ef632d848e630a8cb963806d8bd0a005df36
 
 # Diff at Mon, 18 Mar 2024 07:41:50 GMT:
 

--- a/packages/backend/discovery/immutablezkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/immutablezkevm/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "immutablezkevm",
   "chain": "ethereum",
-  "blockNumber": 19460262,
-  "configHash": "0xe594698860e3ce578a365d256380c647ca98e4e597cda6f423741991d1be2f2e",
+  "blockNumber": 19468251,
+  "configHash": "0xd48c792b7b7ba66515fff219b7e00954236493cfc3ade965424ac999cff14a48",
   "version": 3,
   "contracts": [
     {
@@ -114,7 +114,7 @@
         "VARIABLE_MANAGER_ROLE": "0x5b94a8cd68affa84315f488cc2e6e456f761d334859cae8a073ef8fe13fb0ee6",
         "WITHDRAW_SIG": "0x7a8dc26796a1e50e6e190b70259f58f6a4edd5b22280ceecc82b687b8e982869",
         "withdrawalDelay": 86400,
-        "withdrawalQueueActivated": false
+        "withdrawalQueueActivated": true
       },
       "derivedName": "RootERC20BridgeFlowRate"
     },

--- a/packages/config/src/bridges/immutablezkevm.ts
+++ b/packages/config/src/bridges/immutablezkevm.ts
@@ -1,4 +1,9 @@
-import { EthereumAddress, ProjectId, UnixTime } from '@l2beat/shared-pure'
+import {
+  EthereumAddress,
+  formatSeconds,
+  ProjectId,
+  UnixTime,
+} from '@l2beat/shared-pure'
 
 import { CONTRACTS } from '../common'
 import { ProjectDiscovery } from '../discovery/ProjectDiscovery'
@@ -43,8 +48,9 @@ export const immutablezkevm: Bridge = {
     destination: ['Immutable zkEVM'],
     principleOfOperation: {
       name: 'Principle of Operation',
-      description:
-        "Immutable zkEVM bridge makes use of Axelar network to transfer assets between Ethereum and Immutable zkEVM. A deposit starts by a user depositing tokens on the Bridge contract and then the tokens are minted on the destination chain.\n\nWithdrawals to Ethereum can be delayed by a predefined time with a flow rate mechanism that controls outflows of the bridge escrow. The ProxyAdmin or an address with the rate_control role can define so-called buckets for each token: Each bucket has a capacity and a refill rate. All withdrawals that exceed the tokens bucket capacity trigger the withdrawal queue, which delays subsequent withdrawals of *any* of the bridges' assets for a time defined in withdrawalDelay.",
+      description: `Immutable zkEVM bridge makes use of Axelar network to transfer assets between Ethereum and Immutable zkEVM. A deposit starts by a user depositing tokens on the Bridge contract and then the tokens are minted on the destination chain.
+
+Withdrawals to Ethereum can be delayed by a predefined time with a flow rate mechanism that controls outflows of the bridge escrow. The ProxyAdmin or an address with the rate_control role can define so-called buckets for each token: Each bucket has a capacity and a refill rate. All withdrawals that exceed the tokens bucket capacity trigger the withdrawal queue, which delays subsequent withdrawals of *any* of the bridges' assets for a time defined in withdrawalDelay (currently ${formatSeconds(discovery.getContractValue('Bridge', 'withdrawalDelay'))}).`,
       references: [],
       risks: [],
     },


### PR DESCRIPTION
Resolves L2B-4482

The queue gets activated too often by larger token withdrawals.