### PR TITLE
Fix template similarity threshold

### DIFF
--- a/packages/backend/discovery/bobanetwork/ethereum/diffHistory.md
+++ b/packages/backend/discovery/bobanetwork/ethereum/diffHistory.md
@@ -1,3 +1,49 @@
+Generated with discovered.json: 0xc060048ef91e8642990dd4d32e274dd821640612
+
+# Diff at Thu, 12 Sep 2024 15:23:01 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@e6761599b8d9e0b597372bb0e9ca885e08af7101 block: 19960612
+- current block number: 19960612
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 19960612 (main branch discovery), not current.
+
+```diff
+    contract BobaMultisig (0x56121a8612474C3eB65D69a3b871f284705b9bC4) {
+    +++ description: None
+      receivedPermissions.7.description:
++        "upgrading bridge implementation allows to access all funds and change every system component."
+    }
+```
+
+```diff
+    contract ProxyAdmin (0x6e598cec2701FfAA3c06175dc3Af0317a749a0Dc) {
+    +++ description: None
+      directlyReceivedPermissions.7.description:
++        "upgrading bridge implementation allows to access all funds and change every system component."
+    }
+```
+
+```diff
+    contract L1StandardBridge (0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00) {
+    +++ description: The main entry point to deposit ERC20 tokens from host chain to this chain. This contract can store any token.
+      issuedPermissions.0.via.0.description:
++        "upgrading bridge implementation allows to access all funds and change every system component."
+      template:
++        "opstack/L1StandardBridge"
+      descriptions:
++        ["The main entry point to deposit ERC20 tokens from host chain to this chain. This contract can store any token."]
+    }
+```
+
 Generated with discovered.json: 0xdd09bcc44cb14bff547f4232604978480e013848
 
 # Diff at Sun, 08 Sep 2024 17:17:59 GMT:

--- a/packages/backend/discovery/bobanetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/bobanetwork/ethereum/discovered.json
@@ -158,6 +158,7 @@
         {
           "permission": "upgrade",
           "target": "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00",
+          "description": "upgrading bridge implementation allows to access all funds and change every system component.",
           "via": [{ "address": "0x6e598cec2701FfAA3c06175dc3Af0317a749a0Dc" }]
         }
       ],
@@ -254,7 +255,8 @@
         },
         {
           "permission": "upgrade",
-          "target": "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00"
+          "target": "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00",
+          "description": "upgrading bridge implementation allows to access all funds and change every system component."
         }
       ],
       "sinceTimestamp": 1710967823,
@@ -453,7 +455,11 @@
     {
       "name": "L1StandardBridge",
       "address": "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00",
+      "template": "opstack/L1StandardBridge",
       "proxyType": "EIP1967 proxy",
+      "descriptions": [
+        "The main entry point to deposit ERC20 tokens from host chain to this chain. This contract can store any token."
+      ],
       "categories": ["Gateways&Escrows"],
       "issuedPermissions": [
         {
@@ -462,7 +468,8 @@
           "via": [
             {
               "address": "0x6e598cec2701FfAA3c06175dc3Af0317a749a0Dc",
-              "delay": 0
+              "delay": 0,
+              "description": "upgrading bridge implementation allows to access all funds and change every system component."
             }
           ]
         }
@@ -863,6 +870,7 @@
     "GnosisSafe": "0x55dd1039f19d840b39ef504eac8a631b912d707343588aed9ac96bd4e874f837",
     "opstack/AddressManager": "0xfb6d6075e699db3b1ad9532230a19c5ef12e12cfc656e9d93f912051a30f0e7b",
     "opstack/L1ERC721Bridge": "0x9157c1cd7ed3201c1a946c31dcc053cf7ef28179fdf11cba202ffa8e8d1ab519",
+    "opstack/L1StandardBridge": "0x7c91cbcf32ab13db3161a1e3d8e2eea263bba09e1793d4b374b7a0f4d2db953d",
     "opstack/L2OutputOracle": "0x1d833a9768af12de67d65ad7dd09fc4b96db543bde5f5fdc2ff0ea0c571ceadf",
     "opstack/OptimismMintableERC20Factory": "0xcb5e318435eea9104576cca55f13180f9a41bd1900179ad8bf47d1aac60d725c",
     "opstack/OptimismPortal": "0xcc1b405a2bf545f58a88bb104ba298351e252fc507b40d0e1ef40bf6bbe34152",

--- a/packages/discovery/src/discovery/analysis/TemplateService.ts
+++ b/packages/discovery/src/discovery/analysis/TemplateService.ts
@@ -22,7 +22,7 @@ import { readJsonc } from '../utils/readJsonc'
 
 const TEMPLATES_PATH = path.join('discovery', '_templates')
 const TEMPLATE_SHAPE_FOLDER = 'shape'
-const TEMPLATE_SIMILARITY_THRESHOLD = 0.999 // TODO: why two identical files are not 1.0?
+const TEMPLATE_SIMILARITY_THRESHOLD = 0.995 // TODO: why two identical files are not 1.0?
 
 export interface MatchResult {
   similarity: number


### PR DESCRIPTION
Due to the way code similarity is calculated and some additional inconsistencies (e.g. `pragma` is added just before flattened file is saved, so discovered source differs slightly from saved source), required similarity for template shape to match has been set 0.999. It turns out that it's still too high and needs to be set to 0.995.

This is a temporary situation and will be gone after L2B-7246 is implemented (by comparing formatted files directly for 100% match).