### PR TITLE
Add STONE on Mode Network

### DIFF
--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1282,6 +1282,17 @@
       "bridgedUsing": {
         "bridge": "Connext",
         "slug": "connext"
+      },
+    {
+      "symbol": "STONE",
+      "address": "0x80137510979822322193FC997d400D5A6C747bf7",
+      "coingeckoId": "stakestone-ether",
+      "type": "EBV",
+      "formula": "totalSupply",
+      "bridgedUsing": {
+          "bridge": "Layer Zero",
+          "slug": "omnichain"
+       }
       }
     }
   ]


### PR DESCRIPTION
added STONE (StakeStone ETH) as a token on Mode Network, using LayerZero bridge