### PR TITLE
Better heuristic for isRevert

### DIFF
--- a/packages/discovery/src/discovery/utils/isRevert.ts
+++ b/packages/discovery/src/discovery/utils/isRevert.ts
@@ -1,6 +1,14 @@
+import { z } from 'zod'
+
 export function isRevert(e: unknown): boolean {
   if (!(e instanceof Error)) {
     return false
+  }
+  if ('error' in e) {
+    const parsed = ethersError.parse(e.error)
+    if (parsed.reason === 'bad response' && parsed.status !== undefined) {
+      return false
+    }
   }
   return (
     e.message.includes('invalid opcode: INVALID') ||
@@ -9,3 +17,8 @@ export function isRevert(e: unknown): boolean {
     e.message.includes('reverted')
   )
 }
+
+const ethersError = z.object({
+  reason: z.string(),
+  status: z.number().optional(),
+})


### PR DESCRIPTION
Resolves L2B-5251

ethers.js does not indicate that a revert occured in a well-structured way. How we checked if a call reverted is to just catch the error it throws and look into the message if it contains the word "revert" or "reverted". This works when the call actually reverted and the return status code is 200. There is a problem though, assume the provider returns with a status code like 408 [Request Timeout], 503 [Internal Server Error] or any status code that indicates an error that is not handled internally by ethers.js (like 429 [Rate Limited]). In such case ethers.js throws an error with the following message:

missing revert data in call exception; Transaction reverted without a reason string [ See: https://links.ethers.org/v5-errors-CALL_EXCEPTION ]

Even though deeper in the message it says the following thing:

```
{ "reason":"timeout", "code":"TIMEOUT" }
```

That timeout message probably came from the RPC provider, but ethers.js ignores it and throws basically the same error as in the case of a 200 status code [Ok] with revert represented in the response as

```
{
  "errors": {
    "code": -32000,
    "message": "execution reverted"
  }
}
```

There is no well defined behaviour that nodes will follow to indicate an error during handling an RPC call. All we can do is sharpen our heuristic. We do that by checking the reason of the error as defined by ethers.js - "bad response" means that the status code was unexpected. Encountered status code is written into the "status" property of the error. If that reason is encountered and the status property is set this error cannot indicate a revert during this call. Offending error later gets propagated up the stack and ends up crashing discovery.