### PR TITLE
Changes related to adding Nova as a Orbit Stack

### DIFF
--- a/packages/config/src/discovery/PermissionedContract.ts
+++ b/packages/config/src/discovery/PermissionedContract.ts
@@ -33,6 +33,10 @@ export class PermissionedContract {
     return this.roleDescriptions.join(' ')
   }
 
+  getByTag(tag: StackPermissionsTag): string[] {
+    return this.tags[tag] ?? []
+  }
+
   formatTags(): string {
     return Object.entries(this.tags)
       .map(([tag, contracts]) => {

--- a/packages/config/src/projects/layer2s/templates/orbitStack.ts
+++ b/packages/config/src/projects/layer2s/templates/orbitStack.ts
@@ -13,7 +13,9 @@ import {
   ScalingProjectContract,
   ScalingProjectEscrow,
   ScalingProjectPermission,
+  ScalingProjectRiskView,
   ScalingProjectTechnology,
+  ScalingProjectTechnologyChoice,
   ScalingProjectTransactionApi,
   TECHNOLOGY_DATA_AVAILABILITY,
   addSentimentToDataAvailability,
@@ -27,6 +29,25 @@ import { getStage } from '../common/stages/getStage'
 import { Layer2, Layer2Display, Layer2TxConfig } from '../types'
 
 const ETHEREUM_EXPLORER_URL = 'https://etherscan.io/address/{0}#code'
+export const DEFAULT_OTHER_CONSIDERATIONS: ScalingProjectTechnologyChoice[] = [
+  {
+    name: 'EVM compatible smart contracts are supported',
+    description:
+      'Arbitrum One uses Nitro technology that allows running fraud proofs by executing EVM code on top of WASM.',
+    risks: [
+      {
+        category: 'Funds can be lost if',
+        text: 'there are mistakes in the highly complex Nitro and WASM one-step prover implementation.',
+      },
+    ],
+    references: [
+      {
+        text: 'Inside Arbitrum Nitro',
+        href: 'https://developer.offchainlabs.com/inside-arbitrum-nitro/',
+      },
+    ],
+  },
+]
 
 export interface OrbitStackConfigCommon {
   discovery: ProjectDiscovery
@@ -42,7 +63,9 @@ export interface OrbitStackConfigCommon {
   sequencerInbox: ContractParameters
   nonTemplatePermissions?: ScalingProjectPermission[]
   nonTemplateTechnology?: Partial<ScalingProjectTechnology>
+  additiveConsiderations?: ScalingProjectTechnologyChoice[]
   nonTemplateContracts?: ScalingProjectContract[]
+  nonTemplateRiskView?: Partial<ScalingProjectRiskView>
   rpcUrl?: string
   transactionApi?: ScalingProjectTransactionApi
   milestones?: Milestone[]
@@ -86,16 +109,17 @@ export function orbitStackCommon(
     'sequencerVersion',
   )
   const postsToExternalDA = sequencerVersion !== '0x00'
-  const upgradeability = templateVars.upgradeability ?? {
-    upgradableBy: ['ProxyAdmin'],
-    upgradeDelay: 'No delay',
-  }
+
+  const resolvedTemplates = templateVars.discovery.resolveOrbitStackTemplates({
+    'validators.0': 'Validators/Proposers',
+    'batchPosters.0': 'Sequencers',
+  })
 
   return {
     id: ProjectId(templateVars.discovery.projectName),
     contracts: {
       addresses: [
-        ...templateVars.discovery.getOrbitStackContractDetails(upgradeability),
+        ...resolvedTemplates.contracts,
         ...(templateVars.nonTemplateContracts ?? []),
       ],
       risks: [CONTRACTS.UPGRADE_NO_DELAY_RISK],
@@ -225,32 +249,12 @@ export function orbitStackCommon(
         },
         EXITS.AUTONOMOUS,
       ],
-      otherConsiderations: templateVars.nonTemplateTechnology
-        ?.otherConsiderations ?? [
-        {
-          name: 'EVM compatible smart contracts are supported',
-          description:
-            'Arbitrum One uses Nitro technology that allows running fraud proofs by executing EVM code on top of WASM.',
-          risks: [
-            {
-              category: 'Funds can be lost if',
-              text: 'there are mistakes in the highly complex Nitro and WASM one-step prover implementation.',
-            },
-          ],
-          references: [
-            {
-              text: 'Inside Arbitrum Nitro',
-              href: 'https://developer.offchainlabs.com/inside-arbitrum-nitro/',
-            },
-          ],
-        },
-      ],
+      otherConsiderations:
+        templateVars.nonTemplateTechnology?.otherConsiderations ??
+        DEFAULT_OTHER_CONSIDERATIONS,
     },
     permissions: [
-      ...templateVars.discovery.getOrbitStackPermissions({
-        'validators.0': 'Validators/Proposers',
-        'batchPosters.0': 'Sequencers',
-      }),
+      ...resolvedTemplates.permissions,
       ...(templateVars.nonTemplatePermissions ?? []),
     ],
     milestones: templateVars.milestones,
@@ -327,26 +331,38 @@ export function orbitStackL3(templateVars: OrbitStackConfigL3): Layer3 {
           mode: 'Transactions data (compressed)',
         }),
     riskView: makeBridgeCompatible({
-      stateValidation: RISK_VIEW.STATE_ARBITRUM_FRAUD_PROOFS(nOfChallengers),
-      dataAvailability: postsToExternalDA
-        ? (() => {
-            const DAC = templateVars.discovery.getContractValue<{
-              membersCount: number
-              requiredSignatures: number
-            }>('SequencerInbox', 'dacKeyset')
-            const { membersCount, requiredSignatures } = DAC
-            return RISK_VIEW.DATA_EXTERNAL_DAC({
-              membersCount,
-              requiredSignatures,
-            })
-          })()
-        : RISK_VIEW.DATA_ON_CHAIN_L3,
-      exitWindow: RISK_VIEW.EXIT_WINDOW(0, selfSequencingDelay),
-      sequencerFailure: RISK_VIEW.SEQUENCER_SELF_SEQUENCE(selfSequencingDelay),
+      stateValidation:
+        templateVars.nonTemplateRiskView?.stateValidation ??
+        RISK_VIEW.STATE_ARBITRUM_FRAUD_PROOFS(nOfChallengers),
+      dataAvailability:
+        templateVars.nonTemplateRiskView?.dataAvailability ?? postsToExternalDA
+          ? (() => {
+              const DAC = templateVars.discovery.getContractValue<{
+                membersCount: number
+                requiredSignatures: number
+              }>('SequencerInbox', 'dacKeyset')
+              const { membersCount, requiredSignatures } = DAC
+              return RISK_VIEW.DATA_EXTERNAL_DAC({
+                membersCount,
+                requiredSignatures,
+              })
+            })()
+          : RISK_VIEW.DATA_ON_CHAIN_L3,
+      exitWindow:
+        templateVars.nonTemplateRiskView?.exitWindow ??
+        RISK_VIEW.EXIT_WINDOW(0, selfSequencingDelay),
+      sequencerFailure:
+        templateVars.nonTemplateRiskView?.sequencerFailure ??
+        RISK_VIEW.SEQUENCER_SELF_SEQUENCE(selfSequencingDelay),
       proposerFailure:
+        templateVars.nonTemplateRiskView?.proposerFailure ??
         RISK_VIEW.PROPOSER_SELF_PROPOSE_WHITELIST_DROPPED(validatorAfkTime),
-      validatedBy: RISK_VIEW.VALIDATED_BY_L2(templateVars.hostChain),
-      destinationToken: RISK_VIEW.NATIVE_AND_CANONICAL(),
+      validatedBy:
+        templateVars.nonTemplateRiskView?.validatedBy ??
+        RISK_VIEW.VALIDATED_BY_L2(templateVars.hostChain),
+      destinationToken:
+        templateVars.nonTemplateRiskView?.destinationToken ??
+        RISK_VIEW.NATIVE_AND_CANONICAL(),
     }),
     config: {
       associatedTokens: templateVars.associatedTokens,
@@ -483,26 +499,38 @@ export function orbitStackL2(templateVars: OrbitStackConfigL2): Layer2 {
         }),
     chainConfig: templateVars.chainConfig,
     riskView: makeBridgeCompatible({
-      stateValidation: RISK_VIEW.STATE_ARBITRUM_FRAUD_PROOFS(nOfChallengers),
-      dataAvailability: postsToExternalDA
-        ? (() => {
-            const DAC = templateVars.discovery.getContractValue<{
-              membersCount: number
-              requiredSignatures: number
-            }>('SequencerInbox', 'dacKeyset')
-            const { membersCount, requiredSignatures } = DAC
-            return RISK_VIEW.DATA_EXTERNAL_DAC({
-              membersCount,
-              requiredSignatures,
-            })
-          })()
-        : RISK_VIEW.DATA_ON_CHAIN,
-      exitWindow: RISK_VIEW.EXIT_WINDOW(0, selfSequencingDelay),
-      sequencerFailure: RISK_VIEW.SEQUENCER_SELF_SEQUENCE(selfSequencingDelay),
+      stateValidation:
+        templateVars.nonTemplateRiskView?.stateValidation ??
+        RISK_VIEW.STATE_ARBITRUM_FRAUD_PROOFS(nOfChallengers),
+      dataAvailability:
+        templateVars.nonTemplateRiskView?.dataAvailability ?? postsToExternalDA
+          ? (() => {
+              const DAC = templateVars.discovery.getContractValue<{
+                membersCount: number
+                requiredSignatures: number
+              }>('SequencerInbox', 'dacKeyset')
+              const { membersCount, requiredSignatures } = DAC
+              return RISK_VIEW.DATA_EXTERNAL_DAC({
+                membersCount,
+                requiredSignatures,
+              })
+            })()
+          : RISK_VIEW.DATA_ON_CHAIN,
+      exitWindow:
+        templateVars.nonTemplateRiskView?.exitWindow ??
+        RISK_VIEW.EXIT_WINDOW(0, selfSequencingDelay),
+      sequencerFailure:
+        templateVars.nonTemplateRiskView?.sequencerFailure ??
+        RISK_VIEW.SEQUENCER_SELF_SEQUENCE(selfSequencingDelay),
       proposerFailure:
+        templateVars.nonTemplateRiskView?.proposerFailure ??
         RISK_VIEW.PROPOSER_SELF_PROPOSE_WHITELIST_DROPPED(validatorAfkTime),
-      validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,
-      destinationToken: RISK_VIEW.NATIVE_AND_CANONICAL(),
+      validatedBy:
+        templateVars.nonTemplateRiskView?.validatedBy ??
+        RISK_VIEW.VALIDATED_BY_ETHEREUM,
+      destinationToken:
+        templateVars.nonTemplateRiskView?.destinationToken ??
+        RISK_VIEW.NATIVE_AND_CANONICAL(),
     }),
     config: {
       associatedTokens: templateVars.associatedTokens,


### PR DESCRIPTION
Resolves L2B-5323

- allows to specify non-templetized risk view values
- simplifies expanding on `otherConsiderations`
- automatically detect which permissioned contract can upgrade a contract in contracts section, only for orbit stack for now