### PR TITLE
Do not link Eigen's `usedIn` dynamically

### DIFF
--- a/packages/config/src/projects/other/da-beat/dac/eigenDA.ts
+++ b/packages/config/src/projects/other/da-beat/dac/eigenDA.ts
@@ -3,7 +3,6 @@ import { donatuz } from '../../../layer3s/donatuz'
 import { NO_BRIDGE } from '../templates/no-bridge-template'
 import { DaEconomicSecurityRisk, DaFraudDetectionRisk } from '../types'
 import { DaLayer } from '../types/DaLayer'
-import { linkByDA } from '../utils/link-by-da'
 import { toUsedInProject } from '../utils/to-used-in-project'
 import { eigenDAbridge } from './bridges/eigenDABridge'
 
@@ -83,9 +82,7 @@ export const eigenDA: DaLayer = {
     }),
     eigenDAbridge,
   ],
-  usedIn: linkByDA({
-    layer: (layer) => layer === 'EigenDA',
-  }),
+  usedIn: [...toUsedInProject([donatuz])],
   risks: {
     economicSecurity: DaEconomicSecurityRisk.OnChainNotSlashable('EIGEN'),
     fraudDetection: DaFraudDetectionRisk.NoFraudDetection,


### PR DESCRIPTION
Fixes usedBy: nobody in the da-layer header on detailed page (not a single project has EigenDA specified, no-bridge have donatuz linked explicitly)

Resoves L2B-8105