### PR TITLE
Fix polygoncdk permissions

### DIFF
--- a/packages/backend/discovery/astarzkevm/ethereum/config.jsonc
+++ b/packages/backend/discovery/astarzkevm/ethereum/config.jsonc
@@ -7,11 +7,10 @@
     "0x0775e11309d75aA6b0967917fB0213C5673eDf81"
   ],
   "names": {
-    "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80": "AstarValidiumEtrog",
+    "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80": "AstarValidium",
     "0x0775e11309d75aA6b0967917fB0213C5673eDf81": "AstarVerifier",
     "0x9CCD205052c732Ac1Df2cf7bf8aACC0E371eE0B0": "AstarValidiumDAC",
-    "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E": "ProxyAdminOwner",
-    "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb": "GlobalExitRootV2"
+    "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E": "LocalAdmin"
   },
   "sharedModules": {
     "PolygonRollupManager": "shared-polygon-cdk"
@@ -28,7 +27,7 @@
         }
       }
     },
-    "AstarValidiumEtrog": {
+    "AstarValidium": {
       "ignoreInWatchMode": ["lastAccInputHash"]
     }
   }

--- a/packages/backend/discovery/astarzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/astarzkevm/ethereum/diffHistory.md
@@ -8,7 +8,7 @@ Generated with discovered.json: 0x623832859454f6f8ca034607d5b18f835be8a731
 
 ## Description
 
-Provide description of changes. This section will be preserved.
+Introduced a new LocalAdmin, not handled by the shared template, which mainContract admin (not the upgradeabilityAdmin) and who can change local system configs. This role was wrongly given to the SharedProxyAdminOwner before.
 
 ## Config/verification related changes
 

--- a/packages/backend/discovery/astarzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/astarzkevm/ethereum/diffHistory.md
@@ -1,3 +1,39 @@
+Generated with discovered.json: 0x623832859454f6f8ca034607d5b18f835be8a731
+
+# Diff at Wed, 17 Jul 2024 08:27:23 GMT:
+
+- author: sekuba (<29250140+sekuba@users.noreply.github.com>)
+- comparing to: main@0df6fda263b58edb9acce032017abb5ebd61f5fd block: 20188651
+- current block number: 20325048
+
+## Description
+
+Provide description of changes. This section will be preserved.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 20188651 (main branch discovery), not current.
+
+```diff
+    contract AstarValidiumEtrog (0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80) {
+    +++ description: None
+      name:
+-        "AstarValidiumEtrog"
++        "AstarValidium"
+    }
+```
+
+```diff
+    contract ProxyAdminOwner (0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E) {
+    +++ description: None
+      name:
+-        "ProxyAdminOwner"
++        "LocalAdmin"
+    }
+```
+
 Generated with discovered.json: 0x4c1a1e744f8a16bc777c372929ab36767c7bcb20
 
 # Diff at Fri, 28 Jun 2024 07:20:22 GMT:

--- a/packages/backend/discovery/astarzkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/astarzkevm/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "astarzkevm",
   "chain": "ethereum",
-  "blockNumber": 20188651,
-  "configHash": "0xf2b3d10827c63ab3d798f45bfb9f8ad5fffc5af1f77d50b964917975d3627e7c",
+  "blockNumber": 20325048,
+  "configHash": "0xa75ac3d3673e70efc5004b51931bfbf779c046e09be2455ba9855c5111382b42",
   "version": 9,
   "contracts": [
     {
@@ -25,7 +25,7 @@
       }
     },
     {
-      "name": "AstarValidiumEtrog",
+      "name": "AstarValidium",
       "address": "0x1E163594e13030244DCAf4cDfC2cd0ba3206DA80",
       "proxyType": "EIP1967 proxy",
       "ignoreInWatchMode": ["lastAccInputHash"],
@@ -52,7 +52,7 @@
         "INITIALIZE_TX_DATA_LEN_EMPTY_METADATA": 228,
         "INITIALIZE_TX_EFFECTIVE_PERCENTAGE": "0xff",
         "isSequenceWithDataAvailabilityAllowed": false,
-        "lastAccInputHash": "0x570e9af1e44fcc05f58c86647913d6697f238af2f9cdd3eec63afca1c95e5b13",
+        "lastAccInputHash": "0x46dbccfee8a6b6c69390347d9379ec493f19310f1453b97b7331f8fd004071fb",
         "lastForceBatch": 0,
         "lastForceBatchSequenced": 0,
         "networkName": "Astar zkEVM",
@@ -131,7 +131,7 @@
       "derivedName": "PolygonDataCommittee"
     },
     {
-      "name": "ProxyAdminOwner",
+      "name": "LocalAdmin",
       "address": "0xf98ee8c46baEa2B11e4f0450AD9D01861265F76E",
       "template": "GnosisSafe",
       "proxyType": "gnosis safe",

--- a/packages/backend/discovery/shared-polygon-cdk/ethereum/diffHistory.md
+++ b/packages/backend/discovery/shared-polygon-cdk/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xb9c8c05e197286310dd97840a64338bf3bff0c9a
+Generated with discovered.json: 0x23c7a93f1611af5cdb06c554d1a6480530d8a6a7
 
 # Diff at Fri, 12 Jul 2024 10:13:30 GMT:
 

--- a/packages/backend/discovery/shared-polygon-cdk/ethereum/discovered.json
+++ b/packages/backend/discovery/shared-polygon-cdk/ethereum/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "shared-polygon-cdk",
   "chain": "ethereum",
-  "blockNumber": 20289749,
+  "blockNumber": 20324826,
   "configHash": "0xfc6f3aa2203ba2ad7cb9b608ac6e1db52d10d28227970e4509b2cab925cd688d",
   "version": 9,
   "contracts": [
@@ -69,7 +69,7 @@
         "gasTokenAddress": "0x0000000000000000000000000000000000000000",
         "gasTokenMetadata": "0x",
         "gasTokenNetwork": 0,
-        "getRoot": "0xdbd283bdfb1275f283946435831e4dc8e0556b1785a2f4e11b563e989d087502",
+        "getRoot": "0xdb146e38338dea081cb72df7112c43f6814d8690fe6b9444ebd4ed8abca82a03",
         "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
         "isEmergencyState": false,
         "networkID": 0,
@@ -220,7 +220,7 @@
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "emergencyStateCount": 1,
         "getBatchFee": "100000000000000000",
-        "getRollupExitRoot": "0xcb940dd67d63b7d4688127d077eced1d34edf470242d828610a41055eb93fb3b",
+        "getRollupExitRoot": "0xec228d9ca71190d6cbc357c3086c0ba26379f3704ee7112243d1ff16a4a062ab",
         "globalExitRootManager": "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb",
         "isEmergencyState": false,
         "isVerifyingBatches": [
@@ -233,7 +233,7 @@
           [true],
           [true]
         ],
-        "lastAggregationTimestamp": 1720779179,
+        "lastAggregationTimestamp": 1721201795,
         "lastDeactivatedEmergencyStateTimestamp": 1711323791,
         "nondeterministicPendingState": [],
         "pendingStateTimeout": 432000,
@@ -308,8 +308,8 @@
             "0x0775e11309d75aA6b0967917fB0213C5673eDf81"
           ]
         ],
-        "totalSequencedBatches": 226709,
-        "totalVerifiedBatches": 226248,
+        "totalSequencedBatches": 236699,
+        "totalVerifiedBatches": 236217,
         "trustedAggregatorTimeout": 432000,
         "verifyBatchTimeTarget": 1800
       },
@@ -326,8 +326,8 @@
         "$admin": "0x0F99738B2Fc14D77308337f3e2596b63aE7BCC4A",
         "$implementation": "0x2E38cD55163137483E30580Cb468C2dFf1d85077",
         "bridgeAddress": "0x2a3DD3EB832aF982ec71669E178424b10Dca2EDe",
-        "depositCount": 37331,
-        "getRoot": "0x13ea0cae62e7d899278cca0f4fced4cb033bece66b40e9ddcb0d2355f1ffea35",
+        "depositCount": 37964,
+        "getRoot": "0x216a37adecad064abbbf2ebcd504c84f30c80c40cf27d085ef004b286ca54b56",
         "rollupManager": "0x5132A183E9F3CB7C848b0AAC5Ae0c4f0491B7aB2"
       },
       "derivedName": "PolygonZkEVMGlobalExitRootV2"

--- a/packages/backend/discovery/xlayer/ethereum/config.jsonc
+++ b/packages/backend/discovery/xlayer/ethereum/config.jsonc
@@ -7,12 +7,11 @@
     "0x0775e11309d75aA6b0967917fB0213C5673eDf81"
   ],
   "names": {
-    "0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507": "XLayerValidiumEtrog",
-    "0x0775e11309d75aA6b0967917fB0213C5673eDf81": "XLayerVerifier",
-    "0x580bda1e7A0CFAe92Fa7F6c20A3794F169CE3CFb": "GlobalExitRootV2",
-    "0x455e53CBB86018Ac2B8092FdCd39d8444aFFC3F6": "POL",
+    "0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507": "XLayerValidium",
     "0x05652Ec92366F3C2255991a265c499E01Ba58e6a": "XLayerValidiumDAC",
-    "0x0F99738B2Fc14D77308337f3e2596b63aE7BCC4A": "SharedProxyAdmin"
+    "0x0775e11309d75aA6b0967917fB0213C5673eDf81": "XLayerVerifier",
+    "0x491619874b866c3cDB7C8553877da223525ead01": "LocalAdmin",
+    "0xE4c5BFaddbf21a1F35AE66F180F78822078FBfDE": "DACProxyAdminOwner"
   },
   "sharedModules": {
     "PolygonRollupManager": "shared-polygon-cdk"
@@ -29,7 +28,7 @@
         }
       }
     },
-    "XLayerValidiumEtrog": {
+    "XLayerValidium": {
       "ignoreInWatchMode": ["lastAccInputHash"]
     }
   }

--- a/packages/backend/discovery/xlayer/ethereum/diffHistory.md
+++ b/packages/backend/discovery/xlayer/ethereum/diffHistory.md
@@ -8,7 +8,7 @@ Generated with discovered.json: 0x459a4296a728dd54469b94dcfd86df1667462957
 
 ## Description
 
-Provide description of changes. This section will be preserved.
+Introduced a new LocalAdmin, not handled by the shared template, which mainContract admin (not the upgradeabilityAdmin) and who can change local system configs. This role was wrongly given to the SharedProxyAdminOwner before.
 
 ## Config/verification related changes
 

--- a/packages/backend/discovery/xlayer/ethereum/diffHistory.md
+++ b/packages/backend/discovery/xlayer/ethereum/diffHistory.md
@@ -1,3 +1,30 @@
+Generated with discovered.json: 0x459a4296a728dd54469b94dcfd86df1667462957
+
+# Diff at Wed, 17 Jul 2024 08:35:19 GMT:
+
+- author: sekuba (<29250140+sekuba@users.noreply.github.com>)
+- comparing to: main@0df6fda263b58edb9acce032017abb5ebd61f5fd block: 19882097
+- current block number: 20325087
+
+## Description
+
+Provide description of changes. This section will be preserved.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19882097 (main branch discovery), not current.
+
+```diff
+    contract XLayerValidiumEtrog (0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507) {
+    +++ description: None
+      name:
+-        "XLayerValidiumEtrog"
++        "XLayerValidium"
+    }
+```
+
 Generated with discovered.json: 0xedecf8c6eda26e5959db341cbc0c301a4ee07513
 
 # Diff at Thu, 16 May 2024 10:59:54 GMT:

--- a/packages/backend/discovery/xlayer/ethereum/discovered.json
+++ b/packages/backend/discovery/xlayer/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "xlayer",
   "chain": "ethereum",
-  "blockNumber": 19882097,
-  "configHash": "0x5c2e13725be665937c712e81a269b21125759be2198f03a5b419fed3924fecc0",
+  "blockNumber": 20325087,
+  "configHash": "0x1faa6e35d2bc7ed2a0ebe00bbb2796abcb918b5266d117b92e441acd4aded7bf",
   "version": 9,
   "contracts": [
     {
@@ -51,7 +51,7 @@
       }
     },
     {
-      "name": "XLayerValidiumEtrog",
+      "name": "XLayerValidium",
       "address": "0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507",
       "proxyType": "EIP1967 proxy",
       "ignoreInWatchMode": ["lastAccInputHash"],
@@ -78,7 +78,7 @@
         "INITIALIZE_TX_DATA_LEN_EMPTY_METADATA": 228,
         "INITIALIZE_TX_EFFECTIVE_PERCENTAGE": "0xff",
         "isSequenceWithDataAvailabilityAllowed": false,
-        "lastAccInputHash": "0xffc9ae1e7894026765ca2f46a04d7d4ff761eccc812675b0202b89ce77615b14",
+        "lastAccInputHash": "0x2f47fc343d6bd90f3098bf78737782176f902a41f2a0e694333e2207d47ca079",
         "lastForceBatch": 0,
         "lastForceBatchSequenced": 0,
         "networkName": "X Layer",

--- a/packages/config/src/projects/layer2s/astarzkevm.ts
+++ b/packages/config/src/projects/layer2s/astarzkevm.ts
@@ -17,13 +17,11 @@ const requiredSignaturesDAC = discovery.getContractValue<number>(
 )
 
 const isForcedBatchDisallowed =
-  discovery.getContractValue<string>(
-    'AstarValidiumEtrog',
-    'forceBatchAddress',
-  ) !== '0x0000000000000000000000000000000000000000'
+  discovery.getContractValue<string>('AstarValidium', 'forceBatchAddress') !==
+  '0x0000000000000000000000000000000000000000'
 
 const upgradeability = {
-  upgradableBy: ['ProxyAdminOwner'],
+  upgradableBy: ['LocalAdmin'],
   upgradeDelay: 'None',
 }
 
@@ -43,9 +41,9 @@ export const astarzkevm: Layer2 = polygonCDKStack({
       }),
       sources: [
         {
-          contract: 'AstarValidiumEtrog',
+          contract: 'PolygonDataCommittee.sol',
           references: [
-            'https://etherscan.io/address/0x9cf80f7eB1C76ec5AE7A88b417e373449b73ac30',
+            'https://etherscan.io/address/0xF4e87685e323818E0aE35dCdFc3B65106002E456#code',
           ],
         },
       ],
@@ -63,13 +61,13 @@ export const astarzkevm: Layer2 = polygonCDKStack({
       ],
       references: [
         {
-          text: 'AstarValidiumEtrog.sol - Etherscan source code, sequenceBatches function',
-          href: 'https://etherscan.io/address/0x519E42c24163192Dca44CD3fBDCEBF6be9130987',
+          text: 'PolygonValidiumStorageMigration.sol - Etherscan source code, sequenceBatchesValidium function',
+          href: 'https://etherscan.io/address/0x10D296e8aDd0535be71639E5D1d1c30ae1C6bD4C#code#F1#L126',
         },
       ],
     },
   },
-  rollupModuleContract: discovery.getContract('AstarValidiumEtrog'),
+  rollupModuleContract: discovery.getContract('AstarValidium'),
   rollupVerifierContract: discovery.getContract('AstarVerifier'),
   display: {
     name: 'Astar zkEVM',
@@ -110,8 +108,14 @@ export const astarzkevm: Layer2 = polygonCDKStack({
     genesisState:
       'The genesis state, whose corresponding root is accessible as Batch 0 root in the `getRollupBatchNumToStateRoot` method of PolygonRollupManager, is available [here](https://github.com/0xPolygonHermez/zkevm-contracts/blob/1ad7089d04910c319a257ff4f3674ffd6fc6e64e/tools/addRollupType/genesis.json).',
     dataFormat:
-      'The trusted sequencer request signatures from DAC members off-chain, and posts hashed batches with signatures to the AstarValidiumEtrog contract.',
+      'The trusted sequencer request signatures from DAC members off-chain, and posts hashed batches with signatures to the AstarValidium contract.',
   },
+  nonTemplatePermissions: [
+    ...discovery.getMultisigPermission(
+      'LocalAdmin',
+      'Admin of the AstarValidium contract, can set core system parameters like timeouts, sequencer, activate forced transactions, update the DA mode and upgrade the AstarValidiumDAC contract',
+    ),
+  ],
   nonTemplateContracts: [
     discovery.getContractDetails('AstarValidiumDAC', {
       description:

--- a/packages/config/src/projects/layer2s/polygonzkevm.ts
+++ b/packages/config/src/projects/layer2s/polygonzkevm.ts
@@ -102,6 +102,16 @@ export const polygonzkevm: Layer2 = polygonCDKStack({
       'EscrowsAdmin',
       'Escrows Admin can instantly upgrade wstETH, DAI and USDC bridges.',
     ),
+    {
+      name: 'LocalAdmin',
+      accounts: [
+        discovery.formatPermissionedAccount(
+          discovery.getContractValue('PolygonZkEVMEtrog', 'admin'),
+        ),
+      ],
+      description:
+        'Admin of the PolygonZkEVMEtrog contract, can set core system parameters like timeouts, sequencer, activate forced transactions and update the DA mode. In the case on Polygon zkEVM, this is also the RollupManagerAdminMultisig.',
+    },
   ],
   nonTemplateTrackedTxs: [
     {

--- a/packages/config/src/projects/layer2s/templates/polygonCDKStack.ts
+++ b/packages/config/src/projects/layer2s/templates/polygonCDKStack.ts
@@ -478,15 +478,6 @@ export function polygonCDKStack(templateVars: PolygonCDKStackConfig): Layer2 {
     stateValidation: templateVars.stateValidation,
     permissions: [
       {
-        name: 'ProxyAdminOwner',
-        accounts: [
-          templateVars.discovery.formatPermissionedAccount(
-            shared.getContractValue('SharedProxyAdmin', 'owner'), // could be EOA or multisig
-          ),
-        ],
-        description: `Admin of the ${templateVars.rollupModuleContract.name} rollup, can set core system parameters like timeouts, sequencer, activate forced transactions and update the DA mode.`,
-      },
-      {
         name: 'Sequencer',
         accounts: [
           templateVars.discovery.getPermissionedAccount(

--- a/packages/config/src/projects/layer2s/xlayer.ts
+++ b/packages/config/src/projects/layer2s/xlayer.ts
@@ -17,13 +17,11 @@ const requiredSignaturesDAC = discovery.getContractValue<number>(
 )
 
 const isForcedBatchDisallowed =
-  discovery.getContractValue<string>(
-    'XLayerValidiumEtrog',
-    'forceBatchAddress',
-  ) !== '0x0000000000000000000000000000000000000000'
+  discovery.getContractValue<string>('XLayerValidium', 'forceBatchAddress') !==
+  '0x0000000000000000000000000000000000000000'
 
 const upgradeability = {
-  upgradableBy: ['ProxyAdminOwner'],
+  upgradableBy: ['DACProxyAdminOwner'],
   upgradeDelay: 'No delay',
 }
 
@@ -44,9 +42,9 @@ export const xlayer: Layer2 = polygonCDKStack({
       }),
       sources: [
         {
-          contract: 'XLayerValidiumEtrog',
+          contract: 'PolygonDataCommittee.sol',
           references: [
-            'https://etherscan.io/address/0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507',
+            'https://etherscan.io/address/0xd620Ca1ad5c3888e4521c3374cE4088Cb78079b8#code',
           ],
         },
       ],
@@ -64,8 +62,8 @@ export const xlayer: Layer2 = polygonCDKStack({
       ],
       references: [
         {
-          text: 'XLayerValidiumEtrog.sol - Etherscan source code, sequenceBatches function',
-          href: 'https://etherscan.io/address/0x2B0ee28D4D51bC9aDde5E58E295873F61F4a0507',
+          text: 'PolygonValidiumStorageMigration.sol - Etherscan source code, sequenceBatchesValidium function',
+          href: 'https://etherscan.io/address/0x10D296e8aDd0535be71639E5D1d1c30ae1C6bD4C#code#F1#L126',
         },
       ],
     },
@@ -98,7 +96,7 @@ export const xlayer: Layer2 = polygonCDKStack({
     },
   ],
   knowledgeNuggets: [],
-  rollupModuleContract: discovery.getContract('XLayerValidiumEtrog'),
+  rollupModuleContract: discovery.getContract('XLayerValidium'),
   rollupVerifierContract: discovery.getContract('XLayerVerifier'),
   rpcUrl: 'https://rpc.xlayer.tech',
   isForcedBatchDisallowed,
@@ -107,6 +105,28 @@ export const xlayer: Layer2 = polygonCDKStack({
       ...NEW_CRYPTOGRAPHY.ZK_BOTH,
     },
   },
+  nonTemplatePermissions: [
+    {
+      name: 'LocalAdmin',
+      accounts: [
+        discovery.formatPermissionedAccount(
+          discovery.getContractValue('XLayerValidium', 'admin'),
+        ),
+      ],
+      description:
+        'Admin of the XLayerValidium contract, can set core system parameters like timeouts, sequencer, activate forced transactions and update the DA mode.',
+    },
+    {
+      name: 'DACProxyAdminOwner',
+      accounts: [
+        discovery.formatPermissionedAccount(
+          discovery.getContractValue('ProxyAdmin', 'owner'),
+        ),
+      ],
+      description:
+        "Owner of the XLayerValidiumDAC's ProxyAdmin. Can upgrade the contract.",
+    },
+  ],
   nonTemplateContracts: [
     discovery.getContractDetails('XLayerValidiumDAC', {
       description:


### PR DESCRIPTION
This is a prerequisite for adding the new polyCDK chains. When reviewing them, i found an error in our permissions.
I introduced a new LocalAdmin, not handled by the shared template, which for each project usually is the mainContract admin (not the upgradeabilityAdmin) and who can change local system configs. This role was wrongly given to the SharedProxyAdminOwner before.

Usually perms look like this, which is now correcly shown on frontend for Astar, Poly, Xlayer zkEVMs:
![image](https://github.com/user-attachments/assets/3b149fbd-3781-4ebe-94be-17837853e96c)
