### PR TITLE
Show missing envs keys when failing

### DIFF
--- a/packages/backend/src/test/config-smoke-test.ts
+++ b/packages/backend/src/test/config-smoke-test.ts
@@ -1,4 +1,3 @@
-import { expect } from 'earl'
 import { getConfig } from '../config'
 
 /**
@@ -8,6 +7,7 @@ import { getConfig } from '../config'
  */
 describe('Configuration Smoke Test', () => {
   it('should load configuration without throwing', () => {
-    expect(() => getConfig()).not.toThrow()
+    // no expect on purpose - getConfig will throw with a meaningful error message
+    getConfig()
   })
 })


### PR DESCRIPTION
Resolves L2B-6538

Simply reused OG `getConfig` message:
<img width="599" alt="image" src="https://github.com/user-attachments/assets/192611af-1157-42fb-909b-60785389074e">
