### PR TITLE
Add CATI to mantle

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -1214,12 +1214,12 @@
       "decimals": 18,
       "deploymentTimestamp": 1615354524,
       "coingeckoListingTimestamp": 1625875200,
+      "untilTimestamp": 1725840000,
       "category": "other",
       "iconUrl": "https://assets.coingecko.com/coins/images/16414/large/rhinologo.png?1697736807",
       "chainId": 1,
       "source": "canonical",
-      "supply": "zero",
-      "untilTimestamp": 1725840000
+      "supply": "zero"
     },
     {
       "name": "DEXTF Token",
@@ -6365,6 +6365,20 @@
       }
     },
     {
+      "name": "Catizen",
+      "coingeckoId": "catizen",
+      "address": "0x1Bdd8878252DaddD3Af2ba30628813271294eDc0",
+      "symbol": "CATI",
+      "decimals": 18,
+      "deploymentTimestamp": 1725608100,
+      "coingeckoListingTimestamp": 1726617600,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/50236/large/cati.png?1726638258",
+      "chainId": 5000,
+      "source": "native",
+      "supply": "circulatingSupply"
+    },
+    {
       "name": "Ether",
       "coingeckoId": "wrapped-ether-mantle-bridge",
       "address": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
@@ -8832,6 +8846,7 @@
       "chainId": 167000,
       "source": "external",
       "supply": "totalSupply",
+      "excludeFromTotal": true,
       "bridgedUsing": {
         "bridges": [
           {
@@ -8839,8 +8854,7 @@
             "slug": "stargatev2"
           }
         ]
-      },
-      "excludeFromTotal": true
+      }
     },
     {
       "name": "Tether USD",
@@ -8855,6 +8869,7 @@
       "chainId": 167000,
       "source": "external",
       "supply": "totalSupply",
+      "excludeFromTotal": true,
       "bridgedUsing": {
         "bridges": [
           {
@@ -8862,8 +8877,7 @@
             "slug": "stargatev2"
           }
         ]
-      },
-      "excludeFromTotal": true
+      }
     },
     {
       "name": "Ether",
@@ -9092,6 +9106,7 @@
       "chainId": 1380012617,
       "source": "external",
       "supply": "totalSupply",
+      "excludeFromTotal": true,
       "bridgedUsing": {
         "bridges": [
           {
@@ -9099,8 +9114,7 @@
             "slug": "stargatev2"
           }
         ]
-      },
-      "excludeFromTotal": true
+      }
     },
     {
       "name": "Tether USD",
@@ -9115,6 +9129,7 @@
       "chainId": 1380012617,
       "source": "external",
       "supply": "totalSupply",
+      "excludeFromTotal": true,
       "bridgedUsing": {
         "bridges": [
           {
@@ -9122,8 +9137,7 @@
             "slug": "stargatev2"
           }
         ]
-      },
-      "excludeFromTotal": true
+      }
     }
   ]
 }

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -2827,6 +2827,13 @@
   ],
   "mantle": [
     {
+      "symbol": "CATI",
+      "address": "0x1Bdd8878252DaddD3Af2ba30628813271294eDc0",
+      "source": "native",
+      "coingeckoId": "catizen",
+      "supply": "circulatingSupply"
+    },
+    {
       "symbol": "MNT",
       "source": "canonical",
       "supply": "zero"


### PR DESCRIPTION
native to mantle and TON, main activity is on TON and CG only tracks TON so we are tracking TON circulating supply for mantle TVL here.

Closes L2B-7375