### PR TITLE
add ZF, cSTONE tokens

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -3301,6 +3301,21 @@
       "formula": "locked"
     },
     {
+      "id": "cstone-stone-carnival-lp",
+      "name": "STONE Carnival LP",
+      "coingeckoId": "stakestone-ether",
+      "address": "0x4d831e22F062b5327dFdB15f0b6a5dF20E2E3dD0",
+      "symbol": "cSTONE",
+      "decimals": 18,
+      "deploymentTimestamp": 1711799423,
+      "coingeckoListingTimestamp": 1700611200,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/33103/large/200_200.png?1702602672",
+      "chainId": 1,
+      "type": "CBV",
+      "formula": "locked"
+    },
+    {
       "id": "super-superfarm",
       "name": "SuperFarm",
       "coingeckoId": "superfarm",
@@ -4590,6 +4605,21 @@
       "coingeckoListingTimestamp": 1703894400,
       "category": "other",
       "iconUrl": "https://assets.coingecko.com/coins/images/34101/large/rsz_logo2.png?1703959505",
+      "chainId": 324,
+      "type": "NMV",
+      "formula": "circulatingSupply"
+    },
+    {
+      "id": "zksync2:zf-zkswap-finance",
+      "name": "zkSwap Finance",
+      "coingeckoId": "zkswap-finance",
+      "address": "0x31C2c031fDc9d33e974f327Ab0d9883Eae06cA4A",
+      "symbol": "ZF",
+      "decimals": 18,
+      "deploymentTimestamp": 1685413427,
+      "coingeckoListingTimestamp": 1694476800,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/31633/large/zf.png?1696530449",
       "chainId": 324,
       "type": "NMV",
       "formula": "circulatingSupply"

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -896,6 +896,11 @@
       "address": "0x7122985656e38BDC0302Db86685bb972b145bD3C"
     },
     {
+      "symbol": "cSTONE",
+      "address": "0x4d831e22F062b5327dFdB15f0b6a5dF20E2E3dD0",
+      "coingeckoId": "stakestone-ether"
+    },
+    {
       "symbol": "STRK",
       "address": "0xca14007eff0db1f8135f4c25b34de49ab0d42766"
     },
@@ -1899,6 +1904,12 @@
       "coingeckoId": "frax-ether"
     },
     {
+      "symbol": "HOLD",
+      "address": "0xed4040fd47629e7c8fbb7da76bb50b3e7695f0f2",
+      "type": "NMV",
+      "formula": "circulatingSupply"
+    },
+    {
       "symbol": "sfrxETH",
       "address": "0x22F91E9436C220af83fb0Ce27a08918dD1d27D32",
       "type": "EBV",
@@ -1923,8 +1934,8 @@
       "formula": "circulatingSupply"
     },
     {
-      "symbol": "HOLD",
-      "address": "0xed4040fd47629e7c8fbb7da76bb50b3e7695f0f2",
+      "symbol": "ZF",
+      "address": "0x31C2c031fDc9d33e974f327Ab0d9883Eae06cA4A",
       "type": "NMV",
       "formula": "circulatingSupply"
     }


### PR DESCRIPTION
Closes L2B-5186

ZF is NMV (non-multichain) with circSupply from CG
cSTONE is 90-day-locked STONE, canonBridged, locking can only happen on L1 ethereum
  using STONE price and symbol from CG
