### PR TITLE
Simple finality

### DIFF
--- a/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.test.ts
+++ b/packages/backend/src/modules/finality/analyzers/LineaFinalityAnalyzer.test.ts
@@ -108,9 +108,9 @@ describe(LineaFinalityAnalyzer.name, () => {
             }),
         })
 
-        const l2provider = getMockL2RpcClient([
-          1706143000, 1706145000, 1706144000, 1706146000,
-        ])
+        const blockTimestamps = [1706143000, 1706145000, 1706144000, 1706146000]
+
+        const l2provider = getMockL2RpcClient(blockTimestamps)
 
         const calculator = new LineaFinalityAnalyzer(
           provider,
@@ -126,10 +126,10 @@ describe(LineaFinalityAnalyzer.name, () => {
 
         if (results) {
           expect(results).toEqualUnsorted([
-            firstL1Timestamp - 1706143000,
-            firstL1Timestamp - 1706144000,
-            secondL1Timestamp - 1706145000,
-            secondL1Timestamp - 1706146000,
+            firstL1Timestamp - blockTimestamps[0],
+            firstL1Timestamp - blockTimestamps[1],
+            secondL1Timestamp - blockTimestamps[2],
+            secondL1Timestamp - blockTimestamps[3],
           ])
         }
 

--- a/packages/backend/src/modules/finality/analyzers/types/BaseAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/types/BaseAnalyzer.ts
@@ -21,7 +21,7 @@ export abstract class BaseAnalyzer {
     from: UnixTime,
     to: UnixTime,
     granularity: number,
-  ) {
+  ): Promise<number[] | undefined> {
     const interval = this.getInterval(from, to, granularity)
 
     const transactions = (
@@ -44,15 +44,13 @@ export abstract class BaseAnalyzer {
       return undefined
     }
 
-    const finalityDelays = (
-      await Promise.all(
-        transactions.map(async (transaction) => {
-          return this.getFinality(transaction)
-        }),
-      )
-    ).flat()
+    const finalityDelays = []
+    for (const tx of transactions) {
+      const delay = await this.getFinality(tx)
+      finalityDelays.push(delay)
+    }
 
-    return finalityDelays
+    return finalityDelays.flat()
   }
 
   private getInterval(from: UnixTime, to: UnixTime, granularity: number) {


### PR DESCRIPTION
This PR aims to fix problem with linea finality by introducing a simpler way of counting finality delays (for loop vs Promise.all()). This will degrade the time performance, but improve space performance, hopefully getting rid of `JavaScript heap out of memory` error. The performance degrading should not be a problem, as this calculation is happening once a day.