### PR TITLE
Ethereum stake refresh & better logging

### DIFF
--- a/packages/backend/src/modules/da-beat/DaBeatStakeRefresher.ts
+++ b/packages/backend/src/modules/da-beat/DaBeatStakeRefresher.ts
@@ -4,6 +4,7 @@ import {
   DaEconomicSecurityType,
   DaLayer,
   daLayers,
+  ethereumDaLayer,
 } from '@l2beat/config'
 import { HttpClient } from '@l2beat/shared'
 import { assertUnreachable } from '@l2beat/shared-pure'
@@ -41,6 +42,7 @@ export class DaBeatStakeRefresher {
         ...new Set(
           compact(
             daLayers
+              .concat(ethereumDaLayer)
               .filter(this.isBlockchainDaLayer)
               .map((layer) => layer.economicSecurity?.type),
           ),
@@ -88,9 +90,13 @@ export class DaBeatStakeRefresher {
     )
     this.refreshQueue = new TaskQueue<void>(
       async () => {
-        this.logger.info('Refresh started')
+        this.logger.info('Refresh started', {
+          types: Object.keys(this.analyzers),
+        })
         await this.refresh()
-        this.logger.info('Refresh finished')
+        this.logger.info('Refresh finished', {
+          types: Object.keys(this.analyzers),
+        })
       },
       this.logger.for('refreshQueue'),
       { metricsId: 'DaBeatStakeRefresher' },
@@ -106,14 +112,20 @@ export class DaBeatStakeRefresher {
       Object.entries(this.analyzers).map(async ([type, analyzer]) => {
         try {
           const { totalStake, thresholdStake } = await analyzer.analyze()
-          this.logger.info(`Stake data for ${type} refreshed`)
+          this.logger.info(`Stake data refreshed`, {
+            type,
+            totalStake,
+            thresholdStake,
+          })
           await database.stake.upsert({
             id: type,
             totalStake,
             thresholdStake,
           })
         } catch (e) {
-          this.logger.error(`Failed to refresh stake data for ${type}: ${e}`)
+          this.logger.error(`Failed to refresh stake data: ${e}`, {
+            type,
+          })
         }
       }),
     )


### PR DESCRIPTION
It wasn't enabled since we made ethereum da separate entry.

Now works fine:
<img width="882" alt="image" src="https://github.com/user-attachments/assets/aafbf1d1-8766-4e6b-9941-c714fe36c202">
