### PR TITLE
Add cvxFXS token (convex pooled FXS gov token)

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -977,6 +977,21 @@
       "supply": "zero"
     },
     {
+      "id": "cvxfxs-convex-fxs",
+      "name": "Convex FXS",
+      "coingeckoId": "convex-fxs",
+      "address": "0xFEEf77d3f69374f66429C91d732A244f074bdf74",
+      "symbol": "cvxFXS",
+      "decimals": 18,
+      "deploymentTimestamp": 1640164144,
+      "coingeckoListingTimestamp": 1676160000,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/29001/large/cvxfxs.png?1696527973",
+      "chainId": 1,
+      "source": "canonical",
+      "supply": "zero"
+    },
+    {
       "id": "cvx-convex-token",
       "name": "Convex Token",
       "coingeckoId": "convex-finance",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -327,6 +327,10 @@
       "address": "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B"
     },
     {
+      "symbol": "cvxFXS",
+      "address": "0xFEEf77d3f69374f66429C91d732A244f074bdf74"
+    },
+    {
       "symbol": "cvxCRV",
       "address": "0x62B9c7356A2Dc64a1969e19C23e4f579F9810Aa7"
     },


### PR DESCRIPTION
Closes L2B-6581

This token is canonically bridged to fraxtal. FXS-->cvxFXS conversion is possible on ethereum and fraxtal, but only in this one direction. So there is a higher value of cvxFXS on fraxtal than in the escrow (currently 4,5M vs. 2,5M)
As long as we only count locked value in the escrow, we are fine.