### PR TITLE
Add USD+ to Kinto

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -6161,6 +6161,21 @@
       }
     },
     {
+      "id": "kinto:usd+-usd+",
+      "name": "USD+",
+      "coingeckoId": "dinari-usd",
+      "address": "0x6F086dB0f6A621a915bC90295175065c9e5d9b8c",
+      "symbol": "USD+",
+      "decimals": 6,
+      "deploymentTimestamp": 1718908690,
+      "coingeckoListingTimestamp": 1719360000,
+      "category": "stablecoin",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38879/large/USDplus-200.png?1719374938",
+      "chainId": 7887,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "id": "kinto:weeth-wrapped-eeth",
       "name": "Wrapped eETH",
       "coingeckoId": "wrapped-eeth",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -2430,6 +2430,14 @@
   ],
   "kinto": [
     {
+      "symbol": "USD+",
+      "address": "0x6F086dB0f6A621a915bC90295175065c9e5d9b8c",
+      "category": "stablecoin",
+      "source": "native",
+      "supply": "totalSupply",
+      "coingeckoId": "dinari-usd"
+    },
+    {
       "symbol": "weETH",
       "category": "ether",
       "address": "0x0Ee700095AeDFe0814fFf7d6DFD75461De8e2b19",


### PR DESCRIPTION
Stablecoin backed by US short term treasuries ([Dinari](https://usd.dinari.com))
natively minted on Kinto 
