### PR TITLE
Add mode tokens bridged via XLink

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -6956,6 +6956,44 @@
       "supply": "zero"
     },
     {
+      "id": "mode:abtc-abtc",
+      "name": "aBTC",
+      "coingeckoId": "xlink-bridged-btc-stacks",
+      "address": "0x7A087e75807F2E5143C161a817E64dF6dC5EAFe0",
+      "symbol": "aBTC",
+      "decimals": 18,
+      "deploymentTimestamp": 1721774411,
+      "coingeckoListingTimestamp": 1701648000,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/33363/large/abtc_%281%29.png?1701606956",
+      "chainId": 34443,
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "XLink bridge"
+      },
+      "excludeFromTotal": true
+    },
+    {
+      "id": "mode:alex-alex",
+      "name": "ALEX",
+      "coingeckoId": "alexgo",
+      "address": "0xdfd0660032c2D0D38a9092a43d1669D6568cAF71",
+      "symbol": "ALEX",
+      "decimals": 18,
+      "deploymentTimestamp": 1721774433,
+      "coingeckoListingTimestamp": 1662508800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/25837/large/ALEX_Token.png?1696524922",
+      "chainId": 34443,
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "XLink bridge"
+      },
+      "excludeFromTotal": true
+    },
+    {
       "id": "mode:rseth-kelpdao-restaked-eth",
       "name": "KelpDao Restaked ETH",
       "coingeckoId": "kelp-dao-restaked-eth",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -2906,6 +2906,28 @@
   ],
   "mode": [
     {
+      "symbol": "aBTC",
+      "address": "0x7A087e75807F2E5143C161a817E64dF6dC5EAFe0",
+      "excludeFromTotal": true,
+      "coingeckoId": "xlink-bridged-btc-stacks",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "XLink bridge" // lock-mint bridge locking on Ethereum and L2s (wBTC) and on Bitcoin (BTC) and minting at the destination
+      }
+    },
+    {
+      "symbol": "ALEX",
+      "address": "0xdfd0660032c2D0D38a9092a43d1669D6568cAF71",
+      "excludeFromTotal": true,
+      "coingeckoId": "alexgo",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridge": "XLink bridge"
+      }
+    },
+    {
       "symbol": "ezETH",
       "category": "ether",
       "address": "0x2416092f143378750bb29b79eD961ab195CcEea5",


### PR DESCRIPTION
Closes L2B-7007

Three tokens bridged via XLink. This is a lock-mint bridge locking on Ethereum / L2s (wBTC) and on Bitcoin (BTC) and minting at the destination, therefore we exclude it from total TVL.

aBTC added, but only [one Holder](https://modescan.io/address/0x0055797647eA5aE4977bB8CB444E8D7ac1b20fB3)
ALEX added
vLiSTx not added (not on CG)