### PR TITLE
Lower l2costs cache interval

### DIFF
--- a/packages/backend/src/modules/tracked-txs/modules/l2-costs/api/L2CostsController.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/l2-costs/api/L2CostsController.ts
@@ -94,11 +94,11 @@ export class L2CostsController {
     this.taskQueue.addToFront()
     this.logger.info('Caching: initial caching scheduled')
 
-    const tenMinutes = 10 * 60 * 1000
+    const thirtyMinutes = 30 * 60 * 1000
     setInterval(() => {
       this.taskQueue.addIfEmpty()
       this.logger.info('Caching: refetch scheduled')
-    }, tenMinutes)
+    }, thirtyMinutes)
   }
 
   async getL2Costs(): Promise<L2CostsResult> {


### PR DESCRIPTION
This endpoint is slow and calculating for a few minutes so 10 minutes as cache interval is too low. I have lowered that for 30 minutes, which should make more sense.