### PR TITLE
Cbridge update: SentinelAdmin changed to SimpleGov

### DIFF
--- a/packages/backend/discovery/cbridge/ethereum/diffHistory.md
+++ b/packages/backend/discovery/cbridge/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xa5fa9f35f275df1e3c511462365e6ba39f6153f1
+Generated with discovered.json: 0xd8d108b7b19308cda326d243fc41e4d24ae821a2
 
 # Diff at Sat, 20 Apr 2024 19:31:25 GMT:
 
@@ -9,6 +9,8 @@ Generated with discovered.json: 0xa5fa9f35f275df1e3c511462365e6ba39f6153f1
 ## Description
 
 Cbridge bridge contracts were paused for a few minutes and the guards are set to a 'relaxed' state before the bridges are unpaused again.
+
+The Sentinel ProxyAdmin owner was changes from 'Celer Network: Deployer 2' to the CelerBridge Governance contract 'SimpleGovernance' called 'Bridge Governance (2)' on our website. Since the SimpleGovernance contract has a higher threshold than the deployer EOA, and additional Governance logic, this is an increase in security.
 
 ## Watched changes
 

--- a/packages/backend/discovery/cbridge/ethereum/discovered.json
+++ b/packages/backend/discovery/cbridge/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "cbridge",
   "chain": "ethereum",
-  "blockNumber": 19698726,
+  "blockNumber": 19704406,
   "configHash": "0xaefd4ad630423ac7314704b457cb0518fe5a5ccfa2e6d8dc6956c0c61e5a129a",
   "version": 3,
   "contracts": [
@@ -77,7 +77,7 @@
       },
       "sinceTimestamp": 1638346811,
       "values": {
-        "addseq": 5200,
+        "addseq": 5203,
         "delayPeriod": 1800,
         "epochLength": 1800,
         "governors": [
@@ -99,8 +99,8 @@
           "0xF140024969F6c76494a78518D9a99c8776B55f70"
         ],
         "resetTime": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-        "ssHash": "0x817bc4b7a9aa2282420bc1e2a3650572d22fea32264aa1a3656aae5fc49bebf5",
-        "triggerTime": 1713373736
+        "ssHash": "0xfd7c46285b689dfcf5495bb5f63064a9b4ca578873c69de8be230c4a4e326349",
+        "triggerTime": 1713646500
       },
       "derivedName": "Bridge"
     },

--- a/packages/config/src/bridges/cBridge.ts
+++ b/packages/config/src/bridges/cBridge.ts
@@ -230,7 +230,7 @@ export const cBridge: Bridge = {
     {
       name: 'Bridge Governance (2)',
       description:
-        'The owner of the Token Bridge, Liquidity Network and Transfer Agent is a governance contract with the permissions to manage: signers responsible for messages relaying, pausers with the ability to pause the bridge as well as governance of the system.',
+        'The owner of both PeggedTokenBridges, the Liquidity Network, the TransferAgent and Sentinel is a governance contract with the permissions to manage: signers responsible for messages relaying, pausers with the ability to pause the bridge as well as governance of the system.',
       accounts: [
         discovery.getPermissionedAccount('OriginalTokenVaultV2', 'owner'),
       ],


### PR DESCRIPTION
Also made a note for myself to go through the contracts and permissions sections as i think that we use 'Token Bridge' as a contract name without saying which contract we mean