### PR TITLE
Hide token controls and fix tooltip trigger width on TVL breakdown

### DIFF
--- a/packages/frontend/src/components/chart/TokenControls.tsx
+++ b/packages/frontend/src/components/chart/TokenControls.tsx
@@ -25,7 +25,8 @@ export function TokenControls({
   }
 
   return (
-    <div className={cn('flex h-full')} data-role="chart-token-element">
+    // <div className={cn('flex h-full')} data-role="chart-token-element">
+    <div className={cn('hidden h-full')} data-role="chart-token-element">
       <RichSelect
         label="Tokens"
         id="token-select"

--- a/packages/frontend/src/components/tvl-breakdown/table/TVLBreakdownTableView.tsx
+++ b/packages/frontend/src/components/tvl-breakdown/table/TVLBreakdownTableView.tsx
@@ -122,13 +122,21 @@ export function TVLBreakdownTableView<
                     <td
                       key={j}
                       className={cn(
-                        'h-9 py-2 pr-2 align-top first:rounded-l first:pl-2 last:rounded-r last:pr-2 md:h-10 md:pl-4 first:md:pl-6 last:md:pr-6',
+                        'h-9 py-2 pr-2 first:rounded-l first:pl-2 last:rounded-r last:pr-2 md:h-10 md:pl-4 first:md:pl-6 last:md:pr-6',
                         column.highlight && highlightedColumnClassNames,
                         column.align === 'right' && 'text-right',
                         column.align === 'center' && 'text-center',
                       )}
                     >
-                      {column.getValue(item, i)}
+                      <div
+                        className={cn(
+                          'flex items-center',
+                          column.align === 'right' && 'justify-end',
+                          column.align === 'center' && 'justify-center',
+                        )}
+                      >
+                        {column.getValue(item, i)}
+                      </div>
                     </td>
                   )
                 })}


### PR DESCRIPTION
This pull request includes the following changes:

- Hides token controls by changing the class name of a div element.

- Fixes the tooltip trigger width on the TVL breakdown table view.