### PR TITLE
Add moar tokens

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -8454,6 +8454,27 @@
       }
     },
     {
+      "name": "InceptionLRT restaked ETH",
+      "coingeckoId": "genesislrt-restaked-eth",
+      "address": "0x5A7a183B6B44Dc4EC2E3d2eF43F98C5152b1d76d",
+      "symbol": "inETH",
+      "decimals": 18,
+      "deploymentTimestamp": 1714467441,
+      "coingeckoListingTimestamp": 1713657600,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/34127/large/inETH.png?1715036464",
+      "chainId": 59144,
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Inception Bridge (xERC-20)"
+          }
+        ]
+      }
+    },
+    {
       "name": "KelpDao Restaked ETH",
       "coingeckoId": "kelp-dao-restaked-eth",
       "address": "0x4186BFC76E2E237523CBC30FD220FE055156b41F",

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -7328,6 +7328,20 @@
       "supply": "circulatingSupply"
     },
     {
+      "name": "CATCH",
+      "coingeckoId": "spacecatch",
+      "address": "0xbC4c97Fb9befaa8B41448e1dFcC5236dA543217F",
+      "symbol": "CATCH",
+      "decimals": 18,
+      "deploymentTimestamp": 1718880774,
+      "coingeckoListingTimestamp": 1712016000,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/36632/large/Logomark_colours.png?1712022405",
+      "chainId": 42161,
+      "source": "native",
+      "supply": "circulatingSupply"
+    },
+    {
       "name": "CHEESE",
       "coingeckoId": "cheese-2",
       "address": "0x05AEa20947A9A376eF50218633BB0a5A05d40A0C",
@@ -7563,6 +7577,20 @@
       "chainId": 42161,
       "source": "native",
       "supply": "totalSupply"
+    },
+    {
+      "name": "GAM3S.GG",
+      "coingeckoId": "gam3s-gg",
+      "address": "0xc24A365A870821EB83Fd216c9596eDD89479d8d7",
+      "symbol": "G3",
+      "decimals": 18,
+      "deploymentTimestamp": 1712151381,
+      "coingeckoListingTimestamp": 1712620800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/35662/large/G3_logo.jpg?1709454143",
+      "chainId": 42161,
+      "source": "native",
+      "supply": "circulatingSupply"
     },
     {
       "name": "Gho Token",
@@ -7837,6 +7865,20 @@
       "supply": "circulatingSupply"
     },
     {
+      "name": "Neuron",
+      "coingeckoId": "neuron",
+      "address": "0xdadeca1167fe47499e53Eb50F261103630974905",
+      "symbol": "NRN",
+      "decimals": 18,
+      "deploymentTimestamp": 1717527783,
+      "coingeckoListingTimestamp": 1719187200,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38838/large/Nrn_with_gradient_-NEW_TO_BE_UPDATED.png?1728551601",
+      "chainId": 42161,
+      "source": "native",
+      "supply": "circulatingSupply"
+    },
+    {
       "name": "Polkamon",
       "coingeckoId": "polychain-monsters",
       "address": "0xBC9B77acA82f6BE43927076D71cd453b625165B8",
@@ -8031,6 +8073,20 @@
           }
         ]
       }
+    },
+    {
+      "name": "StarHeroes",
+      "coingeckoId": "starheroes",
+      "address": "0xB299751B088336E165dA313c33e3195B8c6663A6",
+      "symbol": "STAR",
+      "decimals": 18,
+      "deploymentTimestamp": 1709244341,
+      "coingeckoListingTimestamp": 1710201600,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/34147/large/Screenshot_2024-03-08_180444.png?1709892309",
+      "chainId": 42161,
+      "source": "native",
+      "supply": "circulatingSupply"
     },
     {
       "name": "TapToken",

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -9139,6 +9139,20 @@
       }
     },
     {
+      "name": "NURI Token",
+      "coingeckoId": "nuri-exchange",
+      "address": "0xAAAE8378809bb8815c08D3C59Eb0c7D1529aD769",
+      "symbol": "NURI",
+      "decimals": 18,
+      "deploymentTimestamp": 1708049272,
+      "coingeckoListingTimestamp": 1719187200,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38831/large/nuri_discord.png?1723623524",
+      "chainId": 534352,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "Staked USDe",
       "coingeckoId": "ethena-staked-usde",
       "address": "0x211Cc4DD073734dA055fbF44a2b4667d5E5fE5d2",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1529,6 +1529,31 @@
   ],
   "arbitrum": [
     {
+      "symbol": "STAR",
+      "address": "0xB299751B088336E165dA313c33e3195B8c6663A6",
+      "source": "native",
+      "supply": "circulatingSupply"
+    },
+    {
+      "symbol": "CATCH",
+      "address": "0xbC4c97Fb9befaa8B41448e1dFcC5236dA543217F",
+      "source": "native",
+      "supply": "circulatingSupply"
+    },
+
+    {
+      "symbol": "NRN",
+      "address": "0xdadeca1167fe47499e53Eb50F261103630974905",
+      "source": "native",
+      "supply": "circulatingSupply"
+    },
+    {
+      "symbol": "G3",
+      "address": "0xc24A365A870821EB83Fd216c9596eDD89479d8d7",
+      "source": "native", // native on arb, ITS type 0 on other chains
+      "supply": "circulatingSupply"
+    },
+    {
       "symbol": "EGP",
       "address": "0x7E7a7C916c19a45769f6BDAF91087f93c6C12F78",
       "source": "native",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -3007,6 +3007,19 @@
   ],
   "linea": [
     {
+      "symbol": "inETH",
+      "address": "0x5A7a183B6B44Dc4EC2E3d2eF43F98C5152b1d76d",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Inception Bridge (xERC-20)"
+          }
+        ]
+      }
+    },
+    {
       "symbol": "M-BTC",
       "address": "0xe4D584ae9b753e549cAE66200A6475d2f00705f7",
       "coingeckoId": "merlin-s-seal-btc",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -3609,6 +3609,12 @@
   ],
   "scroll": [
     {
+      "symbol": "NURI",
+      "address": "0xAAAE8378809bb8815c08D3C59Eb0c7D1529aD769",
+      "source": "native",
+      "supply": "totalSupply" // CG does not have circulating but seems fully liquid
+    },
+    {
       "symbol": "SolvBTC",
       "address": "0x3Ba89d490AB1C0c9CC2313385b30710e838370a4",
       "supply": "totalSupply",


### PR DESCRIPTION
Linea: 
* inETH: LRT wrapper, native multichain with custom bridge using the xERC-20 standard, all underlyings sitting on ethereum

Scroll:
* Nuri: native

Arbitrum:
* G3: arb native with [lockbox](https://arbiscan.io/address/0xe4d475614359d25847252d2c55b867a58a14f281), native ITS (Axelar) on ethereum (type 0 tokenmanager)
* NRN: arb native
* CATCH: arb native
* STAR: arb native with [oftadapter](https://arbiscan.io/address/0xc14a29474dec256935d070d5c7194893b9ef2088) (lzV1), layerzerov1 native oft on ethereum


Closes L2B-7784, L2B-7733