### PR TITLE
Update cronoszkevm.ts

### DIFF
--- a/packages/config/src/projects/layer2s/cronoszkevm.ts
+++ b/packages/config/src/projects/layer2s/cronoszkevm.ts
@@ -123,7 +123,7 @@ export const cronoszkevm: Layer2 = zkStackL2({
   //   nodeSoftware: `The node software is open-source, and its source code can be found [here](https://github.com/matter-labs/zksync-era).
   //   The main node software does not rely on Layer 1 (L1) to reconstruct the state, but you can use [this tool](https://github.com/eqlabs/zksync-state-reconstruct) for that purpose. Currently, there is no straightforward method to inject the state into the main node, but ZKsync is actively working on a solution for this.`,
   //   compressionScheme:
-  //     'Bytecodes undergo compression before deployment on Layer 1 (L1). You can find additional information on this process [here](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/advanced/11_compression.md).',
+  //     'Bytecodes undergo compression before deployment on Layer 1 (L1). You can find additional information on this process [here](https://github.com/matter-labs/zksync-era/blob/main/docs/src/guides/advanced/11_compression.md).',
   //   genesisState: 'There have been neither genesis states nor regenesis.',
   //   dataFormat:
   //     'Details on data format can be found [here](https://github.com/matter-labs/zksync-era/blob/main/docs/guides/advanced/09_pubdata.md).',


### PR DESCRIPTION
Fixed broken documentation link in the compression scheme section. Updated the URL path to include /src/ in the documentation link for L1 compression information.