### PR TITLE
Increase Coingecko interpolation window

### DIFF
--- a/packages/shared/src/services/coingecko/CoingeckoQueryService.test.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoQueryService.test.ts
@@ -45,9 +45,9 @@ describe(CoingeckoQueryService.name, () => {
         ).toHaveBeenOnlyCalledWith(
           CoingeckoId('weth'),
           'usd',
-          UnixTime.fromDate(new Date('2021-01-01')).add(-7, 'days'),
+          UnixTime.fromDate(new Date('2021-01-01')).add(-14, 'days'),
           UnixTime.fromDate(new Date('2021-01-01')).add(
-            MAX_DAYS_FOR_HOURLY_PRECISION - 7,
+            MAX_DAYS_FOR_HOURLY_PRECISION - 14,
             'days',
           ),
           undefined,

--- a/packages/shared/src/services/coingecko/CoingeckoQueryService.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoQueryService.ts
@@ -12,7 +12,7 @@ import { CoinMarketChartRangeData } from './model'
 
 export const MAX_DAYS_FOR_HOURLY_PRECISION = 80
 const SECONDS_IN_DAY = 24 * 60 * 60
-export const COINGECKO_INTERPOLATION_WINDOW_DAYS = 7
+export const COINGECKO_INTERPOLATION_WINDOW_DAYS = 14
 
 export interface QueryResultPoint {
   value: number


### PR DESCRIPTION
Increase the interpolation window from 7D to 14D. So when there is no recent data we will go as far as 14D into history