### PR TITLE
Add used template to discovered.json, enhance logging

### DIFF
--- a/packages/discovery-types/src/Discovery.ts
+++ b/packages/discovery-types/src/Discovery.ts
@@ -16,6 +16,7 @@ export interface DiscoveryOutput {
 export interface ContractParameters {
   name: string
   derivedName?: string
+  template?: string
   unverified?: true
   sinceTimestamp?: number
   address: EthereumAddress

--- a/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
+++ b/packages/discovery/src/discovery/analysis/AddressAnalyzer.ts
@@ -136,6 +136,13 @@ export class AddressAnalyzer {
       }
     }
 
+    const templateLog =
+      extendedTemplate !== undefined
+        ? `"${extendedTemplate?.template}" (${extendedTemplate?.reason})`
+        : 'none'
+
+    logger.log(`  Template: ${templateLog}`)
+
     const { results, values, errors } = await this.handlerExecutor.execute(
       address,
       sources.abi,

--- a/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
+++ b/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
@@ -16,7 +16,7 @@ import { shouldSkip } from './shouldSkip'
 // causing a difference in discovery output
 
 // Last change: add implementations to the output
-export const DISCOVERY_LOGIC_VERSION = 4
+export const DISCOVERY_LOGIC_VERSION = 5
 export class DiscoveryEngine {
   constructor(
     private readonly addressAnalyzer: AddressAnalyzer,
@@ -103,6 +103,11 @@ export class DiscoveryEngine {
             templates,
           )
           resolved[address.toString()] = analysis
+          if (analysis.type === 'Contract') {
+            bufferedLogger.log(
+              `Relatives: [${Object.keys(analysis.relatives)}]`,
+            )
+          }
 
           if (analysis.type === 'Contract') {
             for (const [address, suggestedTemplates] of Object.entries(

--- a/packages/discovery/src/discovery/output/toDiscoveryOutput.ts
+++ b/packages/discovery/src/discovery/output/toDiscoveryOutput.ts
@@ -39,6 +39,7 @@ export function processAnalysis(
           name: x.name,
           address: x.address,
           unverified: x.isVerified ? undefined : (true as const),
+          template: x.extendedTemplate?.template,
           ignoreInWatchMode: x.ignoreInWatchMode,
           upgradeability: x.upgradeability,
           implementations:


### PR DESCRIPTION
- `discovered.json` will include the template used.
- discovery process will log template that's used for discovery of each contract and relatives it found

Caution: due to "template" showing up in discovered.json, diffHistory will show this as a new config related change. Bumping discovery version doesn't help here because config related changes rely on already committed file. But I think this is actually a good thing - it allows us to review templates that are currently applied to each project.

Update-monitor will ignore the new "template" field.