### PR TITLE
Add Starknet CBTs

### DIFF
--- a/packages/config/src/projects/layer2s/starknet.ts
+++ b/packages/config/src/projects/layer2s/starknet.ts
@@ -402,9 +402,9 @@ export const starknet: Layer2 = {
       }),
       discovery.getEscrowDetails({
         address: EthereumAddress(ESCROW_MULTIBRIDGE_ADDRESS),
-        tokens: ['EKUBO'],
+        tokens: ['EKUBO', 'ZEND', 'NSTR'],
         description:
-          'StarkGate bridge for EKUBO (and potentially other tokens listed via StarkgateManager).' +
+          'StarkGate bridge for EKUBO, ZEND, NSTR (and potentially other tokens listed via StarkgateManager).' +
           ' ' +
           escrowEKUBOMaxTotalBalanceString,
         upgradeDelay: formatSeconds(escrowMultibridgeDelaySeconds),

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -2851,6 +2851,21 @@
       "supply": "zero"
     },
     {
+      "id": "nstr-nostra",
+      "name": "Nostra",
+      "coingeckoId": "nostra",
+      "address": "0x610dBd98A28EbbA525e9926b6aaF88f9159edbfd",
+      "symbol": "NSTR",
+      "decimals": 18,
+      "deploymentTimestamp": 1716711455,
+      "coingeckoListingTimestamp": 1718236800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/28282/large/Nostra_200x200b.png?1719434526",
+      "chainId": 1,
+      "source": "canonical",
+      "supply": "zero"
+    },
+    {
       "id": "nu-nucypher",
       "name": "NuCypher",
       "coingeckoId": "nucypher",
@@ -4916,6 +4931,21 @@
       "coingeckoListingTimestamp": 1612396800,
       "category": "other",
       "iconUrl": "https://assets.coingecko.com/coins/images/13866/large/ZMT_Token.png?1696513611",
+      "chainId": 1,
+      "source": "canonical",
+      "supply": "zero"
+    },
+    {
+      "id": "zend-zklend-token",
+      "name": "zkLend Token",
+      "coingeckoId": "zklend-2",
+      "address": "0xb2606492712D311be8f41d940AFE8CE742A52D44",
+      "symbol": "ZEND",
+      "decimals": 18,
+      "deploymentTimestamp": 1699950167,
+      "coingeckoListingTimestamp": 1710460800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/35979/large/zkLend_ZEND_logo_square_transparent_background_%281%29.png?1710306648",
       "chainId": 1,
       "source": "canonical",
       "supply": "zero"

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -800,6 +800,10 @@
       "address": "0x8E0fE2947752BE0d5ACF73aaE77362Daf79cB379"
     },
     {
+      "symbol": "NSTR",
+      "address": "0x610dbd98a28ebba525e9926b6aaf88f9159edbfd"
+    },
+    {
       "symbol": "NU",
       "address": "0x4fE83213D56308330EC302a8BD641f1d0113A4Cc"
     },
@@ -1371,6 +1375,10 @@
     {
       "symbol": "YGG",
       "address": "0x25f8087EAD173b73D6e8B84329989A8eEA16CF73"
+    },
+    {
+      "symbol": "ZEND",
+      "address": "0xb2606492712D311be8f41d940AFE8CE742A52D44"
     },
     {
       "symbol": "ZKS",


### PR DESCRIPTION
The tokens are locked in the Multibridge contract that we added already for EKUBO. 
They don't have a bridge cap.

Resolves L2B-5899