### PR TITLE
Clear backend tests outputs

### DIFF
--- a/packages/backend/src/modules/activity/SequenceProcessor.test.ts
+++ b/packages/backend/src/modules/activity/SequenceProcessor.test.ts
@@ -235,7 +235,7 @@ describeDatabase(SequenceProcessor.name, (db) => {
     })
 
     it('re-processes data when from > getLatest', async () => {
-      const time = install()
+      const time = install({ shouldClearNativeTimers: true })
 
       const reportError = mockFn().returns(undefined)
       sequenceProcessor = createSequenceProcessor({
@@ -263,7 +263,7 @@ describeDatabase(SequenceProcessor.name, (db) => {
     })
 
     it('works when processRange throws', async () => {
-      const time = install()
+      const time = install({ shouldClearNativeTimers: true })
 
       const errorMessage = 'Force-failing during tests!'
       const reportError = mockFn().returns(undefined)

--- a/packages/backend/src/modules/metrics/MetricsRouter.ts
+++ b/packages/backend/src/modules/metrics/MetricsRouter.ts
@@ -8,12 +8,6 @@ import { MetricsAuthConfig } from '../../config/Config'
 export function createMetricsRouter(config: Config) {
   const router = new Router()
 
-  if (!config.metricsAuth) {
-    console.warn(
-      '/metrics accessible without any authorization. This is fine for local environment but not for production',
-    )
-  }
-
   router.get('/metrics', async (ctx) => {
     const credentials = auth(ctx.req)
 


### PR DESCRIPTION
Gets rid of those annoying logs:

```
FakeTimers: clearTimeout was invoked to clear a native timer instead of one created by this library.
To automatically clean-up native timers, use `shouldClearNativeTimers`
```

```
/metrics accessible without any authorization. This is fine for local environment but not for production
```