### PR TITLE
Protect infa against invalidation

### DIFF
--- a/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.test.ts
+++ b/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.test.ts
@@ -58,7 +58,7 @@ describe(BlockTargetIndexer.name, () => {
       ).toHaveBeenNthCalledWith(1, LAST_HOUR)
     })
 
-    it('throws when fetch block number is smaller', async () => {
+    it('throws when fetched block number is smaller than previously fetched', async () => {
       const clock = mockObject<Clock>({
         getLastHour: () => LAST_HOUR,
       })

--- a/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.ts
+++ b/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.ts
@@ -1,6 +1,5 @@
-import { assert } from 'console'
 import { Logger } from '@l2beat/backend-tools'
-import { ProjectId } from '@l2beat/shared-pure'
+import { assert, ProjectId } from '@l2beat/shared-pure'
 import { Indexer, RootIndexer } from '@l2beat/uif'
 import { Clock } from '../../../tools/Clock'
 import { BlockTimestampProvider } from '../../tvl/services/BlockTimestampProvider'

--- a/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.ts
+++ b/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.ts
@@ -5,6 +5,9 @@ import { Clock } from '../../../tools/Clock'
 import { BlockTimestampProvider } from '../../tvl/services/BlockTimestampProvider'
 
 export class BlockTargetIndexer extends RootIndexer {
+  // used only for runtime invalidation protection
+  blockHeight = 0
+
   constructor(
     logger: Logger,
     private readonly clock: Clock,
@@ -35,9 +38,11 @@ export class BlockTargetIndexer extends RootIndexer {
       await this.blockTimestampProvider.getBlockNumberAtOrBefore(timestamp)
 
     assert(
-      blockNumber >= this.safeHeight,
+      blockNumber >= this.blockHeight,
       `Block number cannot be smaller: ${blockNumber}`,
     )
+
+    this.blockHeight = blockNumber
     return blockNumber
   }
 }

--- a/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.ts
+++ b/packages/backend/src/modules/activity/indexers/BlockTargetIndexer.ts
@@ -1,3 +1,4 @@
+import { assert } from 'console'
 import { Logger } from '@l2beat/backend-tools'
 import { ProjectId } from '@l2beat/shared-pure'
 import { Indexer, RootIndexer } from '@l2beat/uif'
@@ -34,6 +35,10 @@ export class BlockTargetIndexer extends RootIndexer {
     const blockNumber =
       await this.blockTimestampProvider.getBlockNumberAtOrBefore(timestamp)
 
+    assert(
+      blockNumber >= this.safeHeight,
+      `Block number cannot be smaller: ${blockNumber}`,
+    )
     return blockNumber
   }
 }

--- a/packages/backend/src/modules/tvl/indexers/BlockTimestampIndexer.test.ts
+++ b/packages/backend/src/modules/tvl/indexers/BlockTimestampIndexer.test.ts
@@ -60,6 +60,42 @@ describe(BlockTimestampIndexer.name, () => {
       expect(newSafeHeight).toEqual(timestampToSync.toNumber())
     })
 
+    it('throws when fetched block number is smaller than previously fetched', async () => {
+      const from = 100
+      const to = 300
+      const timestampToSync = new UnixTime(200)
+      const syncOptimizer = mockObject<SyncOptimizer>({
+        getTimestampToSync: mockFn().returns(timestampToSync),
+      })
+
+      const BLOCK_NUMBER = 123
+      const blockTimestampProvider = mockObject<BlockTimestampProvider>({
+        getBlockNumberAtOrBefore: mockFn()
+          .returnsOnce(123)
+          .returnsOnce(BLOCK_NUMBER - 1),
+      })
+      const blockTimestampRepository = mockObject<Database['blockTimestamp']>({
+        insert: async () => undefined,
+      })
+
+      const chain = 'ethereum'
+      const indexer = new BlockTimestampIndexer({
+        logger: Logger.SILENT,
+        parents: [],
+        blockTimestampProvider,
+        indexerService: mockObject<IndexerService>({}),
+        db: mockDatabase({ blockTimestamp: blockTimestampRepository }),
+        chain,
+        minHeight: 0,
+        syncOptimizer,
+      })
+
+      await indexer.update(from, to)
+      await expect(async () => await indexer.update(from, to)).toBeRejectedWith(
+        'Block number cannot be smaller',
+      )
+    })
+
     it('returns if optimized timestamp is later than to', async () => {
       const from = 100
       const to = 300

--- a/packages/backend/src/modules/tvl/indexers/BlockTimestampIndexer.ts
+++ b/packages/backend/src/modules/tvl/indexers/BlockTimestampIndexer.ts
@@ -1,10 +1,12 @@
 import {} from '@l2beat/shared'
-import { UnixTime } from '@l2beat/shared-pure'
+import { assert, UnixTime } from '@l2beat/shared-pure'
 import { Indexer } from '@l2beat/uif'
 import { ManagedChildIndexer } from '../../../tools/uif/ManagedChildIndexer'
 import { BlockTimestampIndexerDeps } from './types'
 
 export class BlockTimestampIndexer extends ManagedChildIndexer {
+  blockHeight = 0
+
   constructor(private readonly $: BlockTimestampIndexerDeps) {
     super({
       ...$,
@@ -37,6 +39,11 @@ export class BlockTimestampIndexer extends ManagedChildIndexer {
       blockNumber,
     })
 
+    assert(
+      blockNumber >= this.blockHeight,
+      `Block number cannot be smaller: ${blockNumber}`,
+    )
+
     await this.$.db.blockTimestamp.insert({
       chain: this.$.chain,
       timestamp,
@@ -48,6 +55,7 @@ export class BlockTimestampIndexer extends ManagedChildIndexer {
       blockNumber,
     })
 
+    this.blockHeight = blockNumber
     return timestamp.toNumber()
   }
 

--- a/packages/backend/src/modules/tvl/indexers/BlockTimestampIndexer.ts
+++ b/packages/backend/src/modules/tvl/indexers/BlockTimestampIndexer.ts
@@ -1,10 +1,10 @@
-import {} from '@l2beat/shared'
 import { assert, UnixTime } from '@l2beat/shared-pure'
 import { Indexer } from '@l2beat/uif'
 import { ManagedChildIndexer } from '../../../tools/uif/ManagedChildIndexer'
 import { BlockTimestampIndexerDeps } from './types'
 
 export class BlockTimestampIndexer extends ManagedChildIndexer {
+  // used only for runtime invalidation protection
   blockHeight = 0
 
   constructor(private readonly $: BlockTimestampIndexerDeps) {

--- a/packages/backend/src/tools/uif/IndexerService.ts
+++ b/packages/backend/src/tools/uif/IndexerService.ts
@@ -1,5 +1,4 @@
 import { Database, IndexerStateRecord } from '@l2beat/database'
-import {} from '@l2beat/shared-pure'
 import { Configuration, SavedConfiguration } from './multi/types'
 
 export class IndexerService {

--- a/packages/shared/src/clients/rpc/RpcClient2.ts
+++ b/packages/shared/src/clients/rpc/RpcClient2.ts
@@ -40,6 +40,10 @@ export class RpcClient2 extends ClientCore implements BlockClient {
 
     const block = EVMBlockResponse.safeParse(blockResponse)
     if (!block.success) {
+      this.$.logger.warn(`Invalid response`, {
+        blockNumber,
+        response: JSON.stringify(blockResponse),
+      })
       throw new Error(`Block ${blockNumber}: Error during parsing`)
     }
     return { ...block.data.result }
@@ -56,10 +60,11 @@ export class RpcClient2 extends ClientCore implements BlockClient {
 
     const balance = EVMBalanceResponse.safeParse(balanceResponse)
     if (!balance.success) {
-      this.$.logger.warn(
-        `Cannot fetch ${holder} at block ${blockNumber}`,
-        JSON.stringify(balanceResponse),
-      )
+      this.$.logger.warn(`Invalid response`, {
+        blockNumber,
+        holder,
+        response: JSON.stringify(balanceResponse),
+      })
       throw new Error(
         `Balance of ${holder} at block ${blockNumber}: Error during parsing`,
       )

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -10,7 +10,9 @@ export class BlockProvider {
   async getBlockWithTransactions(x: number): Promise<Block> {
     for (const [index, client] of this.clients.entries()) {
       try {
-        return await client.getBlockWithTransactions(x)
+        const block = await client.getBlockWithTransactions(x)
+        assert(block.number === x, `Invalid response ${JSON.stringify(block)}`)
+        return block
       } catch (error) {
         if (index === this.clients.length - 1) throw error
       }

--- a/packages/uops-dashboard/src/server/clients/code/RpcCodeClient.ts
+++ b/packages/uops-dashboard/src/server/clients/code/RpcCodeClient.ts
@@ -1,5 +1,4 @@
 import { createHash } from 'crypto'
-import {} from '@l2beat/shared'
 import { providers } from 'ethers'
 import { Chain } from '../../../chains'
 import { getApiUrl } from '../apiUrls'

--- a/packages/uops-dashboard/src/server/clients/contract/ScanClient.ts
+++ b/packages/uops-dashboard/src/server/clients/contract/ScanClient.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod'
-import {} from '../apiUrls'
 import type { ContractClient } from './ContractClient'
 
 const Response = z.object({


### PR DESCRIPTION
This issue aims to prevent issue we had with xlayer activity. RPC started returning block number `0` for all `eth_getBlockByNumber` without any error in HTTP or body.  It resulted in "tick 0" from BlockTargetIndexer, which as a parent of BlockActivityIndexer changed it height to 0 and triggered its invalidation - all activity records for xlayer got removed ;c

We will prevent such issues in TVL and Activity with simple asserts in Provider and Indexer. While the systematic solution in UIF is possible, it is not worth the effort at the moment.

![image](https://github.com/user-attachments/assets/e79dda54-cb25-4f8f-aff8-1ae853ef5c75)


Food for thought for later: Maybe we can split invalidation action into two "InitialInvalidation" and "RuntimeInvalidation". Maybe disabling RuntimeInvalidation would also resolve the issue above. What is worth adding is that we would need to somehow pass from parent to child that this invalidation is initial not runtime. Maybe simple entry in the state would be sufficient.

Resolves L2B-8044