### PR TITLE
Reduce Coingecko calls per minute

### DIFF
--- a/packages/shared/src/services/coingecko/CoingeckoClient.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoClient.ts
@@ -29,7 +29,7 @@ export class CoingeckoClient {
     private readonly apiKey: string | undefined,
   ) {
     const rateLimiter = new RateLimiter({
-      callsPerMinute: apiKey ? 450 : 10,
+      callsPerMinute: apiKey ? 400 : 10,
     })
     this.query = rateLimiter.wrap(this.query.bind(this))
   }


### PR DESCRIPTION
We are getting this error from time to time:

```
Server responded with non-2XX result: 429 Too Many Requests Throttled
```