### PR TITLE
Fix discovery configs formatting

### DIFF
--- a/packages/backend/discovery/amarok/ethereum/config.jsonc
+++ b/packages/backend/discovery/amarok/ethereum/config.jsonc
@@ -25,7 +25,6 @@
     "0xF1c78967584D5E0ffF66dA103b8eb06c82EC020d": "GnosisHubConnector",
     "0x86E4Dc95c7FBdBf52e33D563BbDB00823894C287": "RootChain",
     "0xE8cF9EbB1cFB137c692a0a4E470E257B9417d116": "PolygonHubConnector",
-
     "0xf5a3372ed529FCD0690b6013EAaE04170ec0626b": "NewWormholeHubConnector",
     "0x5B0E1a507E786f0a7c11C972ad5F4dd254661e24": "MantleHubConnector",
     "0x23b7abe4cc664F24Eb68E80cFAdc572857799a94": "NewOptimismHubConnector",

--- a/packages/backend/discovery/ancient/ethereum/config.jsonc
+++ b/packages/backend/discovery/ancient/ethereum/config.jsonc
@@ -68,7 +68,9 @@
         }
       }
     },
-    "L1ERC721BridgeImplementation": { "ignoreDiscovery": true },
+    "L1ERC721BridgeImplementation": {
+      "ignoreDiscovery": true
+    },
     "Ancient8Multisig": {
       "ignoreInWatchMode": ["nonce"]
     }

--- a/packages/backend/discovery/astarzkevm/ethereum/config.jsonc
+++ b/packages/backend/discovery/astarzkevm/ethereum/config.jsonc
@@ -53,7 +53,9 @@
         }
       }
     },
-    "Bridge": { "ignoreDiscovery": true },
+    "Bridge": {
+      "ignoreDiscovery": true
+    },
     "AstarValidiumDAC": {
       "fields": {
         "members": {

--- a/packages/backend/discovery/aztec/ethereum/config.jsonc
+++ b/packages/backend/discovery/aztec/ethereum/config.jsonc
@@ -43,7 +43,6 @@
           "valueKey": "providerAddress",
           "flagKey": "valid"
         },
-
         "removedRollupProviders": {
           "type": "arrayFromOneEvent",
           "event": "RollupProviderUpdated",

--- a/packages/backend/discovery/blobstream/arbitrum/config.jsonc
+++ b/packages/backend/discovery/blobstream/arbitrum/config.jsonc
@@ -14,7 +14,9 @@
       "ignoreMethods": ["state_dataCommitments", "proxiableUUID"],
       "ignoreInWatchMode": ["latestBlock", "state_proofNonce"],
       "fields": {
-        "accessControl": { "type": "accessControl" }
+        "accessControl": {
+          "type": "accessControl"
+        }
       }
     },
     "SuccinctGateway": {

--- a/packages/backend/discovery/blobstream/base/config.jsonc
+++ b/packages/backend/discovery/blobstream/base/config.jsonc
@@ -14,7 +14,9 @@
       "ignoreMethods": ["state_dataCommitments", "proxiableUUID"],
       "ignoreInWatchMode": ["latestBlock", "state_proofNonce"],
       "fields": {
-        "accessControl": { "type": "accessControl" }
+        "accessControl": {
+          "type": "accessControl"
+        }
       }
     },
     "SuccinctGateway": {

--- a/packages/backend/discovery/degen/base/config.jsonc
+++ b/packages/backend/discovery/degen/base/config.jsonc
@@ -16,7 +16,6 @@
     "0x67812161Bbb6aCF891aA6028BC614a660961ceD8": "ChallengeManager",
     "0xaA3A7A2ec2477A61082E1C41a2c6710587917028": "UpgradeExecutor",
     "0x7dCe2FEE5e30EFf298cD3d9B92649f00EBDfc104": "RollupOwnerMultisig",
-
     "0x43019F8BE1F192587883b67dEA2994999f5a2de2": "UTBDecent", // Decent omnichain service (LayerZero)
     "0xf70da97812CB96acDF810712Aa562db8dfA3dbEF": "Relay Bridge" // EOA Bridge / Liquidity network https://relay.link/transactions/
   },

--- a/packages/backend/discovery/dydx/ethereum/config.jsonc
+++ b/packages/backend/discovery/dydx/ethereum/config.jsonc
@@ -224,7 +224,9 @@
       ],
       "ignoreMethods": ["read"]
     },
-    "USDC": { "ignoreDiscovery": true },
+    "USDC": {
+      "ignoreDiscovery": true
+    },
     "TreasuryVester": {
       "ignoreInWatchMode": ["lastUpdate"]
     },

--- a/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
+++ b/packages/backend/discovery/polygonzkevm/ethereum/config.jsonc
@@ -61,7 +61,9 @@
         }
       }
     },
-    "Bridge": { "ignoreDiscovery": true },
+    "Bridge": {
+      "ignoreDiscovery": true
+    },
     "wstETHBridge": {
       "ignoreRelatives": ["originTokenAddress", "wrappedTokenAddress"],
       "ignoreMethods": ["proxiableUUID", "getStETHByWstETH", "getWstETHByStETH"]

--- a/packages/backend/discovery/sygma/ethereum/config.jsonc
+++ b/packages/backend/discovery/sygma/ethereum/config.jsonc
@@ -19,7 +19,9 @@
   "overrides": {
     "FeeHandlerRouter": {
       "fields": {
-        "accessControl": { "type": "accessControl" }
+        "accessControl": {
+          "type": "accessControl"
+        }
       }
     },
     "Bridge": {
@@ -37,7 +39,6 @@
         }
       }
     },
-
     "AccessControlSegregator": {
       "fields": {
         "role_pauseTransfers": {
@@ -114,7 +115,6 @@
     }
   }
 }
-
 /*
         "0xffaac0eb": {
           "type": "storage",

--- a/packages/backend/discovery/xlayer/ethereum/config.jsonc
+++ b/packages/backend/discovery/xlayer/ethereum/config.jsonc
@@ -52,7 +52,9 @@
         }
       }
     },
-    "Bridge": { "ignoreDiscovery": true },
+    "Bridge": {
+      "ignoreDiscovery": true
+    },
     "XLayerValidiumDAC": {
       "fields": {
         "members": {

--- a/packages/backend/discovery/zkspace/ethereum/config.jsonc
+++ b/packages/backend/discovery/zkspace/ethereum/config.jsonc
@@ -76,7 +76,6 @@
         "totalOpenPriorityRequests"
       ]
     },
-
     "UniswapV2Factory": {
       "ignoreMethods": ["allPairs", "allPairsLength"]
     },


### PR DESCRIPTION
This is a simple `JSON.parse` -> `JSON.stringify` -> `yarn format:fix` on all config.jsonc files using comment-json lib to make sure further scripts *writing* config.jsonc files don't cause any formatting diffs.