### PR TITLE
Fix activity API response handling

### DIFF
--- a/packages/backend/src/modules/activity/api/ActivityRouter.ts
+++ b/packages/backend/src/modules/activity/api/ActivityRouter.ts
@@ -15,8 +15,13 @@ export function createActivityRouter(activityController: ActivityController) {
   const router = new Router()
 
   router.get('/api/activity', async (ctx) => {
-    const data = await activityController.getActivity()
-    ctx.body = data
+    const result = await activityController.getActivity()
+    if (result.type === 'error') {
+      handleActivityError(ctx, result)
+      return
+    }
+
+    ctx.body = result.data
   })
 
   router.get(
@@ -38,15 +43,15 @@ export function createActivityRouter(activityController: ActivityController) {
           return
         }
 
-        const data = await activityController.getAggregatedActivity(
+        const aggregatedResult = await activityController.getAggregatedActivity(
           projectIdsResult.data,
         )
-        if (data.type === 'error') {
-          handleActivityError(ctx, data)
+        if (aggregatedResult.type === 'error') {
+          handleActivityError(ctx, aggregatedResult)
           return
         }
 
-        ctx.body = data
+        ctx.body = aggregatedResult.data
       },
     ),
   )

--- a/packages/backend/src/modules/tracked-txs/modules/liveness/api/LivenessController.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/liveness/api/LivenessController.ts
@@ -26,14 +26,14 @@ import {
 } from './calculateIntervalWithAverages'
 import { groupByType } from './groupByType'
 
-type LivenessResult = Result<LivenessApiResponse, 'DATA_NOT_SYNCED'>
+export type LivenessResult = Result<LivenessApiResponse, 'DATA_NOT_SYNCED'>
 
 interface LivenessTransactionsDetail {
   txHash: string
   timestamp: UnixTime
 }
 
-type LivenessTransactionsResult = Result<
+export type LivenessTransactionsResult = Result<
   {
     projects: Record<
       string,


### PR DESCRIPTION
This pull request fixes the handling of the API response in the activity router. It now properly handles error responses and returns the correct data in the success case.