### PR TITLE
Stop activity sync when project becomes archived

### DIFF
--- a/packages/backend/src/config/features/activity.ts
+++ b/packages/backend/src/config/features/activity.ts
@@ -8,6 +8,11 @@ const DEFAULT_RPC_CALLS_PER_MINUTE = 60
 const DEFAULT_RESYNC_LAST_DAYS = 7
 
 export function getProjectsWithActivity() {
+  const projects = [
+    ...layer2s.filter((layer2) => !layer2.isArchived),
+    ...layer3s,
+  ]
+
   return [
     {
       id: ProjectId.ETHEREUM,
@@ -17,7 +22,7 @@ export function getProjectsWithActivity() {
         startBlock: 8929324,
       } as ScalingProjectTransactionApi,
     },
-    ...[...layer2s, ...layer3s].flatMap((x) =>
+    ...projects.flatMap((x) =>
       x.config.transactionApi
         ? [{ id: x.id, transactionApi: x.config.transactionApi }]
         : [],


### PR DESCRIPTION
This pull request stops the synchronization of activity when a project becomes archived. It includes changes to the `getProjectsWithActivity` function to exclude archived projects from the list of projects to sync activity for.