### PR TITLE
Starknet uses compressed state diffs for DA

### DIFF
--- a/packages/config/src/projects/layer2s/starknet.ts
+++ b/packages/config/src/projects/layer2s/starknet.ts
@@ -752,7 +752,7 @@ export const starknet: Layer2 = {
     addSentimentToDataAvailability({
       layers: [DA_LAYERS.ETH_BLOBS_OR_CALLLDATA],
       bridge: DA_BRIDGES.ENSHRINED,
-      mode: DA_MODES.STATE_DIFFS,
+      mode: DA_MODES.STATE_DIFFS_COMPRESSED,
     }),
   ],
   riskView: {


### PR DESCRIPTION
requested via telegram

the last update introduced compression, see link in diffhistory