### PR TITLE
fix condition for showing others on activity

### DIFF
--- a/packages/frontend/src/app/(side-nav)/scaling/activity/_components/scaling-activity-tabs.tsx
+++ b/packages/frontend/src/app/(side-nav)/scaling/activity/_components/scaling-activity-tabs.tsx
@@ -63,7 +63,7 @@ export function ScalingActivityTabs({
               {filteredEntries.validiumsAndOptimiums.length - 1}
             </CountBadge>
           </DirectoryTabsTrigger>
-          {filteredEntries.others.length > 0 && (
+          {filteredEntries.others.length > 1 && (
             <DirectoryTabsTrigger value="others">
               Others <CountBadge>{filteredEntries.others.length}</CountBadge>
             </DirectoryTabsTrigger>


### PR DESCRIPTION
The condition for showing the "Others" tab on the activity page has been fixed. Previously, the tab was displayed when there was only one entry in the "Others" category, but now it will only be shown when there are two or more entries.