### PR TITLE
Remove reorged L3s activity data

### DIFF
--- a/packages/backend/src/peripherals/database/migrations/114_resync_degen_popapex.ts
+++ b/packages/backend/src/peripherals/database/migrations/114_resync_degen_popapex.ts
@@ -1,0 +1,34 @@
+/*
+                      ====== IMPORTANT NOTICE ======
+DO NOT EDIT OR RENAME THIS FILE
+This is a migration file. Once created the file should not be renamed or edited,
+because migrations are only run once on the production server.
+If you find that something was incorrectly set up in the `up` function you
+should create a new migration file that fixes the issue.
+*/
+
+import { Knex } from 'knex'
+
+export async function up(knex: Knex) {
+  await knex('activity.block')
+    .delete()
+    .where('project_id', '=', 'degen')
+    .orWhere('project_id', '=', 'popapex')
+
+  await knex('sequence_processor')
+    .delete()
+    .where('id', '=', 'degen')
+    .orWhere('id', '=', 'popapex')
+}
+
+export async function down(knex: Knex) {
+  await knex('activity.block')
+    .delete()
+    .where('project_id', '=', 'degen')
+    .orWhere('project_id', '=', 'popapex')
+
+  await knex('sequence_processor')
+    .delete()
+    .where('id', '=', 'degen')
+    .orWhere('id', '=', 'popapex')
+}

--- a/packages/backend/src/peripherals/database/migrations/114_resync_degen_popapex.ts
+++ b/packages/backend/src/peripherals/database/migrations/114_resync_degen_popapex.ts
@@ -9,6 +9,8 @@ should create a new migration file that fixes the issue.
 
 import { Knex } from 'knex'
 
+// This migration is to resync the degen and popapex projects
+// The resync is needed because of the reorg that happened on the network
 export async function up(knex: Knex) {
   await knex('activity.block')
     .delete()
@@ -21,14 +23,4 @@ export async function up(knex: Knex) {
     .orWhere('id', '=', 'popapex')
 }
 
-export async function down(knex: Knex) {
-  await knex('activity.block')
-    .delete()
-    .where('project_id', '=', 'degen')
-    .orWhere('project_id', '=', 'popapex')
-
-  await knex('sequence_processor')
-    .delete()
-    .where('id', '=', 'degen')
-    .orWhere('id', '=', 'popapex')
-}
+export async function down() {}


### PR DESCRIPTION
This pull request includes a migration that removes reorged L3s activity. The migration deletes records from the 'activity.block' and 'sequence_processor' tables where the project_id or id is 'degen' or 'popapex'.