### PR TITLE
Add GRT token to Arbitrum TVL

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -4063,6 +4063,24 @@
       "formula": "circulatingSupply"
     },
     {
+      "id": "arbitrum:grt-graph-token",
+      "name": "Graph Token",
+      "coingeckoId": "the-graph",
+      "address": "0x9623063377AD1B27544C965cCd7342f7EA7e88C7",
+      "symbol": "GRT",
+      "decimals": 18,
+      "deploymentTimestamp": 1669815527,
+      "coingeckoListingTimestamp": 1608163200,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/13397/large/Graph_Token.png?1696513159",
+      "chainId": 42161,
+      "type": "EBV",
+      "formula": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "The Graph Custom Gateway"
+      }
+    },
+    {
       "id": "arbitrum:hdn-hydranet",
       "name": "Hydranet",
       "coingeckoId": "hydranet",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1088,6 +1088,15 @@
       "address": "0x4cb9a7ae498cedcbb5eae9f25736ae7d428c9d66",
       "type": "NMV",
       "formula": "circulatingSupply"
+    },
+    {
+      "symbol": "GRT",
+      "address": "0x9623063377AD1B27544C965cCd7342f7EA7e88C7",
+      "type": "EBV",
+      "formula": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "The Graph Custom Gateway"
+      }
     }
   ],
   "optimism": [


### PR DESCRIPTION
Resolves L2B-4637.

Add The Graph Token (GRT) as externally bridged, since it using a Custom Gateway bridge that introduces additional risks.
In particular, the invariant defined for canonical bridges _total_balance_minted_on_L2 <= total_balance_escrowed_on_L1_ does not hold true, and the Custom Gateway additionally grants minting rights to the L1 escrow:

    function finalizeInboundTransfer(
        address _l1Token,
        address _from,
        address _to,
        uint256 _amount,
        bytes calldata // _data, contains exitNum, unused by this contract
    ) external payable override notPaused onlyL2Counterpart {
        IGraphToken token = graphToken();
        require(_l1Token == address(token), "TOKEN_NOT_GRT");

        uint256 escrowBalance = token.balanceOf(escrow);
        if (_amount > escrowBalance) {
            // This will revert if trying to mint more than allowed
            _mintFromL2(_amount.sub(escrowBalance));
        }
        token.transferFrom(escrow, _to, _amount);
        
For these reasons, it is added to the TVL as externally bridged. 
