### PR TITLE
Make Taiko proposer failure green

### DIFF
--- a/packages/config/src/projects/layer2s/taiko.ts
+++ b/packages/config/src/projects/layer2s/taiko.ts
@@ -199,8 +199,8 @@ export const taiko: Layer2 = {
     },
     proposerFailure: {
       description:
-        'Provers can examine the proposed blocks on the TaikoL1 contract, and generate SGX proofs for them. Currently, any prover providing a valid SGX attestation can register a SGX instance and create proofs for proposed blocks. However, the TaikoAdmin multisig can delete SGX instances and revoke certificates without delay, which would prevent valid SGX proofs from being accepted.',
-      sentiment: 'warning',
+        'Provers can examine the proposed blocks on the TaikoL1 contract, and generate SGX proofs for them. Currently, any prover providing a valid SGX attestation can register a SGX instance and create proofs for proposed blocks.',
+      sentiment: 'good',
       value: 'Self propose',
     },
     validatedBy: RISK_VIEW.VALIDATED_BY_ETHEREUM,


### PR DESCRIPTION
The risk should only be accounted in the Exit Window risk since it is equivalent to upgradability risk. The risk is already described in the Permission section.