### PR TITLE
Fix Ronin threshold 

### DIFF
--- a/packages/config/src/projects/bridges/ronin.ts
+++ b/packages/config/src/projects/bridges/ronin.ts
@@ -12,11 +12,12 @@ const operatorsCount = discovery.getPermissionedAccounts(
   'getBridgeOperators',
 ).length
 
-const thresholdArray = discovery.getContractValue<number[]>(
-  'MainchainGateway',
-  'getThreshold',
-)
-const thresholdPerc = thresholdArray[0]
+const thresholdArray = discovery.getContractValue<{
+  num_: number
+  denom_: number
+}>('MainchainGateway', 'getThreshold')
+
+const thresholdPerc = thresholdArray.num_
 
 const operatorsString = `${thresholdPerc}% out of ${operatorsCount}`
 


### PR DESCRIPTION
Resolves L2B-5940

Threshold ended up Undefined after tooling change from array to objects
<img width="455" alt="image" src="https://github.com/l2beat/l2beat/assets/10850139/8c21fc20-5498-446d-b3f0-969e1a282407">
