### PR TITLE
Undecimal keep floating point, format

### DIFF
--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -24,6 +24,7 @@
     "@l2beat/shared": "*",
     "@l2beat/shared-pure": "*",
     "@mradomski/fast-solidity-parser": "0.1.1",
+    "bignumber.js": "^9.1.2",
     "chalk": "^4.1.2",
     "deep-diff": "^1.0.2",
     "dotenv": "^16.0.3",

--- a/packages/discovery/src/discovery/type-casters/Undecimal.test.ts
+++ b/packages/discovery/src/discovery/type-casters/Undecimal.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'earl'
+import { Undecimal } from './Undecimal'
+
+interface TestData {
+  decimals: number
+  incomingValue: string
+  expected: string
+}
+
+const testData: TestData[] = [
+  { decimals: 18, incomingValue: '0', expected: '0' },
+  {
+    decimals: 6,
+    incomingValue: '1233458934095843',
+    expected: '1,233,458,934.095843',
+  },
+  {
+    decimals: 10,
+    incomingValue: '1233458934095843',
+    expected: '123,345.8934095843',
+  },
+  {
+    decimals: 18,
+    incomingValue: '123345893409584392323164',
+    expected: '123,345.893409584392323164',
+  },
+  { decimals: 18, incomingValue: '1000000000000000000', expected: '1' },
+]
+
+describe('Undecimal', () => {
+  for (const data of testData) {
+    it(`should cast a number to a ContractValue`, () => {
+      const result = Undecimal.cast(
+        { decimals: data.decimals },
+        data.incomingValue,
+      )
+      expect(result).toEqual(data.expected)
+    })
+  }
+})

--- a/packages/discovery/src/discovery/type-casters/Undecimal.ts
+++ b/packages/discovery/src/discovery/type-casters/Undecimal.ts
@@ -1,6 +1,6 @@
 import { assert } from '@l2beat/backend-tools'
 import { ContractValue } from '@l2beat/discovery-types'
-import { BigNumber } from 'ethers'
+import { BigNumber } from 'bignumber.js'
 import { z } from 'zod'
 import { toContractValue } from '../handlers/utils/toContractValue'
 import { ArgType, BaseTypeCaster } from './BaseTypeCaster'
@@ -16,10 +16,10 @@ export const Undecimal: BaseTypeCaster = {
       'Incoming value must be a number or a string',
     )
     const validated = Validator.parse(arg)
-    const asBigInt = BigNumber.from(incomingValue)
-    const decimals = BigNumber.from(validated.decimals)
-    const base = BigNumber.from(10)
+    const asBigInt = BigNumber(incomingValue)
+    const decimals = BigNumber(validated.decimals)
+    const base = BigNumber(10)
 
-    return toContractValue(asBigInt.div(base.pow(decimals)))
+    return toContractValue(asBigInt.div(base.pow(decimals)).toFormat())
   },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7501,7 +7501,7 @@ big.js@^6.0.0:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.2.1.tgz#7205ce763efb17c2e41f26f121c420c6a7c2744f"
   integrity sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==
 
-bignumber.js@^9.0.0:
+bignumber.js@^9.0.0, bignumber.js@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
   integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==


### PR DESCRIPTION
Resolves L2B-6156

`BigInt` is an integer (duh) and drops fraction during division. `BigNumber` from ethers does the same. Because we actually need big number with floating point arithmetic i decided to install `bignumber.js`. 

Example:
`Undecimal18(197872673484967709715094) = 197,872.673484967709715094`
