### PR TITLE
Relax Discovery dashboard code

### DIFF
--- a/packages/backend/src/modules/update-monitor/api/props/utils/getFunctions.ts
+++ b/packages/backend/src/modules/update-monitor/api/props/utils/getFunctions.ts
@@ -23,9 +23,7 @@ export function getViewABI(
     .map((address) => {
       const abi = discoveryABIs[address.toString()]
       if (abi === undefined) {
-        throw new Error(
-          `Programmer Error: ABI for ${address.toString()} not found`,
-        )
+        return []
       }
       return abi.filter((fn) => fn.includes(' view '))
     })


### PR DESCRIPTION
Resolves L2B-6580

Instead of throwing an error just return an empty array. The case where the entry inside the ABI is not found is already gracefully handled in the using code.