### PR TITLE
TVL for Taiko, add SolvBTC

### DIFF
--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -4586,6 +4586,12 @@
       "supply": "totalSupply",
       "excludeFromTotal": true,
       "coingeckoId": "tether"
+    },
+    {
+      "symbol": "solvBTC",
+      "address": "0x541fd749419ca806a8bc7da8ac23d346f2df8b77",
+      "source": "native",
+      "supply": "totalSupply"
     }
   ],
   "rari": [

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -4554,6 +4554,12 @@
   ],
   "taiko": [
     {
+      "symbol": "solvBTC",
+      "address": "0x541fd749419ca806a8bc7da8ac23d346f2df8b77",
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "symbol": "USDC.e",
       "address": "0x19e26B0638bf63aa9fa4d14c6baF8D52eBE86C5C",
       "source": "external",
@@ -4586,12 +4592,6 @@
       "supply": "totalSupply",
       "excludeFromTotal": true,
       "coingeckoId": "tether"
-    },
-    {
-      "symbol": "solvBTC",
-      "address": "0x541fd749419ca806a8bc7da8ac23d346f2df8b77",
-      "source": "native",
-      "supply": "totalSupply"
     }
   ],
   "rari": [


### PR DESCRIPTION
We noticed that the TVL for Taiko is off by a factor of approximately 2x because the token SolvBTC is not being tracked.

I’ve added it as natively minted on Taiko. However, there also appears to be a bridged version with around $9M in TVL, which I’m unsure how to add. (Source: [Avalon Finance](https://app.avalonfinance.xyz/?marketName=proto_taiko_v3))

I hope we can get this in, so the TVL is more accurate. Thanks!