### PR TITLE
Optimize getTvlProjects

### DIFF
--- a/packages/config/src/tvl/getTvlAmountsConfig.ts
+++ b/packages/config/src/tvl/getTvlAmountsConfig.ts
@@ -52,11 +52,6 @@ export function getTvlAmountsConfig(
     ),
   )
 
-  const chainMap: Record<number, ChainConfig> = {}
-  for (const chain of chains) {
-    chainMap[chain.chainId] = chain
-  }
-
   for (const project of projects) {
     for (const escrow of project.escrows) {
       switch (escrow.sharedEscrow?.type) {

--- a/packages/config/src/tvl/getTvlAmountsConfig.ts
+++ b/packages/config/src/tvl/getTvlAmountsConfig.ts
@@ -17,6 +17,7 @@ import { elasticChainEscrowToEntries } from './amounts/custom/elasticChainEscrow
 import { getEscrowEntry } from './amounts/escrow'
 import { getPremintedEntry } from './amounts/preminted'
 import { getTotalSupplyEntry } from './amounts/totalSupply'
+import { keyBy } from 'lodash'
 
 export function getTvlAmountsConfig(
   projects: BackendProject[],
@@ -122,10 +123,7 @@ export function getTvlAmountsConfigForProject(
     entries.push(configEntry)
   }
 
-  const chainMap: Record<number, ChainConfig> = {}
-  for (const chain of chains) {
-    chainMap[chain.chainId] = chain
-  }
+  const chainMap = keyBy(chains, (e) => e.chainId)
 
   for (const escrow of project.escrows) {
     switch (escrow.sharedEscrow?.type) {

--- a/packages/config/src/tvl/getTvlAmountsConfig.ts
+++ b/packages/config/src/tvl/getTvlAmountsConfig.ts
@@ -52,6 +52,11 @@ export function getTvlAmountsConfig(
     ),
   )
 
+  const chainMap: Record<number, ChainConfig> = {}
+  for (const chain of chains) {
+    chainMap[chain.chainId] = chain
+  }
+
   for (const project of projects) {
     for (const escrow of project.escrows) {
       switch (escrow.sharedEscrow?.type) {
@@ -122,6 +127,11 @@ export function getTvlAmountsConfigForProject(
     entries.push(configEntry)
   }
 
+  const chainMap: Record<number, ChainConfig> = {}
+  for (const chain of chains) {
+    chainMap[chain.chainId] = chain
+  }
+
   for (const escrow of project.escrows) {
     switch (escrow.sharedEscrow?.type) {
       case 'AggLayer': {
@@ -144,7 +154,7 @@ export function getTvlAmountsConfigForProject(
       }
       default: {
         for (const token of escrow.tokens) {
-          const chain = chains.find((x) => x.chainId === +token.chainId)
+          const chain = chainMap[+token.chainId]
           assert(chain, `Chain not found for token ${token.id}`)
           assert(
             chain.name === escrow.chain,

--- a/packages/config/src/tvl/getTvlAmountsConfig.ts
+++ b/packages/config/src/tvl/getTvlAmountsConfig.ts
@@ -5,6 +5,7 @@ import {
   ChainId,
   Token,
 } from '@l2beat/shared-pure'
+import { keyBy } from 'lodash'
 import { chainToProject } from '../backend'
 import { BackendProject, BackendProjectEscrow } from '../backend/BackendProject'
 import { chains } from '../chains'
@@ -17,7 +18,6 @@ import { elasticChainEscrowToEntries } from './amounts/custom/elasticChainEscrow
 import { getEscrowEntry } from './amounts/escrow'
 import { getPremintedEntry } from './amounts/preminted'
 import { getTotalSupplyEntry } from './amounts/totalSupply'
-import { keyBy } from 'lodash'
 
 export function getTvlAmountsConfig(
   projects: BackendProject[],

--- a/packages/frontend/src/server/features/scaling/tvl/get-tvl-chart-data.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/get-tvl-chart-data.ts
@@ -40,7 +40,7 @@ export async function getTvlChart(...args: Parameters<typeof getTvlChartData>) {
   return getTvlChartData(...args)
 }
 
-export type TvlChartData = Awaited<ReturnType<typeof getTvlChartData>>
+export type TvlChartData = Awaited<ReturnType<typeof getCachedTvlChartData>>
 export async function getTvlChartData({
   range,
   excludeAssociatedTokens,

--- a/packages/frontend/src/server/features/scaling/tvl/get-tvl-chart-data.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/get-tvl-chart-data.ts
@@ -40,14 +40,14 @@ export async function getTvlChart(...args: Parameters<typeof getTvlChartData>) {
   return getTvlChartData(...args)
 }
 
-export type TvlChartData = Awaited<ReturnType<typeof getCachedTvlChartData>>
+export type TvlChartData = Awaited<ReturnType<typeof getTvlChartData>>
 export async function getTvlChartData({
   range,
   excludeAssociatedTokens,
   filter,
 }: TvlChartDataParams) {
   const projectsFilter = createTvlProjectsFilter(filter)
-  const tvlProjects = getTvlProjects().filter(projectsFilter)
+  const tvlProjects = getTvlProjects(projectsFilter)
 
   const [ethPrices, values] = await Promise.all([
     getEthPrices(),

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-token-breakdown.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-token-breakdown.ts
@@ -2,7 +2,7 @@ import { bridges, layer2s, layer3s } from '@l2beat/config'
 import { env } from '~/env'
 import { calculatePercentageChange } from '~/utils/calculate-percentage-change'
 import { getTokenBreakdown } from './get-token-breakdown'
-import { type TvlProject, getTvlProjects } from './get-tvl-projects'
+import { type BaseProject, getTvlProjects } from './get-tvl-projects'
 import { getTvlValuesForProjects } from './get-tvl-values-for-projects'
 
 export function get7dTokenBreakdown(
@@ -14,7 +14,7 @@ export function get7dTokenBreakdown(
   return get7dTokenBreakdownData(...parameters)
 }
 
-export type LatestTvl = Awaited<ReturnType<typeof get7dTokenBreakdownData>>
+export type LatestTvl = Awaited<ReturnType<typeof getCached7dTokenBreakdown>>
 export async function get7dTokenBreakdownData({
   type,
 }: { type: 'layer2' | 'bridge' }) {

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-token-breakdown.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-token-breakdown.ts
@@ -14,17 +14,17 @@ export function get7dTokenBreakdown(
   return get7dTokenBreakdownData(...parameters)
 }
 
-export type LatestTvl = Awaited<ReturnType<typeof getCached7dTokenBreakdown>>
+export type LatestTvl = Awaited<ReturnType<typeof get7dTokenBreakdownData>>
 export async function get7dTokenBreakdownData({
   type,
 }: { type: 'layer2' | 'bridge' }) {
   const filter =
     type === 'layer2'
-      ? (project: TvlProject) =>
+      ? (project: BaseProject) =>
           project.type === 'layer2' || project.type === 'layer3'
-      : (project: TvlProject) => project.type === 'bridge'
+      : (project: BaseProject) => project.type === 'bridge'
 
-  const projectsToQuery = getTvlProjects().filter(filter)
+  const projectsToQuery = getTvlProjects(filter)
 
   const tvlValues = await getTvlValuesForProjects(projectsToQuery, '7d')
 

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-tvl-breakdown.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-tvl-breakdown.ts
@@ -24,7 +24,7 @@ export type SevenDayTvlBreakdown = Awaited<
 const getCached7dTokenBreakdown = cache(
   async () => {
     const tvlValues = await getTvlValuesForProjects(
-      getTvlProjects().filter(
+      getTvlProjects(
         (project) => project.type === 'layer2' || project.type === 'layer3',
       ),
       '7d',

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-tvl-projects.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-tvl-projects.ts
@@ -18,6 +18,7 @@ import {
   type ProjectId,
   UnixTime,
 } from '@l2beat/shared-pure'
+import { groupBy } from 'lodash'
 import { env } from '~/env'
 
 export interface BaseProject {
@@ -81,11 +82,10 @@ export function getTvlProjects(
     )
 
   const tvlAmounts = getTvlAmountsConfig(projects)
-  const tvlAmountsMap: Record<string, AmountConfigEntry[]> = {}
-  for (const amountEntry of tvlAmounts) {
-    tvlAmountsMap[amountEntry.project] ??= []
-    tvlAmountsMap[amountEntry.project]?.push(amountEntry)
-  }
+  const tvlAmountsMap: Record<string, AmountConfigEntry[]> = groupBy(
+    tvlAmounts,
+    (e) => e.project,
+  )
 
   const result = filteredProjects.flatMap(({ projectId, type, slug }) => {
     const amounts = tvlAmountsMap[projectId]

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-tvl-values-for-projects.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-tvl-values-for-projects.ts
@@ -22,13 +22,15 @@ export async function getTvlValuesForProjects(
       .add(-days, 'days')
 
   // NOTE: This cannot be optimized using from because the values need to be interpolated
-  const valueRecords = await db.value.getForProjects(projects.map((p) => p.id))
+  const valueRecords = await db.value.getForProjects(
+    projects.map((p) => p.projectId),
+  )
 
   const valuesByProject = groupBy(valueRecords, 'projectId')
 
   const result: Dictionary<Dictionary<ValueRecord[]>> = {}
   for (const [projectId, projectValues] of Object.entries(valuesByProject)) {
-    const project = projects.find((p) => p.id === projectId)
+    const project = projects.find((p) => p.projectId === projectId)
     assert(project, `Project ${projectId.toString()} not found`)
 
     const valuesByTimestamp = groupBy(projectValues, 'timestamp')

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-tvl-values-status.test.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-tvl-values-status.test.ts
@@ -83,7 +83,7 @@ function mockValue(source: string, timestamp: number) {
 }
 function mockProject(sources: string[]): TvlProject {
   return {
-    id: ProjectId('project'),
+    projectId: ProjectId('project'),
     minTimestamp: UnixTime.ZERO,
     type: 'layer2', // does not matter here
     slug: 'slug', // does not matter here

--- a/packages/frontend/src/server/features/scaling/tvl/utils/project-filter-utils.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/project-filter-utils.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { type TvlProject } from './get-tvl-projects'
+import { type BaseProject } from './get-tvl-projects'
 
 export const TvlProjectFilter = z.discriminatedUnion('type', [
   z.object({
@@ -19,8 +19,8 @@ export function createTvlProjectsFilter(filter: TvlProjectFilter) {
 
   if (filter.type === 'projects') {
     const projectIds = new Set(filter.projectIds)
-    return (project: TvlProject) => projectIds.has(project.id)
+    return (project: BaseProject) => projectIds.has(project.projectId)
   }
 
-  return (project: TvlProject) => project.type === filter.type
+  return (project: BaseProject) => project.type === filter.type
 }


### PR DESCRIPTION
Part of L2B-7570

- [x] Not recreating the all projects array (-40ms) 
- [x] Removing the n^2 filter from the array (-150ms)
- [x] Filtering sooner so we don't do useless computation (1.5x)
- [x] getTvlAmountsConfig doesn't require all the projects
