### PR TITLE
Remove unused logic from MultiIndexer

### DIFF
--- a/packages/backend/src/tools/uif/multi/MultiIndexer.test.ts
+++ b/packages/backend/src/tools/uif/multi/MultiIndexer.test.ts
@@ -95,10 +95,7 @@ describe(MultiIndexer.name, () => {
         calls.push('multiInitialize')
         return []
       })
-      testIndexer.getInitialConfigurations = mockFn(() => {
-        calls.push('getInitialConfigurations')
-        return []
-      })
+
       testIndexer.getSafeHeight = mockFn(() => {
         calls.push('getSafeHeight')
         return Promise.resolve(undefined)
@@ -106,11 +103,7 @@ describe(MultiIndexer.name, () => {
 
       await testIndexer.initialize()
 
-      expect(calls).toEqual([
-        'multiInitialize',
-        'getInitialConfigurations',
-        'getSafeHeight',
-      ])
+      expect(calls).toEqual(['multiInitialize', 'getSafeHeight'])
     })
 
     it('getSafeHeight lower than saved configs', async () => {
@@ -388,17 +381,6 @@ describe(MultiIndexer.name, () => {
         mockDbMiddleware,
       )
     })
-
-    it('gets configurations from different source', async () => {
-      const testIndexer = new TestMultiIndexer(undefined, [])
-      testIndexer.getInitialConfigurations = () => [
-        actual('a', 100, null),
-        actual('b', 100, null),
-      ]
-
-      const newHeight = await testIndexer.initialize()
-      expect(newHeight).toEqual({ safeHeight: 99 })
-    })
   })
 
   describe('multiUpdate', () => {
@@ -482,7 +464,7 @@ describe(MultiIndexer.name, () => {
 
 class TestMultiIndexer extends MultiIndexer<null> {
   constructor(
-    configurations: Configuration<null>[] | undefined,
+    configurations: Configuration<null>[],
     private readonly _saved: SavedConfiguration<null>[],
   ) {
     super(

--- a/packages/backend/src/tools/uif/multi/MultiIndexer.ts
+++ b/packages/backend/src/tools/uif/multi/MultiIndexer.ts
@@ -14,32 +14,16 @@ import {
 
 export abstract class MultiIndexer<T> extends ChildIndexer {
   private ranges: ConfigurationRange<T>[] = []
-  private configurations: Configuration<T>[] = []
   private saved = new Map<string, SavedConfiguration<T>>()
 
   constructor(
     logger: Logger,
     parents: Indexer[],
     private readonly createDatabaseMiddleware: () => Promise<DatabaseMiddleware>,
-    configurations?: Configuration<T>[],
+    private readonly configurations: Configuration<T>[],
     options?: IndexerOptions,
   ) {
     super(logger, parents, options)
-    if (configurations) {
-      this.configurations = configurations
-    }
-  }
-
-  /**
-   * This will run as the first step of initialize() function.
-   * Allow overriding to provide configurations from a different source.
-   * Example: your configurations have autoincrement id, so you need to
-   * first add them to the database to get the MultiIndexer logic to work (it assumes every
-   * configuration has a unique id)
-   * @returns The configurations that the indexer should use to sync data.
-   */
-  getInitialConfigurations(): Promise<Configuration<T>[]> | Configuration<T>[] {
-    return this.configurations
   }
 
   /**
@@ -134,7 +118,6 @@ export abstract class MultiIndexer<T> extends ChildIndexer {
   async initialize() {
     const previouslySaved = await this.multiInitialize()
 
-    this.configurations = await this.getInitialConfigurations()
     this.ranges = toRanges(this.configurations)
 
     const { toRemove, toSave, safeHeight } = diffConfigurations(


### PR DESCRIPTION
`.getInitialConfigurations()` functionality was added to MultiIndexer in the past when we had an idea to have configurations with dynamic ids set by the DB autoincrement. We have ditched the idea later on, but the code has stayed and is not used anymore. This PR is a cleanup.