### PR TITLE
Feat/scroll chain info update

### DIFF
--- a/packages/config/src/projects/layer2s/scroll.ts
+++ b/packages/config/src/projects/layer2s/scroll.ts
@@ -455,7 +455,7 @@ export const scroll: Layer2 = {
     genesisState:
       'The genesis file can be found [here](https://scrollzkp.notion.site/genesis-json-f89ca24b123f462f98c8844d17bdbb74), which contains two prefunded addresses and five predeployed contracts.',
     dataFormat:
-      'Blocks are grouped into chunks and chunks are grouped into batches. Chunk encoding format can be found [here](https://github.com/scroll-tech/scroll-contracts/blob/main/src/libraries/codec/ChunkCodecV0.sol#L5), and batch encoding format can be found [here](https://github.com/scroll-tech/scroll-contracts/blob/main/src/libraries/codec/BatchHeaderV0Codec.sol#L7).',
+      'Blocks are grouped into chunks, chunks are grouped into batches, and batches are grouped into bundles. Chunk encoding format can be found [here](https://github.com/scroll-tech/scroll-contracts/blob/main/src/libraries/codec/ChunkCodecV0.sol#L5), and batch encoding format can be found [here](https://github.com/scroll-tech/scroll-contracts/blob/main/src/libraries/codec/BatchHeaderV0Codec.sol#L7).',
   },
   stateValidation: {
     description:
@@ -683,7 +683,7 @@ export const scroll: Layer2 = {
         description: 'Plonk verifier used to verify ZK proofs for bundles.',
       }),
       discovery.getContractDetails('L1ETHGateway', {
-        description: 'Contract used to bridge ETH from L1 to L2.',
+        description: 'Contract used to bridge ETH from L1 to L2. NOTE L1ETHGateway was deprecated, current bridge ETH from L1 to L2 can directly use L1ScrollMessenger',
         ...upgradesScrollMultisig,
       }),
       discovery.getContractDetails('L1WETHGateway', {

--- a/packages/config/src/projects/layer2s/scroll.ts
+++ b/packages/config/src/projects/layer2s/scroll.ts
@@ -683,7 +683,7 @@ export const scroll: Layer2 = {
         description: 'Plonk verifier used to verify ZK proofs for bundles.',
       }),
       discovery.getContractDetails('L1ETHGateway', {
-        description: 'Contract used to bridge ETH from L1 to L2. NOTE L1ETHGateway was deprecated, current bridge ETH from L1 to L2 can directly use L1ScrollMessenger',
+        description: 'Deprecated: Contract used to bridge ETH from L1 to L2.',
         ...upgradesScrollMultisig,
       }),
       discovery.getContractDetails('L1WETHGateway', {


### PR DESCRIPTION
* Current, Scroll data structure layer:  Block-> Chunk -> Batch -> Bundle. ComitBatch, FinalizeBundle.
* L1ETHGateway this was Deprecated. [detail](https://github.com/scroll-tech/scroll-contracts/blob/main/src/L1/gateways/L1ETHGateway.sol#L146). current deposit ETH to scroll mainnet don't need to through the `L1ETHGateway`, directly passed to `L1ScrollMessenger`