### PR TITLE
improve BridgesMvpWarning ux

### DIFF
--- a/packages/frontend/src/components/BridgesMvpWarning.tsx
+++ b/packages/frontend/src/components/BridgesMvpWarning.tsx
@@ -1,18 +1,18 @@
-import React from "react";
-import { common } from "../build/config/common";
+import React from 'react';
+import { common } from '../build/config/common';
 
 export function BridgesMvpWarning() {
   return (
     <p className="my-4 rounded-lg bg-yellow-500 p-2 text-center font-medium text-base text-black">
       L2BEAT Bridges is a work in progress. You might find incomplete research
-      or inconsistent naming. Join our{" "}
+      or inconsistent naming. Join our{' '}
       <a
-        className="underline font-medium"
+        className="font-medium underline"
         href={common.links.discord}
         target="_blank"
       >
         Discord
-      </a>{" "}
+      </a>{' '}
       to suggest improvements!
     </p>
   );

--- a/packages/frontend/src/components/BridgesMvpWarning.tsx
+++ b/packages/frontend/src/components/BridgesMvpWarning.tsx
@@ -1,10 +1,19 @@
-import React from 'react'
+import React from "react";
+import { common } from "../build/config/common";
 
 export function BridgesMvpWarning() {
   return (
     <p className="my-4 rounded-lg bg-yellow-500 p-2 text-center font-medium text-base text-black">
       L2BEAT Bridges is a work in progress. You might find incomplete research
-      or inconsistent naming. Join our discord to suggest improvements!
+      or inconsistent naming. Join our{" "}
+      <a
+        className="underline font-medium"
+        href={common.links.discord}
+        target="_blank"
+      >
+        Discord
+      </a>{" "}
+      to suggest improvements!
     </p>
-  )
+  );
 }

--- a/packages/frontend/src/components/BridgesMvpWarning.tsx
+++ b/packages/frontend/src/components/BridgesMvpWarning.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { common } from '../build/config/common';
+import React from 'react'
+import { common } from '../build/config/common'
 
 export function BridgesMvpWarning() {
   return (
@@ -15,5 +15,5 @@ export function BridgesMvpWarning() {
       </a>{' '}
       to suggest improvements!
     </p>
-  );
+  )
 }


### PR DESCRIPTION
Using "Discord" with a capital "D" since it is a proper noun referring to the specific platform. Make it clickable.

### Before
<img width="1205" alt="image" src="https://github.com/l2beat/l2beat/assets/172093886/09f47673-e1d3-4eb9-93d5-d41ff1731d79">



### After
<img width="1208" alt="image" src="https://github.com/l2beat/l2beat/assets/172093886/0fdca413-3cb5-4d28-aedb-16cce46250d1">
