### PR TITLE
Fix blocknumber format in checkrpc script

### DIFF
--- a/packages/l2b/src/implementations/checkrpc.ts
+++ b/packages/l2b/src/implementations/checkrpc.ts
@@ -47,7 +47,7 @@ async function callRpc(
       body: JSON.stringify({
         jsonrpc: '2.0',
         method: method,
-        params: [blockNumber.toString(16), false],
+        params: ['0x' + blockNumber.toString(16), false],
         id: blockNumber,
       }),
       signal: controller.signal,


### PR DESCRIPTION
Current `l2b check-rpc https://eth.drpc.org` does not work, this fixes it