### PR TITLE
Add light monitoring for L2BEAT in OP SC

### DIFF
--- a/packages/backend/discovery/optimism/ethereum/config.jsonc
+++ b/packages/backend/discovery/optimism/ethereum/config.jsonc
@@ -41,7 +41,8 @@
     "0x09f7150D8c019BeF34450d6920f6B3608ceFdAf2": "GuardianMultisig",
     "0x0454092516c9A4d636d3CAfA1e82161376C8a748": "LivenessModule",
     "0x82511d494B5C942BE57498a70Fdd7184Ee33B975": "DelayedWETH_PermissionlessGames",
-    "0x9F9b897e37de5052cD70Db6D08474550DDb07f39": "DelayedWETH_PermissionedGames"
+    "0x9F9b897e37de5052cD70Db6D08474550DDb07f39": "DelayedWETH_PermissionedGames",
+    "0x24424336F04440b1c28685a38303aC33C9D14a25": "LivenessGuard"
   },
   "types": {
     "DisputeGameMap": {
@@ -53,6 +54,30 @@
     }
   },
   "overrides": {
+    "SecurityCouncilMultisig": {
+      "fields": {
+        "isL2beatStillAnOwner": {
+          "handler": {
+            "type": "call",
+            "method": "isOwner",
+            "args": ["0x4A7322258c9E690e4CB8Cea6e5251443E956e61E"] // our address in the Security Council
+          }
+        }
+      }
+    },
+    "LivenessGuard": {
+      "ignoreInWatchMode": ["timeSinceLastL2beatInteraction"],
+      "fields": {
+        "timeSinceLastL2beatInteraction": {
+          "handler": {
+            "type": "call",
+            "method": "lastLive",
+            "args": ["0x4A7322258c9E690e4CB8Cea6e5251443E956e61E"] // our address in the Security Council
+          },
+          "returnType": "(TimeSince)"
+        }
+      }
+    },
     "SynthetixBridgeEscrow": {
       "ignoreRelatives": ["owner"]
     },

--- a/packages/backend/discovery/optimism/ethereum/diffHistory.md
+++ b/packages/backend/discovery/optimism/ethereum/diffHistory.md
@@ -1,3 +1,29 @@
+Generated with discovered.json: 0xbe6d1bd6cdf06c3266e47df316adae1127543239
+
+# Diff at Fri, 06 Dec 2024 21:11:41 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@59fd7a30471906b5a479f280731621e94e22f17c block: 21235656
+- current block number: 21346059
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 21235656 (main branch discovery), not current.
+
+```diff
+    contract SecurityCouncilMultisig (0xc2819DC788505Aac350142A7A707BF9D03E3Bd03) {
+    +++ description: None
+      values.isL2beatStillAnOwner:
++        true
+    }
+```
+
 Generated with discovered.json: 0x6074bd9f8045463b77dc64eb7ce10714e5f3774e
 
 # Diff at Tue, 19 Nov 2024 13:44:31 GMT:

--- a/packages/backend/discovery/optimism/ethereum/discovered.json
+++ b/packages/backend/discovery/optimism/ethereum/discovered.json
@@ -1,8 +1,8 @@
 {
   "name": "optimism",
   "chain": "ethereum",
-  "blockNumber": 21235656,
-  "configHash": "0x2ff32b5168c8625f92877c791409a8507330aa9fa5d96929bda8eadb1045c041",
+  "blockNumber": 21346059,
+  "configHash": "0x30877bf308df894e9de519c655ff0ebcd6fbcc16cd1f8ddb0ec6f96af8dac005",
   "contracts": [
     {
       "name": "LivenessModule",
@@ -327,12 +327,15 @@
       "sourceHashes": [
         "0xe771f3d1c51456e08e2c93a904b12010870dc4fa79ee82e4bc90433557931f05"
       ],
+      "ignoreInWatchMode": ["timeSinceLastL2beatInteraction"],
       "sinceTimestamp": 1717149791,
       "values": {
         "$immutable": true,
         "safe": "0xc2819DC788505Aac350142A7A707BF9D03E3Bd03",
+        "timeSinceLastL2beatInteraction": "1h 23m",
         "version": "1.0.0"
-      }
+      },
+      "derivedName": "LivenessGuard"
     },
     {
       "name": "L1CrossDomainMessenger",
@@ -404,7 +407,7 @@
         ],
         "$upgradeCount": 10,
         "MESSAGE_VERSION": 1,
-        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292765416",
+        "messageNonce": "1766847064778384329583297500742918515827483896875618958121606201292768155",
         "MIN_GAS_CALLDATA_OVERHEAD": 16,
         "MIN_GAS_DYNAMIC_OVERHEAD_DENOMINATOR": 63,
         "MIN_GAS_DYNAMIC_OVERHEAD_NUMERATOR": 64,
@@ -889,7 +892,7 @@
         "name": "Wrapped Ether",
         "owner": "0x5a0Aae59D09fccBdDb6C6CcEB07B7279367C3d2A",
         "symbol": "WETH",
-        "totalSupply": "20415188000000000000",
+        "totalSupply": "20335188000000000000",
         "version": "1.1.0"
       },
       "derivedName": "DelayedWETH"
@@ -1319,7 +1322,7 @@
         "params": {
           "prevBaseFee": 1000000000,
           "prevBoughtGas": 440516,
-          "prevBlockNum": 21235520
+          "prevBlockNum": 21346043
         },
         "paused": false,
         "proofMaturityDelaySeconds": 604800,
@@ -1384,6 +1387,7 @@
         "domainSeparator": "0xdf53d510b56e539b90b369ef08fce3631020fbf921e3136ea5f8747c20bce967",
         "getChainId": 1,
         "GnosisSafe_modules": ["0x0454092516c9A4d636d3CAfA1e82161376C8a748"],
+        "isL2beatStillAnOwner": true,
         "multisigThreshold": "10 of 13 (77%)",
         "nonce": 8,
         "VERSION": "1.3.0"
@@ -1478,7 +1482,7 @@
           ]
         ],
         "$upgradeCount": 1,
-        "gameCount": 3948,
+        "gameCount": 4316,
         "gameImpls": [
           "0xA6f3DFdbf4855a43c529bc42EDE96797252879af",
           "0x050ed6F6273c7D836a111E42153BC00D0380b87d",

--- a/packages/discovery/src/discovery/type-casters/TimeSince.ts
+++ b/packages/discovery/src/discovery/type-casters/TimeSince.ts
@@ -1,7 +1,7 @@
 import { ContractValue } from '@l2beat/discovery-types'
 import { assert } from '@l2beat/shared-pure'
-import { ArgType } from './BaseTypeCaster'
 import { formatSeconds } from '@l2beat/shared-pure'
+import { ArgType } from './BaseTypeCaster'
 
 export const TimeSince = {
   cast: function (_arg: ArgType, incomingValue: ContractValue): ContractValue {

--- a/packages/discovery/src/discovery/type-casters/TimeSince.ts
+++ b/packages/discovery/src/discovery/type-casters/TimeSince.ts
@@ -1,0 +1,14 @@
+import { ContractValue } from '@l2beat/discovery-types'
+import { assert } from '@l2beat/shared-pure'
+import { ArgType } from './BaseTypeCaster'
+import { formatSeconds } from '@l2beat/shared-pure'
+
+export const TimeSince = {
+  cast: function (_arg: ArgType, incomingValue: ContractValue): ContractValue {
+    assert(typeof incomingValue === 'number', 'Incoming value must be a number')
+    // TODO: possibly use the block timestamp instead of Date.now()
+    const now = Math.floor(Date.now() / 1000)
+    const diff = now - incomingValue
+    return formatSeconds(diff)
+  },
+}

--- a/packages/discovery/src/discovery/type-casters/index.ts
+++ b/packages/discovery/src/discovery/type-casters/index.ts
@@ -4,6 +4,7 @@ import { ChainPrefix } from './ChainPrefix'
 import { FormatSeconds } from './FormatSeconds'
 import { GreaterThan } from './GreaterThan'
 import { Mapping } from './Mapping'
+import { TimeSince } from './TimeSince'
 import { Undecimal } from './Undecimal'
 
 export const TypeConverters = {
@@ -12,6 +13,7 @@ export const TypeConverters = {
   Mapping,
   ChainPrefix,
   GreaterThan,
+  TimeSince,
 }
 
 export function isCustomTypeCaster(name: string): boolean {


### PR DESCRIPTION
The LivenessModule in the SC works so that an owner gets removed if there is no interaction within 98d. I added some monitoring to find out how long ago the last interaction was with a new `TimeSince` typecaster. It uses the current local time but I think it makes more sense if it were to use the block timestamp of the discovery block