### PR TITLE
Ignore nested tooltip markdown

### DIFF
--- a/packages/frontend/src/components/table/props/getBridgesTableColumnsConfig.tsx
+++ b/packages/frontend/src/components/table/props/getBridgesTableColumnsConfig.tsx
@@ -97,6 +97,7 @@ export function getActiveBridgesSummaryColumnsConfig() {
                   className="mt-2"
                   text={entry.tvlBreakdown.warning}
                   icon={RoundedWarningIcon}
+                  ignoreMarkdown
                   color={
                     entry.tvlBreakdown.warningSeverity === 'warning'
                       ? 'yellow'


### PR DESCRIPTION
Just a layout drift fix
<img width="306" alt="image" src="https://github.com/l2beat/l2beat/assets/67391475/9e9b1194-c9fb-4956-9ae5-369e2900ce04">
