### PR TITLE
Update FEG token coingecko id

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -1638,7 +1638,7 @@
     {
       "id": "feg-fegtoken",
       "name": "FEGtoken",
-      "coingeckoId": "feg-token",
+      "coingeckoId": "feg-token-2",
       "address": "0x389999216860AB8E0175387A0c90E5c52522C945",
       "symbol": "FEG",
       "decimals": 9,


### PR DESCRIPTION
Id has changed to `feg-token-2` 

https://www.coingecko.com/en/coins/feg-token