### PR TITLE
Add tokens to Mode and Base

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -7004,6 +7004,28 @@
       "supply": "circulatingSupply"
     },
     {
+      "name": "Mode Savings Dai",
+      "coingeckoId": "savings-dai",
+      "address": "0x3f51c6c5927B88CDEc4b61e2787F9BD0f5249138",
+      "symbol": "msDai",
+      "decimals": 18,
+      "deploymentTimestamp": 1721823785,
+      "coingeckoListingTimestamp": 1696982400,
+      "category": "stablecoin",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/32254/large/sdai.png?1697015278",
+      "chainId": 34443,
+      "source": "external",
+      "supply": "totalSupply",
+      "excludeFromTotal": true,
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "XSwap.link"
+          }
+        ]
+      }
+    },
+    {
       "name": "Renzo Restaked ETH",
       "coingeckoId": "renzo-restaked-eth",
       "address": "0x2416092f143378750bb29b79eD961ab195CcEea5",

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -787,6 +787,20 @@
       "supply": "zero"
     },
     {
+      "name": "Coinbase Wrapped BTC",
+      "coingeckoId": "coinbase-wrapped-btc",
+      "address": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+      "symbol": "cbBTC",
+      "decimals": 8,
+      "deploymentTimestamp": 1724165531,
+      "coingeckoListingTimestamp": 1726099200,
+      "category": "ether",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727",
+      "chainId": 1,
+      "source": "canonical",
+      "supply": "zero"
+    },
+    {
       "name": "Coinbase Wrapped Staked ETH",
       "coingeckoId": "coinbase-wrapped-staked-eth",
       "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704",
@@ -6602,6 +6616,20 @@
       "chainId": 8453,
       "source": "native",
       "supply": "circulatingSupply"
+    },
+    {
+      "name": "Coinbase Wrapped BTC",
+      "coingeckoId": "coinbase-wrapped-btc",
+      "address": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+      "symbol": "cbBTC",
+      "decimals": 8,
+      "deploymentTimestamp": 1724165535,
+      "coingeckoListingTimestamp": 1726099200,
+      "category": "stablecoin",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/40143/large/cbbtc.webp?1726136727",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
     },
     {
       "name": "Dai Stablecoin",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -3320,6 +3320,22 @@
   ],
   "mode": [
     {
+      "symbol": "msDai",
+      "coingeckoId": "savings-dai",
+      "address": "0x3f51c6c5927B88CDEc4b61e2787F9BD0f5249138",
+      "excludeFromTotal": true, // lock-mint (although currently focused on ethereum, this bridge supports other l2s)
+      "category": "stablecoin",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "XSwap.link",
+          }
+        ]
+      }
+    },
+    {
       "symbol": "aBTC",
       "address": "0x7A087e75807F2E5143C161a817E64dF6dC5EAFe0",
       "excludeFromTotal": true,

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -254,6 +254,11 @@
       "address": "0xAE12C5930881c53715B369ceC7606B70d8EB229f"
     },
     {
+      "symbol": "cbBTC",
+      "category": "ether",
+      "address": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+    },
+    {
       "symbol": "cbETH",
       "category": "ether",
       "address": "0xBe9895146f7AF43049ca1c1AE358B0541Ea49704"
@@ -2438,6 +2443,13 @@
     }
   ],
   "base": [
+    {
+      "symbol": "cbBTC",
+      "address": "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf",
+      "source": "native",
+      "supply": "totalSupply",
+      "category": "stablecoin"
+    },
     {
       "symbol": "DAI",
       "address": "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -3330,7 +3330,7 @@
       "bridgedUsing": {
         "bridges": [
           {
-            "name": "XSwap.link",
+            "name": "XSwap.link"
           }
         ]
       }


### PR DESCRIPTION
cbBTC  - uses FiatTokenV1_2 (like old USDC), totalSupply, native
msDAI (mode savings dai) - externally bridged, totalSupply, excluded from total due to l2 lock-mint

Closes L2B-7235, L2B-7327