### PR TITLE
Disable strict shape files check

### DIFF
--- a/packages/backend/scripts/refreshDiscovery.ts
+++ b/packages/backend/scripts/refreshDiscovery.ts
@@ -9,7 +9,6 @@ import { keyInYN } from 'readline-sync'
 
 const configReader = new ConfigReader()
 const templateService = new TemplateService()
-const shapeFilesHash = templateService.getShapeFilesHash()
 const allTemplateHashes = templateService.getAllTemplateHashes()
 
 void main().catch((e) => {
@@ -65,9 +64,13 @@ function discoveryNeedsRefresh(
   discovery: DiscoveryOutput,
   config: DiscoveryConfig,
 ): string | undefined {
-  if (discovery.shapeFilesHash !== shapeFilesHash) {
-    return 'some shape files have changed'
-  }
+  // Disable this check because it is too strict
+  // and soon, with new formatter and 1-to-1 shape comparison,
+  // it will not be necessary anymore.
+  //
+  // if (discovery.shapeFilesHash !== shapeFilesHash) {
+  //   return 'some shape files have changed'
+  // }
 
   if (discovery.configHash !== config.hash) {
     return 'project config or used template has changed'

--- a/packages/backend/src/modules/update-monitor/tests/config.test.ts
+++ b/packages/backend/src/modules/update-monitor/tests/config.test.ts
@@ -12,7 +12,6 @@ import { getDiffHistoryHash, getDiscoveryHash } from '../utils/hashing'
 describe('discovery config.jsonc', () => {
   const configReader = new ConfigReader()
   const templateService = new TemplateService()
-  const shapeFilesHash = templateService.getShapeFilesHash()
   const allTemplateHashes = templateService.getAllTemplateHashes()
 
   let chainConfigs: DiscoveryConfig[][] | undefined
@@ -149,10 +148,14 @@ describe('discovery config.jsonc', () => {
       for (const c of configs) {
         const discovery = await configReader.readDiscovery(c.name, c.chain)
 
-        assert(
-          discovery.shapeFilesHash === shapeFilesHash,
-          `Looks like you have added/moved/removed/modified shape files. This requires refreshing discovery of all projects. Run "yarn refresh-discovery"`,
-        )
+        // Disable this check because it is too strict
+        // and soon, with new formatter and 1-to-1 shape comparison,
+        // it will not be necessary anymore.
+        //
+        // assert(
+        //   discovery.shapeFilesHash === shapeFilesHash,
+        //   `Looks like you have added/moved/removed/modified shape files. This requires refreshing discovery of all projects. Run "yarn refresh-discovery"`,
+        // )
 
         const outdatedTemplates = []
         for (const [templateId, templateHash] of Object.entries(


### PR DESCRIPTION
Currently, if a single new shape file is added to any template, tests will fail until *every single project is rediscovered* (because we had no other way to determine where the shape will match).

This turns out to be prohibitively hard requirement - rediscovering all projects locally takes a lot of time and very often fails due to RPC errors etc. On the other hand, it's quite easy to guess which projects should be rediscovered, and even if some project is missed, it will show up on update-monitor and can be dealt with accordingly.

The proper solution to this problem will be to store hashes of formatted files in discovery, but this will be covered by L2B-7246.

This PR comments out the check.