### PR TITLE
chore:spellchecker for *.md

### DIFF
--- a/packages/backend-tools/src/logger/docs.md
+++ b/packages/backend-tools/src/logger/docs.md
@@ -143,7 +143,7 @@ Below is an example log output:
 
 ```
 12:34:56.001 INFO [ PriceService:USD ] Fetched prices
-    { entries: 42, upToDate: true }
+    { entries: 42, up-to-date: true }
 
 12:34:56.002 ERROR [ PriceService:USD ] Error fetching prices
     {
@@ -165,7 +165,7 @@ In this format every message is logged on a single line as a single JSON object.
 Below is an example log output:
 
 ```
-{"time":"2023-01-02T12:34:56.001Z","level":"INFO","service":"PriceService:USD","message":"Fetched prices","parameters":{"entries":42,"upToDate":true}}
+{"time":"2023-01-02T12:34:56.001Z","level":"INFO","service":"PriceService:USD","message":"Fetched prices","parameters":{"entries":42,"up-to-date":true}}
 {"time":"2023-01-02T12:34:56.002Z","level":"ERROR","service":"PriceService:USD","message":"Error fetching prices","error":{"name":"Error","error":"429: You have been rate limited!","stack":["PriceService.fetchPrices (src/PriceService.ts:12:34)","TaxService.computeTaxes (src/TaxService.ts:56:78)"]}}
 ```
 

--- a/packages/backend/discovery/arbitrum/ethereum/diffHistory.md
+++ b/packages/backend/discovery/arbitrum/ethereum/diffHistory.md
@@ -4232,7 +4232,7 @@ Generated with discovered.json: 0x3ea08e093c4fc78a79b685a42dbbadc7258c49c0
 - timelock transactions:
 - arbitrum: - AIP1Point2Action.perform - AIP4Action.perform - GovernanceChainSCMgmtActivationAction.perform - UpdateGasChargeAction.perform - SetSweepReceiverAction.perform - SecurityCouncilMemberSyncAction.perform - SetArbOS11VersionAction.perform - NomineeGovernorV2UpgradeAction.perform - SetArbOS20VersionAction - ArbOneSetAtlasL1PricingRewardAction - ArbOneSetAtlasMinBaseFeeAction
 - ethereum: - L1SCMgmtActivationAction.perform - UpdateL1CoreTimelockAction.perform - SecurityCouncilMemberSyncAction.perform - AddNovaKeysetAction.perform - SetArbOneArbOS11ModuleRootAciton.perform - SetNovaArbOS11ModuleRootAction.perform - AIPSetSequencerInboxMaxTimeVariationArbOneAction - AIPSetSequencerInboxMaxTimeVariationNovaAction - ArbOneAIP4844Action - ArbOneSetBatchPosterManagerAction - NovaSetBatchPosterManagerAction
-- nova: - NonGovernanceChainSCMgmtActivationAction.perfom - SecurityCouncilMemberSyncAction - SetArbOS11VersionAction - NovaAIP4844Action - SetArbOS20VersionAction
+- nova: - NonGovernanceChainSCMgmtActivationAction.perform - SecurityCouncilMemberSyncAction - SetArbOS11VersionAction - NovaAIP4844Action - SetArbOS20VersionAction
 
 ## Watched changes
 

--- a/packages/backend/discovery/degen/base/diffHistory.md
+++ b/packages/backend/discovery/degen/base/diffHistory.md
@@ -401,7 +401,7 @@ Generated with discovered.json: 0x4dc1e62f8d759083d693975e0570bbb5e477dc3a
 
 ## Description
 
-A new OFT adapter contract (for the DEGEN token) is added as allowed Outbox to the main bridge. This gives the OFT adapter the permission to make any calls as the bridge (including sending all tokens from the bridge). See the Sanko L3 on Arbitrum for a similar contruction. The LayerZero AMB now has access to the canonically escrowed funds and the bridge escrow serves doubly as a canonical escrow and OFT adapter lockbox.
+A new OFT adapter contract (for the DEGEN token) is added as allowed Outbox to the main bridge. This gives the OFT adapter the permission to make any calls as the bridge (including sending all tokens from the bridge). See the Sanko L3 on Arbitrum for a similar construction. The LayerZero AMB now has access to the canonically escrowed funds and the bridge escrow serves doubly as a canonical escrow and OFT adapter lockbox.
 
 ## Watched changes
 

--- a/packages/backend/discovery/eclipse/ethereum/diffHistory.md
+++ b/packages/backend/discovery/eclipse/ethereum/diffHistory.md
@@ -320,7 +320,7 @@ Generated with discovered.json: 0xf6bf5966c73218d06e07d411dec3c09220a1b4b8
 
 ## Description
 
-Threshold of the AuthorityMultisig raised to 2. As long as there are no withdrawals, the AuthorityMultisig is essentially a pauser only since upgrades do not change the withdrawals and can only affect a 'virtual' state on the L2 (from ethereum persepective).
+Threshold of the AuthorityMultisig raised to 2. As long as there are no withdrawals, the AuthorityMultisig is essentially a pauser only since upgrades do not change the withdrawals and can only affect a 'virtual' state on the L2 (from ethereum perspective).
 
 ## Watched changes
 

--- a/packages/backend/discovery/eigenda/ethereum/diffHistory.md
+++ b/packages/backend/discovery/eigenda/ethereum/diffHistory.md
@@ -1917,7 +1917,7 @@ Generated with discovered.json: 0x8e81bf69871f9c75df3876cc95e439c7edc13416
 
 ## Description
 
-A third quorum is added. (added config) This new quorum uses a yet unverified strategy to count its stake. (Probbaly related to restaked ALT)
+A third quorum is added. (added config) This new quorum uses a yet unverified strategy to count its stake. (Probably related to restaked ALT)
 
 source: [StakeRegistry.strategyParams(2,0)](https://etherscan.io/address/0x006124Ae7976137266feeBFb3F4D2BE4C073139D#readProxyContract#F20)
 
@@ -2756,7 +2756,7 @@ Generated with discovered.json: 0x6c1f315d53c94420733788742a072d1746dfbbcb
 
 ## Description
 
-EigenDA exposes the address of the RegistryCoordinator while for istance EOracle does not (it's immutable constructor param). Check RC is discovered when adding new AVSes.
+EigenDA exposes the address of the RegistryCoordinator while for instance EOracle does not (it's immutable constructor param). Check RC is discovered when adding new AVSes.
 
 ## Watched changes
 

--- a/packages/backend/discovery/fraxferry/ethereum/diffHistory.md
+++ b/packages/backend/discovery/fraxferry/ethereum/diffHistory.md
@@ -1382,7 +1382,7 @@ Generated with discovered.json: 0x26a1cf6926ad6177aed37b5d7137c132e16081a7
 
 ### Fee change on Fraxtal FPI bridge
 
-The fees of the FPI bridge to / from Fraxtal are lowered. The 0.1% fee is removed and the flat fee is reduced to 1 token (FPI). Other fraxferry bridges and (inlcuding other FPI bridges) have their fees unchanged.
+The fees of the FPI bridge to / from Fraxtal are lowered. The 0.1% fee is removed and the flat fee is reduced to 1 token (FPI). Other fraxferry bridges and (including other FPI bridges) have their fees unchanged.
 
 ## Watched changes
 

--- a/packages/backend/discovery/fraxtal/ethereum/diffHistory.md
+++ b/packages/backend/discovery/fraxtal/ethereum/diffHistory.md
@@ -1490,7 +1490,7 @@ Generated with discovered.json: 0xc3e8941178b3803db5522df6ac9a70c1c4868b70
 
 ## Description
 
-frxETH owner transfered to a 2-day timelock.
+frxETH owner transferred to a 2-day timelock.
 
 ## Watched changes
 

--- a/packages/backend/discovery/kroma/ethereum/diffHistory.md
+++ b/packages/backend/discovery/kroma/ethereum/diffHistory.md
@@ -1932,7 +1932,7 @@ Previously, validators could only withdraw funds to themselves. Now, with the wi
 
 ### 2. Change in block header hash function for Colosseum
 
-With the Shanghai upgrade on the Kroma mainnet, a withdrawalsRoot field has been added to the block header. Accordingly, the hash function for obtaining the block header in Colosseum has been modified. Implemenatation contract address: `0x311b4A33b6dC4e080eE0d98caAaf8dF86C833066`
+With the Shanghai upgrade on the Kroma mainnet, a withdrawalsRoot field has been added to the block header. Accordingly, the hash function for obtaining the block header in Colosseum has been modified. Implementation contract address: `0x311b4A33b6dC4e080eE0d98caAaf8dF86C833066`
 
 ### Current Context
 

--- a/packages/backend/discovery/linea/ethereum/diffHistory.md
+++ b/packages/backend/discovery/linea/ethereum/diffHistory.md
@@ -916,7 +916,7 @@ Generated with discovered.json: 0xf601728a00dd36fda7e9e790618e91b1f1b4b7a2
 ## Description
 
 Deleted two verifiers at `proofType = [6, 7]`. Both of them are identical and
-only differ in the intial setup parameters.
+only differ in the initial setup parameters.
 
 ## Watched changes
 

--- a/packages/backend/discovery/optimism/ethereum/diffHistory.md
+++ b/packages/backend/discovery/optimism/ethereum/diffHistory.md
@@ -1227,7 +1227,7 @@ Generated with discovered.json: 0xe0aaeba96a6b157035d409db6ad8520899fb43b6
 
 ## Description
 
-The deposits on the main Lido escrow for Optimism are paused by the Lido EmergencyBrake Multisig following [an upgrade proposal](https://research.lido.fi/t/steth-on-optimism-upgrade-announcement-and-action-plan/8474) for rebasing L2 stETH. This is a scheduled action and deposits should be reenabled im 2024/10/10.
+The deposits on the main Lido escrow for Optimism are paused by the Lido EmergencyBrake Multisig following [an upgrade proposal](https://research.lido.fi/t/steth-on-optimism-upgrade-announcement-and-action-plan/8474) for rebasing L2 stETH. This is a scheduled action and deposits should be re-enabled im 2024/10/10.
 
 Config related: Move to discovery driven data.
 

--- a/packages/backend/discovery/parallel/ethereum/diffHistory.md
+++ b/packages/backend/discovery/parallel/ethereum/diffHistory.md
@@ -2426,7 +2426,7 @@ Generated with discovered.json: 0x9499a161dab92924ef2ab20a6556f1aa1fc54d83
 
 ## Description
 
-The implementation of SequencerInbox was upgraded to a differenct contract with identical code.
+The implementation of SequencerInbox was upgraded to a different contract with identical code.
 This was done to change the immutable boolean `isUsingFeeToken` to false. This immutable should indeed be false on ethereum mainnet as it signifies the base L1 using a custom fee token. (Used as a check for `submitBatchSpendingReport()` function that is needed for fee sequencer fee reimbursement)
 
 ## Watched changes
@@ -2479,7 +2479,7 @@ In general most updates are EIP-4844 related, also the new role `batchPosterMana
 - new `addSequencerL2BatchFromOrigin()` (with added `prevMessageCount, newMessageCount` in sig, old signature without them is now deprecated), `addSequencerL2BatchFromBlobs()`
 - Gas refunds fetch blob price from Reader4844
 - Rollup owner can update rollup address
-- SequencerInbox contructor reverts if host chain is Arbitrum because blobs are not supported there
+- SequencerInbox constructor reverts if host chain is Arbitrum because blobs are not supported there
   - Checks for fee token usage and reverts if the native token is not ETH
 - `forceInclusion()` now does not change the sequencer message count
 - IBridge interface is introduced to use the vars TimeBounds and BatchDataLocation

--- a/packages/backend/discovery/publicgoodsnetwork/ethereum/diffHistory.md
+++ b/packages/backend/discovery/publicgoodsnetwork/ethereum/diffHistory.md
@@ -10,7 +10,7 @@ Generated with discovered.json: 0x450ab2617c6d7c7826a6f90f48870b03e998d403
 
 Upgrade to a new version of OptimismPortal which adds an `IEthBalanceWithdrawer` that allows the `BALANCE_CLAIMER` address to withdraw ETH and bypass the usual OP stack proving of withdrawals.
 
-A similar uprade is made to the L1StandardBridge regarding ERC20 tokens, and referencing the same privileged address which is the following SC:
+A similar upgrade is made to the L1StandardBridge regarding ERC20 tokens, and referencing the same privileged address which is the following SC:
 
 ### BalanceClaimer.sol
 

--- a/packages/backend/discovery/scroll/ethereum/diffHistory.md
+++ b/packages/backend/discovery/scroll/ethereum/diffHistory.md
@@ -52,7 +52,7 @@ Generated with discovered.json: 0x8523c24bfac779038af8583a650b1aca37ec8f83
 
 Batches reverted due to accidental 'old-version batches'. The reverted batches used the old version 2 and not the new v4 `commitBatchWithBlobProof()`. The post-mortem should appear [here](https://status.scroll.io/incidents/pw1cf3bmxy8s).
 
-In Scroll, batches can be reverted by the EmergencyMultisig anytime before they are proven (which currently happens around 2h after they are commited).
+In Scroll, batches can be reverted by the EmergencyMultisig anytime before they are proven (which currently happens around 2h after they are committed).
 
 ## Watched changes
 
@@ -2237,7 +2237,7 @@ The L2 changes are listed in the blog post.
 
 ### ScrollChain
 
-Batch version > 1 is now suported. This allows for the new batch version 2 to be posted.
+Batch version > 1 is now supported. This allows for the new batch version 2 to be posted.
 
 ### MultipleVersionRollupVerifier (manages verifiers)
 
@@ -2247,7 +2247,7 @@ In the `updateVerifier()` function, a check wether the new verifier's `_startBat
 
 This is the contract in the third slot of `latestVerifier`, added in this upgrade. It is code-identical with the previous one, but points to the new Plonk Verifier.
 
-### New Plonk Verfier
+### New Plonk Verifier
 
 The source code (yul+) can be found at https://circuit-release.s3.us-west-2.amazonaws.com/release-v0.11.4/evm_verifier.yul.
 

--- a/packages/backend/discovery/shared-eigenlayer/ethereum/diffHistory.md
+++ b/packages/backend/discovery/shared-eigenlayer/ethereum/diffHistory.md
@@ -4050,7 +4050,7 @@ Escrow smart contract that is the withdrawal address / credentials for ETH nativ
 Now only needed for withdrawals that are unrelated to shares (which in turn are managed by the DelegationManager):
 
 - Consensus rewards
-- ETH or tokens sent to the EigenPod directly (/ accidently)
+- ETH or tokens sent to the EigenPod directly (/ accidentally)
 
 Maximum delay is raised from 7d to 30d.
 

--- a/packages/backend/discovery/shared-polygon-cdk/ethereum/diffHistory.md
+++ b/packages/backend/discovery/shared-polygon-cdk/ethereum/diffHistory.md
@@ -1305,7 +1305,7 @@ Generated with discovered.json: 0x6124ec4be2edb290f32c6def8e55cfc071ddc45e
 ## Description
 
 Changes related to improving the shared-polygon-cdk module.
-Verifier is no longer part of this shared module - each rollup discoveres it for themselfs.
+Verifier is no longer part of this shared module - each rollup discoveres it for themselves.
 
 ## Config/verification related changes
 

--- a/packages/backend/discovery/shared-sharp-verifier/ethereum/diffHistory.md
+++ b/packages/backend/discovery/shared-sharp-verifier/ethereum/diffHistory.md
@@ -1897,7 +1897,7 @@ Generated with discovered.json: 0xaff8a6ad66c53b2303b9c9c77d308de4890151ad
 
 ## Description
 
-Updated the names and references to new SHARP verfier contracts.
+Updated the names and references to new SHARP verifier contracts.
 
 ## Config/verification related changes
 

--- a/packages/backend/discovery/swell/ethereum/diffHistory.md
+++ b/packages/backend/discovery/swell/ethereum/diffHistory.md
@@ -18,11 +18,11 @@ discovery. Values are for block 20985756 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       descriptions:
--        ["Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem"]
+-        ["Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem"]
       description:
-+        "Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem"
++        "Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem"
     }
 ```
 
@@ -42,7 +42,7 @@ Generated with discovered.json: 0x3548a172928f0df4e9b68a8a9ed5bc2ac911e55e
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       values.$members.6:
 -        "0x5b27b9279251904AaF2127463eeFf91E0037F725"
       values.$members.5:
@@ -73,7 +73,7 @@ One new signer added to SwellMultisig.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       values.$members.6:
 +        "0x5b27b9279251904AaF2127463eeFf91E0037F725"
       values.$members.5:
@@ -120,7 +120,7 @@ discovery. Values are for block 20016207 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       sourceHashes:
 +        ["0x81a7349eebb98ac33b0bc6842e3cb258034a8f2a4ba004570bb8e2e25947f9ff","0xd42bbf9f7dcd3720a7fc6bdc6edfdfae8800a37d6dd4decfa0ef6ca4a2e88940"]
     }
@@ -170,7 +170,7 @@ discovery. Values are for block 20016207 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       values.$multisigThreshold:
 -        "4 of 6 (67%)"
       values.getOwners:
@@ -206,7 +206,7 @@ discovery. Values are for block 20016207 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       fieldMeta:
 +        {"nonce":{"severity":"MEDIUM","description":"Watch out for txs concerning the prelaunch vault and swell L2 launch"}}
     }
@@ -228,7 +228,7 @@ A timelock transaction is queued by the SwellMultisig to support the Lyra-associ
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
 +++ description: Watch out for txs concerning the prelaunch vault and swell L2 launch
 +++ severity: MEDIUM
       values.nonce:
@@ -284,7 +284,7 @@ A timelock transaction is queued to whitelist (`supportToken(address,(bool,bool)
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
 +++ description: Watch out for txs concerning the prelaunch vault and swell L2 launch
 +++ severity: MEDIUM
       values.nonce:

--- a/packages/backend/discovery/synapse/ethereum/diffHistory.md
+++ b/packages/backend/discovery/synapse/ethereum/diffHistory.md
@@ -420,7 +420,7 @@ Generated with discovered.json: 0x318ed27da4a4ee3c26b9a1b4767fea204abb68fe
 ## Description
 
 New EOA is given the GOVERNANCE_ROLE in the bridge contract.
-Roles: GOVERNANCE_ROLE can set fees, pause and unpause; NODEGROUP_ROLE can call bridging funtions; ADMIN_ROLE can setWethAddress()
+Roles: GOVERNANCE_ROLE can set fees, pause and unpause; NODEGROUP_ROLE can call bridging functions; ADMIN_ROLE can setWethAddress()
 
 ## Watched changes
 

--- a/packages/backend/discovery/taiko/ethereum/diffHistory.md
+++ b/packages/backend/discovery/taiko/ethereum/diffHistory.md
@@ -2294,7 +2294,7 @@ Generated with discovered.json: 0x6ea276c960b8bccf9d9d8ae744307cada936d2e3
 
 ## Description
 
-- L1RollupAddressManager.sol: changed harcoded B_TIER_ROUTER address.
+- L1RollupAddressManager.sol: changed hardcoded B_TIER_ROUTER address.
 - Bridge.sol: small change in retryMessage logic.
 - TaikoL1.sol: changes in block verification. assignedProver and hookCalls now DEPRECATED. assignedProver is now msg.sender of proposeBlock tx. New getters (getLastVerifiedBlock, getLastSyncedBlock), and decreased liveness bond to 125 TAIKO. Block proposers can now bribe the Ethereum block builder. Move some functions into libraries.
 - TaikoToken.sol: can now call batchTransfer for multiple recipients and amounts.
@@ -2999,7 +2999,7 @@ Generated with discovered.json: 0xc7cd32149b27868b3a50016ee3970759f8e9aa0d
 
 Two contracts implementation changed, TaikoL1.sol, and Bridge.sol.
 - TaikoL1.sol: introduced B_TIER_ROUTER = bytes32("tier_router") to replace B_TIER_PROVIDER
-- Bridge.sol: Added a max proof size for a message to be processable by a relayer, an insufficent gas check, and added the B_TIER_ROUTER variable support.
+- Bridge.sol: Added a max proof size for a message to be processable by a relayer, an insufficient gas check, and added the B_TIER_ROUTER variable support.
 
 ## Watched changes
 

--- a/packages/backend/discovery/transporter/ethereum/diffHistory.md
+++ b/packages/backend/discovery/transporter/ethereum/diffHistory.md
@@ -10945,7 +10945,7 @@ Generated with discovered.json: 0x98bca27d8f15e7eb491b21bbda22a60aa8152474
 
 ## Description
 
-All signers of the ManyChainMultiSig are moved from group 0 threshold 4 to group 1 with treshold 4. Group 1 has group 0 (threshold 1) as a parent so currently there is no change to the net threshold / permissions. See this explanation of the group structure below:
+All signers of the ManyChainMultiSig are moved from group 0 threshold 4 to group 1 with threshold 4. Group 1 has group 0 (threshold 1) as a parent so currently there is no change to the net threshold / permissions. See this explanation of the group structure below:
 copied from the contract source:
 ```
     // Signing groups are arranged in a tree. Each group is an interior node and has its own quorum.

--- a/packages/backend/discovery/xai/arbitrum/diffHistory.md
+++ b/packages/backend/discovery/xai/arbitrum/diffHistory.md
@@ -3150,7 +3150,7 @@ Generated with discovered.json: 0x897a47e36aae203ad1b76427051d8c24b7bc8dfe
 
 ### Staking Pools upgrade
 
-This implementation uprade adds support for esXAI staking pools and removes the support for adding to normal staking (Withdrawals and rewards from normal staking remain enabled). Since staking V2 is still disabled and some contracts are still managed by the deployer, a new assessment of admin roles is necessary as soon as staking V2 is enabled.
+This implementation upgrade adds support for esXAI staking pools and removes the support for adding to normal staking (Withdrawals and rewards from normal staking remain enabled). Since staking V2 is still disabled and some contracts are still managed by the deployer, a new assessment of admin roles is necessary as soon as staking V2 is enabled.
 edit: Staking pools are active now and the [Xai Deployer EOA](https://arbiscan.io/address/0x7C94E07bbf73518B0E25D1Be200a5b58F46F9dC7) is admin (via owner or ProxyAdmin) of all the staking-related contracts.
 
 #### Referee5

--- a/packages/backend/discovery/zklinknova/scroll/diffHistory.md
+++ b/packages/backend/discovery/zklinknova/scroll/diffHistory.md
@@ -349,7 +349,7 @@ Generated with discovered.json: 0xedbd057508280d9873d1196125e4fa0e7282bc84
 
 ## Description
 
-The governance (owner, admin roles) of the scroll contracts are transfered from an EOA to a new Multisig.
+The governance (owner, admin roles) of the scroll contracts are transferred from an EOA to a new Multisig.
 
 ## Watched changes
 

--- a/packages/backend/discovery/zksync2/ethereum/diffHistory.md
+++ b/packages/backend/discovery/zksync2/ethereum/diffHistory.md
@@ -718,7 +718,7 @@ Each ZK stack chain including zkSync Era has its own diamond contract similar to
 - Governor role removed (onlyGovernor functions are now mostly onlySTM)
 - VerifierParams moved to STM
 - Support for custom native token ('basetoken')
-- Function `upgradeChainFromVersion()` added: Allows to upgrade the diamond with preformed calldata (can be used for synchronous upgrading of multiple chains in the future)
+- Function `upgradeChainFromVersion()` added: Allows to upgrade the diamond with performed calldata (can be used for synchronous upgrading of multiple chains in the future)
 
 #### ExecutorFacet.sol
 


### PR DESCRIPTION
- Due to the large number of spelling errors requiring correction, manual filtering of false positives is needed in addition to tool checks.  Currently, errors are being corrected by file type. 
- It is then suggested to add checks to GitHub Actions to address incremental issues. ref:https://github.com/codespell-project/actions-codespell
