### PR TITLE
Fix Typographical Errors

### DIFF
--- a/packages/backend/discovery/kroma/ethereum/README.md
+++ b/packages/backend/discovery/kroma/ethereum/README.md
@@ -18,7 +18,7 @@ against mainnet.
 As per [documentation](https://book.getfoundry.sh/tutorials/solidity-scripting):
 
 > Solidity scripting is a way to declaratively deploy contracts using Solidity,
-> instead of using the more limiting and less user friendly forge create. [...]
+> instead of using the more limiting and less user-friendly forge create. [...]
 > they are run on the fast Foundry EVM backend, which provides dry-run
 > capabilities.
 

--- a/packages/frontend/src/content/publications/governance-review-9.md
+++ b/packages/frontend/src/content/publications/governance-review-9.md
@@ -49,7 +49,7 @@ The [Snapshot vote](https://snapshot.org/#/arbitrumfoundation.eth/proposal/0x57a
 
 Djinn [submitted a proposal for the creation of a Gaming Catalyst Program](https://forum.arbitrum.foundation/t/catalyze-gaming-ecosystem-growth-on-arbitrum/22368) on behalf of the gaming working group. The Gaming Catalyst Program (GCP) is a model to rapidly accelerate Arbitrum’s support for game builders and also strategically allocate resources towards vetted experts to accelerate the onboarding and go-to-market of the best builders in the gaming industry. The proposal asks the DAO to earmark 200m ARB to develop the gaming ecosystem on Arbitrum and establish the network as the top choice for game builders across the landscape.
 
-The funding will be allocated towards the following initiatives throughout a two year period:
+The funding will be allocated towards the following initiatives throughout a two-year period:
 
 1. Builder Onboarding & Growth - 160m ARB
 2. Infrastructure Bounties - 40m ARB

--- a/packages/frontend/src/content/zk-catalog-descriptions/risczero.md
+++ b/packages/frontend/src/content/zk-catalog-descriptions/risczero.md
@@ -6,6 +6,6 @@ RISC Zero allows to prove with ZK the computation of a RISC-V program. The archi
 
 The repo containing the circuits code can be found [here](https://github.com/risc0/risc0/tree/main). The prover implementation can be found [here]('https://github.com/risc0/risc0/blob/main/risc0/zkp/src/prove/prover.rs').
 
-The wrapper uses Groth16 as the proof system, and therefore requires a circuit specific trusted setup. The ceremony can be found [here](https://ceremony.pse.dev/projects/RISC%20Zero%20STARK-to-SNARK%20Prover). An high level guide on how to verify the setup can be found [here](https://www.risczero.com/blog/verifying-risc-zeros-trusted-setup-ceremony), while the full guide can be found [here](https://dev.risczero.com/api/trusted-setup-ceremony).
+The wrapper uses Groth16 as the proof system, and therefore requires a circuit specific trusted setup. The ceremony can be found [here](https://ceremony.pse.dev/projects/RISC%20Zero%20STARK-to-SNARK%20Prover). A high level guide on how to verify the setup can be found [here](https://www.risczero.com/blog/verifying-risc-zeros-trusted-setup-ceremony), while the full guide can be found [here](https://dev.risczero.com/api/trusted-setup-ceremony).
 
 Info about the security model can be found [here](https://dev.risczero.com/api/security-model), the list of audits [here](https://github.com/risc0/rz-security/tree/main/audits) and a blog post on overall security [here](https://www.risczero.com/blog/risc-zero-take-the-rekt-test).

--- a/packages/frontend/src/content/zk-catalog-descriptions/worldcoin-semaphore.md
+++ b/packages/frontend/src/content/zk-catalog-descriptions/worldcoin-semaphore.md
@@ -12,7 +12,7 @@ The procedure is explained for the semaphore circuit of size 30. While, as menti
 
 ![Semaphore verification process](/images/zk-catalog/semaphore-verification.png)
 
-**From the .circom to the .r1cs file**: the circom version used in the original verification key generation process is non deterministic, meaning that a different r1cs file is generated every time the circom file is compiled. A workaround is currently being investigated.
+**From the .circom to the .r1cs file**: the circom version used in the original verification key generation process is non-deterministic, meaning that a different r1cs file is generated every time the circom file is compiled. A workaround is currently being investigated.
 
 **From the .r1cs to the onchain verification keys**: download the corresponding r1cs file from the semaphore artifacts. This can be done manually or with the following command:
 


### PR DESCRIPTION
This pull request addresses several typographical errors across multiple documentation files:

- Corrected the use of hyphens in compound adjectives.
- Fixed the use of "a" vs. "an" before words starting with vowel sounds.
- Adjusted the term "user friendly" to "user-friendly."
- Updated the phrase "An high level guide" to "A high level guide."
- Corrected "non deterministic" to "non-deterministic."

These changes help improve the clarity and grammatical accuracy of the documentation.

## Type of change:
- [ ] New feature
- [x] Bug fix
- [ ] Optimization

## Checklist:
- [ ] Linked to Github Issue
- [ ] Unit tests added
- [ ] This change requires new documentation.
  - [x] Documentation has been added/updated.
- [ ] This change is an Optimization
  - [ ] Benchmarks added/run
