### PR TITLE
Reduce step size for BlockscoutClient

### DIFF
--- a/packages/shared/src/services/blockscout/BlockscoutClient.ts
+++ b/packages/shared/src/services/blockscout/BlockscoutClient.ts
@@ -67,7 +67,7 @@ export class BlockscoutClient {
           throw new Error(errorObject.message)
         }
 
-        current = current.add(-10, 'minutes')
+        current = current.add(-1, 'minutes')
       }
     }
 


### PR DESCRIPTION
On Etherscan like explorers: 10 minutes
On Blockscout like explorers: 1 minute

You can verify that with:

Block number 2 posted on `1688314977`

Works         - `curl 'https://explorer.mantle.xyz/api?module=block&action=getblocknobytime&timestamp=1688315037&closest=before'`
time diff     - 60 seconds

Does not work - `curl 'https://explorer.mantle.xyz/api?module=block&action=getblocknobytime&timestamp=1688315038&closest=before'`
time diff     - 61 seconds