### PR TITLE
Small improvements to discovery

### DIFF
--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -47,11 +47,13 @@ export async function runDiscovery(
     discoveryFilename: config.discoveryFilename,
   })
 
-  const allConfigs = configReader.readAllConfigsForChain(config.chain.name)
-  const backrefConfigs = allConfigs.filter((c) =>
-    c.sharedModules.includes(config.project),
-  )
-  printSharedModuleInfo(backrefConfigs)
+  if (config.project.startsWith('shared-')) {
+    const allConfigs = configReader.readAllConfigsForChain(config.chain.name)
+    const backrefConfigs = allConfigs.filter((c) =>
+      c.sharedModules.includes(config.project),
+    )
+    printSharedModuleInfo(backrefConfigs)
+  }
 }
 
 export async function dryRunDiscovery(


### PR DESCRIPTION
- Cache reverts
- Cache empty log responses
- Don't print shared module info if project name does not start with `shared-`, saves around 200ms-300ms