### PR TITLE
Update fraxtal minTimestamp and add better logging to EtherscanClient

### DIFF
--- a/packages/config/src/layer2s/fraxtal.ts
+++ b/packages/config/src/layer2s/fraxtal.ts
@@ -116,7 +116,6 @@ export const fraxtal: Layer2 = opStackL2({
   ],
   chainConfig: {
     name: 'fraxtal',
-
     chainId: 252,
     explorerUrl: 'https://fraxscan.com/',
     explorerApi: {
@@ -124,7 +123,7 @@ export const fraxtal: Layer2 = opStackL2({
       type: 'etherscan',
     },
     // ~ Timestamp of block number 1
-    minTimestampForTvl: UnixTime.fromDate(new Date('2024-02-01T06:05:11Z')),
+    minTimestampForTvl: new UnixTime(1706810713),
     coingeckoPlatform: 'fraxtal',
   },
   nonTemplateEscrows: [],

--- a/packages/shared/src/services/etherscan/EtherscanClient.ts
+++ b/packages/shared/src/services/etherscan/EtherscanClient.ts
@@ -111,7 +111,13 @@ export class EtherscanClient implements BlockNumberProvider {
       }
     }
 
-    throw new Error('Could not fetch block number')
+    throw new Error('Could not fetch block number', {
+      cause: {
+        current,
+        timestamp,
+        minTimestamp: this.minTimestamp,
+      },
+    })
   }
 
   async getContractSource(address: EthereumAddress) {


### PR DESCRIPTION
The changes in the code include updating the minTimestamp for the fraxtal chain and adding better logging functionality to the EtherscanClient class.