### PR TITLE
Add scaling summary redirect back to old FE

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,11 @@
 {
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/scaling/summary",
+      "permanent": false
+    }
+  ],
   "rewrites": [
     {
       "source": "/api/projects/:project/tvl/assets/:asset",


### PR DESCRIPTION
Adding it just to prevent confusion caused by Vercel displaying 404 on successful deploys of old FE. This shouldn't affect anything else.