### PR TITLE
Support for shallow routing in `useSearchParamsState`

### DIFF
--- a/packages/frontend2/src/app/_components/tabs.tsx
+++ b/packages/frontend2/src/app/_components/tabs.tsx
@@ -19,7 +19,9 @@ const Tabs = React.forwardRef<
     { defaultValue: passedDefaultValue, storeInSearchParams = true, ...props },
     ref,
   ) => {
-    const state = useSearchParamState('tab', passedDefaultValue)
+    const state = useSearchParamState('tab', passedDefaultValue, {
+      shallow: true,
+    })
     const [value, setValue] = storeInSearchParams ? state : [passedDefaultValue]
 
     return (

--- a/packages/frontend2/src/hooks/use-search-param-state.ts
+++ b/packages/frontend2/src/hooks/use-search-param-state.ts
@@ -1,7 +1,6 @@
 'use client'
 
-import { usePathname, useSearchParams } from 'next/navigation'
-import { useRouter } from 'next/router'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 /**
  * Use state that is persisted in a search param.

--- a/packages/frontend2/src/hooks/use-search-param-state.ts
+++ b/packages/frontend2/src/hooks/use-search-param-state.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { usePathname, useSearchParams } from 'next/navigation'
-import { useRouter } from 'next/navigation'
+import { useRouter } from 'next/router'
 
 /**
  * Use state that is persisted in a search param.
@@ -11,12 +11,18 @@ import { useRouter } from 'next/navigation'
 export function useSearchParamState<T extends string | undefined = string>(
   key: string,
   defaultValue: T,
+  options: { shallow: boolean } = { shallow: false },
 ): [string | undefined, (value: T) => void] {
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
   const value = searchParams.get(key) ?? defaultValue
+
+  const replaceRoute = (pathname: string) =>
+    options.shallow
+      ? window.history.replaceState(null, '', pathname)
+      : router.replace({ pathname })
 
   const setValue = (value: T) => {
     const search = new URLSearchParams(searchParams)
@@ -30,9 +36,9 @@ export function useSearchParamState<T extends string | undefined = string>(
     const stringified = search.toString()
 
     if (stringified) {
-      void router.replace(`${pathname}?${stringified}`)
+      void replaceRoute(`${pathname}?${stringified}`)
     } else {
-      void router.replace(pathname)
+      void replaceRoute(pathname)
     }
   }
 

--- a/packages/frontend2/src/hooks/use-search-param-state.ts
+++ b/packages/frontend2/src/hooks/use-search-param-state.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useCallback } from 'react'
 
 /**
  * Use state that is persisted in a search param.
@@ -18,28 +19,34 @@ export function useSearchParamState<T extends string | undefined = string>(
 
   const value = searchParams.get(key) ?? defaultValue
 
-  const replaceRoute = (pathname: string) =>
-    options.shallow
-      ? window.history.replaceState(null, '', pathname)
-      : router.replace({ pathname })
+  const replaceRoute = useCallback(
+    (pathname: string) =>
+      options.shallow
+        ? window.history.replaceState(null, '', pathname)
+        : router.replace(pathname),
+    [options.shallow, router],
+  )
 
-  const setValue = (value: T) => {
-    const search = new URLSearchParams(searchParams)
+  const setValue = useCallback(
+    (value: T) => {
+      const search = new URLSearchParams(searchParams)
 
-    if (value !== defaultValue && value !== undefined) {
-      search.set(key, value)
-    } else {
-      search.delete(key)
-    }
+      if (value !== defaultValue && value !== undefined) {
+        search.set(key, value)
+      } else {
+        search.delete(key)
+      }
 
-    const stringified = search.toString()
+      const stringified = search.toString()
 
-    if (stringified) {
-      void replaceRoute(`${pathname}?${stringified}`)
-    } else {
-      void replaceRoute(pathname)
-    }
-  }
+      if (stringified) {
+        void replaceRoute(`${pathname}?${stringified}`)
+      } else {
+        void replaceRoute(pathname)
+      }
+    },
+    [defaultValue, key, pathname, replaceRoute, searchParams],
+  )
 
   return [value, setValue]
 }


### PR DESCRIPTION
Updating search params with `useRouter` causes the whole page to re-render, which is unwanted in the current usage of `useSearchParamsState`. This PR adds an option to use the history API directly, as recommended by Next: https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#using-the-native-history-api 