### PR TITLE
Add untilTimestamps to era trackedtxs (pauses liveness and costs tracking)

### DIFF
--- a/packages/config/src/projects/layer2s/zksyncera.ts
+++ b/packages/config/src/projects/layer2s/zksyncera.ts
@@ -179,6 +179,7 @@ export const zksyncera: Layer2 = zkStackL2({
         functionSignature:
           'function commitBatchesSharedBridge(uint256 _chainId, (uint64 batchNumber, bytes32 batchHash, uint64 indexRepeatedStorageChanges, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 l2LogsTreeRoot, uint256 timestamp, bytes32 commitment), (uint64 batchNumber, uint64 timestamp, uint64 indexRepeatedStorageChanges, bytes32 newStateRoot, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 bootloaderHeapInitialContentsHash, bytes32 eventsQueueStateHash, bytes systemLogs, bytes pubdataCommitments)[] _newBatchesData)',
         sinceTimestamp: new UnixTime(1717681823),
+        untilTimestamp: new UnixTime(1722410363), // first cronoszkevm batch commit to the shared ValidatorTimelock https://etherscan.io/tx/0x9c69ea744cdfa74e328234f546b4313dab448d2126a2a1c4dda706f9d233c3a5
       },
     },
     {
@@ -238,6 +239,7 @@ export const zksyncera: Layer2 = zkStackL2({
         functionSignature:
           'function proveBatchesSharedBridge(uint256 _chainId, (uint64 batchNumber, bytes32 batchHash, uint64 indexRepeatedStorageChanges, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 l2LogsTreeRoot, uint256 timestamp, bytes32 commitment), (uint64 batchNumber, bytes32 batchHash, uint64 indexRepeatedStorageChanges, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 l2LogsTreeRoot, uint256 timestamp, bytes32 commitment)[], (uint256[] recursiveAggregationInput, uint256[] serializedProof))',
         sinceTimestamp: new UnixTime(1717694375),
+        untilTimestamp: new UnixTime(1722410363),
       },
     },
     {
@@ -297,6 +299,7 @@ export const zksyncera: Layer2 = zkStackL2({
         functionSignature:
           'function executeBatchesSharedBridge(uint256 _chainId, (uint64 batchNumber, bytes32 batchHash, uint64 indexRepeatedStorageChanges, uint256 numberOfLayer1Txs, bytes32 priorityOperationsHash, bytes32 l2LogsTreeRoot, uint256 timestamp, bytes32 commitment)[] _newBatchesData)',
         sinceTimestamp: new UnixTime(1717683407),
+        untilTimestamp: new UnixTime(1722410363),
       },
     },
   ],


### PR DESCRIPTION
Added the timestamp of the first cronos batch commit as `untilTimestamp` to current era trackedTxs. An issue to support discerning the commitments by chainId in the calldata is created already. Until then, liveness and costs will be comingSoon.