### PR TITLE
Paginate l2 costs queries

### DIFF
--- a/packages/backend/src/modules/tracked-txs/modules/l2-costs/api/L2CostsController.test.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/l2-costs/api/L2CostsController.test.ts
@@ -32,7 +32,8 @@ describe(L2CostsController.name, () => {
   describe(L2CostsController.prototype.getL2Costs.name, () => {
     it('correctly calculates l2costs', async () => {
       const l2CostsRepository = mockObject<L2CostsRepository>({
-        getByProjectAndTimeRange: mockFn().resolvesTo([]),
+        getByProjectAndTimeRangePaginated: mockFn().resolvesTo([]),
+        findCountByProjectAndTimeRange: mockFn().resolvesTo({ count: 51000 }),
       })
       const controller = getMockL2CostsController({
         projects: MOCK_PROJECTS,
@@ -83,17 +84,26 @@ describe(L2CostsController.name, () => {
       const result = await controller.getL2Costs()
 
       expect(
-        l2CostsRepository.getByProjectAndTimeRange,
-      ).toHaveBeenNthCalledWith(1, MOCK_PROJECTS[1].projectId, [
-        NOW_TO_FULL_HOUR.add(-180, 'days'),
-        NOW_TO_FULL_HOUR.add(-90, 'days').toStartOf('day'),
-      ])
+        l2CostsRepository.getByProjectAndTimeRangePaginated,
+      ).toHaveBeenCalledTimes(4)
       expect(
-        l2CostsRepository.getByProjectAndTimeRange,
-      ).toHaveBeenNthCalledWith(2, MOCK_PROJECTS[1].projectId, [
-        NOW_TO_FULL_HOUR.add(-90, 'days').toStartOf('day'),
-        NOW_TO_FULL_HOUR.add(-0, 'days'),
-      ])
+        l2CostsRepository.getByProjectAndTimeRangePaginated,
+      ).toHaveBeenNthCalledWith(
+        1,
+        MOCK_PROJECTS[1].projectId,
+        [NOW_TO_FULL_HOUR.add(-180, 'days'), NOW_TO_FULL_HOUR],
+        0,
+        50000,
+      )
+      expect(
+        l2CostsRepository.getByProjectAndTimeRangePaginated,
+      ).toHaveBeenNthCalledWith(
+        2,
+        MOCK_PROJECTS[1].projectId,
+        [NOW_TO_FULL_HOUR.add(-180, 'days'), NOW_TO_FULL_HOUR],
+        50000,
+        50000,
+      )
       expect(result.type).toEqual('success')
       expect(result.data.projects).toEqual({
         project2: {

--- a/packages/backend/src/modules/tracked-txs/modules/l2-costs/api/L2CostsController.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/l2-costs/api/L2CostsController.ts
@@ -149,7 +149,7 @@ export class L2CostsController {
         ]
 
         const { count } =
-          await this.l2CostsRepository.getCountByProjectAndTimeRange(
+          await this.l2CostsRepository.findCountByProjectAndTimeRange(
             project.projectId,
             timeRanges,
           )

--- a/packages/backend/src/modules/tracked-txs/modules/l2-costs/repositories/L2CostsRepository.test.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/l2-costs/repositories/L2CostsRepository.test.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@l2beat/backend-tools'
 import { ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
+import { range } from 'lodash'
 
 import { describeDatabase } from '../../../../../test/database'
 import { TrackedTxsConfigsRepository } from '../../../repositories/TrackedTxsConfigsRepository'
@@ -99,34 +100,81 @@ describeDatabase(L2CostsRepository.name, (database) => {
     })
   })
 
-  describe(L2CostsRepository.prototype.getByProjectAndTimeRange.name, () => {
-    it('should return all rows for given project id and since timestamp', async () => {
-      const results = await repository.getByProjectAndTimeRange(
-        ProjectId('project-2'),
-        [START, START.add(1, 'hours')],
-      )
+  describe(
+    L2CostsRepository.prototype.findCountByProjectAndTimeRange.name,
+    () => {
+      it('should return count of rows for given project id and range timestamp', async () => {
+        const results = await repository.findCountByProjectAndTimeRange(
+          ProjectId('project-2'),
+          [START.add(-2, 'hours'), START.add(1, 'hours')],
+        )
 
-      expect(results).toEqual([DATA[0]])
-    })
+        expect(results).toEqual({ count: 2 })
+      })
 
-    it('should return all rows for given project id and since timestamp asc timestamp', async () => {
-      const results = await repository.getByProjectAndTimeRange(
-        ProjectId('project-2'),
-        [START.add(-2, 'hours'), START.add(1, 'hours')],
-      )
+      it('should return count of rows equal 0 for given project id and range timestamp', async () => {
+        const results = await repository.findCountByProjectAndTimeRange(
+          ProjectId('project-2'),
+          [START.add(1, 'hours'), START.add(2, 'hours')],
+        )
 
-      expect(results).toEqual([DATA[2], DATA[0]])
-    })
+        expect(results).toEqual({ count: 0 })
+      })
+    },
+  )
 
-    it('should return all rows for given project id and since timestamp with exclusive to', async () => {
-      const results = await repository.getByProjectAndTimeRange(
-        ProjectId('project-2'),
-        [START.add(-1, 'days'), START],
-      )
+  describe(
+    L2CostsRepository.prototype.getByProjectAndTimeRangePaginated.name,
+    () => {
+      it('should return limited number of rows', async () => {
+        const trackedTxId = TrackedTxId.random()
+        await configRepository.deleteAll()
+        await configRepository.addMany([
+          {
+            id: trackedTxId,
+            projectId: ProjectId('project-1'),
+            type: 'liveness',
+            sinceTimestampInclusive: START,
+            debugInfo: '',
+          },
+        ])
+        await repository.deleteAll()
+        const DATA = range(7).map((i) => ({
+          timestamp: START.add(-i, 'hours'),
+          txHash: '0x1',
+          trackedTxId: trackedTxId,
+          data: {
+            type: 2 as const,
+            gasUsed: 100,
+            gasPrice: 1,
+            calldataLength: 100,
+            calldataGasUsed: 100,
+          },
+        }))
+        await repository.addMany(DATA)
 
-      expect(results).toEqual([DATA[2]])
-    })
-  })
+        const results = await repository.getByProjectAndTimeRangePaginated(
+          ProjectId('project-1'),
+          [START.add(-7, 'hours'), START.add(1, 'hours')],
+          0,
+          5,
+        )
+
+        expect(results).toEqualUnsorted(DATA.slice(2, 8))
+      })
+
+      it('should return all rows for given project id and since timestamp with exclusive to', async () => {
+        const results = await repository.getByProjectAndTimeRangePaginated(
+          ProjectId('project-2'),
+          [START.add(-1, 'days'), START],
+          0,
+          5,
+        )
+
+        expect(results).toEqual([DATA[2]])
+      })
+    },
+  )
 
   describe(L2CostsRepository.prototype.getAll.name, () => {
     it('should return all rows', async () => {

--- a/packages/backend/src/modules/tracked-txs/modules/l2-costs/repositories/L2CostsRepository.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/l2-costs/repositories/L2CostsRepository.ts
@@ -53,24 +53,7 @@ export class L2CostsRepository extends BaseRepository {
     return rows.map((r) => toRecord(r))
   }
 
-  async getByProjectAndTimeRange(
-    projectId: ProjectId,
-    timeRange: [UnixTime, UnixTime],
-  ): Promise<L2CostsRecord[]> {
-    const [from, to] = timeRange
-    const knex = await this.knex()
-    const rows = await knex('l2_costs as l')
-      .join('tracked_txs_configs as c', 'l.tracked_tx_id', 'c.id')
-      .where('c.project_id', projectId)
-      .andWhere('l.timestamp', '>=', from.toDate())
-      .andWhere('l.timestamp', '<', to.toDate())
-      .distinct('l.tx_hash')
-      .select('l.timestamp', 'l.tx_hash', 'l.tracked_tx_id', 'l.data')
-      .orderBy('l.timestamp', 'asc')
-    return rows.map(toRecord)
-  }
-
-  async getCountByProjectAndTimeRange(
+  async findCountByProjectAndTimeRange(
     projectId: ProjectId,
     timeRange: [UnixTime, UnixTime],
   ): Promise<{ count: number }> {


### PR DESCRIPTION
Resolves L2B-4744

Pagination has been enabled with window size of 50k. It takes longer but the memory usage is lower. No longer crashes with 512MB limit.