### PR TITLE
Quick fix for finality analyzer

### DIFF
--- a/packages/backend/src/modules/finality/analyzers/arbitrum/ArbitrumT2IAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/arbitrum/ArbitrumT2IAnalyzer.ts
@@ -35,6 +35,9 @@ export class ArbitrumT2IAnalyzer extends BaseAnalyzer {
     this.logger.debug('Getting finality', { transaction })
     // get blobs relevant to the transaction
     const { blobs } = await this.blobClient.getRelevantBlobs(transaction.txHash)
+    if (blobs.length === 0) {
+      return []
+    }
 
     const segments = getSegments(blobs)
     // https://linear.app/l2beat/issue/L2B-4752/refactor-finalityindexer-logic-to-allow-analyzers-different

--- a/packages/backend/src/modules/finality/analyzers/opStack/OpStackT2IAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/opStack/OpStackT2IAnalyzer.ts
@@ -45,6 +45,9 @@ export class OpStackT2IAnalyzer extends BaseAnalyzer {
       const { blobs, blockNumber } = await this.blobClient.getRelevantBlobs(
         transaction.txHash,
       )
+      if (blobs.length === 0) {
+        return []
+      }
       const rollupData = getRollupData(blobs)
       const frames = rollupData.map((ru) => getFrames(ru))
       const channel = this.channelBank.addFramesToChannel(frames, blockNumber)


### PR DESCRIPTION
Currently OPStack and Arbitrum finality analyzers work only for blob txs. For every tx they expect `blobVersionedHashes` array. The problem is that, blob price currently goes up and projects switched back for calldata for a while, and because of that zod schema was throwing an error (there is no blobs for those txs). This PR adds a quick fix of skipping txs of type 2 (there were only few of them last day, so it should not mess the result of our calculation). I will add logic to also decode type 2 txs in the future PR.