### PR TITLE
Specify content type for near stake fetch call

### DIFF
--- a/packages/backend/src/modules/da-beat/stake-analyzers/NearStakeAnalyzer.ts
+++ b/packages/backend/src/modules/da-beat/stake-analyzers/NearStakeAnalyzer.ts
@@ -20,8 +20,12 @@ export class NearStakeAnalyzer extends AbstractStakeAnalyzer {
 
     const res = await this.client.fetch(this.url, {
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify(body),
     })
+
     const json = await res.json()
     const validators = ValidatorsList.parse(json)
 


### PR DESCRIPTION
Resolves L2B-8341

Content type header is now enforced, that's why it was failing with `Content type mismatch` error.
With it in place it works like a charm.

![image](https://github.com/user-attachments/assets/ee31c4c9-e79b-4aa9-badd-50065bf44510)
