### PR TITLE
Update taiko.ts - Fix Doc Link and Update App and Explorer

### DIFF
--- a/packages/config/src/layer2s/taiko.ts
+++ b/packages/config/src/layer2s/taiko.ts
@@ -12,9 +12,9 @@ export const taiko: Layer2 = upcomingL2({
     category: 'ZK Rollup',
     links: {
       websites: ['https://taiko.xyz'],
-      apps: ['https://bridge.test.taiko.xyz'],
-      documentation: ['https://taiko.xyz/docs'],
-      explorers: ['https://katla.taikoscan.network/'],
+      apps: ['https://bridge.hekla.taiko.xyz/'],
+      documentation: ['https://docs.taiko.xyz/'],
+      explorers: ['https://hekla.taikoscan.network/'],
       repositories: ['https://github.com/taikoxyz'],
       socialMedia: [
         'https://twitter.com/taikoxyz',


### PR DESCRIPTION
Hekla is new testnet name.

Old App: https://bridge.test.taiko.xyz
New App: https://bridge.hekla.taiko.xyz/

Old Doc: https://taiko.xyz/docs (Error 404)
New Doc: https://docs.taiko.xyz/

Old Explorer: https://katla.taikoscan.network/
New Explorer: https://hekla.taikoscan.network/