### PR TITLE
update PHA token mechanism

### DIFF
--- a/packages/config/src/bridges/sygma.ts
+++ b/packages/config/src/bridges/sygma.ts
@@ -103,7 +103,7 @@ export const sygma: Bridge = {
     destinationToken: {
       name: 'Destination tokens',
       description:
-        'Tokens received on the destination chain can be either wrapped tokens or native tokens depending on the specific implementation. For example, on Phalas integrated use-case with Sygma, native tokens are burned in Substrate/Polkadot and unlocked on EVM, and vice versa where tokens get locked on EVM and minted in Substrate/Polkadot.',
+        'Tokens received on the destination chain can be either wrapped tokens or native tokens depending on the specific implementation. For example, on Phalas integrated use-case with Sygma, native tokens are locked in Substrate/Polkadot and released on EVM, and vice versa where tokens get locked on EVM and released in Substrate/Polkadot.',
       risks: [],
       references: [],
     },


### PR DESCRIPTION
small mistake that needs to be corrected; 
PHA tokens are locked/released on either side of EVM/substrate - not locked/minted/burned/released