### PR TITLE
fix: Update README Links and Fix API Routes Documentation

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -56,7 +56,7 @@ In some tests rpc calls to ethereum network are performed through Alchemy. In or
 | ImmutableX                        | https://medium.com/@immutablex                           |
 | Layer2.Finance, Layer2.Finance-zk | https://blog.celer.network/                              |
 | Loopring                          | https://medium.com/loopring-protocol                     |
-| Metis                             | https://medium.com/@MetisDAO                             |
+| Metis                             | https://www.metis.io/blog                                |
 | myria                             | https://medium.com/@myriagames                           |
 | OMGNetwork                        | -                                                        |
 | Optimism                          | https://optimism.mirror.xyz/                             |
@@ -64,5 +64,5 @@ In some tests rpc calls to ethereum network are performed through Alchemy. In or
 | RSS3, Value Sublayer              | https://rss3.io/blog                                     |
 | Sorare                            | https://medium.com/sorare                                |
 | Starknet                          | https://medium.com/starkware                             |
-| ZkSpace, ZkSwap V1, ZkSwap V2     | https://medium.com/@zkspaceofficial                      |
+| ZkSpace, ZkSwap V1, ZkSwap V2     | https://alpha.zks.org/blog                               |
 | zkSync                            | https://blog.matter-labs.io                              |

--- a/packages/uops-dashboard/README.md
+++ b/packages/uops-dashboard/README.md
@@ -18,9 +18,9 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+[API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.
 
 This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
 


### PR DESCRIPTION
This pull request fixes outdated and broken links in two README files. It also updates references to API routes in the `uops-dashboard` README file to match the latest Next.js documentation.

### Changes  
1. **Fixed Broken Links**:  
   - Updated `Metis` and `ZkSpace` blog URLs in `packages/config/README.md`.  
2. **Updated API Routes Documentation**:  
   - Adjusted links and descriptions to align with the current Next.js API documentation in `packages/uops-dashboard/README.md`. 