### PR TITLE
Alter `indexer_configurations.properties` column type

### DIFF
--- a/packages/backend/src/peripherals/database/migrations/104_configurations_properties_length_fix.ts
+++ b/packages/backend/src/peripherals/database/migrations/104_configurations_properties_length_fix.ts
@@ -1,0 +1,26 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+
+DO NOT EDIT OR RENAME THIS FILE
+
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server.
+
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex.schema.alterTable('indexer_configurations', function (table) {
+    table.text('properties').notNullable().alter()
+  })
+}
+
+export async function down(knex: Knex) {
+  await knex.schema.alterTable('indexer_configurations', function (table) {
+    table.string('properties').notNullable().alter()
+  })
+}


### PR DESCRIPTION
Previously the string length has been limited to 255 characters, type `text` does not have this limit.

https://knexjs.org/guide/schema-builder.html#text