### PR TITLE
Add TOPIA token

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -3646,6 +3646,21 @@
       "formula": "locked"
     },
     {
+      "id": "topia-topia",
+      "name": "TOPIA",
+      "coingeckoId": "hytopia",
+      "address": "0xcccCb68e1A848CBDB5b60a974E07aAE143ed40C3",
+      "symbol": "TOPIA",
+      "decimals": 18,
+      "deploymentTimestamp": 1684349891,
+      "coingeckoListingTimestamp": 1692144000,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/31283/large/HYCHAIN_Avatar_Circle.png?1710500962",
+      "chainId": 1,
+      "type": "CBV",
+      "formula": "locked"
+    },
+    {
       "id": "trac-trace-token",
       "name": "Trace Token",
       "coingeckoId": "origintrail",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -971,6 +971,10 @@
       "address": "0x582d872A1B094FC48F5DE31D3B73F2D9bE47def1"
     },
     {
+      "symbol": "TOPIA",
+      "address": "0xcccCb68e1A848CBDB5b60a974E07aAE143ed40C3"
+    },
+    {
       "symbol": "TRAC",
       "address": "0xaA7a9CA87d3694B5755f213B5D04094b8d0F0A6F"
     },


### PR DESCRIPTION
HYCHAIN's TVL is 0 because we're not tracking the token that's in the escrow.