### PR TITLE
Discovery UI: indent values for better visibility

### DIFF
--- a/packages/protocolbeat/src/panel-values/Field.tsx
+++ b/packages/protocolbeat/src/panel-values/Field.tsx
@@ -25,7 +25,7 @@ export function FieldDisplay({ field }: FieldDisplayProps) {
           {field.description}
         </div>
       )}
-      <div className="overflow-x-auto bg-coffee-900 px-5 py-0.5">
+      <div className="overflow-x-auto bg-coffee-900 px-10 py-0.5">
         <FieldValueDisplay topLevel value={field.value} />
       </div>
     </li>


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/2cd88add-649d-4ea2-b95a-2c8143ff3257)

after:
![image](https://github.com/user-attachments/assets/4d5c63e6-0fe6-4084-a07e-3dffe6e2b31d)