### PR TITLE
Remove "reporter" property from .mocharc.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "turbo run lint",
     "lint:fix": "wsrun -ecam lint:fix",
     "start": "cd packages/backend && yarn start",
-    "test": "turbo run test --",
+    "test": "turbo run test -- --reporter progress",
     "test:exclude-backend": "turbo run test --filter=!backend",
     "typecheck": "turbo run typecheck",
     "ci:check": "turbo run ci:check",

--- a/packages/backend/.mocharc.json
+++ b/packages/backend/.mocharc.json
@@ -1,7 +1,6 @@
 {
   "spec": ["src/**/*.test.ts", "discovery/*.test.ts"],
   "require": ["esbuild-register", "src/test/hooks.ts"],
-  "reporter": "progress",
   "watchExtensions": "ts",
   "extension": "ts",
   "file": "src/test/setup.ts",

--- a/packages/config/.mocharc.json
+++ b/packages/config/.mocharc.json
@@ -1,7 +1,6 @@
 {
   "spec": "{src,scripts}/**/*.test.ts",
   "require": "esbuild-register",
-  "reporter": "progress",
   "watchExtensions": "ts",
   "extension": "ts"
 }

--- a/packages/frontend/.mocharc.json
+++ b/packages/frontend/.mocharc.json
@@ -1,7 +1,6 @@
 {
   "spec": "src/**/*.test.ts",
   "require": "esbuild-register",
-  "reporter": "progress",
   "watchExtensions": "ts",
   "extension": "ts"
 }

--- a/packages/shared-pure/.mocharc.json
+++ b/packages/shared-pure/.mocharc.json
@@ -1,7 +1,6 @@
 {
   "spec": "{src,test}/**/*.test.ts",
   "require": "esbuild-register",
-  "reporter": "progress",
   "watchExtensions": "ts",
   "extension": "ts",
   "file": "src/test/setup.ts"

--- a/packages/shared/.mocharc.json
+++ b/packages/shared/.mocharc.json
@@ -1,7 +1,6 @@
 {
   "spec": "{src,test}/**/*.test.ts",
   "require": "esbuild-register",
-  "reporter": "progress",
   "watchExtensions": "ts",
   "extension": "ts",
   "file": "src/test/setup.ts"


### PR DESCRIPTION
This pull request removes the "reporter" property from the .mocharc.json files. The "reporter" property was unnecessary and has been removed to simplify the configuration. Also the default "spec" reporter is better for local development.