### PR TITLE
Fix typos and improve documentation clarity

### DIFF
--- a/docs/activity.md
+++ b/docs/activity.md
@@ -22,7 +22,7 @@ If you want to add starkex type project, go to the [next section](#starkex-type-
    - `cast block-number -r <rpc-url>`
    - `cast block -r <rpc-url>`
 
-If you get a response, you are good to go. If not, try to find another RPC. If you can't another,
+If you get a response, you are good to go. If not, try to find another RPC. If you can't find another,
 you need to talk to devs to handle this case.
 
 3. Next step is to fill activity config in project config file. Add `config.transactionApi` property

--- a/packages/backend-tools/src/logger/docs.md
+++ b/packages/backend-tools/src/logger/docs.md
@@ -130,7 +130,7 @@ Along with each transport it is required to provide a formatter which will produ
 
 ### Pretty
 
-Type: `LogFormarretPretty`
+Type: `LogFormatterPretty`
 
 In this format every message is logged on one or more lines with another newline in between the messages. The first line contains the timestamp, log level, service, tag and the message. The following lines contain a representation of the parameters. This form is best suited for local development purposes.
 
@@ -158,7 +158,7 @@ Below is an example log output:
 
 ### JSON
 
-Type: `LogFormarretJson`
+Type: `LogFormatterJson`
 
 In this format every message is logged on a single line as a single JSON object. The object contains the timestamp, log level, service, tag, message, error and parameters. This format is best suited for deployment environments.
 
@@ -171,7 +171,7 @@ Below is an example log output:
 
 ### ECS
 
-Type: `LogFormarretEcs`
+Type: `LogFormatterEcs`
 
 In this format every message is logged on a single line as a single JSON object compatible with [ECS standard](https://www.elastic.co/guide/en/ecs/current/ecs-reference.html). This format is best suited for deployment environments with ElastiSearch enabled
 


### PR DESCRIPTION

## Changes

1. In `packages/backend-tools/src/logger/docs.md`:
- `LogFormarretPretty` → `LogFormatterPretty`
- `LogFormarretJson` → `LogFormatterJson` 
- `LogFormarretEcs` → `LogFormatterEcs`

2. In `docs/activity.md`:
-add find


## Why
- Fixed incorrect formatter type names ("Formarret" → "Formatter")
- Added missing word "find" to improve sentence clarity
