### PR TITLE
Don't ignore the build directory

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.7.0/schema.json",
   "files": {
-    "ignore": ["node_modules/", "build/", ".cache/", "dist/", ".next/"]
+    "ignore": ["node_modules/", ".cache/", "dist/", ".next/"]
   },
   "formatter": {
     "enabled": true,

--- a/packages/frontend/src/build/api/createApi.ts
+++ b/packages/frontend/src/build/api/createApi.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import {
   ActivityApiCharts,
   ActivityApiResponse,
@@ -8,7 +9,6 @@ import {
   TvlApiResponse,
 } from '@l2beat/shared-pure'
 import fsx from 'fs-extra'
-import path from 'path'
 
 import { Config } from '../config'
 
@@ -39,7 +39,10 @@ export function createApi(
     }
   }
 
-  urlCharts.set('tvl/scaling-excluded-associated-tokens', excludedTokensTvlApiResponse.layers2s)
+  urlCharts.set(
+    'tvl/scaling-excluded-associated-tokens',
+    excludedTokensTvlApiResponse.layers2s,
+  )
 
   if (activityApiResponse) {
     urlCharts.set('activity/combined', activityApiResponse.combined)

--- a/packages/frontend/src/build/api/fetchActivityApi.ts
+++ b/packages/frontend/src/build/api/fetchActivityApi.ts
@@ -31,13 +31,18 @@ function getMockActivityApiResponse(): ActivityApiResponse {
     ...allLayer2s.filter((l2) => !l2.isArchived && !l2.isUpcoming),
     ...allLayer3s.filter((l3) => !l3.isUpcoming),
   ]) {
-    const syncedTo =( project.display.slug === 'orb3' || project.display.slug === 'arbitrum' )? now.add(-Math.floor(Math.random() * 100), 'days') : now
+    const syncedTo =
+      project.display.slug === 'orb3' || project.display.slug === 'arbitrum'
+        ? now.add(-Math.floor(Math.random() * 100), 'days')
+        : now
     result.projects[project.id.toString()] = getMockActivityApiChart(syncedTo)
   }
   return result
 }
 
-function getMockActivityApiChart(syncedTo: UnixTime): ActivityApiChartsWithEstimation {
+function getMockActivityApiChart(
+  syncedTo: UnixTime,
+): ActivityApiChartsWithEstimation {
   const now = syncedTo.toStartOf('day')
   const chart: ActivityApiChart = {
     types: ['timestamp', 'transactions', 'ethereumTransactions'],

--- a/packages/frontend/src/build/api/fetchTvlApi.ts
+++ b/packages/frontend/src/build/api/fetchTvlApi.ts
@@ -1,4 +1,4 @@
-import { bridges, layer2s as allLayer2s } from '@l2beat/config'
+import { layer2s as allLayer2s, bridges } from '@l2beat/config'
 import {
   AssetId,
   AssetType,
@@ -12,12 +12,15 @@ import {
 import { JsonHttpClient } from '../caching/JsonHttpClient'
 import { Config } from '../config'
 
-interface Options { tvl2: boolean, excludeAssociatedTokens?: boolean }
+interface Options {
+  tvl2: boolean
+  excludeAssociatedTokens?: boolean
+}
 
 export async function fetchTvlApi(
   backend: Config['backend'],
   http: JsonHttpClient,
-  opts: Options
+  opts: Options,
 ): Promise<TvlApiResponse> {
   if (backend.mock) {
     return getMockTvlApiResponse()
@@ -28,16 +31,14 @@ export async function fetchTvlApi(
   return TvlApiResponse.parse(json)
 }
 
-function getUrl(backend: Config['backend'],opts: Options) {
+function getUrl(backend: Config['backend'], opts: Options) {
   const url = new URL(`${backend.apiUrl}/api/${opts.tvl2 ? 'tvl2' : 'tvl'}`)
-  if(opts.excludeAssociatedTokens){
-    url.searchParams.set("excludeAssociatedTokens", 'true')
+  if (opts.excludeAssociatedTokens) {
+    url.searchParams.set('excludeAssociatedTokens', 'true')
   }
 
   return url.toString()
-
 }
-
 
 function getMockTvlApiResponse(): TvlApiResponse {
   const result: TvlApiResponse = {

--- a/packages/frontend/src/build/api/fetchTvlBreakdownApi.ts
+++ b/packages/frontend/src/build/api/fetchTvlBreakdownApi.ts
@@ -12,14 +12,16 @@ import { Config } from '../config'
 
 export async function fetchTvlBreakdownApi(
   backend: Config['backend'],
-  apiUrl: string,
+  _apiUrl: string,
   http: JsonHttpClient,
-  {tvl2}: {tvl2: boolean}
+  { tvl2 }: { tvl2: boolean },
 ): Promise<ProjectAssetsBreakdownApiResponse> {
   if (backend.mock) {
     return getMockTvlBreakdownApiResponse()
   }
-  const url = tvl2 ? `${backend.apiUrl}/api/tvl2/breakdown` : `${backend.apiUrl}/api/project-assets-breakdown`
+  const url = tvl2
+    ? `${backend.apiUrl}/api/tvl2/breakdown`
+    : `${backend.apiUrl}/api/project-assets-breakdown`
   const json = await http.fetchJson(url)
   return ProjectAssetsBreakdownApiResponse.parse(json)
 }

--- a/packages/frontend/src/build/api/fetchVerifiersApi.ts
+++ b/packages/frontend/src/build/api/fetchVerifiersApi.ts
@@ -1,3 +1,4 @@
+import { layer2s, zkCatalogProjects } from '@l2beat/config'
 import {
   EthereumAddress,
   UnixTime,
@@ -5,7 +6,6 @@ import {
 } from '@l2beat/shared-pure'
 import { JsonHttpClient } from '../caching/JsonHttpClient'
 import { Config } from '../config'
-import { layer2s, zkCatalogProjects } from '@l2beat/config'
 
 export async function fetchVerifiersApi(
   backend: Config['backend'],

--- a/packages/frontend/src/build/api/getVerificationStatus.ts
+++ b/packages/frontend/src/build/api/getVerificationStatus.ts
@@ -1,9 +1,9 @@
+import fs from 'fs'
 import { parseManuallyVerifiedContracts } from '@l2beat/config'
 import {
   ManuallyVerifiedContracts,
   VerificationStatus,
 } from '@l2beat/shared-pure'
-import fs from 'fs'
 
 export function getVerificationStatus(
   supportedChains: string[],

--- a/packages/frontend/src/build/api/sanityCheck.test.ts
+++ b/packages/frontend/src/build/api/sanityCheck.test.ts
@@ -9,13 +9,13 @@ import { expect } from 'earl'
 
 import {
   ActivityProjectData,
+  TvlProjectData,
   activitySanityCheck,
   checkIfDelayedActivity,
   checkIfDelayedTvl,
   checkIfEmptyActivityCharts,
   checkIfEmptyTvlCharts,
   checkIfZeroTpsProjects,
-  TvlProjectData,
   tvlSanityCheck,
 } from './sanityCheck'
 
@@ -314,7 +314,7 @@ describe(activitySanityCheck.name, () => {
         estimatedSince: now,
       }
       expect(() => checkIfDelayedActivity(allProjects, now)).toThrow(
-        'Combined activity data is delayed! 183600 seconds. Acceptable delay is 180000 seconds.'
+        'Combined activity data is delayed! 183600 seconds. Acceptable delay is 180000 seconds.',
       )
     })
   })

--- a/packages/frontend/src/build/api/sanityCheck.ts
+++ b/packages/frontend/src/build/api/sanityCheck.ts
@@ -192,11 +192,12 @@ export function checkIfDelayedActivity(
   response: ActivityApiChartsWithEstimation,
   now: UnixTime,
 ) {
+  // biome-ignore lint/style/noNonNullAssertion: even if it's not there we want to fail
   const lastValue = response.daily.data.at(-1)!
   const lastTimestamp = lastValue[0]
   const delay = now.toNumber() - lastTimestamp.toNumber()
 
-  if(delay > ACTIVITY_ACCEPTABLE_DELAY){
+  if (delay > ACTIVITY_ACCEPTABLE_DELAY) {
     throw new Error(
       `Combined activity data is delayed! ${delay} seconds. Acceptable delay is ${ACTIVITY_ACCEPTABLE_DELAY} seconds.`,
     )

--- a/packages/frontend/src/build/buildPages.ts
+++ b/packages/frontend/src/build/buildPages.ts
@@ -12,6 +12,7 @@ import { fetchL2CostsApi } from './api/fetchL2CostsApi'
 import { fetchLivenessApi } from './api/fetchLivenessApi'
 import { fetchTvlApi } from './api/fetchTvlApi'
 import { fetchTvlBreakdownApi } from './api/fetchTvlBreakdownApi'
+import { fetchVerifiersApi } from './api/fetchVerifiersApi'
 import {
   getManuallyVerifiedContracts,
   getVerificationStatus,
@@ -20,7 +21,6 @@ import { activitySanityCheck, tvlSanityCheck } from './api/sanityCheck'
 import { JsonHttpClient } from './caching/JsonHttpClient'
 import { getConfig } from './config'
 import { getCommonFeatures } from './config/getCommonFeatures'
-import { fetchVerifiersApi } from './api/fetchVerifiersApi'
 
 /**
  * Temporary timeout for HTTP calls due to increased size of new TVL API and flaky connection times
@@ -61,8 +61,11 @@ async function main() {
       l2CostsApiResponse,
       verifiersApiResponse,
     ] = await Promise.all([
-      fetchTvlApi(config.backend, http, {tvl2: config.features.tvl2}),
-      fetchTvlApi(config.backend, http, {tvl2: config.features.tvl2, excludeAssociatedTokens: true}),
+      fetchTvlApi(config.backend, http, { tvl2: config.features.tvl2 }),
+      fetchTvlApi(config.backend, http, {
+        tvl2: config.features.tvl2,
+        excludeAssociatedTokens: true,
+      }),
       config.features.activity
         ? fetchActivityApi(config.backend, http)
         : undefined,
@@ -102,7 +105,13 @@ async function main() {
     console.timeEnd('[SANITY CHECKS]')
 
     console.time('[BUILDING PAGES]')
-    createApi(config, tvlApiResponse,excludedTokensTvlApiResponse,activityApiResponse, l2CostsApiResponse)
+    createApi(
+      config,
+      tvlApiResponse,
+      excludedTokensTvlApiResponse,
+      activityApiResponse,
+      l2CostsApiResponse,
+    )
     const pagesData = {
       tvlApiResponse,
       excludedTokensTvlApiResponse,

--- a/packages/frontend/src/build/caching/JsonHttpClient.ts
+++ b/packages/frontend/src/build/caching/JsonHttpClient.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto'
-import { mkdir, readdir, readFile, rm, stat, writeFile } from 'fs/promises'
+import { mkdir, readFile, readdir, rm, stat, writeFile } from 'fs/promises'
 
 import { HttpClient } from '../../../../shared/build'
 

--- a/packages/frontend/src/build/config/config.local.ts
+++ b/packages/frontend/src/build/config/config.local.ts
@@ -1,5 +1,5 @@
-import { common } from './common'
 import { Config } from './Config'
+import { common } from './common'
 
 export function getLocalConfig(): Config {
   const useMock = process.env.MOCK === 'true'

--- a/packages/frontend/src/build/config/config.production.ts
+++ b/packages/frontend/src/build/config/config.production.ts
@@ -1,5 +1,5 @@
-import { common } from './common'
 import { Config } from './Config'
+import { common } from './common'
 
 export function getProductionConfig(): Config {
   return {

--- a/packages/frontend/src/build/config/config.staging.ts
+++ b/packages/frontend/src/build/config/config.staging.ts
@@ -1,5 +1,5 @@
-import { common } from './common'
 import { Config } from './Config'
+import { common } from './common'
 
 export function getStagingConfig(): Config {
   return {


### PR DESCRIPTION
Ignoring the build directory ignored also the 'src/build/fetch...' in the frontend which is not something we want. Not ignoring the build path does not add any more files to linting and formatting than before.