### PR TITLE
Fix EVMTransaction parsing

### DIFF
--- a/packages/shared/src/clients/rpc/RpcClient2.test.ts
+++ b/packages/shared/src/clients/rpc/RpcClient2.test.ts
@@ -15,7 +15,7 @@ describe(RpcClient2.name, () => {
       const result = await rpc.getBlockWithTransactions(100)
 
       expect(result).toEqual({
-        transactions: [mockTx('0'), mockTx('1')],
+        transactions: [mockTx('0'), mockTx(null)],
         timestamp: 100,
         hash: '0xabcdef',
         number: 100,
@@ -155,21 +155,21 @@ function mockClient(deps: {
 
 const mockResponse = (blockNumber: number) => ({
   result: {
-    transactions: [mockRawTx('0'), mockRawTx('1')],
+    transactions: [mockRawTx('0'), mockRawTx(null)],
     timestamp: `0x${blockNumber.toString(16)}`,
     hash: '0xabcdef',
     number: `0x${blockNumber.toString(16)}`,
   },
 })
 
-const mockRawTx = (data: string) => ({
-  hash: `0x${data}`,
-  to: `0x${data}`,
-  input: `0x${data}`,
+const mockRawTx = (to: string | null) => ({
+  hash: `0x1`,
+  to,
+  input: `0x1`,
 })
 
-const mockTx = (data: string) => ({
-  hash: `0x${data}`,
-  to: `0x${data}`,
-  data: `0x${data}`,
+const mockTx = (to: string | null) => ({
+  hash: `0x1`,
+  to,
+  data: `0x1`,
 })

--- a/packages/shared/src/clients/rpc/types.ts
+++ b/packages/shared/src/clients/rpc/types.ts
@@ -9,14 +9,11 @@ export type EVMTransaction = z.infer<typeof EVMTransaction>
 export const EVMTransaction = z
   .object({
     hash: z.string(),
-    to: z.string(),
-    input: z.string().transform((input) => ({ data: input })),
+    /** Address of the receiver, null when its a contract creation transaction. */
+    to: z.union([z.string(), z.null()]),
+    input: z.string(),
   })
-  .transform(({ hash, to, input }) => ({
-    hash,
-    to,
-    data: input.data,
-  }))
+  .transform(({ hash, to, input }) => ({ hash, to, data: input }))
 
 export const Quantity = {
   decode: z.preprocess((s) => {
@@ -34,7 +31,6 @@ export const Quantity = {
 
 export type EVMBlock = z.infer<typeof EVMBlock>
 export const EVMBlock = z.object({
-  // TODO: add support for including txs body
   transactions: z.array(EVMTransaction),
   timestamp: Quantity.decode.transform((n) => Number(n)),
   hash: z.string(),

--- a/packages/uops-dashboard/src/server/counters/RpcCounter.ts
+++ b/packages/uops-dashboard/src/server/counters/RpcCounter.ts
@@ -227,7 +227,7 @@ export class RpcCounter implements Counter {
     }
   }
 
-  getTransactionType(to?: string): string {
+  getTransactionType(to: string | null): string {
     switch (to?.toLowerCase()) {
       case ENTRY_POINT_ADDRESS_0_6_0:
         return 'ERC-4337 Entry Point 0.6.0'


### PR DESCRIPTION
`to: DATA, 20 Bytes - address of the receiver. null when its a contract creation transaction.`

https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionbyhash