### PR TITLE
Some scaling summary fixes

### DIFF
--- a/packages/frontend2/src/app/(new)/(other)/scaling/summary-next/_components/scaling-summary-tables.tsx
+++ b/packages/frontend2/src/app/(new)/(other)/scaling/summary-next/_components/scaling-summary-tables.tsx
@@ -88,7 +88,7 @@ export function ScalingSummaryTables({ projects }: Props) {
     initialState: {
       sorting: [
         {
-          id: '#',
+          id: 'total',
           desc: false,
         },
       ],

--- a/packages/frontend2/src/app/_components/other-sites.tsx
+++ b/packages/frontend2/src/app/_components/other-sites.tsx
@@ -16,7 +16,7 @@ export function OtherSites() {
       <span className="text-center text-lg font-semibold md:text-left">
         Want to learn more about the different approaches to upgradeability?
       </span>
-      <Link className="text-lg font-bold" href="/multisig-report">
+      <Link className="text-lg font-bold underline" href="/multisig-report">
         Check our report
       </Link>
     </div>

--- a/packages/frontend2/src/server/features/scaling/tvl/utils/order-by-tvl.ts
+++ b/packages/frontend2/src/server/features/scaling/tvl/utils/order-by-tvl.ts
@@ -1,9 +1,4 @@
-import { ProjectId } from '@l2beat/shared-pure'
-
-const useTvlFromMap: Record<string, string> = {
-  astarzkevm: 'polygonzkevm',
-  xlayer: 'polygonzkevm',
-}
+import { type ProjectId } from '@l2beat/shared-pure'
 
 export function orderByTvl<
   T extends { id: ProjectId; isArchived?: boolean; isUpcoming?: boolean },
@@ -17,14 +12,7 @@ export function orderByTvl<
   const getTvl = (project: T) => {
     const tvl = tvls[project.id]
 
-    if (tvl) {
-      return tvl ?? 0
-    }
-
-    const useTvlFrom = useTvlFromMap[project.id.toString()]
-    if (!useTvlFrom) return 0
-    const useTvlFromValue = tvls[ProjectId(useTvlFrom)]
-    return useTvlFromValue ? useTvlFromValue - 1 : 0
+    return tvl ?? 0
   }
 
   const sortByTvl = (a: T, b: T) => getTvl(b) - getTvl(a)

--- a/packages/frontend2/src/server/features/scaling/tvl/utils/order-by-tvl.ts
+++ b/packages/frontend2/src/server/features/scaling/tvl/utils/order-by-tvl.ts
@@ -11,7 +11,6 @@ export function orderByTvl<
 
   const getTvl = (project: T) => {
     const tvl = tvls[project.id]
-
     return tvl ?? 0
   }
 


### PR DESCRIPTION
- underline was missing from `Check the report`
- sorting defaulted to `#` where it should've been `total`
- polygon cdk sorting rule was removed