### PR TITLE
Add LINDA memecoin to Linea

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -5554,6 +5554,21 @@
       }
     },
     {
+      "id": "linea:linda-linda",
+      "name": "Linda",
+      "coingeckoId": "linda-2",
+      "address": "0x82cC61354d78b846016b559e3cCD766fa7E793D5",
+      "symbol": "LINDA",
+      "decimals": 18,
+      "deploymentTimestamp": 1702004773,
+      "coingeckoListingTimestamp": 1702771200,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/33699/large/linda-logo-200.png?1705166731",
+      "chainId": 59144,
+      "type": "NMV",
+      "formula": "totalSupply"
+    },
+    {
       "id": "linea:lube-lube",
       "name": "LUBE",
       "coingeckoId": "lube",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1630,6 +1630,12 @@
       }
     },
     {
+      "symbol": "LINDA", // LayerZero bridged but Linea native with OFT adapter (locking escrow)
+      "address": "0x82cC61354d78b846016b559e3cCD766fa7E793D5",
+      "type": "NMV",
+      "formula": "totalSupply" // no circulating on coingecko and almost totalsupply is close to circ
+    },
+    {
       "symbol": "LUBE",
       "address": "0x1be3735dd0c0eb229fb11094b6c277192349ebbf",
       "type": "NMV",


### PR DESCRIPTION
Native ERC-20 token [with OFT adapter on Linea](https://lineascan.build/address/0xf2dd6dd5410f15e0e7b5cfff6a655d70484e3099), so it is an OFT-20 via LayerZero on all other chains.
Due to being NMV and lock-mint on Linea, this would be circulating supply-based but coingecko has no circulating, so we use totalSupply.