### PR TITLE
Add a script to verify tokens configuration

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -28,12 +28,15 @@ CONFIG_ALCHEMY_API_KEY=
 - `yarn typecheck` - check if the code satisfies the typescript compiler
 - `yarn check-verified-contracts` - verify whether source code of given address is verified on Etherscan
 - `yarn tokens` - update `src/tokens/generated.json` based on `src/tokens/tokens.jsonc`. `generated.jsonc` is a source of truth about each token data.
+- `yarn tokens:verify` - when checking a PR run it to see whether tokens were added using a script
 
 ### How to check PR which adds a new token?
 
 1. Restore `generated.json` to state before PR `git checkout main --src/tokens/generated.json`
 2. Run `yarn tokens`
 3. See whether git detected any changes - if not then it was added using our script
+
+There is a handy script for it: `yarn tokens:verify`
 
 ### Tests dependencies
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -29,6 +29,12 @@ CONFIG_ALCHEMY_API_KEY=
 - `yarn check-verified-contracts` - verify whether source code of given address is verified on Etherscan
 - `yarn tokens` - update `src/tokens/generated.json` based on `src/tokens/tokens.jsonc`. `generated.jsonc` is a source of truth about each token data.
 
+### How to check PR which adds a new token?
+
+1. Restore `generated.json` to state before PR `git checkout main --src/tokens/generated.json`
+2. Run `yarn tokens`
+3. See whether git detected any changes - if not then it was added using our script
+
 ### Tests dependencies
 
 In some tests rpc calls to ethereum network are performed through Alchemy. In order to remove default mainnet url flakiness out of the equation it is possible to use a dedicated key through `CONFIG_ALCHEMY_API_KEY` environment variable (`.env` file is supported).

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,7 +19,7 @@
     "update-socket": "node -r esbuild-register scripts/socket",
     "check-verified-contracts": "node -r esbuild-register scripts/checkVerifiedContracts",
     "tokens": "node -r esbuild-register scripts/tokens/tokens.ts",
-    "tokens:verify": "git checkout main && git pull && git switch - && git checkout main -- src/tokens/generated.json && yarn tokens",
+    "tokens:verify": "sh scripts/tokens/verify.sh",
     "coingecko:platforms": "node -r esbuild-register scripts/getCoingeckoPlatforms.ts"
   },
   "dependencies": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -19,6 +19,7 @@
     "update-socket": "node -r esbuild-register scripts/socket",
     "check-verified-contracts": "node -r esbuild-register scripts/checkVerifiedContracts",
     "tokens": "node -r esbuild-register scripts/tokens/tokens.ts",
+    "tokens:verify": "git checkout main && git pull && git switch - && git checkout main -- src/tokens/generated.json && yarn tokens",
     "coingecko:platforms": "node -r esbuild-register scripts/getCoingeckoPlatforms.ts"
   },
   "dependencies": {

--- a/packages/config/scripts/tokens/verify.sh
+++ b/packages/config/scripts/tokens/verify.sh
@@ -1,0 +1,17 @@
+
+git checkout main 
+git pull 
+git switch - 
+git checkout main -- src/tokens/generated.json 
+yarn tokens
+
+# Check for differences between the current branch and the origin/main branch
+if git diff --quiet origin/main; then
+  # No differences
+  echo "No differences with the main branch."
+  exit 0
+else
+  # Differences found
+  echo "Differences found with the main branch."
+  exit 1
+fi

--- a/packages/config/scripts/tokens/verify.sh
+++ b/packages/config/scripts/tokens/verify.sh
@@ -1,22 +1,5 @@
 git checkout main 
-# git pull 
-# git switch - 
+git pull 
+git switch - 
 git checkout main -- src/tokens/generated.json 
 yarn tokens
-
-#!/bin/bash
-
-# Define the file you want to check
-FILE="src/tokens/generated.json"
-
-# Check for differences in the specified file between the current branch and the origin/main branch
-# Check for differences in the specified file between the current branch and the origin/main branch
-if git diff --quiet origin/main -- "$FILE"; then
-  # No differences in the specified file, print green tick
-  echo "✔ Tokens added using a script."
-  exit 0
-else
-  # Differences found in the specified file, print red cross
-  echo "✘ Manual override detected, please re-run yarn tokens."
-  exit 1
-fi

--- a/packages/config/scripts/tokens/verify.sh
+++ b/packages/config/scripts/tokens/verify.sh
@@ -1,6 +1,6 @@
 git checkout main 
-git pull 
-git switch - 
+# git pull 
+# git switch - 
 git checkout main -- src/tokens/generated.json 
 yarn tokens
 

--- a/packages/config/scripts/tokens/verify.sh
+++ b/packages/config/scripts/tokens/verify.sh
@@ -1,17 +1,22 @@
-
 git checkout main 
 git pull 
 git switch - 
 git checkout main -- src/tokens/generated.json 
 yarn tokens
 
-# Check for differences between the current branch and the origin/main branch
-if git diff --quiet origin/main; then
-  # No differences
-  echo "No differences with the main branch."
+#!/bin/bash
+
+# Define the file you want to check
+FILE="src/tokens/generated.json"
+
+# Check for differences in the specified file between the current branch and the origin/main branch
+# Check for differences in the specified file between the current branch and the origin/main branch
+if git diff --quiet origin/main -- "$FILE"; then
+  # No differences in the specified file, print green tick
+  echo "✔ Tokens added using a script."
   exit 0
 else
-  # Differences found
-  echo "Differences found with the main branch."
+  # Differences found in the specified file, print red cross
+  echo "✘ Manual override detected, please re-run yarn tokens."
   exit 1
 fi

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -2326,16 +2326,16 @@
       "formula": "locked"
     },
     {
-      "id": "phala-network",
+      "id": "pha-phala",
       "name": "Phala",
       "coingeckoId": "pha",
       "address": "0x6c5bA91642F10282b576d91922Ae6448C9d52f4E",
       "symbol": "PHA",
       "decimals": 18,
       "deploymentTimestamp": 1588271785,
-      "coingeckoListingTimestamp": 1573689600,
+      "coingeckoListingTimestamp": 1599868800,
       "category": "other",
-      "iconUrl": "https://assets.coingecko.com/coins/images/12451/standard/phala.png?1696512270",
+      "iconUrl": "https://assets.coingecko.com/coins/images/12451/large/phala.png?1696512270",
       "chainId": 1,
       "type": "CBV",
       "formula": "locked"


### PR DESCRIPTION
Currently there is no way to check that an external contributor has actually run the script. 

This PR add a command into config, now you can run `yarn tokens:verify` and if git does not detect any changes it means the script has been run