### PR TITLE
Fix SVG fill issue for NavCollapseIcon

### DIFF
--- a/packages/frontend/src/icons/nav-collapse.tsx
+++ b/packages/frontend/src/icons/nav-collapse.tsx
@@ -8,6 +8,7 @@ export function NavCollapseIcon(props: SvgIconProps) {
       viewBox="0 0 24 24"
       strokeWidth="1.8"
       strokeLinecap="round"
+      fill="none"
       {...props}
     >
       <path d="M16.5 8L12.0633 12.4367C12.0284 12.4716 12.0284 12.5284 12.0633 12.5633L16.5 17" />


### PR DESCRIPTION
Resolve the issue where the triangle in the NavCollapseIcon appears solid due to an unintended fill color. Update the SVG component to explicitly set fill="none" to prevent the shape from being filled and ensure the icon renders as expected.

### Before vs After

<div style="display: flex; ">
<img  style="margin-right:20px;" width="240" alt="image" src="https://github.com/user-attachments/assets/14aae527-1aa0-4ebf-8265-662b0b7468dc">
<img width="238" alt="image" src="https://github.com/user-attachments/assets/041a1279-d62c-4113-9637-5f47183fd222">
</div>

