### PR TITLE
Fix verification test for Public DA projects

### DIFF
--- a/packages/config/src/test/implementation.ts
+++ b/packages/config/src/test/implementation.ts
@@ -135,9 +135,9 @@ function getDaBridgePermissionsForChain(
       }
 
       return Object.values(b.permissions).flatMap((perChain) => {
-        return perChain.flatMap((a) =>
-          a.accounts.map((a) => ({
-            chain: b.chain.toString(),
+        return perChain.flatMap((p) =>
+          p.accounts.map((a) => ({
+            chain: (p.chain ?? b.chain).toString(),
             address: a.address,
           })),
         )

--- a/packages/config/src/test/verification.test.ts
+++ b/packages/config/src/test/verification.test.ts
@@ -51,7 +51,10 @@ describe('verification status', () => {
         const bridgeId = bridge.id.toString()
         for (const chain of chains) {
           it(`${bridgeId}:${chain}`, () => {
-            const projectIds = bridge.usedIn.map((u) => u.id.toString())
+            const projectIds =
+              daLayer.kind === 'PublicBlockchain'
+                ? [bridge.id]
+                : bridge.usedIn.map((u) => u.id.toString())
             for (const projectId of projectIds) {
               const manuallyVerified = getManuallyVerifiedContracts(chain)
               const addressesOnChain = getUniqueAddressesForDaBridge(


### PR DESCRIPTION
Current test for verified contracts assumed that discoveries for DA projects are actually inside discoveries of projects specified in `DaBridge.usedIn` field. That's only true for non-public DAs. Public DAs like celestia have their own discovery.