### PR TITLE
Fix dydx exit window

### DIFF
--- a/packages/config/src/projects/layer2s/dydx.ts
+++ b/packages/config/src/projects/layer2s/dydx.ts
@@ -206,16 +206,14 @@ export const dydx: Layer2 = {
       ],
     },
     exitWindow: {
-      ...RISK_VIEW.EXIT_WINDOW(maxPriorityDelay, freezeGracePeriod, {
+      ...RISK_VIEW.EXIT_WINDOW(maxPriorityDelay, 0, {
         upgradeDelay2: minPriorityDelay,
       }),
-      description: `There is no exit window. Upgrades have a ${formatSeconds(
+      description: `There is a ${formatSeconds(
         maxPriorityDelay,
-      )} delay, (or ${formatSeconds(
+      )} exit window (or ${formatSeconds(
         minPriorityDelay,
-      )} if shortened by the Priority Controller), but withdrawals can be censored for up to ${formatSeconds(
-        freezeGracePeriod,
-      )}.`,
+      )} if shortened by the Priority Controller).`,
     },
     sequencerFailure: {
       ...RISK_VIEW.SEQUENCER_FORCE_VIA_L1_STARKEX_PERPETUAL(freezeGracePeriod),

--- a/packages/config/src/projects/layer2s/dydx.ts
+++ b/packages/config/src/projects/layer2s/dydx.ts
@@ -206,9 +206,7 @@ export const dydx: Layer2 = {
       ],
     },
     exitWindow: {
-      ...RISK_VIEW.EXIT_WINDOW(maxPriorityDelay, 0, {
-        upgradeDelay2: minPriorityDelay,
-      }),
+      ...RISK_VIEW.EXIT_WINDOW(maxPriorityDelay, 0),
       description: `There is a ${formatSeconds(
         maxPriorityDelay,
       )} exit window (or ${formatSeconds(

--- a/packages/config/src/test/snapshots/dydx.riskView.snapshot
+++ b/packages/config/src/test/snapshots/dydx.riskView.snapshot
@@ -21,10 +21,10 @@
     value: "Canonical"
   }
   exitWindow: {
-    definingMetric: 172800
+    definingMetric: 777600
     description: "There is a 9d exit window (or 2d if shortened by the Priority Controller)."
     secondLine: undefined
-    sentiment: "bad"
+    sentiment: "warning"
     value: "9d"
   }
   proposerFailure: {

--- a/packages/config/src/test/snapshots/dydx.riskView.snapshot
+++ b/packages/config/src/test/snapshots/dydx.riskView.snapshot
@@ -21,11 +21,11 @@
     value: "Canonical"
   }
   exitWindow: {
-    definingMetric: -432000
-    description: "There is no exit window. Upgrades have a 9d delay, (or 2d if shortened by the Priority Controller), but withdrawals can be censored for up to 14d."
+    definingMetric: 172800
+    description: "There is a 9d exit window (or 2d if shortened by the Priority Controller)."
     secondLine: undefined
     sentiment: "bad"
-    value: "None"
+    value: "9d"
   }
   proposerFailure: {
     definingMetric: Infinity


### PR DESCRIPTION
9d exit unless shortened by priority controller (2d)
yellow slice