### PR TITLE
Add revalidate to unstable caches

### DIFF
--- a/packages/frontend/src/app/api/(public)/scaling/activity/[slug]/route.ts
+++ b/packages/frontend/src/app/api/(public)/scaling/activity/[slug]/route.ts
@@ -1,5 +1,5 @@
 import { layer2s, layer3s } from '@l2beat/config'
-import { ProjectId } from '@l2beat/shared-pure'
+import { ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getActivityChart } from '~/server/features/scaling/activity/get-activity-chart'
@@ -86,5 +86,6 @@ const getCachedResponse = cache(
   ['scaling-activity-project-route'],
   {
     tags: ['activity'],
+    revalidate: UnixTime.DAY,
   },
 )

--- a/packages/frontend/src/app/api/(public)/scaling/activity/route.ts
+++ b/packages/frontend/src/app/api/(public)/scaling/activity/route.ts
@@ -1,3 +1,4 @@
+import { UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getActivityChart } from '~/server/features/scaling/activity/get-activity-chart'
@@ -43,5 +44,6 @@ const getCachedResponse = cache(
   ['scaling-activity-route'],
   {
     tags: ['activity'],
+    revalidate: UnixTime.DAY,
   },
 )

--- a/packages/frontend/src/app/api/(public)/scaling/summary/route.ts
+++ b/packages/frontend/src/app/api/(public)/scaling/summary/route.ts
@@ -1,3 +1,4 @@
+import { UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { getScalingApiEntries } from '~/server/features/scaling/summary/get-scaling-api-entries'
@@ -31,5 +32,5 @@ const getCachedData = cache(
     }
   },
   ['scaling-summary-route'],
-  { tags: ['activity'] },
+  { tags: ['activity'], revalidate: UnixTime.DAY },
 )

--- a/packages/frontend/src/app/api/(public)/scaling/tvl/[slug]/breakdown/route.ts
+++ b/packages/frontend/src/app/api/(public)/scaling/tvl/[slug]/breakdown/route.ts
@@ -1,4 +1,5 @@
 import { layer2s, layer3s } from '@l2beat/config'
+import { UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { NextResponse } from 'next/server'
 import { getTvlBreakdownForProject } from '~/server/features/scaling/tvl/breakdown/get-tvl-breakdown-for-project'
@@ -34,5 +35,6 @@ const getCachedResponse = cache(
   ['scaling-tvl-project-breakdown-route'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.HOUR,
   },
 )

--- a/packages/frontend/src/app/api/(public)/scaling/tvl/[slug]/route.ts
+++ b/packages/frontend/src/app/api/(public)/scaling/tvl/[slug]/route.ts
@@ -1,4 +1,5 @@
 import { layer2s, layer3s } from '@l2beat/config'
+import { UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getTvlChart } from '~/server/features/scaling/tvl/get-tvl-chart-data'
@@ -72,5 +73,6 @@ const getCachedResponse = cache(
   ['scaling-tvl-project-route'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.HOUR,
   },
 )

--- a/packages/frontend/src/app/api/(public)/scaling/tvl/route.ts
+++ b/packages/frontend/src/app/api/(public)/scaling/tvl/route.ts
@@ -1,3 +1,4 @@
+import { UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { type NextRequest, NextResponse } from 'next/server'
 import { getTvlChart } from '~/server/features/scaling/tvl/get-tvl-chart-data'
@@ -54,5 +55,6 @@ const getCachedResponse = cache(
   ['scaling-tvl-route'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.HOUR,
   },
 )

--- a/packages/frontend/src/server/features/scaling/activity/get-activity-chart-stats.ts
+++ b/packages/frontend/src/server/features/scaling/activity/get-activity-chart-stats.ts
@@ -1,3 +1,4 @@
+import { UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { getActivityChart } from './get-activity-chart'
 import { type ActivityProjectFilter } from './utils/project-filter-utils'
@@ -61,5 +62,6 @@ export const getCachedActivityChartStats = cache(
   ['activity-chart-stats'],
   {
     tags: ['activity'],
+    revalidate: UnixTime.DAY,
   },
 )

--- a/packages/frontend/src/server/features/scaling/activity/get-activity-chart.ts
+++ b/packages/frontend/src/server/features/scaling/activity/get-activity-chart.ts
@@ -94,6 +94,7 @@ export const getCachedActivityChartData = cache(
   ['activity-chart-data'],
   {
     tags: ['activity'],
+    revalidate: UnixTime.DAY,
   },
 )
 

--- a/packages/frontend/src/server/features/scaling/tvl/breakdown/get-tvl-breakdown-for-project.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/breakdown/get-tvl-breakdown-for-project.ts
@@ -36,6 +36,7 @@ export const getCachedTvlBreakdownForProjectData = cache(
   ['getCachedTvlBreakdownForProject'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.HOUR,
   },
 )
 

--- a/packages/frontend/src/server/features/scaling/tvl/get-tvl-chart-data.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/get-tvl-chart-data.ts
@@ -66,6 +66,7 @@ export const getCachedTvlChartData = cache(
   ['tvl-chart-data'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.HOUR,
   },
 )
 

--- a/packages/frontend/src/server/features/scaling/tvl/tokens/get-token-tvl-chart.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/tokens/get-token-tvl-chart.ts
@@ -111,6 +111,7 @@ export const getCachedTokenTvlChartData = cache(
   ['token-tvl-chart'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.HOUR,
   },
 )
 

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-tvl-breakdown.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-7d-tvl-breakdown.ts
@@ -1,6 +1,7 @@
 import { bridges } from '@l2beat/config'
 import { layer2s } from '@l2beat/config/build/src/projects/layer2s'
 import { layer3s } from '@l2beat/config/build/src/projects/layer3s'
+import { UnixTime } from '@l2beat/shared-pure'
 import { unstable_cache as cache } from 'next/cache'
 import { env } from '~/env'
 import { calculatePercentageChange } from '~/utils/calculate-percentage-change'
@@ -115,6 +116,7 @@ const getCached7dTokenBreakdown = cache(
   ['getCached7dTokenBreakdown'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.DAY,
   },
 )
 

--- a/packages/frontend/src/server/features/scaling/tvl/utils/get-latest-tvl-usd.ts
+++ b/packages/frontend/src/server/features/scaling/tvl/utils/get-latest-tvl-usd.ts
@@ -1,5 +1,5 @@
 import { bridges, layer2s, layer3s } from '@l2beat/config'
-import { type ProjectId } from '@l2beat/shared-pure'
+import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { groupBy, sum } from 'lodash'
 import { unstable_cache as cache } from 'next/cache'
 import { env } from '~/env'
@@ -39,6 +39,7 @@ const getCachedProjectsLatestTvlUsd = cache(
   ['latestTvlUsd'],
   {
     tags: ['tvl'],
+    revalidate: UnixTime.HOUR,
   },
 )
 


### PR DESCRIPTION
Vercel cron jobs work only for production builds, so the preview can have stale data. To prevent this I added revalidate equal to the time that cron jobs revalidate paths so it will not be double revalidating or smth.