### PR TITLE
Show EOA as name of EOA

### DIFF
--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -754,7 +754,7 @@ export class ProjectDiscovery {
       }
       const description = this.describeContractOrEoa(eoa)
       result.push({
-        name: eoa.address.toString(),
+        name: 'EOA',
         accounts: [this.formatPermissionedAccount(eoa.address)],
         chain: this.chain,
         description,


### PR DESCRIPTION
On the website an address link is shown next to the EOA name, which currently is also an address. This PR changes the name shown to "EOA". See Lisk project as an example.