### PR TITLE
Add taiko associated token to taiko

### DIFF
--- a/packages/config/src/projects/layer2s/taiko.ts
+++ b/packages/config/src/projects/layer2s/taiko.ts
@@ -110,6 +110,7 @@ export const taiko: Layer2 = {
     },
   },
   config: {
+    associatedTokens: ['TAIKO'],
     escrows: [
       {
         // Shared ETH bridge

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -3766,6 +3766,21 @@
       "formula": "locked"
     },
     {
+      "id": "taiko-taiko-token",
+      "name": "Taiko Token",
+      "coingeckoId": "taiko",
+      "address": "0x10dea67478c5F8C5E2D90e5E9B26dBe60c54d800",
+      "symbol": "TAIKO",
+      "decimals": 18,
+      "deploymentTimestamp": 1714033799,
+      "coingeckoListingTimestamp": 1717545600,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38058/large/icon.png?1717626867",
+      "chainId": 1,
+      "type": "CBV",
+      "formula": "locked"
+    },
+    {
       "id": "tbtc-tbtc-v2",
       "name": "tBTC v2",
       "coingeckoId": "tbtc",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1013,6 +1013,10 @@
       "address": "0x0f2D719407FdBeFF09D87557AbB7232601FD9F29"
     },
     {
+      "symbol": "TAIKO",
+      "address": "0x10dea67478c5F8C5E2D90e5E9B26dBe60c54d800"
+    },
+    {
       "symbol": "tBTC",
       "address": "0x18084fbA666a33d37592fA2633fD49a74DD93a88"
     },


### PR DESCRIPTION
CBV because:
- totalsupply on taiko is supply in L1 bridge (no other mints)
- no-circulating sits in multisigs on ethereum
- airdrop was minted on ethereum and bridged to taiko before dropping to users