### PR TITLE
Add proposer and challenger fields

### DIFF
--- a/packages/config/src/common/ScalingProjectDisplay.ts
+++ b/packages/config/src/common/ScalingProjectDisplay.ts
@@ -3,7 +3,7 @@ import { ScalingProjectCategory } from './ScalingProjectCategory'
 import { ScalingProjectLinks } from './ScalingProjectLinks'
 import { ScalingProjectPurpose } from './ScalingProjectPurpose'
 
-export interface ScalingProjectDisplay {
+export type ScalingProjectDisplay = {
   /** Name of the scaling project, will be used as a display name on the website */
   name: string
   /** Short name of the scaling project, will be used in some places on the website as a display name */
@@ -12,6 +12,14 @@ export interface ScalingProjectDisplay {
   slug: string
   /** Name of the category the scaling project belongs to */
   category: ScalingProjectCategory
+  proposer?: {
+    value: string
+    secondLine?: string
+  }
+  challenger?: {
+    value: string
+    secondLine?: string
+  }
   /** A warning displayed in the header of the project. Also will be displayed as yellow shield next to project name (table view) */
   headerWarning?: string
   /** Warning for TVL */

--- a/packages/config/src/projects/layer2s/index.test.ts
+++ b/packages/config/src/projects/layer2s/index.test.ts
@@ -11,6 +11,7 @@ import { utils } from 'ethers'
 import { startsWith, uniq } from 'lodash'
 
 import { get$Implementations } from '@l2beat/discovery-types'
+import { describe } from 'mocha'
 import { chains } from '../../chains'
 import {
   NUGGETS,
@@ -23,7 +24,6 @@ import { ProjectDiscovery } from '../../discovery/ProjectDiscovery'
 import { checkRisk } from '../../test/helpers'
 import { tokenList } from '../../tokens'
 import { layer2s, milestonesLayer2s } from './index'
-import { describe } from 'mocha'
 
 describe('layer2s', () => {
   describe('links', () => {

--- a/packages/config/src/projects/layer2s/index.test.ts
+++ b/packages/config/src/projects/layer2s/index.test.ts
@@ -23,6 +23,7 @@ import { ProjectDiscovery } from '../../discovery/ProjectDiscovery'
 import { checkRisk } from '../../test/helpers'
 import { tokenList } from '../../tokens'
 import { layer2s, milestonesLayer2s } from './index'
+import { describe } from 'mocha'
 
 describe('layer2s', () => {
   describe('links', () => {
@@ -636,6 +637,17 @@ describe('layer2s', () => {
       if (layer2.isUpcoming) {
         it(layer2.display.name, () => {
           expect(layer2.createdAt).not.toEqual(undefined)
+        })
+      }
+    }
+  })
+
+  describe('Other category projects have proposer and challenger', () => {
+    for (const layer2 of layer2s) {
+      if (layer2.display.category === 'Other') {
+        it(layer2.display.name, () => {
+          expect(layer2.display.proposer).not.toEqual(undefined)
+          expect(layer2.display.challenger).not.toEqual(undefined)
         })
       }
     }

--- a/packages/config/src/projects/layer2s/templates/underReview.ts
+++ b/packages/config/src/projects/layer2s/templates/underReview.ts
@@ -22,12 +22,12 @@ export interface UnderReviewConfigCommon {
 }
 
 export interface UnderReviewConfigL2 extends UnderReviewConfigCommon {
-  display: Omit<Layer2Display, 'dataAvailabilityMode'>
+  display: Layer2Display
   associatedTokens?: string[]
 }
 
 export interface UnderReviewConfigL3 extends UnderReviewConfigCommon {
-  display: Omit<Layer3Display, 'dataAvailabilityMode'>
+  display: Layer3Display
   hostChain: Layer3['hostChain']
   associatedTokens?: string[]
 }
@@ -37,9 +37,7 @@ export function underReviewL2(templateVars: UnderReviewConfigL2): Layer2 {
     isUnderReview: true,
     type: 'layer2',
     id: ProjectId(templateVars.id),
-    display: {
-      ...templateVars.display,
-    },
+    display: templateVars.display,
     stage: {
       stage:
         templateVars.display.category === 'Optimistic Rollup' ||

--- a/packages/config/src/projects/layer2s/templates/upcoming.ts
+++ b/packages/config/src/projects/layer2s/templates/upcoming.ts
@@ -8,14 +8,14 @@ import { type Layer2, type Layer2Display } from '../types'
 export interface UpcomingConfigL2 {
   id: string
   createdAt: UnixTime
-  display: Omit<Layer2Display, 'dataAvailabilityMode'>
+  display: Layer2Display
   badges?: BadgeId[]
 }
 
 export interface UpcomingConfigL3 {
   id: string
   createdAt: UnixTime
-  display: Omit<Layer3Display, 'dataAvailabilityMode'>
+  display: Layer3Display
   hostChain: Layer3['hostChain']
   badges?: BadgeId[]
 }
@@ -26,9 +26,7 @@ export function upcomingL2(templateVars: UpcomingConfigL2): Layer2 {
     type: 'layer2',
     id: ProjectId(templateVars.id),
     createdAt: templateVars.createdAt,
-    display: {
-      ...templateVars.display,
-    },
+    display: templateVars.display,
     stage: {
       stage: 'NotApplicable',
     },

--- a/packages/config/src/projects/layer2s/types/Layer2.ts
+++ b/packages/config/src/projects/layer2s/types/Layer2.ts
@@ -75,7 +75,7 @@ export interface Layer2 {
   discoveryDrivenData?: boolean
 }
 
-export interface Layer2Display extends ScalingProjectDisplay {
+export type Layer2Display = ScalingProjectDisplay & {
   /** Technology provider */
   provider?: Layer2Provider
   /** Tooltip contents for liveness tab for given project */

--- a/packages/config/src/projects/layer3s/index.test.ts
+++ b/packages/config/src/projects/layer3s/index.test.ts
@@ -171,4 +171,15 @@ describe('layer3s', () => {
       }
     }
   })
+
+  describe('other category projects have proposer and challenger', () => {
+    for (const layer3 of layer3s) {
+      if (layer3.display.category === 'Other') {
+        it(layer3.display.name, () => {
+          expect(layer3.display.proposer).not.toEqual(undefined)
+          expect(layer3.display.challenger).not.toEqual(undefined)
+        })
+      }
+    }
+  })
 })

--- a/packages/config/src/projects/layer3s/types/Layer3.ts
+++ b/packages/config/src/projects/layer3s/types/Layer3.ts
@@ -74,7 +74,7 @@ export interface Layer3Config extends ScalingProjectConfig {
   transactionApi?: ScalingProjectTransactionApi
 }
 
-export interface Layer3Display extends ScalingProjectDisplay {
+export type Layer3Display = ScalingProjectDisplay & {
   /** Technology provider */
   provider?: Layer3Provider
 }


### PR DESCRIPTION
I really find this solution of making the fields optional really ugly. I have tried to create union like: 
```tsx
  {
    category: Exclude<ScalingProjectCategory, 'Other'>
  } 
  | 
  {
    category: Extract<ScalingProjectCategory, 'Other'>
    proposer: ...
    challenger: ...
  }
```

But this introduced a lot of problems in the template files.
Tagging some TS wizards for help @sz-piotr @imxeno
 