### PR TITLE
"the"

### DIFF
--- a/packages/backend/discovery/_templates/orbitstack/OneStepProverHostIo_Celestia/shape/OneStepProverHostIo.sol
+++ b/packages/backend/discovery/_templates/orbitstack/OneStepProverHostIo_Celestia/shape/OneStepProverHostIo.sol
@@ -1171,7 +1171,7 @@ library CelestiaBatchVerifier {
      * @notice Given some batch data with the structre of `BlobPointer`, verifyBatch validates:
      * 1. The Celestia Height for the batch data is in blobsream.
      * 2. The user supplied proof's data root exists in Blobstream.
-     * 2. The the data root from the batch data and the valid user supplied proof match, and the
+     * 2. The data root from the batch data and the valid user supplied proof match, and the
      *    span of shares for the batch data is available (i.e the start + length of a blob does not
      *    go outside the bounds of the origianal celestia data square for the given height)
      *

--- a/packages/backend/discovery/_templates/transporter/CommitStoreV1/shape/CommitStoreV1-1.sol
+++ b/packages/backend/discovery/_templates/transporter/CommitStoreV1/shape/CommitStoreV1-1.sol
@@ -474,7 +474,7 @@ abstract contract OCR2Abstract is ITypeAndVersion {
   /// @param report serialized report, which the signatures are signing.
   /// @param rs ith element is the R components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
   /// @param ss ith element is the S components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
-  /// @param rawVs ith element is the the V component of the ith signature
+  /// @param rawVs ith element is the V component of the ith signature
   function transmit(
     // NOTE: If these parameters are changed, expectedMsgDataLength and/or
     // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly
@@ -663,7 +663,7 @@ abstract contract OCR2Base is OwnerIsCreator, OCR2Abstract {
   /// @param report serialized report, which the signatures are signing.
   /// @param rs ith element is the R components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
   /// @param ss ith element is the S components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
-  /// @param rawVs ith element is the the V component of the ith signature
+  /// @param rawVs ith element is the V component of the ith signature
   function transmit(
     // NOTE: If these parameters are changed, expectedMsgDataLength and/or
     // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly

--- a/packages/backend/discovery/_templates/transporter/CommitStoreV1/shape/CommitStoreV1-2.sol
+++ b/packages/backend/discovery/_templates/transporter/CommitStoreV1/shape/CommitStoreV1-2.sol
@@ -438,7 +438,7 @@ abstract contract OCR2Abstract is TypeAndVersionInterface {
   /// @param report serialized report, which the signatures are signing.
   /// @param rs ith element is the R components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
   /// @param ss ith element is the S components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
-  /// @param rawVs ith element is the the V component of the ith signature
+  /// @param rawVs ith element is the V component of the ith signature
   function transmit(
     // NOTE: If these parameters are changed, expectedMsgDataLength and/or
     // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly
@@ -627,7 +627,7 @@ abstract contract OCR2Base is OwnerIsCreator, OCR2Abstract {
   /// @param report serialized report, which the signatures are signing.
   /// @param rs ith element is the R components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
   /// @param ss ith element is the S components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
-  /// @param rawVs ith element is the the V component of the ith signature
+  /// @param rawVs ith element is the V component of the ith signature
   function transmit(
     // NOTE: If these parameters are changed, expectedMsgDataLength and/or
     // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly

--- a/packages/backend/discovery/_templates/transporter/CommitStoreV1/shape/CommitStoreV1-3.sol
+++ b/packages/backend/discovery/_templates/transporter/CommitStoreV1/shape/CommitStoreV1-3.sol
@@ -679,7 +679,7 @@ abstract contract OCR2Abstract is ITypeAndVersion {
   /// @param report serialized report, which the signatures are signing.
   /// @param rs ith element is the R components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
   /// @param ss ith element is the S components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
-  /// @param rawVs ith element is the the V component of the ith signature
+  /// @param rawVs ith element is the V component of the ith signature
   function transmit(
     // NOTE: If these parameters are changed, expectedMsgDataLength and/or
     // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly
@@ -872,7 +872,7 @@ abstract contract OCR2Base is OwnerIsCreator, OCR2Abstract {
   /// @param report serialized report, which the signatures are signing.
   /// @param rs ith element is the R components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
   /// @param ss ith element is the S components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
-  /// @param rawVs ith element is the the V component of the ith signature
+  /// @param rawVs ith element is the V component of the ith signature
   function transmit(
     // NOTE: If these parameters are changed, expectedMsgDataLength and/or
     // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly


### PR DESCRIPTION
The documentation contained a duplicated word "the" which impacts readability and professionalism of the codebase. This small but important fix: