### PR TITLE
Turn Kroma state validation red because not safe

### DIFF
--- a/packages/config/src/projects/layer2s/kroma.ts
+++ b/packages/config/src/projects/layer2s/kroma.ts
@@ -210,7 +210,7 @@ export const kroma: Layer2 = {
       description:
         RISK_VIEW.STATE_FP_INT_ZK.description +
         " The challenge protocol can be subject to delay attacks and can fail under certain conditions. The current system doesn't use posted L2 txs batches on L1 as inputs to prove a fault, meaning that DA is not enforced.",
-      sentiment: 'warning',
+      sentiment: 'bad',
       secondLine: `${formatSeconds(finalizationPeriod)} challenge period`,
     },
     dataAvailability: {


### PR DESCRIPTION
Kroma proof system doesn't check DA properly and therefore can fail in certain circumstances. The yellow assessment for state validation gets stricter to only allow safe proof systems.