### PR TITLE
Reorder pages

### DIFF
--- a/packages/frontend/src/components/nav/nav-layout.tsx
+++ b/packages/frontend/src/components/nav/nav-layout.tsx
@@ -41,14 +41,18 @@ export async function NavLayout({
           href: '/scaling/summary',
         },
         {
+          title: 'Risk Analysis',
+          shortTitle: 'Risks',
+          href: '/scaling/risk',
+        },
+        {
           title: 'Value Locked',
           shortTitle: 'Value',
           href: '/scaling/tvl',
         },
         {
-          title: 'Risk Analysis',
-          shortTitle: 'Risks',
-          href: '/scaling/risk',
+          title: 'Activity',
+          href: '/scaling/activity',
         },
         {
           title: 'Data Availability',
@@ -62,10 +66,6 @@ export async function NavLayout({
         {
           title: 'Finality',
           href: '/scaling/finality',
-        },
-        {
-          title: 'Activity',
-          href: '/scaling/activity',
         },
         {
           title: 'Costs',


### PR DESCRIPTION
This pull request reorders the pages in the navigation layout for the scaling section. The "Risk Analysis" page is moved below the "Value Locked" page, and the "Activity" page is moved above the "Data Availability" page. This change improves the flow and organization of the navigation menu.