### PR TITLE
Fix PriceUpdater

### DIFF
--- a/packages/shared/src/services/coingecko/CoingeckoQueryService.test.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoQueryService.test.ts
@@ -37,8 +37,8 @@ describe(CoingeckoQueryService.name, () => {
         const coingeckoQueryService = new CoingeckoQueryService(coingeckoClient)
         await coingeckoQueryService.getUsdPriceHistoryHourly(
           CoingeckoId('weth'),
-          UnixTime.fromDate(new Date('2021-01-01')).add(-5, 'minutes'),
-          UnixTime.fromDate(new Date('2021-02-01')).add(5, 'minutes'),
+          UnixTime.fromDate(new Date('2021-01-01')),
+          UnixTime.fromDate(new Date('2021-02-01')),
         )
         expect(
           coingeckoClient.getCoinMarketChartRange,
@@ -46,7 +46,10 @@ describe(CoingeckoQueryService.name, () => {
           CoingeckoId('weth'),
           'usd',
           UnixTime.fromDate(new Date('2021-01-01')).add(-3, 'days'),
-          UnixTime.fromDate(new Date('2021-02-01')).add(3, 'days'),
+          UnixTime.fromDate(new Date('2021-01-01')).add(
+            MAX_DAYS_FOR_HOURLY_PRECISION - 3,
+            'days',
+          ),
           undefined,
         )
       })
@@ -384,7 +387,7 @@ describe(CoingeckoQueryService.name, () => {
   describe(
     CoingeckoQueryService.prototype.queryRawHourlyPricesAndMarketCaps.name,
     () => {
-      it('calls for the data until empty', async () => {
+      it('when from not defined call until empty response', async () => {
         const START = UnixTime.now()
 
         const coingeckoClient = mockObject<CoingeckoClient>({

--- a/packages/shared/src/services/coingecko/CoingeckoQueryService.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoQueryService.ts
@@ -11,6 +11,7 @@ import { CoingeckoClient } from './CoingeckoClient'
 import { CoinMarketChartRangeData } from './model'
 
 export const MAX_DAYS_FOR_HOURLY_PRECISION = 80
+const SECONDS_IN_DAY = 24 * 60 * 60
 export const COINGECKO_INTERPOLATION_WINDOW_DAYS = 3
 
 export interface QueryResultPoint {
@@ -104,6 +105,13 @@ export class CoingeckoQueryService {
       let currentFrom = currentTo.add(-MAX_DAYS_FOR_HOURLY_PRECISION, 'days')
       if (adjustedFrom && currentFrom.lt(adjustedFrom)) {
         currentFrom = adjustedFrom
+        const diff = currentTo.toNumber() - currentFrom.toNumber()
+        if (diff < MAX_DAYS_FOR_HOURLY_PRECISION * SECONDS_IN_DAY) {
+          currentTo = new UnixTime(
+            currentFrom.toNumber() +
+              MAX_DAYS_FOR_HOURLY_PRECISION * SECONDS_IN_DAY,
+          )
+        }
       }
 
       const data = await this.coingeckoClient.getCoinMarketChartRange(


### PR DESCRIPTION
https://app.bugsnag.com/l2beat-staging/staging/errors/660e739d32def100088d6ce6?filters%5Berror.status%5D=open&filters%5Bevent.since%5D=30d

No data received for coin: equation from 2023-10-27T00:00:00.000Z to 2023-10-30T08:00:00.000Z

Our CoingeckoQueryService algorithm splits range into batches of maximum MAX_DAYS_FOR_HOURLY_PRECISION, it goes from the newest to oldest. In a very rare case we get last few days around token listing on coingecko as in above case (just 3 days)

Solution:
If a range is not "full" (MAX_DAYS_FOR_HOURLY_PRECISION) then add MAX_DAYS_FOR_HOURLY_PRECISION to the from