### PR TITLE
Do not optimize config import

### DIFF
--- a/packages/frontend/next.config.js
+++ b/packages/frontend/next.config.js
@@ -6,7 +6,7 @@ import { withSentryConfig } from '@sentry/nextjs'
 const nextConfig = {
   experimental: {
     optimizePackageImports: [
-      '@l2beat/config',
+      // Do not put @l2beat/backend or @l2beat/config here!
       '@l2beat/database',
       '@l2beat/discovery',
       '@l2beat/discovery-types',


### PR DESCRIPTION
Next.js uses file tracing during build to figure out what files are actually needed for the frontend to run.

For an unknown reason packages/backend is included in its entirety

Config manuallyverified.json would be included if not for the fact that @l2beat/config was added to `optimizePackageImports`.