### PR TITLE
Add EGP, ATH to Arbi TVL

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -7221,6 +7221,27 @@
       }
     },
     {
+      "name": "Aethir Token",
+      "coingeckoId": "aethir",
+      "address": "0xc87B37a581ec3257B734886d9d3a581F5A9d056c",
+      "symbol": "ATH",
+      "decimals": 18,
+      "deploymentTimestamp": 1717572209,
+      "coingeckoListingTimestamp": 1718150400,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/36179/large/logogram_circle_dark_green_vb_green_%281%29.png?1718232706",
+      "chainId": 42161,
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Axelar (ITS)"
+          }
+        ]
+      }
+    },
+    {
       "name": "Arbitrum",
       "coingeckoId": "arbitrum",
       "address": "0x912CE59144191C1204E64559FE8253a0e49E6548",
@@ -7352,6 +7373,20 @@
       "coingeckoListingTimestamp": 1684800000,
       "category": "other",
       "iconUrl": "https://assets.coingecko.com/coins/images/30505/large/dmt.png?1696529391",
+      "chainId": 42161,
+      "source": "native",
+      "supply": "circulatingSupply"
+    },
+    {
+      "name": "Eigenpie",
+      "coingeckoId": "eigenpie",
+      "address": "0x7E7a7C916c19a45769f6BDAF91087f93c6C12F78",
+      "symbol": "EGP",
+      "decimals": 18,
+      "deploymentTimestamp": 1726032245,
+      "coingeckoListingTimestamp": 1727222400,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/37810/large/eigenpie.jpeg?1715597613",
       "chainId": 42161,
       "source": "native",
       "supply": "circulatingSupply"

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1527,6 +1527,25 @@
   ],
   "arbitrum": [
     {
+      "symbol": "EGP",
+      "address": "0x7E7a7C916c19a45769f6BDAF91087f93c6C12F78",
+      "source": "native",
+      "supply": "circulatingSupply" // somehow coingecko does not exclude half the supply sitting in a multisig :(
+    },
+    {
+      "symbol": "ATH",
+      "address": "0xc87B37a581ec3257B734886d9d3a581F5A9d056c",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Axelar (ITS)"
+          }
+        ]
+      }
+    },
+    {
       "symbol": "PMON",
       "address": "0xBC9B77acA82f6BE43927076D71cd453b625165B8",
       "source": "canonical",


### PR DESCRIPTION
EGP - Eigenpie: One of the many magpiexyz.io gov tokens, natively minted (coingecko does not exclude half the supply sitting in a MS)
ATH - Aethir, gpu cloud platform token, native ITS (Axelar interchain standard, burn-mint, totalsupply)

Closes L2B-7589