### PR TITLE
Update build command in gulpfile.js to use bunx

### DIFF
--- a/packages/frontend/gulpfile.js
+++ b/packages/frontend/gulpfile.js
@@ -42,7 +42,7 @@ function watchStatic() {
 }
 
 function buildContent() {
-  return exec(`node -r esbuild-register src/build/buildPages.ts`)
+  return exec(`bunx --bun run src/build/buildPages.ts`)
 }
 
 function watchContent() {


### PR DESCRIPTION
The build command in the gulpfile.js has been updated to use the "bunx" command instead of "node -r esbuild-register".