### PR TITLE
Add weETH.mode to mode

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -5068,7 +5068,7 @@
       "iconUrl": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396",
       "chainId": 34443,
       "type": "NMV",
-      "formula": "circulatingSupply",
+      "formula": "totalSupply",
       "bridgedUsing": {
         "bridge": "Layer Zero",
         "slug": "omnichain"

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -5056,6 +5056,25 @@
       }
     },
     {
+      "id": "mode:weeth.mode-wrapped-eeth",
+      "name": "Wrapped eETH",
+      "coingeckoId": "wrapped-eeth",
+      "address": "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A",
+      "symbol": "weETH.mode",
+      "decimals": 18,
+      "deploymentTimestamp": 1713248229,
+      "coingeckoListingTimestamp": 1701648000,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396",
+      "chainId": 34443,
+      "type": "NMV",
+      "formula": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "Layer Zero",
+        "slug": "omnichain"
+      }
+    },
+    {
       "id": "arb-arbitrum",
       "name": "Arbitrum",
       "coingeckoId": "arbitrum",

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -5068,7 +5068,7 @@
       "iconUrl": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396",
       "chainId": 34443,
       "type": "NMV",
-      "formula": "totalSupply",
+      "formula": "circulatingSupply",
       "bridgedUsing": {
         "bridge": "Layer Zero",
         "slug": "omnichain"

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1799,7 +1799,7 @@
       "symbol": "weETH.mode",
       "address": "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A",
       "type": "NMV",
-      "formula": "circulatingSupply",
+      "formula": "totalSupply",
       "coingeckoId": "wrapped-eeth",
       "bridgedUsing": {
         "bridge": "Layer Zero",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1799,7 +1799,7 @@
       "symbol": "weETH.mode",
       "address": "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A",
       "type": "NMV",
-      "formula": "totalSupply",
+      "formula": "circulatingSupply",
       "coingeckoId": "wrapped-eeth",
       "bridgedUsing": {
         "bridge": "Layer Zero",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1794,6 +1794,17 @@
       "bridgedUsing": {
         "bridge": "Free"
       }
+    },
+    {
+      "symbol": "weETH.mode",
+      "address": "0x04C0599Ae5A44757c0af6F9eC3b93da8976c150A",
+      "type": "NMV",
+      "formula": "totalSupply",
+      "coingeckoId": "wrapped-eeth",
+      "bridgedUsing": {
+        "bridge": "Layer Zero",
+        "slug": "omnichain"
+      }
     }
   ],
   "scroll": [


### PR DESCRIPTION
Closes L2B-5130

There is now two weETH on mode:
- canonically bridged weETH
- OFT (NMV) weETH.mode (totalSupply)

both are actively being used while the latter is the 'official' (endorsed by ether.fi) variant