### PR TITLE
[L2B-0] Fix issue with ElasticSearchTransport tests

### DIFF
--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
@@ -63,11 +63,9 @@ function createClientMock(indextExist = true) {
   return mockObject<ElasticSearchClient>({
     indexExist: mockFn(async (_: string): Promise<boolean> => indextExist),
     indexCreate: mockFn(async (_: string): Promise<void> => {}),
-    bulk: mockFn().resolvesTo(
-      mockObject({
-        isSuccess: true,
-      }),
-    ),
+    bulk: mockFn().resolvesTo({
+      isSuccess: true,
+    }),
   })
 }
 


### PR DESCRIPTION
Fix async error in tests:

```
TypeError: Cannot access .then - no mock value provided.
    at Object.get (/Users/maciejopala/source/l2beat/node_modules/earl/src/mocks/mockObject.ts:47:13)
    at Function.resolve (<anonymous>)
    at Function.mock.resolvesTo (/Users/maciejopala/source/l2beat/node_modules/earl/src/mocks/mockFn.ts:171:52)
    at createClientMock (/Users/maciejopala/source/l2beat/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts:66:20)
    at Context.<anonymous> (/Users/maciejopala/source/l2beat/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts:47:24)
    at callFn (/Users/maciejopala/source/l2beat/node_modules/mocha/lib/runnable.js:366:21)
    at Runnable.run (/Users/maciejopala/source/l2beat/node_modules/mocha/lib/runnable.js:354:5)
    at Runner.runTest (/Users/maciejopala/source/l2beat/node_modules/mocha/lib/runner.js:677:10)
    at /Users/maciejopala/source/l2beat/node_modules/mocha/lib/runner.js:800:12
    at next (/Users/maciejopala/source/l2beat/node_modules/mocha/lib/runner.js:592:14)
    at /Users/maciejopala/source/l2beat/node_modules/mocha/lib/runner.js:602:7
    at next (/Users/maciejopala/source/l2beat/node_modules/mocha/lib/runner.js:485:14)
    at Immediate.<anonymous> (/Users/maciejopala/source/l2beat/node_modules/mocha/lib/runner.js:570:5)
    at process.processImmediate (node:internal/timers:476:21)
(node:84583) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 8)
```