### PR TITLE
Remove double-assert inside `TendermintClient` 

### DIFF
--- a/packages/backend/src/peripherals/tendermint/TendermintClient.ts
+++ b/packages/backend/src/peripherals/tendermint/TendermintClient.ts
@@ -1,6 +1,5 @@
 import { RateLimiter } from '@l2beat/backend-tools'
 import { HttpClient } from '@l2beat/shared'
-import { assert } from '@l2beat/shared-pure'
 import { TendermintValidatorsResponseBodySchema } from './schemas'
 
 interface TendermintClientOpts {
@@ -44,11 +43,6 @@ export class TendermintClient {
         per_page: perPage.toString(),
       }).toString()}`,
       {},
-    )
-
-    assert(
-      response.ok,
-      `Tendermint getValidators request failed with status: ${response.status}`,
     )
 
     return TendermintValidatorsResponseBodySchema.parse(response).result


### PR DESCRIPTION
HttpClient refactor made a response returned from `fetch` call any-typed - we were asserting `.ok` two times (thus for the presence of such property even though it was no longer there since fetch now returns promise resolving to body's json).
It will bring Celestia stake analyzer back online.
<img width="412" alt="image" src="https://github.com/user-attachments/assets/7ac477c1-aee2-4040-8212-02a9ecefea22" />
