### PR TITLE
Fix transporter spamming phantom updates

### DIFF
--- a/packages/backend/src/modules/update-monitor/DiscoveryRunner.test.ts
+++ b/packages/backend/src/modules/update-monitor/DiscoveryRunner.test.ts
@@ -43,6 +43,8 @@ describe(DiscoveryRunner.name, () => {
         MOCK_PROVIDER,
         new DiscoveryConfig({
           ...getMockConfig().raw,
+          maxAddresses: 600,
+          maxDepth: 18,
           initialAddresses: [ADDRESS],
         }),
       )

--- a/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
+++ b/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
@@ -127,6 +127,8 @@ export class DiscoveryRunner {
     return new DiscoveryConfig({
       ...config.raw,
       initialAddresses,
+      maxAddresses: (config.raw.maxAddresses ?? 200) * 3,
+      maxDepth: (config.raw.maxDepth ?? 6) * 3,
     })
   }
 }


### PR DESCRIPTION
Resolves L2B-6195

This was caused by an edge case in the logic for skipping discovery of contracts. In the UpdateMonitor we set the initial addresses to the addresses of all contracts present in the discovered.json. This is a neat trick and speeds up the discovery a lot since for example in transporter we discovery ~120 addresses at the same time, batching all of the calls it makes into really big multicalls. Of course most of these addresses are in the `toAnalyze` queue without any template assigned to them. They'd be discovered and at the end of the run they should be overwritten by templates from the config.jsonc propagating and being attached to contracts. The problem is that because we added all of the addresses to be discovered they were counted to the amount of addresses discovered. Since transporter is 100% template driven this caused the amount of discovered addresses to be doubled. In the first half we discovered without template and in the second half where we found those templates and wanted to apply them they where being skipped because the number of discovered addresses overflowed the `maxAddresses`.