### PR TITLE
Eigenlayer discovery: Ignore AVS list in watch mode

### DIFF
--- a/packages/backend/discovery/eigenlayer/ethereum/config.jsonc
+++ b/packages/backend/discovery/eigenlayer/ethereum/config.jsonc
@@ -174,7 +174,8 @@
           "valueKey": "avs"
         }
       },
-      "ignoreRelatives": ["avs"]
+      "ignoreRelatives": ["avs"],
+      "ignoreInWatchMode": ["avs"]
     },
     // ignore discovery, should be ignoreRelative in a strategy but it does not work
     "0xae78736Cd615f374D3085123A210448E74Fc6393": { "ignoreDiscovery": true },

--- a/packages/backend/discovery/eigenlayer/ethereum/diffHistory.md
+++ b/packages/backend/discovery/eigenlayer/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xa6b8279a50f9f4e3f28c301665c8283ef042f7e5
+Generated with discovered.json: 0xcffb6b02de5bb310768147ee3220a56f9af3bdb0
 
 # Diff at Tue, 23 Apr 2024 22:44:53 GMT:
 

--- a/packages/backend/discovery/eigenlayer/ethereum/discovered.json
+++ b/packages/backend/discovery/eigenlayer/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "eigenlayer",
   "chain": "ethereum",
-  "blockNumber": 19721151,
-  "configHash": "0xfff76f5adb4c19c8617856518313cbf901398f8b959fe5156eb8b1bd6f56c56b",
+  "blockNumber": 19732379,
+  "configHash": "0x9e644d1a51cd46b581b24d2841832d7f36b92b70514596360ffcbf92c368bc6a",
   "version": 3,
   "contracts": [
     {
@@ -13,8 +13,8 @@
       },
       "sinceTimestamp": 1602667372,
       "values": {
-        "get_deposit_count": "0x6629160000000000",
-        "get_deposit_root": "0xc63dc7afbceb26e4c47dd0e01f3f252bded023f32bf74af68a90d49328adbe0e"
+        "get_deposit_count": "0xc334160000000000",
+        "get_deposit_root": "0x70979696bf26a2e4006a8c743d1b72e4fc78c3f392c2ccca5bdd489fea41d613"
       },
       "derivedName": "DepositContract"
     },
@@ -50,7 +50,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "176897426945050488540566",
+        "totalShares": "179570046311326946742647",
         "underlyingToken": "0xf951E335afb289353dc249e82926178EaC7DEd78"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -75,7 +75,8 @@
           "0x35F4f28A8d3Ff20EEd10e087e8F96Ea2641E6AA2",
           "0x23221c5bB90C7c57ecc1E75513e2E4257673F0ef",
           "0xed2f4d90b073128ae6769a9A8D51547B1Df766C8",
-          "0xE5445838C475A2980e6a88054ff1514230b83aEb"
+          "0xE5445838C475A2980e6a88054ff1514230b83aEb",
+          "0xd50E0931703302B080880C45148F5D83ea66aE2a"
         ],
         "delegation": "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
         "DOMAIN_TYPEHASH": "0x8cad95687ba82c2ce50e74f7b754645e5117c3a5bec8151c0726d5857980a866",
@@ -108,7 +109,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "1351346469062629501537",
+        "totalShares": "1370754978739599755189",
         "underlyingToken": "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -134,7 +135,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "54824471393392664843629",
+        "totalShares": "55026664196117199622810",
         "underlyingToken": "0xae78736Cd615f374D3085123A210448E74Fc6393"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -160,7 +161,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "170879705913944660407952",
+        "totalShares": "170672174157450696421122",
         "underlyingToken": "0xd5F7838F5C461fefF7FE49ea5ebaF7728bB0ADfa"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -250,7 +251,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "24592509775170861017593",
+        "totalShares": "24568223819875864489363",
         "underlyingToken": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -276,7 +277,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "19328000579252412557428",
+        "totalShares": "19332182534185124087694",
         "underlyingToken": "0xf1C9acDc66974dFB6dEcB12aA385b9cD01190E38"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -314,7 +315,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "83609039400521435758551",
+        "totalShares": "83602371263806604132159",
         "underlyingToken": "0xa2E3356610840701BDf5611a53974510Ae27E2e1"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -429,7 +430,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "25087485496661672845651",
+        "totalShares": "25078803253115198866298",
         "underlyingToken": "0xac3E018457B222d93114458476f3E3416Abbe38F"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -451,7 +452,7 @@
         "denebForkTimestamp": 1710338135,
         "eigenPodBeacon": "0x5a2a4F2F3C18f09179B6703e63D9eDD165909073",
         "ethPOS": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
-        "numPods": 30549,
+        "numPods": 30579,
         "owner": "0x369e6F597e22EaB55fFb173C6d9cD234BD699111",
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
@@ -481,7 +482,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "978638972247861195563778",
+        "totalShares": "993526968880279327105630",
         "underlyingToken": "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -507,7 +508,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "102632306035141314349488",
+        "totalShares": "102636823151288256431245",
         "underlyingToken": "0xA35b1B31Ce002FBF2058D22F30f95D405200A15b"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -533,7 +534,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "15743723236232947437287",
+        "totalShares": "15743959812628793668051",
         "underlyingToken": "0x856c4Efb76C1D1AE02e20CEB03A2A6a08b0b8dC3"
       },
       "derivedName": "StrategyBaseTVLLimits"
@@ -575,7 +576,7 @@
         "paused": 0,
         "pauserRegistry": "0x0c431C66F4dE941d089625E5B423D00707977060",
         "strategyManager": "0x858646372CC42E1A627fcE94aa7A7033e7CF075A",
-        "totalShares": "9899139075848119831346",
+        "totalShares": "9909127031505027886425",
         "underlyingToken": "0x8c1BEd5b9a0928467c9B1341Da1D7BD5e10b6549"
       },
       "derivedName": "StrategyBaseTVLLimits"

--- a/packages/backend/discovery/eigenlayer/ethereum/meta.json
+++ b/packages/backend/discovery/eigenlayer/ethereum/meta.json
@@ -85,17 +85,47 @@
       "name": "DelegationManager",
       "description": "Manages interactions between stakers and Eigenlayer operators, registers operators.",
       "values": {
-        "DELEGATION_TYPEHASH": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "DOMAIN_SEPARATOR": {
+        "DELEGATION_APPROVAL_TYPEHASH": {
           "description": null,
           "severity": null,
           "type": null
         },
         "DOMAIN_TYPEHASH": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "MAX_STAKER_OPT_OUT_WINDOW_BLOCKS": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "MAX_WITHDRAWAL_DELAY_BLOCKS": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "STAKER_DELEGATION_TYPEHASH": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "beaconChainETHStrategy": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "domainSeparator": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "eigenPodManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "minWithdrawalDelayBlocks": {
           "description": null,
           "severity": null,
           "type": null
@@ -193,14 +223,24 @@
       }
     },
     {
+      "name": "EigenLayerBeaconOracle",
+      "values": {
+        "GENESIS_BLOCK_TIMESTAMP": {
+          "description": null,
+          "severity": null,
+          "type": null
+        }
+      }
+    },
+    {
       "name": "EigenPod",
       "values": {
-        "REQUIRED_BALANCE_GWEI": {
+        "GENESIS_TIME": {
           "description": null,
           "severity": null,
           "type": null
         },
-        "REQUIRED_BALANCE_WEI": {
+        "MAX_RESTAKED_BALANCE_GWEI_PER_VALIDATOR": {
           "description": null,
           "severity": null,
           "type": null
@@ -225,7 +265,12 @@
           "severity": null,
           "type": null
         },
-        "mostRecentWithdrawalBlockNumber": {
+        "mostRecentWithdrawalTimestamp": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "nonBeaconChainETHBalanceWei": {
           "description": null,
           "severity": null,
           "type": null
@@ -235,7 +280,12 @@
           "severity": null,
           "type": null
         },
-        "restakedExecutionLayerGwei": {
+        "sumOfPartialWithdrawalsClaimedGwei": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "withdrawableRestakedExecutionLayerGwei": {
           "description": null,
           "severity": null,
           "type": null
@@ -245,7 +295,22 @@
     {
       "name": "EigenPodManager",
       "values": {
+        "beaconChainETHStrategy": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
         "beaconChainOracle": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "delegationManager": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "denebForkTimestamp": {
           "description": null,
           "severity": null,
           "type": null
@@ -256,11 +321,6 @@
           "type": null
         },
         "ethPOS": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "maxPods": {
           "description": null,
           "severity": null,
           "type": null
@@ -614,27 +674,17 @@
           "severity": null,
           "type": null
         },
-        "DOMAIN_SEPARATOR": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
         "DOMAIN_TYPEHASH": {
           "description": null,
           "severity": null,
           "type": null
         },
-        "MAX_WITHDRAWAL_DELAY_BLOCKS": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "beaconChainETHStrategy": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
         "delegation": {
+          "description": null,
+          "severity": null,
+          "type": null
+        },
+        "domainSeparator": {
           "description": null,
           "severity": null,
           "type": null
@@ -670,11 +720,6 @@
           "type": null
         },
         "strategyWhitelister": {
-          "description": null,
-          "severity": null,
-          "type": null
-        },
-        "withdrawalDelayBlocks": {
           "description": null,
           "severity": null,
           "type": null


### PR DESCRIPTION
Closes L2B-5002

A new AVS called _DODOchain MACH (Powered by AltLayer)_ on Eigenbeat with the same implementation contract as the existing Altlayer MACH (0 diff) is added to the Registry.

Moved the AVS list into ignoreInWatchMode to prevent future spam but keep it accessible.