### PR TITLE
Fix Nova explorer link

### DIFF
--- a/packages/config/src/projects/layer2s/nova.ts
+++ b/packages/config/src/projects/layer2s/nova.ts
@@ -134,7 +134,7 @@ export const nova: Layer2 = orbitStackL2({
   chainConfig: {
     name: 'nova',
     chainId: 42170,
-    explorerUrl: 'https://nova.arbiscan.io/',
+    explorerUrl: 'https://nova.arbiscan.io',
     explorerApi: {
       url: 'https://api-nova.arbiscan.io/api',
       type: 'etherscan',


### PR DESCRIPTION
Currently links from the nova project page work but look weird:
```
https://nova.arbiscan.io//address/0x9fCB6F75D99029f28F6F4a1d277bae49c5CAC79f
                        ^
```