### PR TITLE
Fix telegram regex check

### DIFF
--- a/packages/config/src/test/projects.test.ts
+++ b/packages/config/src/test/projects.test.ts
@@ -128,7 +128,9 @@ describe('projects', () => {
               /^https:\/\/discord\.(gg|com\/invite)\/[\w-]+$/,
             )
           } else if (link.includes('t.me')) {
-            expect(link).toMatchRegex(/^https:\/\/t\.me\/(joinchat\/)?[\w\-\+]+$/)
+            expect(link).toMatchRegex(
+              /^https:\/\/t\.me\/(joinchat\/)?[\w\-+]+$/,
+            )
           } else if (link.includes('medium')) {
             expect(link).toMatchRegex(
               /^https:\/\/([\w-]+\.)?medium\.com\/[@\w-]*$/,

--- a/packages/config/src/test/projects.test.ts
+++ b/packages/config/src/test/projects.test.ts
@@ -128,7 +128,7 @@ describe('projects', () => {
               /^https:\/\/discord\.(gg|com\/invite)\/[\w-]+$/,
             )
           } else if (link.includes('t.me')) {
-            expect(link).toMatchRegex(/^https:\/\/t\.me\/(joinchat\/)?\w+$/)
+            expect(link).toMatchRegex(/^https:\/\/t\.me\/(joinchat\/)?[\w\-\+]+$/)
           } else if (link.includes('medium')) {
             expect(link).toMatchRegex(
               /^https:\/\/([\w-]+\.)?medium\.com\/[@\w-]*$/,


### PR DESCRIPTION
Before this link wouldn't be treated as valid even though it is: ```https://t.me/+f8yhoOg-4cNhYWEx```