### PR TITLE
New tokens (base and arbitrum)

### DIFF
--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -7043,6 +7043,20 @@
       "supply": "circulatingSupply"
     },
     {
+      "name": "aixbt by Virtuals",
+      "coingeckoId": "aixbt",
+      "address": "0x4F9Fd6Be4a90f2620860d680c0d4d5Fb53d1A825",
+      "symbol": "AIXBT",
+      "decimals": 18,
+      "deploymentTimestamp": 1730525195,
+      "coingeckoListingTimestamp": 1731974400,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/51784/large/3.png?1731981138",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "Base God",
       "coingeckoId": "base-god",
       "address": "0x0d97F261b1e88845184f678e2d1e7a98D9FD38dE",
@@ -7154,6 +7168,20 @@
       "supply": "circulatingSupply"
     },
     {
+      "name": "GAME by Virtuals",
+      "coingeckoId": "game-by-virtuals",
+      "address": "0x1C4CcA7C5DB003824208aDDA61Bd749e55F463a3",
+      "symbol": "GAME",
+      "decimals": 18,
+      "deploymentTimestamp": 1727091731,
+      "coingeckoListingTimestamp": 1729900800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/51063/large/Gaming_Agent_1fe70d54ba.jpg?1729925539",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "KelpDao Restaked ETH",
       "coingeckoId": "kelp-dao-restaked-eth",
       "address": "0x1Bc71130A0e39942a7658878169764Bbd8A45993",
@@ -7212,6 +7240,20 @@
       }
     },
     {
+      "name": "Luna by Virtuals",
+      "coingeckoId": "luna-by-virtuals",
+      "address": "0x55cD6469F597452B5A7536e2CD98fDE4c1247ee4",
+      "symbol": "LUNA",
+      "decimals": 18,
+      "deploymentTimestamp": 1729083587,
+      "coingeckoListingTimestamp": 1729382400,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/50880/large/luna.png?1729478763",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "Mister Miggles",
       "coingeckoId": "mister-miggles",
       "address": "0xB1a03EdA10342529bBF8EB700a06C60441fEf25d",
@@ -7240,6 +7282,20 @@
       "supply": "circulatingSupply"
     },
     {
+      "name": "Prefrontal Cortex Convo Agent by Virtuals",
+      "coingeckoId": "prefrontal-cortex-convo-agent-by-virtuals",
+      "address": "0xab964f7b7b6391bd6c4e8512eF00d01f255d9c0D",
+      "symbol": "CONVO",
+      "decimals": 18,
+      "deploymentTimestamp": 1727766735,
+      "coingeckoListingTimestamp": 1729900800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/51064/large/Convo_Agent_89ef084f87.jpg?1729926154",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "Renzo Restaked ETH",
       "coingeckoId": "renzo-restaked-eth",
       "address": "0x2416092f143378750bb29b79eD961ab195CcEea5",
@@ -7262,6 +7318,20 @@
       }
     },
     {
+      "name": "Satoshi AI agent by Virtuals",
+      "coingeckoId": "satoshi-ai-agent-by-virtuals",
+      "address": "0x7588880d9c78E81FAde7b7e8DC0781E95995a792",
+      "symbol": "SAINT",
+      "decimals": 18,
+      "deploymentTimestamp": 1731433813,
+      "coingeckoListingTimestamp": 1733097600,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/52336/large/saint.jpg?1733121865",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "Seamless",
       "coingeckoId": "seamless-protocol",
       "address": "0x1C7a460413dD4e964f96D8dFC56E7223cE88CD85",
@@ -7274,6 +7344,20 @@
       "chainId": 8453,
       "source": "native",
       "supply": "circulatingSupply"
+    },
+    {
+      "name": "sekoia by Virtuals",
+      "coingeckoId": "sekoia-by-virtuals",
+      "address": "0x1185cB5122Edad199BdBC0cbd7a0457E448f23c7",
+      "symbol": "SEKOIA",
+      "decimals": 18,
+      "deploymentTimestamp": 1730057321,
+      "coingeckoListingTimestamp": 1731974400,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/51785/large/sekoia.jpg?1731982234",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
     },
     {
       "name": "SmarDex",
@@ -7356,6 +7440,20 @@
       "supply": "circulatingSupply"
     },
     {
+      "name": "tokenbot",
+      "coingeckoId": "tokenbot-2",
+      "address": "0x1bc0c42215582d5A085795f4baDbaC3ff36d1Bcb",
+      "symbol": "CLANKER",
+      "decimals": 18,
+      "deploymentTimestamp": 1731098613,
+      "coingeckoListingTimestamp": 1731196800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/51440/large/CLANKER.png?1731232869",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "Toshi",
       "coingeckoId": "toshi",
       "address": "0xAC1Bd2486aAf3B5C0fc3Fd868558b082a531B2B4",
@@ -7393,6 +7491,20 @@
       "coingeckoListingTimestamp": 1573689600,
       "category": "stablecoin",
       "iconUrl": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694",
+      "chainId": 8453,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
+      "name": "VaderAI by Virtuals",
+      "coingeckoId": "vaderai-by-virtuals",
+      "address": "0x731814e491571A2e9eE3c5b1F7f3b962eE8f4870",
+      "symbol": "VADER",
+      "decimals": 18,
+      "deploymentTimestamp": 1730489361,
+      "coingeckoListingTimestamp": 1732147200,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/51910/large/kare_pepe.png?1733345833",
       "chainId": 8453,
       "source": "native",
       "supply": "totalSupply"

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -8755,6 +8755,27 @@
       "supply": "zero"
     },
     {
+      "name": "TIA",
+      "coingeckoId": "bridged-tia-hyperlane",
+      "address": "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C",
+      "symbol": "TIA.n",
+      "decimals": 6,
+      "deploymentTimestamp": 1699036426,
+      "coingeckoListingTimestamp": 1707004800,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/33199/large/tia.n.png?1701047832",
+      "chainId": 42161,
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Hyperlane (NTT)"
+          }
+        ]
+      }
+    },
+    {
       "name": "Umami",
       "coingeckoId": "umami-finance",
       "address": "0x1622bF67e6e5747b81866fE0b85178a93C7F86e3",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1721,7 +1721,7 @@
       "bridgedUsing": {
         "bridges": [
           {
-            "name": "Hyperlane (NTT)",
+            "name": "Hyperlane (NTT)"
           }
         ]
       }

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -1714,6 +1714,19 @@
   ],
   "arbitrum": [
     {
+      "symbol": "TIA.n",
+      "address": "0xD56734d7f9979dD94FAE3d67C7e928234e71cD4C",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Hyperlane (NTT)",
+          }
+        ]
+      }
+    },
+    {
       "symbol": "SOL",
       "address": "0x2bcC6D6CdBbDC0a4071e48bb3B969b06B3330c07",
       "coingeckoId": "solana",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -2733,6 +2733,54 @@
   ],
   "base": [
     {
+      "symbol": "CLANKER",
+      "address": "0x1bc0c42215582d5A085795f4baDbaC3ff36d1Bcb",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
+      "symbol": "SAINT",
+      "address": "0x7588880d9c78E81FAde7b7e8DC0781E95995a792",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
+      "symbol": "SEKOIA",
+      "address": "0x1185cB5122Edad199BdBC0cbd7a0457E448f23c7",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
+      "symbol": "VADER",
+      "address": "0x731814e491571A2e9eE3c5b1F7f3b962eE8f4870",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
+      "symbol": "CONVO",
+      "address": "0xab964f7b7b6391bd6c4e8512eF00d01f255d9c0D",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
+      "symbol": "GAME",
+      "address": "0x1C4CcA7C5DB003824208aDDA61Bd749e55F463a3",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
+      "symbol": "LUNA",
+      "address": "0x55cD6469F597452B5A7536e2CD98fDE4c1247ee4",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
+      "symbol": "AIXBT",
+      "address": "0x4F9Fd6Be4a90f2620860d680c0d4d5Fb53d1A825",
+      "source": "native",
+      "supply": "totalSupply" // virtuals tokens are fully circulating
+    },
+    {
       "symbol": "UP",
       "address": "0xaC27fa800955849d6D17cC8952Ba9dD6EAA66187",
       "source": "native",


### PR DESCRIPTION
Closes L2B-8380, L2B-8389, L2B-8388

USDx by Synthetix not added [because it is backed by TVL that we count (on arbitrum)](https://docs.synthetix.io/synthetix-v3-user-documentation/liquidity-providers-aka-staking/providing-liquidity-and-earning-rewards/providing-liquidity-on-arbitrum/usdx-the-synthetix-native-stablecoin-on-arbitrum)