### PR TITLE
Fix missing provider consideration in type sort sorting logic

### DIFF
--- a/packages/frontend/src/app/(side-nav)/(other)/scaling/data-availability/_components/table/columns.tsx
+++ b/packages/frontend/src/app/(side-nav)/(other)/scaling/data-availability/_components/table/columns.tsx
@@ -31,6 +31,12 @@ export const columns = [
         {ctx.row.original.category}
       </TypeCell>
     ),
+    sortingFn: (rowA, rowB) => {
+      // Sort by category first, then by provider
+      const categoryComparison = (rowA.original.category ?? '').localeCompare(rowB.original.category ?? '');
+      return categoryComparison !== 0 ? categoryComparison :
+        (rowA.original.provider ?? '').localeCompare(rowB.original.provider ?? '');
+    },
   }),
   columnHelper.accessor('dataAvailability.layer', {
     header: 'DA Layer',

--- a/packages/frontend/src/app/(side-nav)/(other)/scaling/liveness/_components/table/columns.tsx
+++ b/packages/frontend/src/app/(side-nav)/(other)/scaling/liveness/_components/table/columns.tsx
@@ -82,6 +82,12 @@ export const columns = [
     meta: {
       tooltip: <TypeExplanationTooltip showOnlyRollupsDefinitions />,
     },
+    sortingFn: (rowA, rowB) => {
+      // Sort by category first, then by provider
+      const categoryComparison = (rowA.original.category ?? '').localeCompare(rowB.original.category ?? '');
+      return categoryComparison !== 0 ? categoryComparison :
+        (rowA.original.provider ?? '').localeCompare(rowB.original.provider ?? '');
+    },
   }),
   columnHelper.accessor('anomalies', {
     header: '30-day\nanomalies',

--- a/packages/frontend/src/app/(side-nav)/(other)/scaling/summary/_components/table/layer3s/columns.tsx
+++ b/packages/frontend/src/app/(side-nav)/(other)/scaling/summary/_components/table/layer3s/columns.tsx
@@ -22,6 +22,12 @@ export const summaryLayer3sColumns = [
     meta: {
       tooltip: <TypeExplanationTooltip />,
     },
+    sortingFn: (rowA, rowB) => {
+      // Sort by category first, then by provider
+      const categoryComparison = (rowA.original.category ?? '').localeCompare(rowB.original.category ?? '');
+      return categoryComparison !== 0 ? categoryComparison :
+        (rowA.original.provider ?? '').localeCompare(rowB.original.provider ?? '');
+    },
   }),
   columnHelper.accessor('provider', {
     header: 'Technology',


### PR DESCRIPTION
Currently, the type sort function only sorts by category, leading to inconsistent ordering when provider is not taken into account. 
This fix introduces sorting by both category and provider to ensure the correct order and eliminate sorting issues.

### Before
<img width="1209" alt="image" src="https://github.com/user-attachments/assets/b13ec818-291a-4b05-9534-f753dd8f8c60">

### After
<img width="1193" alt="image" src="https://github.com/user-attachments/assets/a74d1764-477f-4f12-9e7c-57c0238fb396">
