### PR TITLE
Add RWA token to re.al

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -8142,6 +8142,21 @@
       }
     },
     {
+      "id": "real:rwa-re.al",
+      "name": "re.al",
+      "coingeckoId": "re-al",
+      "address": "0x4644066f535Ead0cde82D209dF78d94572fCbf14",
+      "symbol": "RWA",
+      "decimals": 18,
+      "deploymentTimestamp": 1715799306,
+      "coingeckoListingTimestamp": 1720483200,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38626/large/RWA_200x200.png?1718168632",
+      "chainId": 111188,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "id": "real:ustb-us-t-bill",
       "name": "US T-Bill",
       "coingeckoId": "real-us-t-bill",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -3163,6 +3163,13 @@
   ],
   "real": [
     {
+      "symbol": "RWA",
+      "address": "0x4644066f535Ead0cde82D209dF78d94572fCbf14",
+      "source": "native",
+      "supply": "totalSupply",
+      "coingeckoId": "re-al"
+    },
+    {
       "symbol": "USTB",
       "address": "0x83fedbc0b85c6e29b589aa6bdefb1cc581935ecd",
       "source": "external",


### PR DESCRIPTION
Closes L2B-6347

counted by totalSupply because it is lower than circulating on coingecko and minted natively on re.al

this token is not the Xend RWA