### PR TITLE
Add read-only mode for backend server

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -77,27 +77,30 @@ export class Application {
       getErrorReportingMiddleware(),
     )
 
-    this.start = config.isReadonly
-      ? async () => {
-          await apiServer.start()
-        }
-      : async () => {
-          logger.for(this).info('Starting', { features: config.flags })
-          const unusedFlags = Object.values(config.flags)
-            .filter((x) => !x.used)
-            .map((x) => x.feature)
-          if (unusedFlags.length > 0) {
-            logger
-              .for(this)
-              .warn('Some feature flags are not used', { unusedFlags })
-          }
-          logger.for(this).info('Log level', config.logger.logLevel)
+    if (config.isReadonly) {
+      this.start = async () => {
+        await apiServer.start()
+      }
+      return
+    }
 
-          await apiServer.start()
-          await database.start()
-          for (const module of modules) {
-            await module?.start?.()
-          }
-        }
+    this.start = async () => {
+      logger.for(this).info('Starting', { features: config.flags })
+      const unusedFlags = Object.values(config.flags)
+        .filter((x) => !x.used)
+        .map((x) => x.feature)
+      if (unusedFlags.length > 0) {
+        logger
+          .for(this)
+          .warn('Some feature flags are not used', { unusedFlags })
+      }
+      logger.for(this).info('Log level', config.logger.logLevel)
+
+      await apiServer.start()
+      await database.start()
+      for (const module of modules) {
+        await module?.start?.()
+      }
+    }
   }
 }

--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -77,23 +77,27 @@ export class Application {
       getErrorReportingMiddleware(),
     )
 
-    this.start = async () => {
-      logger.for(this).info('Starting', { features: config.flags })
-      const unusedFlags = Object.values(config.flags)
-        .filter((x) => !x.used)
-        .map((x) => x.feature)
-      if (unusedFlags.length > 0) {
-        logger
-          .for(this)
-          .warn('Some feature flags are not used', { unusedFlags })
-      }
-      logger.for(this).info('Log level', config.logger.logLevel)
+    this.start = config.isReadonly
+      ? async () => {
+          await apiServer.start()
+        }
+      : async () => {
+          logger.for(this).info('Starting', { features: config.flags })
+          const unusedFlags = Object.values(config.flags)
+            .filter((x) => !x.used)
+            .map((x) => x.feature)
+          if (unusedFlags.length > 0) {
+            logger
+              .for(this)
+              .warn('Some feature flags are not used', { unusedFlags })
+          }
+          logger.for(this).info('Log level', config.logger.logLevel)
 
-      await apiServer.start()
-      await database.start()
-      for (const module of modules) {
-        await module?.start?.()
-      }
-    }
+          await apiServer.start()
+          await database.start()
+          for (const module of modules) {
+            await module?.start?.()
+          }
+        }
   }
 }

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -70,6 +70,7 @@ export interface DatabaseConfig {
     min: number
     max: number
   }
+  readonly isReadonly: boolean
 }
 
 export interface ClockConfig {

--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -18,6 +18,7 @@ import { FinalityProjectConfig } from './features/finality'
 
 export interface Config {
   readonly name: string
+  readonly isReadonly: boolean
   readonly projects: Project[]
   readonly tokens: Token[]
   readonly logger: LoggerConfig

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -34,7 +34,7 @@ export function makeConfig(
   const isReadonly = env.boolean(
     'READONLY',
     // if we connect locally to production db, we want to be readonly!
-    isLocal && env.string('LOCAL_DB_URL').includes('localhost'),
+    isLocal && !env.string('LOCAL_DB_URL').includes('localhost'),
   )
   return {
     name,

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -33,6 +33,7 @@ export function makeConfig(
 
   return {
     name,
+    isReadonly: env.boolean('READONLY', false),
     projects: layer2s.map(layer2ToProject).concat(bridges.map(bridgeToProject)),
     tokens: tokenList,
     logger: {

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -31,7 +31,11 @@ export function makeConfig(
   ).append('status')
   const tvl2Config = getTvl2Config(flags, env, minTimestampOverride)
 
-  const isReadonly = env.boolean('READONLY', false)
+  const isReadonly = env.boolean(
+    'READONLY',
+    // if we connect locally to production db, we want to be readonly!
+    isLocal && env.string('LOCAL_DB_URL').includes('localhost'),
+  )
   return {
     name,
     isReadonly,

--- a/packages/backend/src/peripherals/database/Database.ts
+++ b/packages/backend/src/peripherals/database/Database.ts
@@ -22,6 +22,7 @@ export class Database {
     this.onMigrationsComplete = resolve
   })
   private readonly requiredMajorVersion: number
+  private readonly isReadonly: boolean
 
   constructor(
     private readonly config: DatabaseConfig,
@@ -49,10 +50,12 @@ export class Database {
       },
       pool: config.connectionPoolSize,
     })
+
+    this.isReadonly = config.isReadonly
   }
 
   async getKnex(trx?: Knex.Transaction) {
-    if (!this.migrated) {
+    if (!this.isReadonly && !this.migrated) {
       await this.migrationsComplete
     }
     return trx ?? this.knex

--- a/packages/backend/src/test/database.ts
+++ b/packages/backend/src/test/database.ts
@@ -51,6 +51,7 @@ export function getTestDatabase(
       },
       freshStart: false,
       enableQueryLogging: false,
+      isReadonly: false,
       ...opts,
     },
     Logger.SILENT,


### PR DESCRIPTION
When developing locally you can now set an env `READONLY=true` that will only start the ApiServer, allowing you to develop controller when connecting to the staging/prod db