### PR TITLE
Get reorgSafeDepth (for cache) from env var

### DIFF
--- a/packages/backend/src/config/features/updateMonitor.ts
+++ b/packages/backend/src/config/features/updateMonitor.ts
@@ -40,6 +40,10 @@ export function getChainDiscoveryConfig(
       `${ENV_NAME}_RPC_GETLOGS_MAX_RANGE_FOR_DISCOVERY`,
       `${ENV_NAME}_RPC_GETLOGS_MAX_RANGE`,
     ]),
+    reorgSafeDepth: env.optionalInteger([
+      `${ENV_NAME}_REORG_SAFE_DEPTH_FOR_DISCOVERY`,
+      `${ENV_NAME}_REORG_SAFE_DEPTH`,
+    ]),
     enableCache: env.optionalBoolean([
       `${ENV_NAME}_DISCOVERY_CACHE_ENABLED`,
       'DISCOVERY_CACHE_ENABLED',


### PR DESCRIPTION
I've noticed there is no way to configure it, so I'm adding env variable for it.

I think it was there before (I see it in my local .env) but has been probably refactored out somehow.
