### PR TITLE
Add mbtc and remove other mTokens from Manta

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -5537,44 +5537,6 @@
       }
     },
     {
-      "id": "mantapacific:meth-meth",
-      "name": "mETH",
-      "coingeckoId": "manta-meth",
-      "address": "0xACCBC418a994a27a75644d8d591afC22FaBA594e",
-      "symbol": "mETH",
-      "decimals": 18,
-      "deploymentTimestamp": 1715909059,
-      "coingeckoListingTimestamp": 1717113600,
-      "category": "ether",
-      "iconUrl": "https://coin-images.coingecko.com/coins/images/38337/large/token_m_eth.png?1717126380",
-      "chainId": 169,
-      "source": "external",
-      "supply": "totalSupply",
-      "bridgedUsing": {
-        "bridge": "Layer Zero",
-        "slug": "omnichain"
-      }
-    },
-    {
-      "id": "mantapacific:musd-musd",
-      "name": "mUSD",
-      "coingeckoId": "manta-musd",
-      "address": "0x649d4524897cE85A864DC2a2D5A11Adb3044f44a",
-      "symbol": "mUSD",
-      "decimals": 18,
-      "deploymentTimestamp": 1715909029,
-      "coingeckoListingTimestamp": 1717113600,
-      "category": "stablecoin",
-      "iconUrl": "https://coin-images.coingecko.com/coins/images/38336/large/token_m_usd.png?1717126272",
-      "chainId": 169,
-      "source": "external",
-      "supply": "totalSupply",
-      "bridgedUsing": {
-        "bridge": "Layer Zero",
-        "slug": "omnichain"
-      }
-    },
-    {
       "id": "mantapacific:susde-staked-usde",
       "name": "Staked USDe",
       "coingeckoId": "ethena-staked-usde",

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -5518,6 +5518,25 @@
       "supply": "circulatingSupply"
     },
     {
+      "id": "mantapacific:mbtc-mbtc",
+      "name": "mBTC",
+      "coingeckoId": "manta-mbtc",
+      "address": "0x1468177DbCb2a772F3d182d2F1358d442B553089",
+      "symbol": "mBTC",
+      "decimals": 18,
+      "deploymentTimestamp": 1715909089,
+      "coingeckoListingTimestamp": 1717113600,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38338/large/token_m_btc.png?1717126408",
+      "chainId": 169,
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "Layer Zero",
+        "slug": "omnichain"
+      }
+    },
+    {
       "id": "mantapacific:meth-meth",
       "name": "mETH",
       "coingeckoId": "manta-meth",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -2339,6 +2339,16 @@
   ],
   "mantapacific": [
     {
+      "symbol": "mBTC",
+      "address": "0x1468177dbcb2a772f3d182d2f1358d442b553089",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "Layer Zero",
+        "slug": "omnichain"
+      }
+    },
+    {
       "symbol": "USDC",
       "address": "0xb73603C5d87fA094B7314C74ACE2e64D165016fb",
       "source": "canonical",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -2381,28 +2381,6 @@
       "supply": "circulatingSupply"
     },
     {
-      "symbol": "mETH",
-      "address": "0xaccbc418a994a27a75644d8d591afc22faba594e",
-      "category": "ether",
-      "source": "external",
-      "supply": "totalSupply",
-      "bridgedUsing": {
-        "bridge": "Layer Zero",
-        "slug": "omnichain"
-      }
-    },
-    {
-      "symbol": "mUSD",
-      "address": "0x649d4524897ce85a864dc2a2d5a11adb3044f44a",
-      "category": "stablecoin",
-      "source": "external",
-      "supply": "totalSupply",
-      "bridgedUsing": {
-        "bridge": "Layer Zero",
-        "slug": "omnichain"
-      }
-    },
-    {
       "symbol": "STONE",
       "address": "0xEc901DA9c68E90798BbBb74c11406A32A70652C3",
       "source": "external",


### PR DESCRIPTION
Rationale:
mTokens are LSTs for Manta's CeDeFi program. It is unclear where the underlying tokens are escrowed. (CEXes?)
- mBTC can only be minted on Ethereum and BSC, so we can count it without doubleounting
- other mTokens can be minted on Manta with underlyings that we currently do track, therefore they are removed

Closes L2B-6658