### PR TITLE
Add more fields to template targets

### DIFF
--- a/packages/discovery/schemas/contract.v2.schema.json
+++ b/packages/discovery/schemas/contract.v2.schema.json
@@ -45,6 +45,7 @@
                 }
               ]
             },
+            "target": { "$ref": "#/$defs/targetConfig" },
             "handler": {
               "^.+$": {
                 "type": "object",
@@ -59,7 +60,11 @@
       }
     },
     "description": {
-      "description": "Description for the contract ",
+      "description": "Description for the contract",
+      "type": "string"
+    },
+    "displayName": {
+      "description": "Name that will be displayed instead of the derived smart contract name",
       "type": "string"
     },
     "methods": {
@@ -84,6 +89,53 @@
         "PERMISSION",
         null
       ]
+    },
+    "stackRole": {
+      "type": ["string", "null"],
+      "enum": ["Sequencer", "Proposer", "Challenger", "Guardian", "Validator"]
+    },
+    "permission": {
+      "type": ["string", "null"],
+      "enum": ["admin", "owner"]
+    },
+    "stackCategory": {
+      "type": ["string", "null"],
+      "enum": ["Core", "Gateways&Escrows", "Upgrades&Governance"]
+    },
+    "targetConfig": {
+      "type": "object",
+      "unevaluatedProperties": false,
+      "properties": {
+        "description": { "type": ["string", "null"] },
+        "template": { "type": ["string", "null"] },
+        "role": {
+          "anyOf": [
+            { "$ref": "#/$defs/stackRole" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/$defs/stackRole" }
+            }
+          ]
+        },
+        "category": {
+          "anyOf": [
+            { "$ref": "#/$defs/stackCategory" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/$defs/stackCategory" }
+            }
+          ]
+        },
+        "permission": {
+          "anyOf": [
+            { "$ref": "#/$defs/permission" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/$defs/permission" }
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/packages/discovery/src/discovery/config/RawDiscoveryConfig.ts
+++ b/packages/discovery/src/discovery/config/RawDiscoveryConfig.ts
@@ -12,6 +12,22 @@ export const ValueType = z.enum([
   'PERMISSION',
 ])
 
+export const StackRole = z.enum([
+  'Sequencer',
+  'Proposer',
+  'Challenger',
+  'Guardian',
+  'Validator',
+])
+
+export const Permission = z.enum(['admin', 'owner'])
+
+export const StackCategory = z.enum([
+  'Core',
+  'Gateways&Escrows',
+  'Upgrades&Governance',
+])
+
 export type ContractFieldSeverity = z.infer<typeof ContractFieldSeverity>
 export const ContractFieldSeverity = z.enum(['HIGH', 'MEDIUM', 'LOW'])
 
@@ -19,12 +35,25 @@ export type DiscoveryContractField = z.infer<typeof DiscoveryContractField>
 export const DiscoveryContractField = z.object({
   handler: z.optional(UserHandlerDefinition),
   description: z.string().nullable().optional(),
+  displayName: z.string().nullable().optional(),
   severity: z.optional(ContractFieldSeverity).nullable(),
   target: z
     .object({
+      description: z.string().nullable().optional(),
       template: z.string().nullable().optional(),
+      role: z
+        .union([StackRole, z.array(StackRole)])
+        .nullable()
+        .optional(),
+      category: z
+        .union([StackCategory, z.array(StackCategory)])
+        .nullable()
+        .optional(),
+      permission: z
+        .union([Permission, z.array(Permission)])
+        .nullable()
+        .optional(),
     })
-    .nullable()
     .optional(),
   type: z
     .union([ValueType, z.array(ValueType)])


### PR DESCRIPTION
Currently contract templates can specify `.target.template` for address(es) they're referencing. 

This PR allows to specify additionally (as a value or list of values):

Role:
 - 'Sequencer',
 - 'Proposer',
 - 'Challenger',
 - 'Guardian',
 - 'Validator'

Permission: 
- 'admin', 
- 'owner'

Category:
 - 'Core',
 - 'Gateways&Escrows',
 - 'Upgrades&Governance'

Description: any string

This list and values (especially for Permission) will likely change in the future, but for now this tries to closely represent our current definitions.

Also, a new field has been added for the contract schema: `displayName`. This is the name that should be displayed on the website instead of the derived contract name. Ultimately this should replace the `"names":{}` dictionary currently used in the main `config.json` file. There are two reasons why the key is `displayName` and not `name`. One is that simply using `name` would be confusing - it wouldn't be clear if it's a name of the *template* or the *contract*. Second is that we probably should move away from referencing contracts by name. Discovered.json should have enough information to "display itself", and things like "role", "category", etc. will allow us to put contracts in the right place.