### PR TITLE
Add missing metadata

### DIFF
--- a/packages/frontend/src/app/(side-nav)/bridges/archived/page.tsx
+++ b/packages/frontend/src/app/(side-nav)/bridges/archived/page.tsx
@@ -1,9 +1,16 @@
 import { MainPageCard } from '~/components/main-page-card'
 import { MainPageHeader } from '~/components/main-page-header'
 import { getBridgesArchivedEntries } from '~/server/features/bridges/get-bridges-archived-entries'
+import { getDefaultMetadata } from '~/utils/metadata'
 import { BridgesFilterContextProvider } from '../_components/bridges-filter-context'
 import { BridgesMvpWarning } from '../_components/bridges-mvp-warning'
 import { BridgesArchivedTable } from './_components/table/bridges-archived-table'
+
+export const metadata = getDefaultMetadata({
+  openGraph: {
+    url: '/bridges/archived',
+  },
+})
 
 export default async function Page() {
   const entries = await getBridgesArchivedEntries()

--- a/packages/frontend/src/app/(side-nav)/scaling/archived/page.tsx
+++ b/packages/frontend/src/app/(side-nav)/scaling/archived/page.tsx
@@ -1,8 +1,15 @@
 import { MainPageCard } from '~/components/main-page-card'
 import { MainPageHeader } from '~/components/main-page-header'
 import { getScalingArchivedEntries } from '~/server/features/scaling/archived/get-scaling-archived-entries'
+import { getDefaultMetadata } from '~/utils/metadata'
 import { ScalingFilterContextProvider } from '../_components/scaling-filter-context'
 import { ScalingArchivedTable } from './_components/table/scaling-archived-table'
+
+export const metadata = getDefaultMetadata({
+  openGraph: {
+    url: '/scaling/archived',
+  },
+})
 
 export default async function Page() {
   const entries = await getScalingArchivedEntries()

--- a/packages/frontend/src/app/(side-nav)/scaling/upcoming/page.tsx
+++ b/packages/frontend/src/app/(side-nav)/scaling/upcoming/page.tsx
@@ -1,8 +1,15 @@
 import { MainPageCard } from '~/components/main-page-card'
 import { MainPageHeader } from '~/components/main-page-header'
 import { getScalingUpcomingEntries } from '~/server/features/scaling/upcoming/get-scaling-upcoming-entries'
+import { getDefaultMetadata } from '~/utils/metadata'
 import { ScalingFilterContextProvider } from '../_components/scaling-filter-context'
 import { ScalingUpcomingTable } from './_components/table/scaling-upcoming-table'
+
+export const metadata = getDefaultMetadata({
+  openGraph: {
+    url: '/scaling/upcoming',
+  },
+})
 
 export default function Page() {
   const entries = getScalingUpcomingEntries()


### PR DESCRIPTION
It would be nice to get the open graph URL dynamically but it would have to be done via headers and generateMetadata which is not that nice I guess