### PR TITLE
Add RBX token

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -3046,6 +3046,21 @@
       "formula": "locked"
     },
     {
+      "id": "rbx-rabbitx",
+      "name": "RabbitX",
+      "coingeckoId": "rabbitx",
+      "address": "0x3Ba925fdeAe6B46d0BB4d424D829982Cb2F7309e",
+      "symbol": "RBX",
+      "decimals": 18,
+      "deploymentTimestamp": 1682520515,
+      "coingeckoListingTimestamp": 1682985600,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/30048/large/RBX.png?1696528970",
+      "chainId": 1,
+      "type": "CBV",
+      "formula": "locked"
+    },
+    {
       "id": "rad-radicle",
       "name": "Radicle",
       "coingeckoId": "radicle",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -835,6 +835,10 @@
       "address": "0x50DE6856358Cc35f3A9a57eAAA34BD4cB707d2cd"
     },
     {
+      "symbol": "RBX",
+      "address": "0x3ba925fdeae6b46d0bb4d424d829982cb2f7309e"
+    },
+    {
       "symbol": "rDPX",
       "address": "0x0ff5A8451A839f5F0BB3562689D9A44089738D11"
     },


### PR DESCRIPTION
Resolves L2B-5811
CBT, requested by Blast, locked in the generic escrow we already have