### PR TITLE
Add usdc (socket) as ebv to Reya

### DIFF
--- a/packages/config/src/projects/layer2s/reya.ts
+++ b/packages/config/src/projects/layer2s/reya.ts
@@ -33,6 +33,17 @@ export const reya: Layer2 = orbitStackL2({
     },
     // activityDataSource: 'Blockchain RPC',
   },
+  chainConfig: {
+    name: 'reya',
+    chainId: 1729,
+    explorerUrl: 'https://explorer.aevo.xyz',
+    explorerApi: {
+      url: 'https://explorer.reya.network/api',
+      type: 'blockscout',
+    },
+    multicallContracts: [],
+    minTimestampForTvl: new UnixTime(1709380607),
+  },
   trackedTxs: [
     {
       uses: [

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -4792,6 +4792,25 @@
       }
     },
     {
+      "id": "reya:usdc-usd-coin",
+      "name": "USD Coin",
+      "coingeckoId": "usd-coin",
+      "address": "0x3B860c0b53f2e8bd5264AA7c3451d41263C933F2",
+      "symbol": "USDC",
+      "decimals": 6,
+      "deploymentTimestamp": 1712238549,
+      "coingeckoListingTimestamp": 1573689600,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694",
+      "chainId": 1729,
+      "type": "EBV",
+      "formula": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "Socket",
+        "slug": "socket"
+      }
+    },
+    {
       "id": "aevo:usdc-usd-coin",
       "name": "USD Coin",
       "coingeckoId": "usd-coin",

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -4958,7 +4958,7 @@
       "iconUrl": "https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880",
       "chainId": 8453,
       "type": "CBV",
-      "formula": "locked"
+      "formula": "totalSupply"
     },
     {
       "id": "base:rseth-kelpdao-restaked-eth",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1356,7 +1356,7 @@
     {
       "symbol": "ETH",
       "type": "CBV",
-      "formula": "totalSupply",
+      "formula": "totalSupply", // formula does not matter here
       "category": "ether"
     }
   ],
@@ -1551,7 +1551,7 @@
     {
       "symbol": "ETH",
       "type": "CBV",
-      "formula": "locked",
+      "formula": "totalSupply", // formula does not matter here
       "category": "ether"
     }
   ],

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1355,6 +1355,8 @@
     },
     {
       "symbol": "ETH",
+      "type": "CBV",
+      "formula": "totalSupply",
       "category": "ether"
     }
   ],
@@ -1548,6 +1550,8 @@
     },
     {
       "symbol": "ETH",
+      "type": "CBV",
+      "formula": "locked",
       "category": "ether"
     }
   ],
@@ -2118,6 +2122,19 @@
         "slug": "fraxferry"
       },
       "coingeckoId": "staked-frax"
+    }
+  ],
+  "reya": [
+    {
+      "symbol": "USDC",
+      "address": "0x3B860c0b53f2e8bd5264AA7c3451d41263C933F2",
+      "type": "EBV",
+      "formula": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "Socket",
+        "slug": "socket"
+      },
+      "coingeckoId": "usd-coin"
     }
   ]
 }


### PR DESCRIPTION
USDC was removed from from reya canonical escrows (although it is the only way to bridge usdc to reya, socket has full control over the vault and manages the infrastrusture)

We also now catch all the USDC bridged via socket from other L2s to reya

The changes for ETH on base and arbitrum in tokens.jsonc are a fix for the tokenscript:
- why are we listing eth on base and arbitrum at all?
- why do they have different formulas?