### PR TITLE
fix: discord link detection

### DIFF
--- a/packages/frontend/src/components/project/links/LinkSectionLink.tsx
+++ b/packages/frontend/src/components/project/links/LinkSectionLink.tsx
@@ -48,7 +48,7 @@ export function parseSocial(href: string): SocialDetails {
   if (link.startsWith('discord.gg') || link.startsWith('discord.com/invite/')) {
     return {
       platform: 'discord',
-      text: 'discord.gg',
+      text: 'Discord',
     }
   } else if (link.startsWith('twitter.com')) {
     return {

--- a/packages/frontend/src/components/project/links/LinkSectionLink.tsx
+++ b/packages/frontend/src/components/project/links/LinkSectionLink.tsx
@@ -45,7 +45,7 @@ interface SocialDetails {
 
 export function parseSocial(href: string): SocialDetails {
   const link = formatLink(href)
-  if (link.startsWith('discord.gg')) {
+  if (link.startsWith('discord.gg') || link.startsWith('discord.com/invite/')) {
     return {
       platform: 'discord',
       text: 'discord.gg',


### PR DESCRIPTION
A discord link can also start with `discord.com/invite/`.

Also the text should be `Discord` instead of `discord.gg`?

<img width="152" alt="image" src="https://github.com/l2beat/l2beat/assets/5896343/99f5f318-66fa-49f6-9d8c-6cf920589d55">
