### PR TITLE
Update uif to new version

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,7 +40,7 @@
     "@l2beat/discovery-types": "^0.8.0",
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
-    "@l2beat/uif": "^0.2.4",
+    "@l2beat/uif": "^0.3.0",
     "ansi-to-html": "^0.7.2",
     "basic-auth": "^2.0.1",
     "chalk": "^4.1.2",

--- a/packages/backend/src/modules/finality/FinalityIndexer.test.ts
+++ b/packages/backend/src/modules/finality/FinalityIndexer.test.ts
@@ -30,7 +30,8 @@ describe(FinalityIndexer.name, () => {
       const from = MIN_TIMESTAMP.toNumber()
       const to = MIN_TIMESTAMP.add(-1, 'days').toNumber()
 
-      const result = await finalityIndexer.update(from, to)
+      // TODO: refactor tests after uif update
+      const result = await finalityIndexer.update(from + 1, to)
       expect(result).toEqual(to)
       expect(mockIsConfigurationSynced).not.toHaveBeenCalled()
       expect(finalityRepository.add).not.toHaveBeenCalled()
@@ -50,7 +51,8 @@ describe(FinalityIndexer.name, () => {
       const from = MIN_TIMESTAMP.toNumber()
       const to = MIN_TIMESTAMP.add(1, 'days').toNumber()
 
-      const result = await finalityIndexer.update(from, to)
+      // TODO: refactor tests after uif update
+      const result = await finalityIndexer.update(from + 1, to)
       expect(mockIsConfigurationSynced).toHaveBeenCalledWith(
         new UnixTime(to).toStartOf('day'),
       )
@@ -73,7 +75,8 @@ describe(FinalityIndexer.name, () => {
       const from = MIN_TIMESTAMP.toNumber()
       const to = MIN_TIMESTAMP.add(1, 'days').toNumber()
 
-      const result = await finalityIndexer.update(from, to)
+      // TODO: refactor tests after uif update
+      const result = await finalityIndexer.update(from + 1, to)
       expect(finalityRepository.add).not.toHaveBeenCalled()
       expect(result).toEqual(to)
     })
@@ -92,7 +95,8 @@ describe(FinalityIndexer.name, () => {
       const from = MIN_TIMESTAMP.toNumber()
       const to = MIN_TIMESTAMP.add(1, 'days').toNumber()
 
-      await finalityIndexer.update(from, to)
+      // TODO: refactor tests after uif update
+      await finalityIndexer.update(from + 1, to)
       expect(finalityRepository.add).toHaveBeenCalledWith({
         projectId: ProjectId('project'),
         timestamp: MIN_TIMESTAMP.add(1, 'days'),

--- a/packages/backend/src/modules/finality/FinalityIndexer.ts
+++ b/packages/backend/src/modules/finality/FinalityIndexer.ts
@@ -39,11 +39,11 @@ export class FinalityIndexer extends ChildIndexer {
 
   override async start(): Promise<void> {
     this.logger.info('Starting...')
-    await this.initialize()
     await super.start()
   }
 
   override async update(from: number, to: number): Promise<number> {
+    from -= 1 // TODO: refactor logic after uif update
     const targetTimestamp = new UnixTime(to).toStartOf('day')
 
     if (to < this.configuration.minTimestamp.toNumber()) {
@@ -112,8 +112,9 @@ export class FinalityIndexer extends ChildIndexer {
     }
   }
 
-  private async initialize() {
+  override async initialize(): Promise<number> {
     await this.initializeIndexerState()
+    return await this.getSafeHeight()
   }
 
   async initializeIndexerState() {
@@ -134,7 +135,7 @@ export class FinalityIndexer extends ChildIndexer {
     await this.setSafeHeight(safeHeight)
   }
 
-  override async getSafeHeight(): Promise<number> {
+  async getSafeHeight(): Promise<number> {
     const indexerState = await this.stateRepository.findIndexerState(
       this.indexerId,
     )

--- a/packages/backend/src/modules/tracked-txs/HourlyIndexer.ts
+++ b/packages/backend/src/modules/tracked-txs/HourlyIndexer.ts
@@ -8,13 +8,11 @@ export class HourlyIndexer extends RootIndexer {
     super(logger)
   }
 
-  override async start(): Promise<void> {
+  override async initialize(): Promise<number> {
     this.logger.info('Starting...')
-    await super.start()
-
-    this.requestTick()
 
     this.clock.onNewHour(() => this.requestTick())
+    return this.tick()
   }
 
   tick(): Promise<number> {

--- a/packages/backend/src/modules/tracked-txs/TrackedTxsIndexer.test.ts
+++ b/packages/backend/src/modules/tracked-txs/TrackedTxsIndexer.test.ts
@@ -63,7 +63,8 @@ describe(TrackedTxsIndexer.name, () => {
         await trackedTxIndexer.getConfigurationsToSync(from, to)
 
       const value = await trackedTxIndexer.update(
-        from.toNumber(),
+        // TODO: refactor tests after uif update
+        from.toNumber() + 1,
         to.toNumber(),
       )
 
@@ -109,7 +110,8 @@ describe(TrackedTxsIndexer.name, () => {
       )
 
       const value = await trackedTxsIndexer.update(
-        from.toNumber(),
+        // TODO: refactor tests after uif update
+        from.toNumber() + 1,
         to.toNumber(),
       )
 

--- a/packages/backend/src/modules/tracked-txs/TrackedTxsIndexer.ts
+++ b/packages/backend/src/modules/tracked-txs/TrackedTxsIndexer.ts
@@ -48,12 +48,12 @@ export class TrackedTxsIndexer extends ChildIndexer {
   }
 
   override async start(): Promise<void> {
-    await this.initialize()
     await super.start()
     this.logger.info('Started')
   }
 
   override async update(from: number, to: number): Promise<number> {
+    from -= 1 // TODO: refactor logic after uif update
     const { from: unixFrom, to: unixTo } = adjustRangeForBigQueryCall(from, to)
 
     const [configurations, syncTo] = await this.getConfigurationsToSync(
@@ -115,7 +115,12 @@ export class TrackedTxsIndexer extends ChildIndexer {
     return [configurationsToSync, syncTo]
   }
 
-  private async initialize(): Promise<void> {
+  override async initialize(): Promise<number> {
+    await this.doInitialize()
+    return await this.getSafeHeight()
+  }
+
+  private async doInitialize(): Promise<void> {
     const databaseEntries = await this.configRepository.getAll()
     const { toAdd, toRemove, toChangeUntilTimestamp } =
       diffTrackedTxConfigurations(this.configs, databaseEntries)
@@ -206,7 +211,7 @@ export class TrackedTxsIndexer extends ChildIndexer {
     await this.setSafeHeight(safeHeight, trx)
   }
 
-  override async getSafeHeight(): Promise<number> {
+  async getSafeHeight(): Promise<number> {
     const indexerState = await this.stateRepository.findIndexerState(
       this.indexerId,
     )

--- a/packages/backend/src/modules/tvl2/PriceIndexer.test.ts
+++ b/packages/backend/src/modules/tvl2/PriceIndexer.test.ts
@@ -73,7 +73,11 @@ describe(PriceIndexer.name, () => {
         syncOptimizer,
       )
 
-      const newSafeHeight = await indexer.update(from.toNumber(), to.toNumber())
+      const newSafeHeight = await indexer.update(
+        // TODO: refactor tests after uif update
+        from.toNumber() + 1,
+        to.toNumber(),
+      )
 
       expect(
         coingeckoQueryService.getUsdPriceHistoryHourly,
@@ -119,7 +123,11 @@ describe(PriceIndexer.name, () => {
         }),
       )
 
-      const newSafeHeight = await indexer.update(from.toNumber(), to.toNumber())
+      const newSafeHeight = await indexer.update(
+        // TODO: refactor tests after uif update
+        from.toNumber() + 1,
+        to.toNumber(),
+      )
 
       expect(
         coingeckoQueryService.getUsdPriceHistoryHourly,
@@ -142,7 +150,7 @@ describe(PriceIndexer.name, () => {
     })
   })
 
-  describe(PriceIndexer.prototype.initialize.name, () => {
+  describe(PriceIndexer.prototype.doInitialize.name, () => {
     it('initialize state when not initialized', async () => {
       const stateRepository = mockObject<IndexerStateRepository>({
         findIndexerState: async () => undefined,
@@ -165,7 +173,7 @@ describe(PriceIndexer.name, () => {
         mockObject<SyncOptimizer>({}),
       )
 
-      await indexer.initialize()
+      await indexer.doInitialize()
 
       expect(stateRepository.add).toHaveBeenCalledWith({
         indexerId: indexer.indexerId,
@@ -203,7 +211,7 @@ describe(PriceIndexer.name, () => {
         mockObject<SyncOptimizer>({}),
       )
 
-      await expect(() => indexer.initialize()).toBeRejectedWith(
+      await expect(() => indexer.doInitialize()).toBeRejectedWith(
         'Minimum timestamp of this indexer cannot be updated',
       )
     })

--- a/packages/backend/src/modules/tvl2/PriceIndexer.ts
+++ b/packages/backend/src/modules/tvl2/PriceIndexer.ts
@@ -27,12 +27,12 @@ export class PriceIndexer extends ChildIndexer {
 
   override async start(): Promise<void> {
     this.logger.debug('Starting...')
-    await this.initialize()
     await super.start()
     this.logger.debug('Started')
   }
 
   override async update(_from: number, _to: number): Promise<number> {
+    _from -= 1 // TODO: refactor logic after uif update
     this.logger.debug('Updating...')
 
     const from = this.getAdjustedFrom(_from)
@@ -86,7 +86,12 @@ export class PriceIndexer extends ChildIndexer {
       }))
   }
 
-  override async getSafeHeight(): Promise<number> {
+  override async initialize(): Promise<number> {
+    await this.doInitialize()
+    return await this.getSafeHeight()
+  }
+
+  async getSafeHeight(): Promise<number> {
     const indexerState = await this.stateRepository.findIndexerState(
       this.indexerId,
     )
@@ -102,7 +107,7 @@ export class PriceIndexer extends ChildIndexer {
     await this.stateRepository.setSafeHeight(this.indexerId, safeHeight, trx)
   }
 
-  async initialize() {
+  async doInitialize() {
     this.logger.debug('Initializing...')
 
     const indexerState = await this.stateRepository.findIndexerState(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2462,10 +2462,10 @@
     sqlite3 "^5.1.6"
     zod "^3.22.2"
 
-"@l2beat/uif@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@l2beat/uif/-/uif-0.2.4.tgz#2607275e24dbd91700633d30c362d7ec1838da05"
-  integrity sha512-gxzi+awNBGvNd9bRfhQoupKZC1bOTRfHfrxLvfKKymsUDOpEgG1MeAiJz+bJC5jUorqapNOTuP01doBXlvbxfw==
+"@l2beat/uif@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@l2beat/uif/-/uif-0.3.0.tgz#e2f0fe47ca4f2bdc6895cb1238aa674b53519820"
+  integrity sha512-hmhAHLhL7RZwkTmZ2mgV1SHAZdRuRXvJ1ljah1DhggWvKT4Xtp3AGhN6/60+mDKG+rfZuETSHbwqRyYLQumang==
   dependencies:
     "@l2beat/backend-tools" "^0.5.0"
 


### PR DESCRIPTION
Updates uif.
The changes required:
- `getSafeHeight` was renamed to `initialize`. To combat the fact that we already have `initialize` i renamed `initialize` to `doInitialize` and call it from `initialize`.
- `from` in `update` is now inclusive. To keep the old behavior I subtract 1.

https://github.com/l2beat/tools/blob/f906b33804719b42e4a3292349a82f9f95da30b1/packages/uif/src/Indexer.ts#L222