### PR TITLE
Add mainPermissions to Other category projects

### DIFF
--- a/packages/config/src/common/ScalingProjectDisplay.ts
+++ b/packages/config/src/common/ScalingProjectDisplay.ts
@@ -1,3 +1,4 @@
+import { StringWithAutocomplete } from '@l2beat/shared-pure'
 import { WarningWithSentiment } from '../projects'
 import { ScalingProjectCategory } from './ScalingProjectCategory'
 import { ScalingProjectLinks } from './ScalingProjectLinks'
@@ -13,13 +14,19 @@ export type ScalingProjectDisplay = {
   /** Name of the category the scaling project belongs to */
   category: ScalingProjectCategory
   isOther?: boolean
-  proposer?: {
-    value: string
-    secondLine?: string
-  }
-  challenger?: {
-    value: string
-    secondLine?: string
+  mainPermissions?: {
+    proposer: {
+      value: string
+      secondLine?: string
+    }
+    challenger: {
+      value: StringWithAutocomplete<'None'>
+      secondLine?: string
+    }
+    upgrader: {
+      value: string
+      secondLine?: string
+    }
   }
   /** A warning displayed in the header of the project. Also will be displayed as yellow shield next to project name (table view) */
   headerWarning?: string

--- a/packages/config/src/projects/layer2s/index.test.ts
+++ b/packages/config/src/projects/layer2s/index.test.ts
@@ -620,12 +620,11 @@ describe('layer2s', () => {
     }
   })
 
-  describe('Other category projects have proposer and challenger', () => {
+  describe('Other category projects have other details', () => {
     for (const layer2 of layer2s) {
       if (layer2.display.isOther) {
         it(layer2.display.name, () => {
-          expect(layer2.display.proposer).not.toEqual(undefined)
-          expect(layer2.display.challenger).not.toEqual(undefined)
+          expect(layer2.display.mainPermissions).not.toEqual(undefined)
         })
       }
     }

--- a/packages/config/src/projects/layer3s/index.test.ts
+++ b/packages/config/src/projects/layer3s/index.test.ts
@@ -150,12 +150,11 @@ describe('layer3s', () => {
     }
   })
 
-  describe('other category projects have proposer and challenger', () => {
+  describe('Other category projects have other details', () => {
     for (const layer3 of layer3s) {
       if (layer3.display.isOther) {
         it(layer3.display.name, () => {
-          expect(layer3.display.proposer).not.toEqual(undefined)
-          expect(layer3.display.challenger).not.toEqual(undefined)
+          expect(layer3.display.mainPermissions).not.toEqual(undefined)
         })
       }
     }

--- a/packages/frontend/src/app/(side-nav)/scaling/summary/_components/table/columns.tsx
+++ b/packages/frontend/src/app/(side-nav)/scaling/summary/_components/table/columns.tsx
@@ -133,7 +133,7 @@ export const scalingSummaryOthersColumns = [
     id: 'proposer',
     header: 'Proposer',
     cell: (ctx) => {
-      const value = ctx.row.original.proposer
+      const value = ctx.row.original.mainPermissions?.proposer
       if (!value) {
         return <NoDataBadge />
       }
@@ -152,7 +152,26 @@ export const scalingSummaryOthersColumns = [
     id: 'challenger',
     header: 'Challenger',
     cell: (ctx) => {
-      const value = ctx.row.original.challenger
+      const value = ctx.row.original.mainPermissions?.challenger
+      if (!value) {
+        return <NoDataBadge />
+      }
+
+      return (
+        <TwoRowCell>
+          <TwoRowCell.First>{value.value}</TwoRowCell.First>
+          {value.secondLine && (
+            <TwoRowCell.Second>{value.secondLine}</TwoRowCell.Second>
+          )}
+        </TwoRowCell>
+      )
+    },
+  }),
+  columnHelper.display({
+    id: 'upgrader',
+    header: 'Upgrader',
+    cell: (ctx) => {
+      const value = ctx.row.original.mainPermissions?.upgrader
       if (!value) {
         return <NoDataBadge />
       }

--- a/packages/frontend/src/server/features/scaling/summary/get-scaling-summary-entries.ts
+++ b/packages/frontend/src/server/features/scaling/summary/get-scaling-summary-entries.ts
@@ -100,8 +100,7 @@ function getScalingSummaryEntry(
       hasImplementationChanged,
     }),
     dataAvailability: project.dataAvailability,
-    proposer: project.display.proposer,
-    challenger: project.display.challenger,
+    mainPermissions: project.display.mainPermissions,
     tvl: {
       breakdown: latestTvl?.breakdown,
       change: latestTvl?.change,


### PR DESCRIPTION
This pull request adds the `mainPermissions` field to the display object of Other category projects in the codebase. Previously, only the `proposer` and `challenger` fields were present, but now the `upgrader` field has been added as well. This change ensures that all necessary details are available for Other category projects.