### PR TITLE
Scroll: compressed tx data since Curie upgrade

### DIFF
--- a/packages/config/src/projects/layer2s/scroll.ts
+++ b/packages/config/src/projects/layer2s/scroll.ts
@@ -270,7 +270,7 @@ export const scroll: Layer2 = {
   dataAvailability: addSentimentToDataAvailability({
     layers: ['Ethereum (blobs or calldata)'],
     bridge: { type: 'Enshrined' },
-    mode: 'Transaction data',
+    mode: 'Transaction data (compressed)',
   }),
   riskView: makeBridgeCompatible({
     stateValidation: {


### PR DESCRIPTION
Pinged us on telegram, tx data DA is compressed since the curie upgrade (see diffHistory or the milestone)