### PR TITLE
Fix glossary links not scrolling to correct element

### DIFF
--- a/packages/frontend/src/scripts/configureAlphabetSelectors.ts
+++ b/packages/frontend/src/scripts/configureAlphabetSelectors.ts
@@ -45,7 +45,6 @@ function configureAlphabetSelector(alphabetSelector: HTMLElement) {
 
   if (selectedAlphabetSelectorItem) {
     highlightItem(selectedAlphabetSelectorItem)
-    scrollToItem(selectedAlphabetSelectorItem)
   }
 
   window.addEventListener('scroll', () => {

--- a/packages/frontend/src/scripts/configureGlossarySideNav.ts
+++ b/packages/frontend/src/scripts/configureGlossarySideNav.ts
@@ -37,7 +37,6 @@ export function configureGlossarySideNav() {
 
   if (selectedNavItem) {
     highlightItem(selectedNavItem)
-    scrollToItem(selectedNavItem)
   }
 
   window.addEventListener('scroll', () => {


### PR DESCRIPTION
The issue was that on the page load we want to scroll both - side nav and the page content. The problem is that scrolls via code (side nav) interrupts the scroll of the page (to given section). 