### PR TITLE
Fix total cell layout for costs

### DIFF
--- a/packages/frontend/src/pages/scaling/costs/view/CostsTotalCell.tsx
+++ b/packages/frontend/src/pages/scaling/costs/view/CostsTotalCell.tsx
@@ -162,7 +162,7 @@ function TotalValue({
           <div className="hidden flex-col items-end group-data-[type=PER-L2-TX]/costs-controls-wrapper:flex">
             {data.perL2Tx ? (
               <>
-                <div>
+                <div className="flex items-center gap-1">
                   <span className="text-lg font-semibold">
                     {data.perL2Tx.displayValue}
                   </span>


### PR DESCRIPTION
This pull request fixes the layout of the total cell in the TotalValue component. The issue was that the flexbox container was missing the "flex items-center gap-1" class, causing the display of the value to be misaligned. This PR adds the missing class to ensure proper alignment.