### PR TITLE
Add RWA (xend) to Arbitrum

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -5676,6 +5676,21 @@
       "formula": "circulatingSupply"
     },
     {
+      "id": "arbitrum:rwa-xend-real-world-asset",
+      "name": "Xend Real World Asset",
+      "coingeckoId": "xend-finance",
+      "address": "0x3096e7BFd0878Cc65be71f8899Bc4CFB57187Ba3",
+      "symbol": "RWA",
+      "decimals": 18,
+      "deploymentTimestamp": 1705326742,
+      "coingeckoListingTimestamp": 1616544000,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/14496/large/WeChat_Image_20210325163206.png?1696514181",
+      "chainId": 42161,
+      "type": "NMV",
+      "formula": "circulatingSupply"
+    },
+    {
       "id": "zkfair:zkf-zkf",
       "name": "ZKF",
       "coingeckoId": "zkfair",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1287,6 +1287,12 @@
       }
     },
     {
+      "symbol": "RWA",
+      "address": "0x3096e7BFd0878Cc65be71f8899Bc4CFB57187Ba3",
+      "type": "NMV",
+      "formula": "circulatingSupply"
+    },
+    {
       "symbol": "rsETH",
       "address": "0x4186BFC76E2E237523CBC30FD220FE055156b41F",
       "type": "NMV",


### PR DESCRIPTION
Closes L2B-5136

RWA is NMV on arbitrum. 
They are using a custom (permissioned) bridging method to bridge to/from supported chains (eth, bnb, poly) which work lock(in token contract) - unlock (from destination token contract) so tracking circulating-only is the way.