### PR TITLE
Fix shared module message in discord to include depending projects

### DIFF
--- a/packages/backend/src/modules/update-monitor/UpdateMonitor.ts
+++ b/packages/backend/src/modules/update-monitor/UpdateMonitor.ts
@@ -276,7 +276,7 @@ export class UpdateMonitor {
     chain: string,
   ) {
     if (diff.length > 0) {
-      const dependents = await findDependents(
+      const dependents = findDependents(
         projectConfig.name,
         chain,
         this.configReader,

--- a/packages/backend/src/modules/update-monitor/utils/findDependents.ts
+++ b/packages/backend/src/modules/update-monitor/utils/findDependents.ts
@@ -1,13 +1,13 @@
 import { ConfigReader } from '@l2beat/discovery'
 
-export async function findDependents(
+export function findDependents(
   name: string,
   chain: string,
   configReader: ConfigReader,
 ) {
-  if (!name.startsWith('l2beat')) return []
+  if (!name.startsWith('shared-')) return []
 
-  const configs = await configReader.readAllConfigsForChain(chain)
+  const configs = configReader.readAllConfigsForChain(chain)
   const dependents: string[] = []
   for (const config of configs) {
     if (config.sharedModules.includes(name)) {


### PR DESCRIPTION
This message was missing the list of projects that depend on this shared module, because of stale code. This PR fixes that.

<img width="866" alt="64798" src="https://github.com/l2beat/l2beat/assets/33978857/c3389937-ab02-46b8-bfc9-214e36d65b14">
