### PR TITLE
Discovery UI: stick the preview filter to the top

### DIFF
--- a/packages/protocolbeat/src/panel-preview/PreviewPanel.tsx
+++ b/packages/protocolbeat/src/panel-preview/PreviewPanel.tsx
@@ -31,20 +31,24 @@ export function PreviewPanel() {
 
   return (
     <div className="flex h-full w-full select-none flex-col text-sm">
-      <OptionsPanel
-        showOnlySelected={showOnlySelected}
-        setShowOnlySelected={setShowOnlySelected}
-      />
-      <PermissionsPreview
-        permissionsPerChain={response.permissionsPerChain}
-        selectedAddress={selectedAddress}
-        showOnlySelected={showOnlySelected}
-      />
-      <ContractsPreview
-        contractsPerChain={response.contractsPerChain}
-        selectedAddress={selectedAddress}
-        showOnlySelected={showOnlySelected}
-      />
+      <div className="sticky top-0 z-10">
+        <OptionsPanel
+          showOnlySelected={showOnlySelected}
+          setShowOnlySelected={setShowOnlySelected}
+        />
+      </div>
+      <div className="overflow-auto">
+        <PermissionsPreview
+          permissionsPerChain={response.permissionsPerChain}
+          selectedAddress={selectedAddress}
+          showOnlySelected={showOnlySelected}
+        />
+        <ContractsPreview
+          contractsPerChain={response.contractsPerChain}
+          selectedAddress={selectedAddress}
+          showOnlySelected={showOnlySelected}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
The "Show only selected address" should be always visible:

![image](https://github.com/user-attachments/assets/e59c10d8-3571-4b5f-9aa9-0c08f8630c2f)
