### PR TITLE
Update zkLink Nova URLs

### DIFF
--- a/packages/config/src/projects/layer3s/zkLinkNova.ts
+++ b/packages/config/src/projects/layer3s/zkLinkNova.ts
@@ -10,7 +10,7 @@ export const zklinknova: Layer3 = underReviewL3({
     name: 'zkLink Nova',
     slug: 'zklinknova',
     description:
-      'zkLink Nova is a multi-chain rollup infrastructure based on zero-knowledge technology.',
+      'zkLink Nova is the first zkEVM network to aggregate Ethereum rollups onto one Layer 3.',
     purposes: ['Universal'],
     category: 'Validium',
     provider: 'zkLink Nexus',

--- a/packages/config/src/projects/layer3s/zkLinkNova.ts
+++ b/packages/config/src/projects/layer3s/zkLinkNova.ts
@@ -15,10 +15,10 @@ export const zklinknova: Layer3 = underReviewL3({
     category: 'Validium',
     provider: 'zkLink Nexus',
     links: {
-      websites: ['https://zk.link'],
-      apps: ['https://playground-nexus.zk.link'],
-      documentation: ['https://docs.zk.link'],
-      explorers: ['https://scan-nexus.zk.link'],
+      websites: ['https://zklink.io', 'https://zk.link'],
+      apps: ['https://app.zklink.io', 'https://portal.zklink.io'],
+      documentation: ['https://docs.zklink.io'],
+      explorers: ['https://explorer.zklink.io'],
       repositories: ['https://github.com/zkLinkProtocol'],
       socialMedia: [
         'https://blog.zk.link',


### PR DESCRIPTION
zkLink Nova is the industry’s largest aggregated Layer 3 zkEVM Rollup network that allows for scattered assets across Ethereum Layer 2s to be aggregated for interoperable trade and transactions, while inheriting security from Ethereum.