### PR TITLE
Remove _headers file

### DIFF
--- a/packages/frontend/src/static/_headers
+++ b/packages/frontend/src/static/_headers
@@ -1,2 +1,0 @@
-/api/dydx.json
-  Access-Control-Allow-Origin: *


### PR DESCRIPTION
This pull request removes the _headers file from the repository. This was done because /api/dydx has already been removed and it was a omitted leftover.