### PR TITLE
Make defaultUrl for transactionApi required

### DIFF
--- a/packages/config/src/common/ScalingProjectTransactionApi.ts
+++ b/packages/config/src/common/ScalingProjectTransactionApi.ts
@@ -4,13 +4,13 @@ export type AssessCount = (count: number, blockNumber: number) => number
 
 export interface SimpleTransactionApi<T extends string> {
   type: T
-  defaultUrl?: string
+  defaultUrl: string
   defaultCallsPerMinute?: number
 }
 
 export interface RpcTransactionApi {
   type: 'rpc'
-  defaultUrl?: string
+  defaultUrl: string
   defaultCallsPerMinute?: number
   assessCount?: AssessCount
   startBlock?: number

--- a/packages/config/src/projects/layer2s/aevo.ts
+++ b/packages/config/src/projects/layer2s/aevo.ts
@@ -49,6 +49,7 @@ export const aevo: Layer2 = opStackL2({
   },
   transactionApi: {
     type: 'rpc',
+    defaultUrl: 'https://l2-aevo-mainnet-prod-0.t.conduit.xyz/',
     startBlock: 1,
     defaultCallsPerMinute: 800,
     assessCount: subtractOne,


### PR DESCRIPTION
Resolves L2B-5602

Before a user could define a `transactionApi` object without providing the `defaultUrl`. This would cause the backend to look for it in the env variables. If it wasn't set (and it was not for most of the cases) the backend would die. This problem is solved by making the `defaultUrl` required which could always be replaced by providing a different value in the env variables.