### PR TITLE
Allow to call matchFlat in Discovery UI

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/executeTerminalCommand.ts
+++ b/packages/l2b/src/implementations/discovery-ui/executeTerminalCommand.ts
@@ -7,6 +7,10 @@ function sendSSE(res: Response, data: string) {
 }
 
 export function executeTerminalCommand(command: string, res: Response): void {
+  res.setHeader('Content-Type', 'text/event-stream')
+  res.setHeader('Cache-Control', 'no-cache')
+  res.setHeader('Connection', 'keep-alive')
+
   const proc = spawn(command, {
     shell: true,
     env: {

--- a/packages/protocolbeat/src/api/api.ts
+++ b/packages/protocolbeat/src/api/api.ts
@@ -47,17 +47,28 @@ export async function getPreview(project: string): Promise<ApiPreviewResponse> {
   return data as ApiPreviewResponse
 }
 
-export function executeCommand(
-  command: string,
+export function executeDiscover(
   project: string,
   chain: string,
   devMode: boolean,
 ): EventSource {
   const params = new URLSearchParams({
-    command,
     project,
     chain,
     devMode: devMode.toString(),
   })
-  return new EventSource(`/api/terminal/execute?${params}`)
+  return new EventSource(`/api/terminal/discover?${params}`)
+}
+
+export function executeMatchFlat(
+  project: string,
+  address: string,
+  against: 'templates' | 'projects',
+): EventSource {
+  const params = new URLSearchParams({
+    project,
+    address,
+    against,
+  })
+  return new EventSource(`/api/terminal/match-flat?${params}`)
 }

--- a/packages/shared/src/tools/CliLogger.ts
+++ b/packages/shared/src/tools/CliLogger.ts
@@ -8,6 +8,9 @@ const CLEAR_SCREEN: string = '\x1b[J'
 
 export type StatusLineHandle = string
 
+const getWindowSize: (() => [number, number]) | undefined =
+  process.stdout.getWindowSize
+
 export class CliLogger {
   private readonly REDRAW_DELAY: number = 1000 / 30 // 30fps
   private readonly statusLines: Map<string, string> = new Map()
@@ -16,7 +19,8 @@ export class CliLogger {
   private lastLines: number = 0
   private lastRedraw: number = 0
   private drawTimeoutId?: ReturnType<typeof setTimeout>
-  private termWidth: number = process.stdout.getWindowSize()[0]
+  private termWidth: number =
+    getWindowSize ? process.stdout.getWindowSize()[0] : 80
 
   logLine(input: string) {
     this.logs.push(input + '\n')


### PR DESCRIPTION
It simply runs `l2b match-flat` against tempates or all projects in the terminal and stream the output.

![image](https://github.com/user-attachments/assets/7b25a713-6c75-42ff-bc82-9bf57df8c19f)

![image](https://github.com/user-attachments/assets/3ed8ecf7-bae8-4045-aa97-0ad07f564b76)

The HTML terminal output doesn't support progress bars so in the future this will need to be addressed. 