### PR TITLE
Exclude USDC from canonical bridge

### DIFF
--- a/packages/config/src/projects/layer2s/taiko.ts
+++ b/packages/config/src/projects/layer2s/taiko.ts
@@ -104,7 +104,7 @@ export const taiko: Layer2 = {
         // Shared ERC20 vault
         address: EthereumAddress('0x996282cA11E5DEb6B5D122CC3B9A1FcAAD4415Ab'),
         sinceTimestamp: new UnixTime(1714550603),
-        tokens: '*',
+        tokens: ['ETH', 'LRC', 'UNI', 'WETH', 'USDT'], // temporary exclude USDC
       },
     ],
     transactionApi: {


### PR DESCRIPTION
Taiko uses the same L2 contract for CBV USDC and NMV USDC from circle.
This removes the CBV USDC by listing other tokens currently in the escrow until we have an option to exclude tokens from an escrow.