### PR TITLE
Fix spETH for Kroma

### DIFF
--- a/packages/config/src/projects/layer2s/kroma.ts
+++ b/packages/config/src/projects/layer2s/kroma.ts
@@ -151,14 +151,6 @@ export const kroma: Layer2 = {
         tokens: ['USDC'],
         description: 'Main entry point for users depositing USDC.',
       }),
-      discovery.getEscrowDetails({
-        address: EthereumAddress('0x88b6bBb148748C18B377A57c9d4E6c714AF28078'),
-        sinceTimestamp: new UnixTime(1715953739),
-        tokens: ['spETH'],
-        description: 'Escrow for the spETH custom gateway.',
-        upgradableBy: ['Spectrum EOA Admin'],
-        upgradeDelay: 'No delay',
-      }),
     ],
     transactionApi: {
       type: 'rpc',

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -3394,10 +3394,10 @@
       "id": "speth-spectrum-staked-eth",
       "name": "Spectrum Staked ETH",
       "coingeckoId": "wrapped-eeth",
-      "address": "0x05F3e2b5f90EF4543D3E147AD4DDAa0C7A8C3Fcc",
+      "address": "0xf96d4B1e0a0B129e1471e88dF6f1281b933Bc474",
       "symbol": "spETH",
       "decimals": 18,
-      "deploymentTimestamp": 1715574719,
+      "deploymentTimestamp": 1715574731,
       "coingeckoListingTimestamp": 1701648000,
       "category": "other",
       "iconUrl": "https://assets.coingecko.com/coins/images/33033/large/weETH.png?1701438396",
@@ -6606,6 +6606,21 @@
       "formula": "circulatingSupply"
     },
     {
+      "id": "linea:nile-nile-exchange",
+      "name": "Nile Exchange",
+      "coingeckoId": "nile",
+      "address": "0xAAAac83751090C6ea42379626435f805DDF54DC8",
+      "symbol": "NILE",
+      "decimals": 18,
+      "deploymentTimestamp": 1705968000,
+      "coingeckoListingTimestamp": 1709078400,
+      "category": "other",
+      "iconUrl": "https://assets.coingecko.com/coins/images/34828/standard/nile.png",
+      "chainId": 59144,
+      "type": "NMV",
+      "formula": "circulatingSupply"
+    },
+    {
       "id": "linea:ezeth-renzo-restaked-eth",
       "name": "Renzo Restaked ETH",
       "coingeckoId": "renzo-restaked-eth",
@@ -6834,21 +6849,6 @@
       "bridgedUsing": {
         "bridge": "Free Bridge"
       }
-    },
-    {
-      "id": "linea:nile-nile-exchange",
-      "name": "Nile Exchange",
-      "coingeckoId": "nile",
-      "address": "0xaaaac83751090c6ea42379626435f805ddf54dc8",
-      "symbol": "NILE",
-      "decimals": 18,
-      "deploymentTimestamp": 1705968000,
-      "coingeckoListingTimestamp": 1709078400,
-      "category": "other",
-      "iconUrl": "https://assets.coingecko.com/coins/images/34828/standard/nile.png",
-      "chainId": 59144,
-      "type": "NMV",
-      "formula": "circulatingSupply"
     }
   ]
 }

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -937,7 +937,7 @@
     },
     {
       "symbol": "spETH",
-      "address": "0x05F3e2b5f90EF4543D3E147AD4DDAa0C7A8C3Fcc",
+      "address": "0xf96d4B1e0a0B129e1471e88dF6f1281b933Bc474",
       "coingeckoId": "wrapped-eeth" // 1:1 backed by it, spETH currently not on CG
     },
     {


### PR DESCRIPTION
Removed the escrow from the frontend since the resulting token (spETH) is canonically bridged.
Changed the spETH token address to the correct token.