### PR TITLE
Fix MultiIndexer logic

### DIFF
--- a/packages/backend/src/tools/uif/multi/MultiIndexer.test.ts
+++ b/packages/backend/src/tools/uif/multi/MultiIndexer.test.ts
@@ -407,7 +407,7 @@ describe(MultiIndexer.name, () => {
 
       testIndexer.multiUpdate.resolvesTo(300)
 
-      const newHeight = await testIndexer.update(200, 300)
+      const newHeight = await testIndexer.update(201, 300)
       expect(newHeight).toEqual(300)
       expect(testIndexer.setSavedConfigurations).toHaveBeenOnlyCalledWith([
         saved('a', 100, 300, 300),
@@ -424,7 +424,7 @@ describe(MultiIndexer.name, () => {
 
       testIndexer.multiUpdate.resolvesTo(250)
 
-      const newHeight = await testIndexer.update(200, 300)
+      const newHeight = await testIndexer.update(201, 300)
       expect(newHeight).toEqual(250)
       expect(testIndexer.setSavedConfigurations).toHaveBeenOnlyCalledWith([
         saved('a', 100, 300, 250),

--- a/packages/backend/src/tools/uif/multi/MultiIndexer.ts
+++ b/packages/backend/src/tools/uif/multi/MultiIndexer.ts
@@ -229,7 +229,7 @@ function getConfigurationsInRange<T>(
       if (
         saved &&
         saved.currentHeight !== null &&
-        saved.currentHeight > currentHeight
+        saved.currentHeight >= currentHeight
       ) {
         minCurrentHeight = Math.min(minCurrentHeight, saved.currentHeight)
         return { ...configuration, hasData: true }


### PR DESCRIPTION
When adding `untilTimestamp` to old configuration we where making an update `from` and `to` on the same timestamp, because of that we where fetching the data that we already had in our db. 