### PR TITLE
Fix toFixed error

### DIFF
--- a/packages/frontend/src/utils/getFirstTwoNonZeroPrecision.test.ts
+++ b/packages/frontend/src/utils/getFirstTwoNonZeroPrecision.test.ts
@@ -5,6 +5,7 @@ import { getFirstTwoNonZeroPrecision } from './getFirstTwoNonZeroPrecision'
 describe(getFirstTwoNonZeroPrecision.name, () => {
   const testCases = [
     { value: 99e-15, expected: 15 },
+    { value: 1e-12, expected: 6, maxPrecision: 6 },
     { value: 1e-12, expected: 13 },
     { value: 0.000009347, expected: 7 },
     { value: 0.009, expected: 4 },
@@ -15,21 +16,33 @@ describe(getFirstTwoNonZeroPrecision.name, () => {
 
   for (const testCase of testCases) {
     it(`should return ${testCase.expected} for ${testCase.value}`, () => {
-      expect(getFirstTwoNonZeroPrecision(testCase.value)).toEqual(
-        testCase.expected,
-      )
+      expect(
+        getFirstTwoNonZeroPrecision(testCase.value, testCase.maxPrecision),
+      ).toEqual(testCase.expected)
     })
 
     it(`should return ${testCase.expected} for -${testCase.value}`, () => {
-      expect(getFirstTwoNonZeroPrecision(-testCase.value)).toEqual(
-        testCase.expected,
-      )
+      expect(
+        getFirstTwoNonZeroPrecision(-testCase.value, testCase.maxPrecision),
+      ).toEqual(testCase.expected)
     })
   }
 
   it('should throw an error if value is greater than 1', () => {
     expect(() => getFirstTwoNonZeroPrecision(1)).toThrow(
       'Value must be less than 1',
+    )
+  })
+
+  it('should throw an error if precision is less than 0', () => {
+    expect(() => getFirstTwoNonZeroPrecision(0.1, -1)).toThrow(
+      'Precision must be between 0 and 100',
+    )
+  })
+
+  it('should throw an error if precision is greater than 100', () => {
+    expect(() => getFirstTwoNonZeroPrecision(0.1, 101)).toThrow(
+      'Precision must be between 0 and 100',
     )
   })
 })

--- a/packages/frontend/src/utils/getFirstTwoNonZeroPrecision.ts
+++ b/packages/frontend/src/utils/getFirstTwoNonZeroPrecision.ts
@@ -1,7 +1,13 @@
-export function getFirstTwoNonZeroPrecision(value: number) {
-  if (value >= 1) {
-    throw new Error('Value must be less than 1')
-  }
+import { assert } from '@l2beat/shared-pure'
 
-  return 1 - Math.floor(Math.log(Math.abs(value)) / Math.log(10))
+export function getFirstTwoNonZeroPrecision(value: number, maxPrecision = 32) {
+  assert(value < 1, 'Value must be less than 1')
+  assert(
+    maxPrecision >= 0 && maxPrecision <= 100,
+    'Precision must be between 0 and 100',
+  )
+
+  const precision = 1 - Math.floor(Math.log(Math.abs(value)) / Math.log(10))
+
+  return Math.min(precision, maxPrecision)
 }


### PR DESCRIPTION
This pull request fixes the toFixed error in the getFirstTwoNonZeroPrecision function. The error occurred when the precision parameter was set to a value less than 0 or greater than 100. The fix adds validation for the precision parameter and throws an error if it is outside the valid range.