### PR TITLE
Warn about storage handler shortcomings in mappings 

### DIFF
--- a/packages/backend/discovery/README.md
+++ b/packages/backend/discovery/README.md
@@ -116,7 +116,7 @@ The storage handler allows you to read values directly from storage.
   - a number, e.g. `1`
   - a hex string, e.g. `"0x1234"`
   - a reference to another field, e.g. `"{{ value }}"`
-  - an array of the above values. In this case the values are hashed to produce a key corresponding to a mapping. Given a mapping of `address => boolean` at the storage location `5` to get the value for some specific address you should set the slot to: `[5, "0x6B175474E89094C44Da98b954EedeAC495271d0F"]`
+  - an array of the above values. In this case the values are hashed to produce a key corresponding to a mapping. Given a mapping of `address => boolean` at the storage location `5` to get the value for some specific address you should set the slot to: `[5, "0x6B175474E89094C44Da98b954EedeAC495271d0F"]`. Mappings with keys of `bytes4` (like `bytes4`) and `string` type are not supported since they use a different path for computing the slot. Quick solution to this problem is to precompute the slot using `cast index`.
 - `offset` - (optional) value to be added to the slot. This is useful if whatever you are accessing is a large struct and you want to get a specific field.
 - `returnType` - (optional) specifies how to interpret the resulting `bytes32` result. Possible options are `"address"`, `"bytes"` (default), `"number"`.
 - `ignoreRelative` - (optional) if set to `true`, the method's result will not be considered a relative. This is useful when the method returns a value that a contract address, but it's not a contract that should be discovered.


### PR DESCRIPTION
# Explanation 

If we have a `mapping(K key => T)` the way the `key` gets transformed into the resulting storage slot where the T is stored is the following:

The value corresponding to a mapping key `k` is located at `keccak256(h(k) . p)` where `.` is concatenation and `h` is a function that is applied to the key depending on its type:

- for value types, `h` pads the value to 32 bytes in the same way as when storing the value in memory.
- for strings and byte arrays, `h(k)` is just the unpadded data.

In the Sygma bridge case they have a `mapping(bytes4 => address)`. Since `bytes4` is really `bytes32` the slot for mapping stored at slot 0 is going to be computed as

`keccak(0x12345678000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000)`

But we only support the first case (padding to 32bytes with zeros). So our code does

`keccak(0x00000000000000000000000000000000000000000000000000000000123456780000000000000000000000000000000000000000000000000000000000000000)`

If we want to support the `bytesX` and `string` as the key type in mappings we would need to provide the mapping abi in the storage handler definition. For now the problems has been solved by precomputing the storage slot.