### PR TITLE
code-Update Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,14 @@ ARG VARIANT=22-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:dev-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
- RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends libgbm-dev gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libnss3 lsb-release xdg-utils wget postgresql-client
+RUN apt-get -y install --no-install-recommends \
+    ca-certificates fonts-liberation gconf-service libc6 libcairo2 libcups2 \
+    libdbus-1-3 libexpat1 libfontconfig1 libgconf-2-4 libgdk-pixbuf2.0-0 libgdb-dev \
+    libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 \
+    libstdc++6 libx11-6 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 \
+    libxfixes3 libxft2 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release \
+    postgresql-client wget xdg-utils
+
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10


### PR DESCRIPTION
# Fix: Sorted package names alphanumerically in Dockerfile

## Changes
- `Dockerfile`: Sorted package names in the `RUN apt-get install` command to follow alphanumeric order.

  - **Before**:
    ```dockerfile
    RUN apt-get -y install --no-install-recommends \
        libgdb-dev gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 \
        libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 \
        libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 \
        libx11-6 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
        libxft2 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation \
        libnss3 lsb-release xdg-utils wget postgresql-client
    ```

  - **After**:
    ```dockerfile
    RUN apt-get -y install --no-install-recommends \
        ca-certificates fonts-liberation gconf-service libc6 libcairo2 libcups2 \
        libdbus-1-3 libexpat1 libfontconfig1 libgconf-2-4 libgdk-pixbuf2.0-0 libgdb-dev \
        libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 \
        libstdc++6 libx11-6 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 \
        libxfixes3 libxft2 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release \
        postgresql-client wget xdg-utils
    ```

## Purpose
- Ensured consistency and maintainability by sorting package names alphanumerically.
- Improved readability and resolved SonarQube warning.
