### PR TITLE
Create all templates of OP stack

### DIFF
--- a/packages/backend/discovery/_templates/GnosisSafe/shape/GnosisSafe.sol
+++ b/packages/backend/discovery/_templates/GnosisSafe/shape/GnosisSafe.sol
@@ -1,0 +1,952 @@
+// Compiled with solc version: undefined
+
+library GnosisSafeMath {
+    /**
+     * @dev Multiplies two numbers, reverts on overflow.
+     */
+    function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        uint256 c = a * b;
+        require(c / a == b);
+
+        return c;
+    }
+
+    /**
+     * @dev Subtracts two numbers, reverts on overflow (i.e. if subtrahend is greater than minuend).
+     */
+    function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+        require(b <= a);
+        uint256 c = a - b;
+
+        return c;
+    }
+
+    /**
+     * @dev Adds two numbers, reverts on overflow.
+     */
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        uint256 c = a + b;
+        require(c >= a);
+
+        return c;
+    }
+
+    /**
+     * @dev Returns the largest of two numbers.
+     */
+    function max(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a >= b ? a : b;
+    }
+}
+
+contract GuardManager is SelfAuthorized {
+    event ChangedGuard(address guard);
+    // keccak256("guard_manager.guard.address")
+    bytes32 internal constant GUARD_STORAGE_SLOT = 0x4a204f620c8c5ccdca3fd54d003badd85ba500436a431f0cbda4f558c93c34c8;
+
+    /// @dev Set a guard that checks transactions before execution
+    /// @param guard The address of the guard to be used or the 0 address to disable the guard
+    function setGuard(address guard) external authorized {
+        bytes32 slot = GUARD_STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            sstore(slot, guard)
+        }
+        emit ChangedGuard(guard);
+    }
+
+    function getGuard() internal view returns (address guard) {
+        bytes32 slot = GUARD_STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            guard := sload(slot)
+        }
+    }
+}
+
+contract StorageAccessible {
+    /**
+     * @dev Reads `length` bytes of storage in the currents contract
+     * @param offset - the offset in the current contract's storage in words to start reading from
+     * @param length - the number of words (32 bytes) of data to read
+     * @return the bytes that were read.
+     */
+    function getStorageAt(uint256 offset, uint256 length) public view returns (bytes memory) {
+        bytes memory result = new bytes(length * 32);
+        for (uint256 index = 0; index < length; index++) {
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                let word := sload(add(offset, index))
+                mstore(add(add(result, 0x20), mul(index, 0x20)), word)
+            }
+        }
+        return result;
+    }
+
+    /**
+     * @dev Performs a delegetecall on a targetContract in the context of self.
+     * Internally reverts execution to avoid side effects (making it static).
+     *
+     * This method reverts with data equal to `abi.encode(bool(success), bytes(response))`.
+     * Specifically, the `returndata` after a call to this method will be:
+     * `success:bool || response.length:uint256 || response:bytes`.
+     *
+     * @param targetContract Address of the contract containing the code to execute.
+     * @param calldataPayload Calldata that should be sent to the target contract (encoded method name and arguments).
+     */
+    function simulateAndRevert(address targetContract, bytes memory calldataPayload) external {
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let success := delegatecall(gas(), targetContract, add(calldataPayload, 0x20), mload(calldataPayload), 0, 0)
+
+            mstore(0x00, success)
+            mstore(0x20, returndatasize())
+            returndatacopy(0x40, 0, returndatasize())
+            revert(0, add(returndatasize(), 0x40))
+        }
+    }
+}
+
+contract FallbackManager is SelfAuthorized {
+    event ChangedFallbackHandler(address handler);
+
+    // keccak256("fallback_manager.handler.address")
+    bytes32 internal constant FALLBACK_HANDLER_STORAGE_SLOT = 0x6c9a6c4a39284e37ed1cf53d337577d14212a4870fb976a4366c693b939918d5;
+
+    function internalSetFallbackHandler(address handler) internal {
+        bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            sstore(slot, handler)
+        }
+    }
+
+    /// @dev Allows to add a contract to handle fallback calls.
+    ///      Only fallback calls without value and with data will be forwarded.
+    ///      This can only be done via a Safe transaction.
+    /// @param handler contract to handle fallbacks calls.
+    function setFallbackHandler(address handler) public authorized {
+        internalSetFallbackHandler(handler);
+        emit ChangedFallbackHandler(handler);
+    }
+
+    // solhint-disable-next-line payable-fallback,no-complex-fallback
+    fallback() external {
+        bytes32 slot = FALLBACK_HANDLER_STORAGE_SLOT;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let handler := sload(slot)
+            if iszero(handler) {
+                return(0, 0)
+            }
+            calldatacopy(0, 0, calldatasize())
+            // The msg.sender address is shifted to the left by 12 bytes to remove the padding
+            // Then the address without padding is stored right after the calldata
+            mstore(calldatasize(), shl(96, caller()))
+            // Add 20 bytes for the address appended add the end
+            let success := call(gas(), handler, 0, 0, add(calldatasize(), 20), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+            if iszero(success) {
+                revert(0, returndatasize())
+            }
+            return(0, returndatasize())
+        }
+    }
+}
+
+contract ISignatureValidatorConstants {
+    // bytes4(keccak256("isValidSignature(bytes,bytes)")
+    bytes4 internal constant EIP1271_MAGIC_VALUE = 0x20c13b0b;
+}
+
+contract SecuredTokenTransfer {
+    /// @dev Transfers a token and returns if it was a success
+    /// @param token Token that should be transferred
+    /// @param receiver Receiver to whom the token should be transferred
+    /// @param amount The amount of tokens that should be transferred
+    function transferToken(
+        address token,
+        address receiver,
+        uint256 amount
+    ) internal returns (bool transferred) {
+        // 0xa9059cbb - keccack("transfer(address,uint256)")
+        bytes memory data = abi.encodeWithSelector(0xa9059cbb, receiver, amount);
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // We write the return value to scratch space.
+            // See https://docs.soliditylang.org/en/v0.7.6/internals/layout_in_memory.html#layout-in-memory
+            let success := call(sub(gas(), 10000), token, 0, add(data, 0x20), mload(data), 0, 0x20)
+            switch returndatasize()
+                case 0 {
+                    transferred := success
+                }
+                case 0x20 {
+                    transferred := iszero(or(iszero(success), iszero(mload(0))))
+                }
+                default {
+                    transferred := 0
+                }
+        }
+    }
+}
+
+contract SignatureDecoder {
+    /// @dev divides bytes signature into `uint8 v, bytes32 r, bytes32 s`.
+    /// @notice Make sure to peform a bounds check for @param pos, to avoid out of bounds access on @param signatures
+    /// @param pos which signature to read. A prior bounds check of this parameter should be performed, to avoid out of bounds access
+    /// @param signatures concatenated rsv signatures
+    function signatureSplit(bytes memory signatures, uint256 pos)
+        internal
+        pure
+        returns (
+            uint8 v,
+            bytes32 r,
+            bytes32 s
+        )
+    {
+        // The signature format is a compact form of:
+        //   {bytes32 r}{bytes32 s}{uint8 v}
+        // Compact means, uint8 is not padded to 32 bytes.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            let signaturePos := mul(0x41, pos)
+            r := mload(add(signatures, add(signaturePos, 0x20)))
+            s := mload(add(signatures, add(signaturePos, 0x40)))
+            // Here we are loading the last 32 bytes, including 31 bytes
+            // of 's'. There is no 'mload8' to do this.
+            //
+            // 'byte' is not working due to the Solidity parser, so lets
+            // use the second best option, 'and'
+            v := and(mload(add(signatures, add(signaturePos, 0x41))), 0xff)
+        }
+    }
+}
+
+contract OwnerManager is SelfAuthorized {
+    event AddedOwner(address owner);
+    event RemovedOwner(address owner);
+    event ChangedThreshold(uint256 threshold);
+
+    address internal constant SENTINEL_OWNERS = address(0x1);
+
+    mapping(address => address) internal owners;
+    uint256 internal ownerCount;
+    uint256 internal threshold;
+
+    /// @dev Setup function sets initial storage of contract.
+    /// @param _owners List of Safe owners.
+    /// @param _threshold Number of required confirmations for a Safe transaction.
+    function setupOwners(address[] memory _owners, uint256 _threshold) internal {
+        // Threshold can only be 0 at initialization.
+        // Check ensures that setup function can only be called once.
+        require(threshold == 0, "GS200");
+        // Validate that threshold is smaller than number of added owners.
+        require(_threshold <= _owners.length, "GS201");
+        // There has to be at least one Safe owner.
+        require(_threshold >= 1, "GS202");
+        // Initializing Safe owners.
+        address currentOwner = SENTINEL_OWNERS;
+        for (uint256 i = 0; i < _owners.length; i++) {
+            // Owner address cannot be null.
+            address owner = _owners[i];
+            require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this) && currentOwner != owner, "GS203");
+            // No duplicate owners allowed.
+            require(owners[owner] == address(0), "GS204");
+            owners[currentOwner] = owner;
+            currentOwner = owner;
+        }
+        owners[currentOwner] = SENTINEL_OWNERS;
+        ownerCount = _owners.length;
+        threshold = _threshold;
+    }
+
+    /// @dev Allows to add a new owner to the Safe and update the threshold at the same time.
+    ///      This can only be done via a Safe transaction.
+    /// @notice Adds the owner `owner` to the Safe and updates the threshold to `_threshold`.
+    /// @param owner New owner address.
+    /// @param _threshold New threshold.
+    function addOwnerWithThreshold(address owner, uint256 _threshold) public authorized {
+        // Owner address cannot be null, the sentinel or the Safe itself.
+        require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this), "GS203");
+        // No duplicate owners allowed.
+        require(owners[owner] == address(0), "GS204");
+        owners[owner] = owners[SENTINEL_OWNERS];
+        owners[SENTINEL_OWNERS] = owner;
+        ownerCount++;
+        emit AddedOwner(owner);
+        // Change threshold if threshold was changed.
+        if (threshold != _threshold) changeThreshold(_threshold);
+    }
+
+    /// @dev Allows to remove an owner from the Safe and update the threshold at the same time.
+    ///      This can only be done via a Safe transaction.
+    /// @notice Removes the owner `owner` from the Safe and updates the threshold to `_threshold`.
+    /// @param prevOwner Owner that pointed to the owner to be removed in the linked list
+    /// @param owner Owner address to be removed.
+    /// @param _threshold New threshold.
+    function removeOwner(
+        address prevOwner,
+        address owner,
+        uint256 _threshold
+    ) public authorized {
+        // Only allow to remove an owner, if threshold can still be reached.
+        require(ownerCount - 1 >= _threshold, "GS201");
+        // Validate owner address and check that it corresponds to owner index.
+        require(owner != address(0) && owner != SENTINEL_OWNERS, "GS203");
+        require(owners[prevOwner] == owner, "GS205");
+        owners[prevOwner] = owners[owner];
+        owners[owner] = address(0);
+        ownerCount--;
+        emit RemovedOwner(owner);
+        // Change threshold if threshold was changed.
+        if (threshold != _threshold) changeThreshold(_threshold);
+    }
+
+    /// @dev Allows to swap/replace an owner from the Safe with another address.
+    ///      This can only be done via a Safe transaction.
+    /// @notice Replaces the owner `oldOwner` in the Safe with `newOwner`.
+    /// @param prevOwner Owner that pointed to the owner to be replaced in the linked list
+    /// @param oldOwner Owner address to be replaced.
+    /// @param newOwner New owner address.
+    function swapOwner(
+        address prevOwner,
+        address oldOwner,
+        address newOwner
+    ) public authorized {
+        // Owner address cannot be null, the sentinel or the Safe itself.
+        require(newOwner != address(0) && newOwner != SENTINEL_OWNERS && newOwner != address(this), "GS203");
+        // No duplicate owners allowed.
+        require(owners[newOwner] == address(0), "GS204");
+        // Validate oldOwner address and check that it corresponds to owner index.
+        require(oldOwner != address(0) && oldOwner != SENTINEL_OWNERS, "GS203");
+        require(owners[prevOwner] == oldOwner, "GS205");
+        owners[newOwner] = owners[oldOwner];
+        owners[prevOwner] = newOwner;
+        owners[oldOwner] = address(0);
+        emit RemovedOwner(oldOwner);
+        emit AddedOwner(newOwner);
+    }
+
+    /// @dev Allows to update the number of required confirmations by Safe owners.
+    ///      This can only be done via a Safe transaction.
+    /// @notice Changes the threshold of the Safe to `_threshold`.
+    /// @param _threshold New threshold.
+    function changeThreshold(uint256 _threshold) public authorized {
+        // Validate that threshold is smaller than number of owners.
+        require(_threshold <= ownerCount, "GS201");
+        // There has to be at least one Safe owner.
+        require(_threshold >= 1, "GS202");
+        threshold = _threshold;
+        emit ChangedThreshold(threshold);
+    }
+
+    function getThreshold() public view returns (uint256) {
+        return threshold;
+    }
+
+    function isOwner(address owner) public view returns (bool) {
+        return owner != SENTINEL_OWNERS && owners[owner] != address(0);
+    }
+
+    /// @dev Returns array of owners.
+    /// @return Array of Safe owners.
+    function getOwners() public view returns (address[] memory) {
+        address[] memory array = new address[](ownerCount);
+
+        // populate return array
+        uint256 index = 0;
+        address currentOwner = owners[SENTINEL_OWNERS];
+        while (currentOwner != SENTINEL_OWNERS) {
+            array[index] = currentOwner;
+            currentOwner = owners[currentOwner];
+            index++;
+        }
+        return array;
+    }
+}
+
+contract SelfAuthorized {
+    function requireSelfCall() private view {
+        require(msg.sender == address(this), "GS031");
+    }
+
+    modifier authorized() {
+        // This is a function call as it minimized the bytecode size
+        requireSelfCall();
+        _;
+    }
+}
+
+contract Executor {
+    function execute(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 txGas
+    ) internal returns (bool success) {
+        if (operation == Enum.Operation.DelegateCall) {
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                success := delegatecall(txGas, to, add(data, 0x20), mload(data), 0, 0)
+            }
+        } else {
+            // solhint-disable-next-line no-inline-assembly
+            assembly {
+                success := call(txGas, to, value, add(data, 0x20), mload(data), 0, 0)
+            }
+        }
+    }
+}
+
+contract ModuleManager is SelfAuthorized, Executor {
+    event EnabledModule(address module);
+    event DisabledModule(address module);
+    event ExecutionFromModuleSuccess(address indexed module);
+    event ExecutionFromModuleFailure(address indexed module);
+
+    address internal constant SENTINEL_MODULES = address(0x1);
+
+    mapping(address => address) internal modules;
+
+    function setupModules(address to, bytes memory data) internal {
+        require(modules[SENTINEL_MODULES] == address(0), "GS100");
+        modules[SENTINEL_MODULES] = SENTINEL_MODULES;
+        if (to != address(0))
+            // Setup has to complete successfully or transaction fails.
+            require(execute(to, 0, data, Enum.Operation.DelegateCall, gasleft()), "GS000");
+    }
+
+    /// @dev Allows to add a module to the whitelist.
+    ///      This can only be done via a Safe transaction.
+    /// @notice Enables the module `module` for the Safe.
+    /// @param module Module to be whitelisted.
+    function enableModule(address module) public authorized {
+        // Module address cannot be null or sentinel.
+        require(module != address(0) && module != SENTINEL_MODULES, "GS101");
+        // Module cannot be added twice.
+        require(modules[module] == address(0), "GS102");
+        modules[module] = modules[SENTINEL_MODULES];
+        modules[SENTINEL_MODULES] = module;
+        emit EnabledModule(module);
+    }
+
+    /// @dev Allows to remove a module from the whitelist.
+    ///      This can only be done via a Safe transaction.
+    /// @notice Disables the module `module` for the Safe.
+    /// @param prevModule Module that pointed to the module to be removed in the linked list
+    /// @param module Module to be removed.
+    function disableModule(address prevModule, address module) public authorized {
+        // Validate module address and check that it corresponds to module index.
+        require(module != address(0) && module != SENTINEL_MODULES, "GS101");
+        require(modules[prevModule] == module, "GS103");
+        modules[prevModule] = modules[module];
+        modules[module] = address(0);
+        emit DisabledModule(module);
+    }
+
+    /// @dev Allows a Module to execute a Safe transaction without any further confirmations.
+    /// @param to Destination address of module transaction.
+    /// @param value Ether value of module transaction.
+    /// @param data Data payload of module transaction.
+    /// @param operation Operation type of module transaction.
+    function execTransactionFromModule(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) public virtual returns (bool success) {
+        // Only whitelisted modules are allowed.
+        require(msg.sender != SENTINEL_MODULES && modules[msg.sender] != address(0), "GS104");
+        // Execute transaction without further confirmations.
+        success = execute(to, value, data, operation, gasleft());
+        if (success) emit ExecutionFromModuleSuccess(msg.sender);
+        else emit ExecutionFromModuleFailure(msg.sender);
+    }
+
+    /// @dev Allows a Module to execute a Safe transaction without any further confirmations and return data
+    /// @param to Destination address of module transaction.
+    /// @param value Ether value of module transaction.
+    /// @param data Data payload of module transaction.
+    /// @param operation Operation type of module transaction.
+    function execTransactionFromModuleReturnData(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) public returns (bool success, bytes memory returnData) {
+        success = execTransactionFromModule(to, value, data, operation);
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            // Load free memory location
+            let ptr := mload(0x40)
+            // We allocate memory for the return data by setting the free memory location to
+            // current free memory location + data size + 32 bytes for data size value
+            mstore(0x40, add(ptr, add(returndatasize(), 0x20)))
+            // Store the size
+            mstore(ptr, returndatasize())
+            // Store the data
+            returndatacopy(add(ptr, 0x20), 0, returndatasize())
+            // Point the return data to the correct memory location
+            returnData := ptr
+        }
+    }
+
+    /// @dev Returns if an module is enabled
+    /// @return True if the module is enabled
+    function isModuleEnabled(address module) public view returns (bool) {
+        return SENTINEL_MODULES != module && modules[module] != address(0);
+    }
+
+    /// @dev Returns array of modules.
+    /// @param start Start of the page.
+    /// @param pageSize Maximum number of modules that should be returned.
+    /// @return array Array of modules.
+    /// @return next Start of the next page.
+    function getModulesPaginated(address start, uint256 pageSize) external view returns (address[] memory array, address next) {
+        // Init array with max page size
+        array = new address[](pageSize);
+
+        // Populate return array
+        uint256 moduleCount = 0;
+        address currentModule = modules[start];
+        while (currentModule != address(0x0) && currentModule != SENTINEL_MODULES && moduleCount < pageSize) {
+            array[moduleCount] = currentModule;
+            currentModule = modules[currentModule];
+            moduleCount++;
+        }
+        next = currentModule;
+        // Set correct size of returned array
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            mstore(array, moduleCount)
+        }
+    }
+}
+
+contract Singleton {
+    // singleton always needs to be first declared variable, to ensure that it is at the same location as in the Proxy contract.
+    // It should also always be ensured that the address is stored alone (uses a full word)
+    address private singleton;
+}
+
+contract EtherPaymentFallback {
+    event SafeReceived(address indexed sender, uint256 value);
+
+    /// @dev Fallback function accepts Ether transactions.
+    receive() external payable {
+        emit SafeReceived(msg.sender, msg.value);
+    }
+}
+
+contract GnosisSafe is
+    EtherPaymentFallback,
+    Singleton,
+    ModuleManager,
+    OwnerManager,
+    SignatureDecoder,
+    SecuredTokenTransfer,
+    ISignatureValidatorConstants,
+    FallbackManager,
+    StorageAccessible,
+    GuardManager
+{
+    using GnosisSafeMath for uint256;
+
+    string public constant VERSION = "1.3.0";
+
+    // keccak256(
+    //     "EIP712Domain(uint256 chainId,address verifyingContract)"
+    // );
+    bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
+
+    // keccak256(
+    //     "SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
+    // );
+    bytes32 private constant SAFE_TX_TYPEHASH = 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8;
+
+    event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler);
+    event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
+    event SignMsg(bytes32 indexed msgHash);
+    event ExecutionFailure(bytes32 txHash, uint256 payment);
+    event ExecutionSuccess(bytes32 txHash, uint256 payment);
+
+    uint256 public nonce;
+    bytes32 private _deprecatedDomainSeparator;
+    // Mapping to keep track of all message hashes that have been approve by ALL REQUIRED owners
+    mapping(bytes32 => uint256) public signedMessages;
+    // Mapping to keep track of all hashes (message or transaction) that have been approve by ANY owners
+    mapping(address => mapping(bytes32 => uint256)) public approvedHashes;
+
+    // This constructor ensures that this contract can only be used as a master copy for Proxy contracts
+    constructor() {
+        // By setting the threshold it is not possible to call setup anymore,
+        // so we create a Safe with 0 owners and threshold 1.
+        // This is an unusable Safe, perfect for the singleton
+        threshold = 1;
+    }
+
+    /// @dev Setup function sets initial storage of contract.
+    /// @param _owners List of Safe owners.
+    /// @param _threshold Number of required confirmations for a Safe transaction.
+    /// @param to Contract address for optional delegate call.
+    /// @param data Data payload for optional delegate call.
+    /// @param fallbackHandler Handler for fallback calls to this contract
+    /// @param paymentToken Token that should be used for the payment (0 is ETH)
+    /// @param payment Value that should be paid
+    /// @param paymentReceiver Adddress that should receive the payment (or 0 if tx.origin)
+    function setup(
+        address[] calldata _owners,
+        uint256 _threshold,
+        address to,
+        bytes calldata data,
+        address fallbackHandler,
+        address paymentToken,
+        uint256 payment,
+        address payable paymentReceiver
+    ) external {
+        // setupOwners checks if the Threshold is already set, therefore preventing that this method is called twice
+        setupOwners(_owners, _threshold);
+        if (fallbackHandler != address(0)) internalSetFallbackHandler(fallbackHandler);
+        // As setupOwners can only be called if the contract has not been initialized we don't need a check for setupModules
+        setupModules(to, data);
+
+        if (payment > 0) {
+            // To avoid running into issues with EIP-170 we reuse the handlePayment function (to avoid adjusting code of that has been verified we do not adjust the method itself)
+            // baseGas = 0, gasPrice = 1 and gas = payment => amount = (payment + 0) * 1 = payment
+            handlePayment(payment, 0, 1, paymentToken, paymentReceiver);
+        }
+        emit SafeSetup(msg.sender, _owners, _threshold, to, fallbackHandler);
+    }
+
+    /// @dev Allows to execute a Safe transaction confirmed by required number of owners and then pays the account that submitted the transaction.
+    ///      Note: The fees are always transferred, even if the user transaction fails.
+    /// @param to Destination address of Safe transaction.
+    /// @param value Ether value of Safe transaction.
+    /// @param data Data payload of Safe transaction.
+    /// @param operation Operation type of Safe transaction.
+    /// @param safeTxGas Gas that should be used for the Safe transaction.
+    /// @param baseGas Gas costs that are independent of the transaction execution(e.g. base transaction fee, signature check, payment of the refund)
+    /// @param gasPrice Gas price that should be used for the payment calculation.
+    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
+    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
+    /// @param signatures Packed signature data ({bytes32 r}{bytes32 s}{uint8 v})
+    function execTransaction(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures
+    ) public payable virtual returns (bool success) {
+        bytes32 txHash;
+        // Use scope here to limit variable lifetime and prevent `stack too deep` errors
+        {
+            bytes memory txHashData =
+                encodeTransactionData(
+                    // Transaction info
+                    to,
+                    value,
+                    data,
+                    operation,
+                    safeTxGas,
+                    // Payment info
+                    baseGas,
+                    gasPrice,
+                    gasToken,
+                    refundReceiver,
+                    // Signature info
+                    nonce
+                );
+            // Increase nonce and execute transaction.
+            nonce++;
+            txHash = keccak256(txHashData);
+            checkSignatures(txHash, txHashData, signatures);
+        }
+        address guard = getGuard();
+        {
+            if (guard != address(0)) {
+                Guard(guard).checkTransaction(
+                    // Transaction info
+                    to,
+                    value,
+                    data,
+                    operation,
+                    safeTxGas,
+                    // Payment info
+                    baseGas,
+                    gasPrice,
+                    gasToken,
+                    refundReceiver,
+                    // Signature info
+                    signatures,
+                    msg.sender
+                );
+            }
+        }
+        // We require some gas to emit the events (at least 2500) after the execution and some to perform code until the execution (500)
+        // We also include the 1/64 in the check that is not send along with a call to counteract potential shortings because of EIP-150
+        require(gasleft() >= ((safeTxGas * 64) / 63).max(safeTxGas + 2500) + 500, "GS010");
+        // Use scope here to limit variable lifetime and prevent `stack too deep` errors
+        {
+            uint256 gasUsed = gasleft();
+            // If the gasPrice is 0 we assume that nearly all available gas can be used (it is always more than safeTxGas)
+            // We only substract 2500 (compared to the 3000 before) to ensure that the amount passed is still higher than safeTxGas
+            success = execute(to, value, data, operation, gasPrice == 0 ? (gasleft() - 2500) : safeTxGas);
+            gasUsed = gasUsed.sub(gasleft());
+            // If no safeTxGas and no gasPrice was set (e.g. both are 0), then the internal tx is required to be successful
+            // This makes it possible to use `estimateGas` without issues, as it searches for the minimum gas where the tx doesn't revert
+            require(success || safeTxGas != 0 || gasPrice != 0, "GS013");
+            // We transfer the calculated tx costs to the tx.origin to avoid sending it to intermediate contracts that have made calls
+            uint256 payment = 0;
+            if (gasPrice > 0) {
+                payment = handlePayment(gasUsed, baseGas, gasPrice, gasToken, refundReceiver);
+            }
+            if (success) emit ExecutionSuccess(txHash, payment);
+            else emit ExecutionFailure(txHash, payment);
+        }
+        {
+            if (guard != address(0)) {
+                Guard(guard).checkAfterExecution(txHash, success);
+            }
+        }
+    }
+
+    function handlePayment(
+        uint256 gasUsed,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver
+    ) private returns (uint256 payment) {
+        // solhint-disable-next-line avoid-tx-origin
+        address payable receiver = refundReceiver == address(0) ? payable(tx.origin) : refundReceiver;
+        if (gasToken == address(0)) {
+            // For ETH we will only adjust the gas price to not be higher than the actual used gas price
+            payment = gasUsed.add(baseGas).mul(gasPrice < tx.gasprice ? gasPrice : tx.gasprice);
+            require(receiver.send(payment), "GS011");
+        } else {
+            payment = gasUsed.add(baseGas).mul(gasPrice);
+            require(transferToken(gasToken, receiver, payment), "GS012");
+        }
+    }
+
+    /**
+     * @dev Checks whether the signature provided is valid for the provided data, hash. Will revert otherwise.
+     * @param dataHash Hash of the data (could be either a message hash or transaction hash)
+     * @param data That should be signed (this is passed to an external validator contract)
+     * @param signatures Signature data that should be verified. Can be ECDSA signature, contract signature (EIP-1271) or approved hash.
+     */
+    function checkSignatures(
+        bytes32 dataHash,
+        bytes memory data,
+        bytes memory signatures
+    ) public view {
+        // Load threshold to avoid multiple storage loads
+        uint256 _threshold = threshold;
+        // Check that a threshold is set
+        require(_threshold > 0, "GS001");
+        checkNSignatures(dataHash, data, signatures, _threshold);
+    }
+
+    /**
+     * @dev Checks whether the signature provided is valid for the provided data, hash. Will revert otherwise.
+     * @param dataHash Hash of the data (could be either a message hash or transaction hash)
+     * @param data That should be signed (this is passed to an external validator contract)
+     * @param signatures Signature data that should be verified. Can be ECDSA signature, contract signature (EIP-1271) or approved hash.
+     * @param requiredSignatures Amount of required valid signatures.
+     */
+    function checkNSignatures(
+        bytes32 dataHash,
+        bytes memory data,
+        bytes memory signatures,
+        uint256 requiredSignatures
+    ) public view {
+        // Check that the provided signature data is not too short
+        require(signatures.length >= requiredSignatures.mul(65), "GS020");
+        // There cannot be an owner with address 0.
+        address lastOwner = address(0);
+        address currentOwner;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        uint256 i;
+        for (i = 0; i < requiredSignatures; i++) {
+            (v, r, s) = signatureSplit(signatures, i);
+            if (v == 0) {
+                // If v is 0 then it is a contract signature
+                // When handling contract signatures the address of the contract is encoded into r
+                currentOwner = address(uint160(uint256(r)));
+
+                // Check that signature data pointer (s) is not pointing inside the static part of the signatures bytes
+                // This check is not completely accurate, since it is possible that more signatures than the threshold are send.
+                // Here we only check that the pointer is not pointing inside the part that is being processed
+                require(uint256(s) >= requiredSignatures.mul(65), "GS021");
+
+                // Check that signature data pointer (s) is in bounds (points to the length of data -> 32 bytes)
+                require(uint256(s).add(32) <= signatures.length, "GS022");
+
+                // Check if the contract signature is in bounds: start of data is s + 32 and end is start + signature length
+                uint256 contractSignatureLen;
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    contractSignatureLen := mload(add(add(signatures, s), 0x20))
+                }
+                require(uint256(s).add(32).add(contractSignatureLen) <= signatures.length, "GS023");
+
+                // Check signature
+                bytes memory contractSignature;
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    // The signature data for contract signatures is appended to the concatenated signatures and the offset is stored in s
+                    contractSignature := add(add(signatures, s), 0x20)
+                }
+                require(ISignatureValidator(currentOwner).isValidSignature(data, contractSignature) == EIP1271_MAGIC_VALUE, "GS024");
+            } else if (v == 1) {
+                // If v is 1 then it is an approved hash
+                // When handling approved hashes the address of the approver is encoded into r
+                currentOwner = address(uint160(uint256(r)));
+                // Hashes are automatically approved by the sender of the message or when they have been pre-approved via a separate transaction
+                require(msg.sender == currentOwner || approvedHashes[currentOwner][dataHash] != 0, "GS025");
+            } else if (v > 30) {
+                // If v > 30 then default va (27,28) has been adjusted for eth_sign flow
+                // To support eth_sign and similar we adjust v and hash the messageHash with the Ethereum message prefix before applying ecrecover
+                currentOwner = ecrecover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", dataHash)), v - 4, r, s);
+            } else {
+                // Default is the ecrecover flow with the provided data hash
+                // Use ecrecover with the messageHash for EOA signatures
+                currentOwner = ecrecover(dataHash, v, r, s);
+            }
+            require(currentOwner > lastOwner && owners[currentOwner] != address(0) && currentOwner != SENTINEL_OWNERS, "GS026");
+            lastOwner = currentOwner;
+        }
+    }
+
+    /// @dev Allows to estimate a Safe transaction.
+    ///      This method is only meant for estimation purpose, therefore the call will always revert and encode the result in the revert data.
+    ///      Since the `estimateGas` function includes refunds, call this method to get an estimated of the costs that are deducted from the safe with `execTransaction`
+    /// @param to Destination address of Safe transaction.
+    /// @param value Ether value of Safe transaction.
+    /// @param data Data payload of Safe transaction.
+    /// @param operation Operation type of Safe transaction.
+    /// @return Estimate without refunds and overhead fees (base transaction and payload data gas costs).
+    /// @notice Deprecated in favor of common/StorageAccessible.sol and will be removed in next version.
+    function requiredTxGas(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation
+    ) external returns (uint256) {
+        uint256 startGas = gasleft();
+        // We don't provide an error message here, as we use it to return the estimate
+        require(execute(to, value, data, operation, gasleft()));
+        uint256 requiredGas = startGas - gasleft();
+        // Convert response to string and return via error message
+        revert(string(abi.encodePacked(requiredGas)));
+    }
+
+    /**
+     * @dev Marks a hash as approved. This can be used to validate a hash that is used by a signature.
+     * @param hashToApprove The hash that should be marked as approved for signatures that are verified by this contract.
+     */
+    function approveHash(bytes32 hashToApprove) external {
+        require(owners[msg.sender] != address(0), "GS030");
+        approvedHashes[msg.sender][hashToApprove] = 1;
+        emit ApproveHash(hashToApprove, msg.sender);
+    }
+
+    /// @dev Returns the chain id used by this contract.
+    function getChainId() public view returns (uint256) {
+        uint256 id;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            id := chainid()
+        }
+        return id;
+    }
+
+    function domainSeparator() public view returns (bytes32) {
+        return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, getChainId(), this));
+    }
+
+    /// @dev Returns the bytes that are hashed to be signed by owners.
+    /// @param to Destination address.
+    /// @param value Ether value.
+    /// @param data Data payload.
+    /// @param operation Operation type.
+    /// @param safeTxGas Gas that should be used for the safe transaction.
+    /// @param baseGas Gas costs for that are independent of the transaction execution(e.g. base transaction fee, signature check, payment of the refund)
+    /// @param gasPrice Maximum gas price that should be used for this transaction.
+    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
+    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
+    /// @param _nonce Transaction nonce.
+    /// @return Transaction hash bytes.
+    function encodeTransactionData(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    ) public view returns (bytes memory) {
+        bytes32 safeTxHash =
+            keccak256(
+                abi.encode(
+                    SAFE_TX_TYPEHASH,
+                    to,
+                    value,
+                    keccak256(data),
+                    operation,
+                    safeTxGas,
+                    baseGas,
+                    gasPrice,
+                    gasToken,
+                    refundReceiver,
+                    _nonce
+                )
+            );
+        return abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator(), safeTxHash);
+    }
+
+    /// @dev Returns hash to be signed by owners.
+    /// @param to Destination address.
+    /// @param value Ether value.
+    /// @param data Data payload.
+    /// @param operation Operation type.
+    /// @param safeTxGas Fas that should be used for the safe transaction.
+    /// @param baseGas Gas costs for data used to trigger the safe transaction.
+    /// @param gasPrice Maximum gas price that should be used for this transaction.
+    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
+    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
+    /// @param _nonce Transaction nonce.
+    /// @return Transaction hash.
+    function getTransactionHash(
+        address to,
+        uint256 value,
+        bytes calldata data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address refundReceiver,
+        uint256 _nonce
+    ) public view returns (bytes32) {
+        return keccak256(encodeTransactionData(to, value, data, operation, safeTxGas, baseGas, gasPrice, gasToken, refundReceiver, _nonce));
+    }
+}

--- a/packages/backend/discovery/_templates/GnosisSafe/template.jsonc
+++ b/packages/backend/discovery/_templates/GnosisSafe/template.jsonc
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../../../discovery/schemas/contract.v2.schema.json",
+  "ignoreInWatchMode": ["nonce"]
+}

--- a/packages/backend/discovery/_templates/opstack/AddressManager/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/AddressManager/template.jsonc
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "AddressManager",
+  "fields": {
+    "owner": {
+      "target": {
+        "permission": "owner"
+      }
+    }
+  }
+}

--- a/packages/backend/discovery/_templates/opstack/L1CrossDomainMessenger/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/L1CrossDomainMessenger/template.jsonc
@@ -1,5 +1,19 @@
 {
   "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "L1CrossDomainMessenger",
+  "description": "Sends messages from L1 to L2, and relays messages from L2 onto L1. In the event that a message sent from L1 to L2 is rejected for exceeding the L2 epoch gas limit, it can be resubmitted via this contract's replay function.",
   "ignoreMethods": ["xDomainMessageSender"],
-  "ignoreInWatchMode": ["messageNonce"]
+  "ignoreInWatchMode": ["messageNonce"],
+  "fields": {
+    "addressManager": {
+      "target": {
+        "template": "opstack/AddressManager"
+      }
+    },
+    "portal": {
+      "target": {
+        "template": "opstack/OptimismPortal"
+      }
+    }
+  }
 }

--- a/packages/backend/discovery/_templates/opstack/L1StandardBridge/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/L1StandardBridge/template.jsonc
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
-  "displayName": "L1ERC721Bridge",
-  "description": "Used to bridge ERC-721 tokens from L1 to L2",
+  "displayName": "L1StandardBridge",
+  "description": "The main entry point to deposit ERC20 tokens from L1 to L2. This contract can store any token.",
   "fields": {
     "superchainConfig": {
       "target": {

--- a/packages/backend/discovery/_templates/opstack/L2OutputOracle/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/L2OutputOracle/template.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
-  "description": "Central actor allowed to post new L2 state roots to L1.",
+  "displayName": "L2OutputOracle",
+  "description": "Contains a list of proposed state roots which Proposers assert to be a result of block execution. Currently only the PROPOSER address can submit new state roots.",
   "ignoreMethods": [
     "getL2OutputAfter",
     "getL2OutputIndexAfter",
@@ -14,6 +15,16 @@
     "latestOutputIndex"
   ],
   "fields": {
+    "proposer": {
+      "target": {
+        "role": "Proposer"
+      }
+    },
+    "challenger": {
+      "target": {
+        "role": "Challenger"
+      }
+    },
     "deletedOutputs": {
       "handler": {
         "type": "stateFromEvent",

--- a/packages/backend/discovery/_templates/opstack/OptimismMintableERC20Factory/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/OptimismMintableERC20Factory/template.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "OptimismMintableERC20Factory",
+  "description": "A helper contract that generates OptimismMintableERC20 contracts on the network it's deployed to. OptimismMintableERC20 is a standard extension of the base ERC20 token contract designed to allow the L1StandardBridge contracts to mint and burn tokens. This makes it possible to use an OptimismMintablERC20 as the L2 representation of an L1 token, or vice-versa.",
+  "fields": {
+    "bridge": {
+      "target": {
+        "template": "opstack/L1StandardBridge",
+        "category": "Gateways&Escrows"
+      }
+    }
+  }
+}

--- a/packages/backend/discovery/_templates/opstack/OptimismPortal/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/OptimismPortal/template.jsonc
@@ -1,5 +1,24 @@
 {
   "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "OptimismPortal",
+  "description": "The main entry point to deposit funds from L1 to L2. It also allows to prove and finalize withdrawals.",
   "ignoreMethods": ["isOutputFinalized"],
-  "ignoreInWatchMode": ["params"]
+  "ignoreInWatchMode": ["params"],
+  "fields": {
+    "guardian": {
+      "target": {
+        "role": "Guardian"
+      }
+    },
+    "l2Oracle": {
+      "target": {
+        "template": "opstack/L2OutputOracle"
+      }
+    },
+    "systemConfig": {
+      "target": {
+        "template": "opstack/SystemConfig"
+      }
+    }
+  }
 }

--- a/packages/backend/discovery/_templates/opstack/SuperchainConfig/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/SuperchainConfig/template.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "SuperchainConfig",
+  "description": "Used to manage global configuration values for multiple OP Chains within a single Superchain network. The SuperchainConfig contract manages the `PAUSED_SLOT`, a boolean value indicating whether the Superchain is paused, and `GUARDIAN_SLOT`, the address of the guardian which can pause and unpause the system.",
+  "fields": {
+    "guardian": {
+      "target": {
+        "role": "Guardian"
+      }
+    }
+  }
+}

--- a/packages/backend/discovery/_templates/opstack/SystemConfig/template.jsonc
+++ b/packages/backend/discovery/_templates/opstack/SystemConfig/template.jsonc
@@ -1,8 +1,13 @@
 {
   "$schema": "../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "SystemConfig",
+  "description": "Contains configuration parameters such as the Sequencer address, the L2 gas limit and the unsafe block signer address.",
   "fields": {
     // this overrides the batcherHash method return type (bytes32 -> address) so our discovery detects it as an address
     "batcherHash": {
+      "target": {
+        "role": "Sequencer"
+      },
       "handler": {
         "type": "call",
         "method": "function batcherHash() view returns (address)",
@@ -20,6 +25,10 @@
         "type": "opStackSequencerInbox",
         "sequencerAddress": "{{ batcherHash }}"
       }
+    },
+    "gasLimit": {
+      "description": "Gas limit for blocks on L2.",
+      "severity": "LOW"
     }
   },
   "ignoreInWatchMode": ["scalar", "overhead"]

--- a/packages/backend/discovery/cyber/ethereum/diffHistory.md
+++ b/packages/backend/discovery/cyber/ethereum/diffHistory.md
@@ -1,3 +1,37 @@
+Generated with discovered.json: 0xa45f8662b8b343e031a33e1425a4ef1dfe5d27cf
+
+# Diff at Thu, 06 Jun 2024 12:37:16 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@5302ef2899ddfb7175df497ceaa47fba4e383655 block: 19888830
+- current block number: 20032828
+
+## Description
+
+Discovery output now includes names of templates used for contract analysis.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19888830 (main branch discovery), not current.
+
+```diff
+    contract L2OutputOracle (0xa669A743b065828682eE16109273F5CFeF5e676d) {
+    +++ description: Contains a list of proposed state roots which Proposers assert to be a result of block execution. Currently only the PROPOSER address can submit new state roots.
+      template:
++        "opstack/L2OutputOracle"
+    }
+```
+
+```diff
+    contract ProxyAdminOwner (0xc2259E7Fb719411f97aBdCdf449f6Ba3B9D75398) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
 Generated with discovered.json: 0x97e1f05644a07a906b0c40d7e6979a3d9279b28e
 
 # Diff at Fri, 17 May 2024 09:35:04 GMT:

--- a/packages/backend/discovery/cyber/ethereum/discovered.json
+++ b/packages/backend/discovery/cyber/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
   "name": "cyber",
   "chain": "ethereum",
-  "blockNumber": 19888830,
-  "configHash": "0x28c81e171f3ba4b900bdc48d52f5c8020f7497b87049c53d47dafc194fa13284",
-  "version": 4,
+  "blockNumber": 20032828,
+  "configHash": "0x58948ec9c78e306432f92054013a1d25b458c2f09d79881ec191a9031916f302",
+  "version": 5,
   "contracts": [
     {
       "name": "DataAvailabilityChallenge",
@@ -82,6 +82,7 @@
     {
       "name": "OptimismPortal",
       "address": "0x1d59bc9fcE6B8E2B1bf86D4777289FFd83D24C99",
+      "ignoreInWatchMode": ["params"],
       "upgradeability": {
         "type": "EIP1967 proxy",
         "implementation": "0xACfD93B4887cef4F05cF3440d150D2cE97339142",
@@ -95,7 +96,7 @@
         "L2_ORACLE": "0xa669A743b065828682eE16109273F5CFeF5e676d",
         "l2Oracle": "0xa669A743b065828682eE16109273F5CFeF5e676d",
         "l2Sender": "0x000000000000000000000000000000000000dEaD",
-        "params": [1000000000, 500000, 19888749],
+        "params": [1000000000, 21000, 20032435],
         "paused": false,
         "superchainConfig": "0x1aeC4c3BE47C30d0BEfa7514Cf9D99EaC596959D",
         "SYSTEM_CONFIG": "0x5D1F4bbaF6D484fA9D5D9705f92dE6063bff6055",
@@ -107,6 +108,7 @@
     {
       "name": "L1CrossDomainMessenger",
       "address": "0x3c01ebF22e9c111528c1E027D68944eDaB08Dfc9",
+      "ignoreInWatchMode": ["messageNonce"],
       "upgradeability": {
         "type": "resolved delegate proxy",
         "addressManager": "0x19b5804B88F10262A55ac731f28A3BbC4209853a",
@@ -117,7 +119,7 @@
       "sinceTimestamp": 1713430427,
       "values": {
         "MESSAGE_VERSION": 1,
-        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292619968",
+        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292619998",
         "MIN_GAS_CALLDATA_OVERHEAD": 16,
         "MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR": 63,
         "MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR": 64,
@@ -174,6 +176,7 @@
     {
       "name": "SystemConfig",
       "address": "0x5D1F4bbaF6D484fA9D5D9705f92dE6063bff6055",
+      "ignoreInWatchMode": ["scalar"],
       "upgradeability": {
         "type": "EIP1967 proxy",
         "implementation": "0x726C6ac8A53061e56AfB2c890545348ba6f0DF0E",
@@ -213,7 +216,7 @@
           1000000,
           "340282366920938463463374607431768211455"
         ],
-        "scalar": 20000,
+        "scalar": 40000,
         "sequencerInbox": "0xfF00000000000000000000000000000000001d88",
         "START_BLOCK_SLOT": "0xa11ee3ab75b40e88a0105e935d17cd36c8faee0138320d776c411291bdbbb19f",
         "startBlock": 19681300,
@@ -240,6 +243,13 @@
     {
       "name": "L2OutputOracle",
       "address": "0xa669A743b065828682eE16109273F5CFeF5e676d",
+      "template": "opstack/L2OutputOracle",
+      "ignoreInWatchMode": [
+        "nextBlockNumber",
+        "nextOutputIndex",
+        "latestBlockNumber",
+        "latestOutputIndex"
+      ],
       "upgradeability": {
         "type": "EIP1967 proxy",
         "implementation": "0x93E1c0D8ef27930130fb809CE18ca681A8C32F85",
@@ -255,10 +265,10 @@
         "finalizationPeriodSeconds": 604800,
         "L2_BLOCK_TIME": 2,
         "l2BlockTime": 2,
-        "latestBlockNumber": 1233000,
-        "latestOutputIndex": 684,
-        "nextBlockNumber": 1234800,
-        "nextOutputIndex": 685,
+        "latestBlockNumber": 2100600,
+        "latestOutputIndex": 1166,
+        "nextBlockNumber": 2102400,
+        "nextOutputIndex": 1167,
         "proposer": "0xF2987f0A626c8D29dFB2E0A21144ca3026d6F1E1",
         "PROPOSER": "0xF2987f0A626c8D29dFB2E0A21144ca3026d6F1E1",
         "startingBlockNumber": 0,
@@ -272,6 +282,8 @@
     {
       "name": "ProxyAdminOwner",
       "address": "0xc2259E7Fb719411f97aBdCdf449f6Ba3B9D75398",
+      "template": "GnosisSafe",
+      "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",

--- a/packages/backend/discovery/fraxtal/ethereum/diffHistory.md
+++ b/packages/backend/discovery/fraxtal/ethereum/diffHistory.md
@@ -1,3 +1,53 @@
+Generated with discovered.json: 0x1a1f89074dabc9fd237dc883d069e5422a9bd5a2
+
+# Diff at Thu, 06 Jun 2024 12:39:01 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@5302ef2899ddfb7175df497ceaa47fba4e383655 block: 19982475
+- current block number: 20032836
+
+## Description
+
+Discovery output now includes names of templates used for contract analysis.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19982475 (main branch discovery), not current.
+
+```diff
+    contract SystemConfig (0x34a9f273cbD847d49c3De015FC26c3E66825f8b2) {
+    +++ description: Contains configuration parameters such as the Sequencer address, the L2 gas limit and the unsafe block signer address.
+      template:
++        "opstack/SystemConfig"
+    }
+```
+
+```diff
+    contract frxETHMultisig (0x8306300ffd616049FD7e4b0354a64Da835c1A81C) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract TimelockMultisig (0xB1748C79709f4Ba2Dd82834B8c82D4a505003f27) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract FraxtalMultisig (0xe0d7755252873c4eF5788f7f45764E0e17610508) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
 Generated with discovered.json: 0xf0c97ee110e8ec5c671f43cd04bf06c74a0ebd67
 
 # Diff at Thu, 30 May 2024 11:50:41 GMT:

--- a/packages/backend/discovery/fraxtal/ethereum/discovered.json
+++ b/packages/backend/discovery/fraxtal/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
   "name": "fraxtal",
   "chain": "ethereum",
-  "blockNumber": 19982475,
-  "configHash": "0x6cba85c2f2b6ccf53cd0ff0ffc4fb2276ab73dac5738dc6f3b9897fe827ee6ec",
-  "version": 4,
+  "blockNumber": 20032836,
+  "configHash": "0x82302d2f83f4b92e2adf822fe7cfc2c1981b0930381ba7c5ee23803de5dc52ec",
+  "version": 5,
   "contracts": [
     {
       "name": "DepositContract",
@@ -14,8 +14,8 @@
       },
       "sinceTimestamp": 1602667372,
       "values": {
-        "get_deposit_count": "0x1ae7160000000000",
-        "get_deposit_root": "0xed655db0af0bfedb220d080ae5228548bf7c7b3344dcb6196a2190cda53f019d"
+        "get_deposit_count": "0xaf2f170000000000",
+        "get_deposit_root": "0x6047d68e5b57749124a7f6812a75d0ded51f72ad8f14a9b3470dbcbab3e973c6"
       },
       "derivedName": "DepositContract"
     },
@@ -50,7 +50,7 @@
       "sinceTimestamp": 1706811599,
       "values": {
         "MESSAGE_VERSION": 1,
-        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292623724",
+        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292623859",
         "MIN_GAS_CALLDATA_OVERHEAD": 16,
         "MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR": 63,
         "MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR": 64,
@@ -85,6 +85,7 @@
     {
       "name": "SystemConfig",
       "address": "0x34a9f273cbD847d49c3De015FC26c3E66825f8b2",
+      "template": "opstack/SystemConfig",
       "ignoreInWatchMode": ["scalar", "overhead"],
       "upgradeability": {
         "type": "EIP1967 proxy",
@@ -177,7 +178,7 @@
         "L2_ORACLE": "0x66CC916Ed5C6C2FA97014f7D1cD141528Ae171e4",
         "l2Oracle": "0x66CC916Ed5C6C2FA97014f7D1cD141528Ae171e4",
         "l2Sender": "0x000000000000000000000000000000000000dEaD",
-        "params": [10000000, 491822, 19980592],
+        "params": [10000000, 490798, 20032024],
         "paused": false,
         "superchainConfig": "0x61ca43CB037aC9181d8Fa5CD0073dC314065Ccc4",
         "SYSTEM_CONFIG": "0x34a9f273cbD847d49c3De015FC26c3E66825f8b2",
@@ -206,7 +207,7 @@
         "owner": "0x8306300ffd616049FD7e4b0354a64Da835c1A81C",
         "symbol": "frxETH",
         "timelock_address": "0x8412ebf45bAC1B340BbE8F318b928C466c4E39CA",
-        "totalSupply": "198360266646901485751031"
+        "totalSupply": "197872673484967709715094"
       },
       "derivedName": "frxETH"
     },
@@ -253,10 +254,10 @@
         "finalizationPeriodSeconds": 604800,
         "L2_BLOCK_TIME": 2,
         "l2BlockTime": 2,
-        "latestBlockNumber": 5126400,
-        "latestOutputIndex": 2847,
-        "nextBlockNumber": 5128200,
-        "nextOutputIndex": 2848,
+        "latestBlockNumber": 5430600,
+        "latestOutputIndex": 3016,
+        "nextBlockNumber": 5432400,
+        "nextOutputIndex": 3017,
         "proposer": "0xFb90465f3064fF63FC460F01A6307eC73d64bc50",
         "PROPOSER": "0xFb90465f3064fF63FC460F01A6307eC73d64bc50",
         "startingBlockNumber": 0,
@@ -270,6 +271,7 @@
     {
       "name": "frxETHMultisig",
       "address": "0x8306300ffd616049FD7e4b0354a64Da835c1A81C",
+      "template": "GnosisSafe",
       "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
@@ -290,7 +292,7 @@
           "0x6e74053a3798e0fC9a9775F7995316b27f21c4D2"
         ],
         "getThreshold": 3,
-        "nonce": 991,
+        "nonce": 995,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -364,21 +366,22 @@
         "asset": "0x5E8422345238F34275888049021821E8E08CAa1f",
         "decimals": 18,
         "DOMAIN_SEPARATOR": "0xe8254029df4a5fbfcf2de75f8fcf68b1060354a363693b1507e1197cc3dcc29b",
-        "lastRewardAmount": "103923000000000000000",
-        "lastSync": 1717034507,
+        "lastRewardAmount": "102798000000000000000",
+        "lastSync": 1717633271,
         "name": "Staked Frax Ether",
-        "pricePerShare": "1087714024630704981",
-        "rewardsCycleEnd": 1717632000,
+        "pricePerShare": "1088443547393823654",
+        "rewardsCycleEnd": 1718236800,
         "rewardsCycleLength": 604800,
         "symbol": "sfrxETH",
-        "totalAssets": "156876310483667497118362",
-        "totalSupply": "144225694374888038726616"
+        "totalAssets": "157243627381178792589624",
+        "totalSupply": "144466497833244509491027"
       },
       "derivedName": "sfrxETH"
     },
     {
       "name": "TimelockMultisig",
       "address": "0xB1748C79709f4Ba2Dd82834B8c82D4a505003f27",
+      "template": "GnosisSafe",
       "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
@@ -399,7 +402,7 @@
           "0x05FB8eC3C41da95b26fCb85503DaF8B89B89A935"
         ],
         "getThreshold": 3,
-        "nonce": 5606,
+        "nonce": 5614,
         "VERSION": "1.3.0"
       },
       "derivedName": "GnosisSafe"
@@ -413,7 +416,7 @@
       },
       "sinceTimestamp": 1665022895,
       "values": {
-        "currentWithheldETH": "98075291029465833123",
+        "currentWithheldETH": "114731124162530620602",
         "DEPOSIT_SIZE": "32000000000000000000",
         "depositContract": "0x00000000219ab540356cBB839Cbe05303d7705Fa",
         "depositEtherPaused": false,
@@ -432,6 +435,7 @@
     {
       "name": "FraxtalMultisig",
       "address": "0xe0d7755252873c4eF5788f7f45764E0e17610508",
+      "template": "GnosisSafe",
       "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",

--- a/packages/backend/discovery/mint/ethereum/diffHistory.md
+++ b/packages/backend/discovery/mint/ethereum/diffHistory.md
@@ -1,3 +1,61 @@
+Generated with discovered.json: 0xd2c0b2ff8ec740693879026f081391f26dedc33e
+
+# Diff at Thu, 06 Jun 2024 12:44:26 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@5302ef2899ddfb7175df497ceaa47fba4e383655 block: 19982484
+- current block number: 20032860
+
+## Description
+
+Discovery output now includes names of templates used for contract analysis.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19982484 (main branch discovery), not current.
+
+```diff
+    contract ConduitMultisig (0x4a4962275DF8C60a80d3a25faEc5AA7De116A746) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract OptimismPortal (0x59625d1FE0Eeb8114a4d13c863978F39b3471781) {
+    +++ description: The main entry point to deposit funds from L1 to L2. It also allows to prove and finalize withdrawals.
+      template:
++        "opstack/OptimismPortal"
+    }
+```
+
+```diff
+    contract L2OutputOracle (0xB751A613f2Db932c6cdeF5048E6D2af05F9B98ED) {
+    +++ description: Contains a list of proposed state roots which Proposers assert to be a result of block execution. Currently only the PROPOSER address can submit new state roots.
+      template:
++        "opstack/L2OutputOracle"
+    }
+```
+
+```diff
+    contract SystemConfig (0xC975862927797812371A9Fb631f83F8f5e2240D5) {
+    +++ description: Contains configuration parameters such as the Sequencer address, the L2 gas limit and the unsafe block signer address.
+      template:
++        "opstack/SystemConfig"
+    }
+```
+
+```diff
+    contract L1CrossDomainMessenger (0xf80be9f7a74ab776b69d3F0dC5C08c39b3A0bA19) {
+    +++ description: Sends messages from L1 to L2, and relays messages from L2 onto L1. In the event that a message sent from L1 to L2 is rejected for exceeding the L2 epoch gas limit, it can be resubmitted via this contract's replay function.
+      template:
++        "opstack/L1CrossDomainMessenger"
+    }
+```
+
 Generated with discovered.json: 0x88e0f828470372caf9a8af58d6227cfdd9d9c65d
 
 # Diff at Thu, 23 May 2024 13:58:42 GMT:

--- a/packages/backend/discovery/mint/ethereum/discovered.json
+++ b/packages/backend/discovery/mint/ethereum/discovered.json
@@ -1,9 +1,9 @@
 {
   "name": "mint",
   "chain": "ethereum",
-  "blockNumber": 19982484,
-  "configHash": "0x139e3f88bca1a3c69db36eb19c3900a926ac23b631cb708cbc334c5e1b04ae64",
-  "version": 4,
+  "blockNumber": 20032860,
+  "configHash": "0x01eaf3d259572d9d2473cd46a774b5753e167a8babcf1f2db67dfe72a996e649",
+  "version": 5,
   "contracts": [
     {
       "name": "L1StandardBridge",
@@ -27,6 +27,7 @@
     {
       "name": "ConduitMultisig",
       "address": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+      "template": "GnosisSafe",
       "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
@@ -57,6 +58,7 @@
     {
       "name": "OptimismPortal",
       "address": "0x59625d1FE0Eeb8114a4d13c863978F39b3471781",
+      "template": "opstack/OptimismPortal",
       "ignoreInWatchMode": ["params"],
       "upgradeability": {
         "type": "EIP1967 proxy",
@@ -69,7 +71,7 @@
         "GUARDIAN": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
         "L2_ORACLE": "0xB751A613f2Db932c6cdeF5048E6D2af05F9B98ED",
         "l2Sender": "0x000000000000000000000000000000000000dEaD",
-        "params": [1000000000, 491310, 19982347],
+        "params": [1000000000, 491310, 20032800],
         "paused": false,
         "SYSTEM_CONFIG": "0xC975862927797812371A9Fb631f83F8f5e2240D5",
         "version": "1.7.2"
@@ -79,6 +81,7 @@
     {
       "name": "L2OutputOracle",
       "address": "0xB751A613f2Db932c6cdeF5048E6D2af05F9B98ED",
+      "template": "opstack/L2OutputOracle",
       "ignoreInWatchMode": [
         "nextBlockNumber",
         "nextOutputIndex",
@@ -97,10 +100,10 @@
         "deletedOutputs": [],
         "FINALIZATION_PERIOD_SECONDS": 604800,
         "L2_BLOCK_TIME": 2,
-        "latestBlockNumber": 712800,
-        "latestOutputIndex": 32,
-        "nextBlockNumber": 734400,
-        "nextOutputIndex": 33,
+        "latestBlockNumber": 1015200,
+        "latestOutputIndex": 46,
+        "nextBlockNumber": 1036800,
+        "nextOutputIndex": 47,
         "PROPOSER": "0x3d53Df1e69A32F98dFCcf23CCB689763E21A78bA",
         "startingBlockNumber": 0,
         "startingTimestamp": 1715608931,
@@ -125,6 +128,7 @@
     {
       "name": "SystemConfig",
       "address": "0xC975862927797812371A9Fb631f83F8f5e2240D5",
+      "template": "opstack/SystemConfig",
       "ignoreInWatchMode": ["scalar", "overhead"],
       "upgradeability": {
         "type": "EIP1967 proxy",
@@ -174,6 +178,7 @@
     {
       "name": "L1CrossDomainMessenger",
       "address": "0xf80be9f7a74ab776b69d3F0dC5C08c39b3A0bA19",
+      "template": "opstack/L1CrossDomainMessenger",
       "ignoreInWatchMode": ["messageNonce"],
       "upgradeability": {
         "type": "resolved delegate proxy",
@@ -185,7 +190,7 @@
       "sinceTimestamp": 1715609063,
       "values": {
         "MESSAGE_VERSION": 1,
-        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292628976",
+        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292629881",
         "MIN_GAS_CALLDATA_OVERHEAD": 16,
         "MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR": 63,
         "MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR": 64,

--- a/packages/backend/discovery/zora/ethereum/config.jsonc
+++ b/packages/backend/discovery/zora/ethereum/config.jsonc
@@ -23,23 +23,11 @@
     "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746": "ConduitMultisig" // Conduit Multisig
   },
   "overrides": {
+    "0xc52BC7344e24e39dF1bf026fe05C4e6E23CfBcFf": {
+      "extends": "opstack/OptimismMintableERC20Factory"
+    },
     "0x83A4521A3573Ca87f3a971B169C5A0E1d34481c3": {
       "extends": "opstack/L1ERC721Bridge"
-    },
-    "ConduitMultisig": {
-      "ignoreInWatchMode": ["nonce"]
-    },
-    "OptimismPortal": {
-      "extends": "opstack/OptimismPortal"
-    },
-    "L2OutputOracle": {
-      "extends": "opstack/L2OutputOracle"
-    },
-    "ZoraMultisig": {
-      "ignoreInWatchMode": ["nonce"]
-    },
-    "SystemConfig": {
-      "extends": "opstack/SystemConfig"
     }
   }
 }

--- a/packages/backend/discovery/zora/ethereum/diffHistory.md
+++ b/packages/backend/discovery/zora/ethereum/diffHistory.md
@@ -1,3 +1,141 @@
+Generated with discovered.json: 0x061b8314d180cd714b79c9ff7496ce6106de7109
+
+# Diff at Thu, 06 Jun 2024 12:23:14 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@5302ef2899ddfb7175df497ceaa47fba4e383655 block: 19982489
+- current block number: 20032759
+
+## Description
+
+Discovery output now includes names of templates used for contract analysis.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19982489 (main branch discovery), not current.
+
+```diff
+    contract OptimismPortal (0x1a0ad011913A150f69f6A19DF447A0CfD9551054) {
+    +++ description: None
+      template:
++        "opstack/OptimismPortal"
+    }
+```
+
+```diff
+    contract L1StandardBridge (0x3e2Ea9B92B7E48A52296fD261dc26fd995284631) {
+    +++ description: None
+      template:
++        "opstack/L1StandardBridge"
+    }
+```
+
+```diff
+    contract GnosisSafe (0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract ConduitMultisig (0x4a4962275DF8C60a80d3a25faEc5AA7De116A746) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract SuperchainProxyAdminOwner (0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract L1ERC721Bridge (0x83A4521A3573Ca87f3a971B169C5A0E1d34481c3) {
+    +++ description: None
+      template:
++        "opstack/L1ERC721Bridge"
+    }
+```
+
+```diff
+    contract FoundationMultisig_1 (0x847B5c174615B1B7fDF770882256e2D3E95b9D92) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract SuperchainConfig (0x95703e0982140D16f8ebA6d158FccEde42f04a4C) {
+    +++ description: None
+      template:
++        "opstack/SuperchainConfig"
+    }
+```
+
+```diff
+    contract L2OutputOracle (0x9E6204F750cD866b299594e2aC9eA824E2e5f95c) {
+    +++ description: None
+      template:
++        "opstack/L2OutputOracle"
+    }
+```
+
+```diff
+    contract SystemConfig (0xA3cAB0126d5F504B071b81a3e8A2BBBF17930d86) {
+    +++ description: None
+      template:
++        "opstack/SystemConfig"
+    }
+```
+
+```diff
+    contract SecurityCouncilMultisig (0xc2819DC788505Aac350142A7A707BF9D03E3Bd03) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract OptimismMintableERC20Factory (0xc52BC7344e24e39dF1bf026fe05C4e6E23CfBcFf) {
+    +++ description: None
+      template:
++        "opstack/OptimismMintableERC20Factory"
+    }
+```
+
+```diff
+    contract ZoraMultisig (0xC72aE5c7cc9a332699305E29F68Be66c73b60542) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract ChallengerMultisig (0xcA4571b1ecBeC86Ea2E660d242c1c29FcB55Dc72) {
+    +++ description: None
+      template:
++        "GnosisSafe"
+    }
+```
+
+```diff
+    contract L1CrossDomainMessenger (0xdC40a14d9abd6F410226f1E6de71aE03441ca506) {
+    +++ description: None
+      template:
++        "opstack/L1CrossDomainMessenger"
+    }
+```
+
 Generated with discovered.json: 0x971b070707f5c7c01728fdc8f02fb4e6903fec67
 
 # Diff at Wed, 22 May 2024 20:13:47 GMT:

--- a/packages/backend/discovery/zora/ethereum/discovered.json
+++ b/packages/backend/discovery/zora/ethereum/discovered.json
@@ -1,13 +1,14 @@
 {
   "name": "zora",
   "chain": "ethereum",
-  "blockNumber": 19982489,
-  "configHash": "0x93f6b97ea0abf1e92c7765100a0834bf452357efa8186554504c772bb730df12",
-  "version": 4,
+  "blockNumber": 20032759,
+  "configHash": "0xbf4b72151b34e9a5872927c2ed72d96ca7cd301807554c1beccd204094fefaec",
+  "version": 5,
   "contracts": [
     {
       "name": "OptimismPortal",
       "address": "0x1a0ad011913A150f69f6A19DF447A0CfD9551054",
+      "template": "opstack/OptimismPortal",
       "ignoreInWatchMode": ["params"],
       "upgradeability": {
         "type": "EIP1967 proxy",
@@ -22,7 +23,7 @@
         "L2_ORACLE": "0x9E6204F750cD866b299594e2aC9eA824E2e5f95c",
         "l2Oracle": "0x9E6204F750cD866b299594e2aC9eA824E2e5f95c",
         "l2Sender": "0x000000000000000000000000000000000000dEaD",
-        "params": [1000000000, 100000, 19982475],
+        "params": [1000000000, 100000, 20032751],
         "paused": false,
         "superchainConfig": "0x95703e0982140D16f8ebA6d158FccEde42f04a4C",
         "SYSTEM_CONFIG": "0xA3cAB0126d5F504B071b81a3e8A2BBBF17930d86",
@@ -34,6 +35,7 @@
     {
       "name": "L1StandardBridge",
       "address": "0x3e2Ea9B92B7E48A52296fD261dc26fd995284631",
+      "template": "opstack/L1StandardBridge",
       "upgradeability": {
         "type": "EIP1967 proxy",
         "implementation": "0x64B5a5Ed26DCb17370Ff4d33a8D503f0fbD06CfF",
@@ -56,6 +58,8 @@
     {
       "name": "GnosisSafe",
       "address": "0x42d27eEA1AD6e22Af6284F609847CB3Cd56B9c64",
+      "template": "GnosisSafe",
+      "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
@@ -79,6 +83,7 @@
     {
       "name": "ConduitMultisig",
       "address": "0x4a4962275DF8C60a80d3a25faEc5AA7De116A746",
+      "template": "GnosisSafe",
       "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
@@ -123,6 +128,8 @@
     {
       "name": "SuperchainProxyAdminOwner",
       "address": "0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A",
+      "template": "GnosisSafe",
+      "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
@@ -147,6 +154,7 @@
     {
       "name": "L1ERC721Bridge",
       "address": "0x83A4521A3573Ca87f3a971B169C5A0E1d34481c3",
+      "template": "opstack/L1ERC721Bridge",
       "upgradeability": {
         "type": "EIP1967 proxy",
         "implementation": "0xAE2AF01232a6c4a4d3012C5eC5b1b35059caF10d",
@@ -167,6 +175,8 @@
     {
       "name": "FoundationMultisig_1",
       "address": "0x847B5c174615B1B7fDF770882256e2D3E95b9D92",
+      "template": "GnosisSafe",
+      "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
@@ -196,6 +206,7 @@
     {
       "name": "SuperchainConfig",
       "address": "0x95703e0982140D16f8ebA6d158FccEde42f04a4C",
+      "template": "opstack/SuperchainConfig",
       "upgradeability": {
         "type": "EIP1967 proxy",
         "implementation": "0x53c165169401764778F780a69701385eb0FF19B7",
@@ -244,6 +255,7 @@
     {
       "name": "L2OutputOracle",
       "address": "0x9E6204F750cD866b299594e2aC9eA824E2e5f95c",
+      "template": "opstack/L2OutputOracle",
       "ignoreInWatchMode": [
         "nextBlockNumber",
         "nextOutputIndex",
@@ -265,10 +277,10 @@
         "finalizationPeriodSeconds": 604800,
         "L2_BLOCK_TIME": 2,
         "l2BlockTime": 2,
-        "latestBlockNumber": 15184980,
-        "latestOutputIndex": 8660,
-        "nextBlockNumber": 15186780,
-        "nextOutputIndex": 8661,
+        "latestBlockNumber": 15489180,
+        "latestOutputIndex": 8829,
+        "nextBlockNumber": 15490980,
+        "nextOutputIndex": 8830,
         "proposer": "0x48247032092e7b0ecf5dEF611ad89eaf3fC888Dd",
         "PROPOSER": "0x48247032092e7b0ecf5dEF611ad89eaf3fC888Dd",
         "startingBlockNumber": 0,
@@ -282,6 +294,7 @@
     {
       "name": "SystemConfig",
       "address": "0xA3cAB0126d5F504B071b81a3e8A2BBBF17930d86",
+      "template": "opstack/SystemConfig",
       "ignoreInWatchMode": ["scalar", "overhead"],
       "upgradeability": {
         "type": "EIP1967 proxy",
@@ -336,6 +349,8 @@
     {
       "name": "SecurityCouncilMultisig",
       "address": "0xc2819DC788505Aac350142A7A707BF9D03E3Bd03",
+      "template": "GnosisSafe",
+      "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
@@ -371,6 +386,7 @@
     {
       "name": "OptimismMintableERC20Factory",
       "address": "0xc52BC7344e24e39dF1bf026fe05C4e6E23CfBcFf",
+      "template": "opstack/OptimismMintableERC20Factory",
       "upgradeability": {
         "type": "EIP1967 proxy",
         "implementation": "0xE01efbeb1089D1d1dB9c6c8b135C934C0734c846",
@@ -387,6 +403,7 @@
     {
       "name": "ZoraMultisig",
       "address": "0xC72aE5c7cc9a332699305E29F68Be66c73b60542",
+      "template": "GnosisSafe",
       "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
@@ -418,6 +435,8 @@
     {
       "name": "ChallengerMultisig",
       "address": "0xcA4571b1ecBeC86Ea2E660d242c1c29FcB55Dc72",
+      "template": "GnosisSafe",
+      "ignoreInWatchMode": ["nonce"],
       "upgradeability": {
         "type": "gnosis safe",
         "masterCopy": "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
@@ -459,6 +478,7 @@
     {
       "name": "L1CrossDomainMessenger",
       "address": "0xdC40a14d9abd6F410226f1E6de71aE03441ca506",
+      "template": "opstack/L1CrossDomainMessenger",
       "ignoreInWatchMode": ["messageNonce"],
       "upgradeability": {
         "type": "resolved delegate proxy",
@@ -470,7 +490,7 @@
       "sinceTimestamp": 1686694019,
       "values": {
         "MESSAGE_VERSION": 1,
-        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292621896",
+        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292621913",
         "MIN_GAS_CALLDATA_OVERHEAD": 16,
         "MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR": 63,
         "MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR": 64,


### PR DESCRIPTION
As an example, Zora's config has been refactored to fully use OP stack templates and provide only the entrypoint addresses.

Also, a shape for GnosisSafe has been added.

Due to config hash changes, discovery had to be rerun (with no significant changes found) for: ethereum-cyber, ethereum-fraxtal, ethereum-mint