### PR TITLE
Allow to specify Ethereum as chain in native contracts

### DIFF
--- a/packages/frontend/src/pages/project/common/getContractSection.ts
+++ b/packages/frontend/src/pages/project/common/getContractSection.ts
@@ -123,7 +123,7 @@ export function getContractSection(
     id: 'contracts',
     chainName,
     title: 'Smart contracts',
-    nativeContracts: nativeContracts,
+    nativeContracts,
     contracts: contracts ?? [],
     escrows: escrows,
     risks: risks,
@@ -518,6 +518,9 @@ function areAllAddressesUnverified(
 }
 
 function slugToDisplayName(slug: string): string {
+  if (slug === 'ethereum') {
+    return 'Ethereum'
+  }
   const isL2 = layer2s.find((l2) => l2.id === slug)
   if (isL2 !== undefined) {
     return isL2.display.name

--- a/packages/frontend/src/pages/project/components/sections/ContractsSection/ContractsSection.tsx
+++ b/packages/frontend/src/pages/project/components/sections/ContractsSection/ContractsSection.tsx
@@ -33,6 +33,7 @@ export interface ContractsSectionProps {
 export function ContractsSection(props: ContractsSectionProps) {
   if (
     props.contracts.length === 0 &&
+    Object.keys(props.nativeContracts).length === 0 &&
     props.escrows.length === 0 &&
     props.risks.length === 0 &&
     !props.isUnderReview


### PR DESCRIPTION
Resolves L2B-6107

Also show contracts section if there is zero contracts in contracts but there are native contracts to show.