### PR TITLE
Add split mode to powerdiff

### DIFF
--- a/packages/l2b/.mocharc.json
+++ b/packages/l2b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+  "spec": "src/**/*.test.ts",
+  "require": "esbuild-register",
+  "watchExtensions": "ts",
+  "extension": "ts"
+}

--- a/packages/l2b/package.json
+++ b/packages/l2b/package.json
@@ -23,6 +23,7 @@
     "@l2beat/shared": "*",
     "@l2beat/config": "*",
     "@l2beat/shared-pure": "*",
+    "@mradomski/fast-solidity-parser": "0.1.1",
     "cmd-ts": "^0.13.0",
     "ethers": "^5.7.2",
     "chalk": "^4.1.2"

--- a/packages/l2b/package.json
+++ b/packages/l2b/package.json
@@ -15,17 +15,22 @@
     "format": "biome format .",
     "format:fix": "biome format --write .",
     "lint:fix": "biome check --formatter-enabled=false --apply .",
-    "lint": "biome check --formatter-enabled=false ."
+    "lint": "biome check --formatter-enabled=false .",
+    "test": "mocha"
   },
   "dependencies": {
     "@l2beat/backend-tools": "*",
+    "@l2beat/config": "*",
     "@l2beat/discovery-types": "*",
     "@l2beat/shared": "*",
-    "@l2beat/config": "*",
     "@l2beat/shared-pure": "*",
     "@mradomski/fast-solidity-parser": "0.1.1",
+    "chalk": "^4.1.2",
     "cmd-ts": "^0.13.0",
-    "ethers": "^5.7.2",
-    "chalk": "^4.1.2"
+    "ethers": "^5.7.2"
+  },
+  "devDependencies": {
+    "@types/mock-fs": "^4.13.4",
+    "mock-fs": "^5.2.0"
   }
 }

--- a/packages/l2b/src/commands/Powerdiff.ts
+++ b/packages/l2b/src/commands/Powerdiff.ts
@@ -1,6 +1,21 @@
-import { command, option, positional, string } from 'cmd-ts'
-import { powerdiff } from '../implementations/powerdiff'
+import { Type, command, option, positional, string } from 'cmd-ts'
+import {
+  DIFFING_MODES,
+  DiffingMode,
+  powerdiff,
+} from '../implementations/powerdiff'
 import { Directory } from './types'
+
+export const DiffingModeType: Type<string, DiffingMode> = {
+  async from(str): Promise<DiffingMode> {
+    return new Promise((resolve, reject) => {
+      if (!DIFFING_MODES.includes(str as DiffingMode)) {
+        reject(new Error(`Diffing modes are: ${DIFFING_MODES.join(', ')}`))
+      }
+      resolve(str as DiffingMode)
+    })
+  },
+}
 
 export const Powerdiff = command({
   name: 'powerdiff',
@@ -15,8 +30,14 @@ export const Powerdiff = command({
       long: 'difftastic-path',
       defaultValue: () => 'difft',
     }),
+    mode: option({
+      type: DiffingModeType,
+      long: 'mode',
+      short: 'm',
+      defaultValue: () => 'together' as const,
+    }),
   },
-  handler: (args) => {
-    powerdiff(args.leftPath, args.rightPath, args.difftasticPath)
+  handler: ({ leftPath, rightPath, difftasticPath, mode }) => {
+    powerdiff(leftPath, rightPath, difftasticPath, mode)
   },
 })

--- a/packages/l2b/src/implementations/powerdiff/splitIntoFiles.test.ts
+++ b/packages/l2b/src/implementations/powerdiff/splitIntoFiles.test.ts
@@ -1,0 +1,182 @@
+import * as fs from 'fs'
+import * as path from 'path'
+import { expect } from 'earl'
+import mockFs from 'mock-fs'
+import { LeftRightPair } from '../powerdiff'
+import { splitIntoSubfiles } from './splitIntoFiles'
+import { Configuration } from './types'
+
+describe('splitIntoSubfiles', () => {
+  const testDir = path.join(__dirname, 'fixtures', 'splitIntoSubfiles')
+  const leftDir = path.join(testDir, 'left')
+  const rightDir = path.join(testDir, 'right')
+  let config: Configuration
+
+  before(() => {
+    // Set up test directories
+    fs.mkdirSync(leftDir, { recursive: true })
+    fs.mkdirSync(rightDir, { recursive: true })
+    mockFs({
+      [leftDir]: {},
+      [rightDir]: {},
+      '/tmp': {},
+    })
+
+    config = {
+      path1: leftDir,
+      path2: rightDir,
+      difftasticPath: 'difft',
+    }
+  })
+
+  after(() => {
+    mockFs.restore()
+  })
+
+  it('should split Solidity files into subfiles', () => {
+    const leftContent = `
+      contract Test1 {
+        function foo() public {}
+      }
+      contract Test2 {
+        uint256 public value;
+      }
+    `
+    const rightContent = `
+      contract Test3 {
+        function foo() public {
+          // Modified
+        }
+      }
+      contract Test4 {
+        uint256 public value;
+        function getValue() public view returns (uint256) {
+          return value;
+        }
+      }
+    `
+
+    fs.writeFileSync(path.join(leftDir, 'test.sol'), leftContent)
+    fs.writeFileSync(path.join(rightDir, 'test.sol'), rightContent)
+
+    const filePathsList: LeftRightPair[] = [
+      {
+        left: path.join(leftDir, 'test.sol'),
+        right: path.join(rightDir, 'test.sol'),
+      },
+    ]
+
+    const result = splitIntoSubfiles(config, filePathsList)
+
+    expect(result.filePathsList).toHaveLength(1)
+    expect(result.filePathsList[0].left).toInclude('/tmp/0x')
+    expect(result.filePathsList[0].right).toInclude('/tmp/0x')
+
+    // Check if subfiles were created
+    const leftSubfiles = fs.readdirSync(result.filePathsList[0].left)
+    const rightSubfiles = fs.readdirSync(result.filePathsList[0].right)
+
+    expect(leftSubfiles).toEqualUnsorted(['Test1.sol', 'Test2.sol'])
+    expect(rightSubfiles).toEqualUnsorted(['Test3.sol', 'Test4.sol'])
+
+    // Check content of subfiles
+    const leftTest1Content = fs.readFileSync(
+      path.join(result.filePathsList[0].left, 'Test1.sol'),
+      'utf8',
+    )
+    const rightTest1Content = fs.readFileSync(
+      path.join(result.filePathsList[0].right, 'Test3.sol'),
+      'utf8',
+    )
+
+    expect(leftTest1Content).toInclude('function foo() public {}')
+    expect(rightTest1Content).toInclude('function foo() public {')
+    expect(rightTest1Content).toInclude('// Modified')
+  })
+
+  it('should handle non-Solidity files', () => {
+    fs.writeFileSync(path.join(leftDir, 'readme.md'), '# Test')
+    fs.writeFileSync(path.join(rightDir, 'readme.md'), '# Test\n\nUpdated')
+
+    const filePathsList: LeftRightPair[] = [
+      {
+        left: path.join(leftDir, 'readme.md'),
+        right: path.join(rightDir, 'readme.md'),
+      },
+    ]
+
+    const result = splitIntoSubfiles(config, filePathsList)
+
+    expect(result.filePathsList).toHaveLength(0)
+  })
+
+  it('should handle missing files gracefully', () => {
+    const filePathsList: LeftRightPair[] = [
+      {
+        left: path.join(leftDir, 'non-existent.sol'),
+        right: path.join(rightDir, 'non-existent.sol'),
+      },
+    ]
+
+    const result = splitIntoSubfiles(config, filePathsList)
+
+    expect(result.filePathsList).toHaveLength(0)
+  })
+
+  it('should handle complex Solidity structures', () => {
+    const complexContent = `
+      pragma solidity ^0.8.0;
+
+      import "./SomeContract.sol";
+
+      contract ComplexContract {
+        struct MyStruct {
+          uint256 id;
+          string name;
+        }
+
+        enum Status { Active, Inactive }
+
+        event StatusChanged(Status newStatus);
+
+        function doSomething() public {
+          // Function body
+        }
+
+        modifier onlyOwner() {
+          // Modifier body
+          _;
+        }
+
+        error CustomError(string message);
+      }
+
+      contract SimpleContract {
+        struct MyStruct {
+          uint256 id;
+          uint256 hash;
+        }
+      }
+    `
+
+    fs.writeFileSync(path.join(leftDir, 'complex.sol'), complexContent)
+    fs.writeFileSync(path.join(rightDir, 'complex.sol'), complexContent)
+
+    const filePathsList: LeftRightPair[] = [
+      {
+        left: path.join(leftDir, 'complex.sol'),
+        right: path.join(rightDir, 'complex.sol'),
+      },
+    ]
+
+    const result = splitIntoSubfiles(config, filePathsList)
+
+    expect(result.filePathsList).toHaveLength(1)
+
+    const subfiles = fs.readdirSync(result.filePathsList[0].left)
+    expect(subfiles).toEqualUnsorted([
+      'ComplexContract.sol',
+      'SimpleContract.sol',
+    ])
+  })
+})

--- a/packages/l2b/src/implementations/powerdiff/splitIntoFiles.ts
+++ b/packages/l2b/src/implementations/powerdiff/splitIntoFiles.ts
@@ -25,7 +25,6 @@ export function splitIntoSubfiles(
     if (result !== undefined) {
       newFilePathList.push(result)
     } else {
-      console.log(`[SKIP]: ${fullPaths.left} & ${fullPaths.right}`)
     }
   }
 
@@ -77,12 +76,14 @@ function splitFileIntoDirectory(atPath: string, outputDirectory: string): void {
     assert(child.range !== undefined)
     const childContent = content.substring(child.range[0], child.range[1] + 1)
     const childName = getASTTopLevelChildName(child)
-    const outputPath = path.join(outputDirectory, `${childName}.sol`)
-    fs.writeFileSync(outputPath, childContent)
+    if (childName !== undefined) {
+      const outputPath = path.join(outputDirectory, `${childName}.sol`)
+      fs.writeFileSync(outputPath, childContent)
+    }
   }
 }
 
-function getASTTopLevelChildName(child: ASTNode): string {
+function getASTTopLevelChildName(child: ASTNode): string | undefined {
   switch (child.type) {
     case 'UsingForDeclaration':
       assert(child.libraryName !== null)
@@ -105,6 +106,9 @@ function getASTTopLevelChildName(child: ASTNode): string {
       return child.name
     case 'EventDefinition':
       return child.name
+    case 'PragmaDirective':
+    case 'ImportDirective':
+      return undefined
     default: {
       assert(false)
     }

--- a/packages/l2b/src/implementations/powerdiff/splitIntoFiles.ts
+++ b/packages/l2b/src/implementations/powerdiff/splitIntoFiles.ts
@@ -1,0 +1,155 @@
+import { createHash } from 'crypto'
+import { Configuration } from './types'
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { assert } from '@l2beat/backend-tools'
+import { ASTNode, parse } from '@mradomski/fast-solidity-parser'
+import { LeftRightPair } from '../powerdiff'
+
+interface Result {
+  filePathsList: LeftRightPair[]
+  path1: string
+  path2: string
+}
+
+export function splitIntoSubfiles(
+  config: Configuration,
+  filePathsList: LeftRightPair[],
+): Result {
+  const newFilePathList: LeftRightPair[] = []
+  for (const fullPaths of filePathsList) {
+    const truncPaths = removeCommonPath(fullPaths)
+    const result = splitPair(fullPaths, truncPaths)
+
+    if (result !== undefined) {
+      newFilePathList.push(result)
+    } else {
+      console.log(`[SKIP]: ${fullPaths.left} & ${fullPaths.right}`)
+    }
+  }
+
+  return {
+    filePathsList: newFilePathList,
+    path1: config.path1,
+    path2: config.path2,
+  }
+}
+
+function splitPair(
+  fullPaths: LeftRightPair,
+  truncPaths: LeftRightPair,
+): LeftRightPair | undefined {
+  if (
+    isFile(fullPaths.left) &&
+    isFile(fullPaths.right) &&
+    fullPaths.left.endsWith('.sol') &&
+    fullPaths.right.endsWith('.sol')
+  ) {
+    return {
+      left: splitSolidityFiles(fullPaths.left, truncPaths.left),
+      right: splitSolidityFiles(fullPaths.right, truncPaths.right),
+    }
+  }
+
+  return undefined
+}
+
+function splitSolidityFiles(atPath: string, outputPrefix: string): string {
+  const hash = getSmallHash(atPath)
+  const outputPath = path.join(
+    '/tmp',
+    hash,
+    path.join(path.dirname(outputPrefix), path.basename(outputPrefix, '.sol')),
+  )
+  console.log(atPath, outputPath)
+
+  fs.mkdirSync(outputPath, { recursive: true })
+  splitFileIntoDirectory(atPath, outputPath)
+  return outputPath
+}
+
+function splitFileIntoDirectory(atPath: string, outputDirectory: string): void {
+  const content = fs.readFileSync(atPath, 'utf8')
+  const AST = parse(content, { range: true })
+
+  for (const child of AST.children) {
+    assert(child.range !== undefined)
+    const childContent = content.substring(child.range[0], child.range[1] + 1)
+    const childName = getASTTopLevelChildName(child)
+    const outputPath = path.join(outputDirectory, `${childName}.sol`)
+    fs.writeFileSync(outputPath, childContent)
+  }
+}
+
+function getASTTopLevelChildName(child: ASTNode): string {
+  switch (child.type) {
+    case 'UsingForDeclaration':
+      assert(child.libraryName !== null)
+      return child.libraryName
+    case 'ContractDefinition':
+      return child.name
+    case 'FunctionDefinition':
+      assert(child.name !== null)
+      return child.name
+    case 'VariableDeclaration':
+      assert(child.name !== null)
+      return child.name
+    case 'StructDefinition':
+      return child.name
+    case 'EnumDefinition':
+      return child.name
+    case 'UserDefinedTypeName':
+      return child.namePath
+    case 'CustomErrorDefinition':
+      return child.name
+    case 'EventDefinition':
+      return child.name
+    default: {
+      assert(false)
+    }
+  }
+}
+
+function removeCommonPath(paths: LeftRightPair): LeftRightPair {
+  const findCommonPath = (array: string[]): string => {
+    const firstPath = array[0]
+    const parts = firstPath.split('/')
+    let commonPrefix = ''
+
+    for (let i = 0; i < parts.length; i++) {
+      const currentPrefix = parts.slice(0, i + 1).join('/')
+      if (array.every((path) => path.startsWith(currentPrefix + '/'))) {
+        commonPrefix = currentPrefix
+      } else {
+        break
+      }
+    }
+
+    return commonPrefix
+  }
+
+  const commonPath = findCommonPath([paths.left, paths.right])
+  const commonPathLength = commonPath.length + (commonPath ? 1 : 0) // Add 1 for the trailing slash if common path exists
+
+  return {
+    left: paths.left.substring(commonPathLength),
+    right: paths.right.substring(commonPathLength),
+  }
+}
+
+function getSmallHash(path: string): string {
+  const hasher = createHash('sha256')
+  hasher.update(path)
+  return `0x${hasher.digest('hex').slice(0, 8)}`
+}
+
+function isFile(path: string): boolean {
+  try {
+    const stats = fs.statSync(path)
+    return stats.isFile()
+  } catch (error) {
+    console.error(`Error checking if path is a file: ${path}`, error)
+    return false
+  }
+}

--- a/packages/l2b/src/implementations/powerdiff/types.ts
+++ b/packages/l2b/src/implementations/powerdiff/types.ts
@@ -1,0 +1,5 @@
+export interface Configuration {
+  path1: string
+  path2: string
+  difftasticPath: string
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6359,6 +6359,13 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.6.tgz#818551d39113081048bdddbef96701b4e8bb9d1b"
   integrity sha512-dJvrYWxP/UcXm36Qn36fxhUKu8A/xMRXVT2cliFF1Z7UA9liG5Psj3ezNSZw+5puH2czDXRLcXQxf8JbJt0ejg==
 
+"@types/mock-fs@^4.13.4":
+  version "4.13.4"
+  resolved "https://registry.yarnpkg.com/@types/mock-fs/-/mock-fs-4.13.4.tgz#e73edb4b4889d44d23f1ea02d6eebe50aa30b09a"
+  integrity sha512-mXmM0o6lULPI8z3XNnQCpL0BGxPwx1Ul1wXYEPBGl4efShyxW2Rln0JOPEWGyZaYZMM6OVXM/15zUuFMY52ljg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ms@*":
   version "0.7.34"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.34.tgz#10964ba0dee6ac4cd462e2795b6bebd407303433"
@@ -14061,6 +14068,11 @@ mocha@^10.2.0:
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
+
+mock-fs@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-5.2.0.tgz#3502a9499c84c0a1218ee4bf92ae5bf2ea9b2b5e"
+  integrity sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==
 
 mockdate@^3.0.5:
   version "3.0.5"


### PR DESCRIPTION
Resolves L2B-6420

Added `--mode=split` to powerdiff. Instead of doing diffs `file <-> file` it does diffs `TopLevelDecl <-> TopLevelDecl`.