### PR TITLE
add description for Kintos stf-enforced kyc technology

### DIFF
--- a/packages/config/src/projects/layer2s/kinto.ts
+++ b/packages/config/src/projects/layer2s/kinto.ts
@@ -28,11 +28,7 @@ export const kinto: Layer2 = orbitStackL2({
       websites: ['https://kinto.xyz'],
       apps: ['https://engen.kinto.xyz'],
       documentation: ['https://docs.kinto.xyz'],
-      explorers: [
-        'https://explorer.kinto.xyz/',
-        'https://kintoscan.io/',
-        'https://searchkinto.com/',
-      ],
+      explorers: ['https://explorer.kinto.xyz/', 'https://kintoscan.io/'],
       repositories: ['https://github.com/kintoxyz'],
       socialMedia: [
         'https://twitter.com/kintoxyz',

--- a/packages/config/src/projects/layer2s/kinto.ts
+++ b/packages/config/src/projects/layer2s/kinto.ts
@@ -102,6 +102,31 @@ export const kinto: Layer2 = orbitStackL2({
         'https://docs.kinto.xyz/kinto-the-safe-l2/security-kyc-aml/security-council',
     },
   ),
+  nonTemplateTechnology: {
+    otherConsiderations: [
+      {
+        name: 'Enforced smart wallets and KYC',
+        description: `The Kinto L2 node is a fork of arbitrum's geth implementation with notable changes to the state transition function. 
+        A valid state transition in Kinto [disallows all contract calls by EOAs](https://github.com/KintoXYZ/kinto-go-ethereum/blob/7aba9b812a82d9339d29a2345946c3d7030a0377/core/kinto_hardfork_7.go#L58) and new contract creation, unless whitelisted. 
+        The current whitelist is sourced live from the KintoAppRegistry smart contract on Kinto L2, and can be modified by its Owner without delay. 
+        This setup effectively enforces smart wallet use because the auxiliary contracts of the standard KintoWallet smart wallet (like the EntryPoint and the KintoWalletFactory) are whitelisted. 
+        
+        The KYC validation is part of the KintoWallet signature verification. Since all users must use the same implementation of this smart wallet, all user transactions on Kinto check for an up-to-date KYC flag, and are dropped in case the check fails.`,
+        risks: [
+          {
+            category: 'Users can be censored if',
+            text: "a KYC provider changes the users' KYC status.",
+          },
+        ],
+        references: [
+          {
+            text: 'User Owned KYC - Kinto documentation',
+            href: 'https://docs.kinto.xyz/kinto-the-safe-l2/security-kyc-aml/how-does-kinto-solve-it',
+          },
+        ],
+      },
+    ],
+  },
   trackedTxs: [
     {
       uses: [

--- a/packages/config/src/projects/layer2s/optimism.ts
+++ b/packages/config/src/projects/layer2s/optimism.ts
@@ -383,7 +383,7 @@ export const optimism: Layer2 = {
     stateCorrectness: {
       name: 'Fraud proofs ensure state correctness',
       description:
-        'After some period of time, the published state root is assumed to be correct. For a certain time period, one of the whitelisted actors can submit a fraud proof that shows that the state was incorrect.',
+        'After some period of time, the published state root is assumed to be correct. During the challenge period, anyone is allowed to submit a fraud proof that shows that the state was incorrect.',
       risks: [
         {
           category: 'Funds can be stolen if',


### PR DESCRIPTION
also rephrased the short description of optimistic validation in OP mainnets tech section

Kinto will need a 'native contracts' and 'native permissions' section, which is almost ready (discovery already has all the descriptions) but needs some discovery improvements, especially to correctly resolve permissions for nested discovered values.