### PR TITLE
[L2B-8619] Unify env var names for Polygon

### DIFF
--- a/packages/backend-tools/src/env.test.ts
+++ b/packages/backend-tools/src/env.test.ts
@@ -3,6 +3,13 @@ import { expect } from 'earl'
 import { Env } from './env'
 
 describe(Env.name, () => {
+  describe(Env.key.name, () => {
+    it('returns correct environment variable key', () => {
+      const result = Env.key('polygon-pos', 'ETHERSCAN_API_KEY')
+      expect(result).toEqual('POLYGONPOS_ETHERSCAN_API_KEY')
+    })
+  })
+
   describe(Env.prototype.string.name, () => {
     it('returns the environment variable', () => {
       const env = new Env({ TEST_A: 'foo' })

--- a/packages/backend-tools/src/env.ts
+++ b/packages/backend-tools/src/env.ts
@@ -24,6 +24,10 @@ export class Env {
     return value !== undefined ? { value, key } : value
   }
 
+  static key(...inputs: string[]): string {
+    return inputs.join('_').replace(/-/g, '').toUpperCase()
+  }
+
   string(key: string | string[], fallback?: string): string {
     const value = this.optionalString(key)
     if (value !== undefined) {

--- a/packages/backend/src/config/chain/getChainConfig.ts
+++ b/packages/backend/src/config/chain/getChainConfig.ts
@@ -18,8 +18,11 @@ export function getChainConfig(env: Env): ChainApi[] {
     }
     const project = projects.find((p) => p.id === chain)
     assert(project, `${chain}: Project not found`)
+    // TODO: we need to find a better way to link project to it's chain
+    const chainConfig = chains.find((c) => c.name === chain.replace(/-/g, ''))
 
-    const indexerConfig = project.chainConfig?.explorerApi
+    const indexerConfig =
+      project.chainConfig?.explorerApi || chainConfig?.explorerApi
     const indexerApis: IndexerApi[] = []
     if (indexerConfig) {
       const type = indexerConfig.type

--- a/packages/backend/src/config/chain/getChainConfig.ts
+++ b/packages/backend/src/config/chain/getChainConfig.ts
@@ -29,7 +29,7 @@ export function getChainConfig(env: Env): ChainApi[] {
         indexerApis.push({
           type,
           url,
-          apiKey: env.string(`${chain.toUpperCase()}_ETHERSCAN_API_KEY`),
+          apiKey: env.string(Env.key(chain, 'ETHERSCAN_API_KEY')),
         })
       } else {
         indexerApis.push({
@@ -43,7 +43,7 @@ export function getChainConfig(env: Env): ChainApi[] {
     const rpcUrls = getRpcUrlsFromEnv(env, chain)
     for (const url of rpcUrls) {
       const callsPerMinute = env.integer(
-        `${chain.toUpperCase()}_RPC_CALLS_PER_MINUTE`,
+        Env.key(chain, 'RPC_CALLS_PER_MINUTE'),
         60,
       )
       blockApis.push({
@@ -82,9 +82,9 @@ export function getChainConfig(env: Env): ChainApi[] {
 
 function getRpcUrlsFromEnv(env: Env, chain: string) {
   return [
-    env.optionalString(`${chain.toUpperCase()}_RPC_URL`),
-    env.optionalString(`${chain.toUpperCase()}_RPC_URL_FOR_TVL`),
-    env.optionalString(`${chain.toUpperCase()}_RPC_URL_FOR_ACTIVITY`),
+    env.optionalString(Env.key(chain, 'RPC_URL')),
+    env.optionalString(Env.key(chain, 'RPC_URL_FOR_TVL')),
+    env.optionalString(Env.key(chain, 'RPC_URL_FOR_ACTIVITY')),
   ].filter(notUndefined)
 }
 

--- a/packages/backend/src/config/features/activity.ts
+++ b/packages/backend/src/config/features/activity.ts
@@ -66,13 +66,12 @@ export function getChainActivityBlockExplorerConfig(
   if (!project.explorerApi || !project.name) {
     return undefined
   }
-  const ENV_NAME = project.name.toUpperCase()
   return project.explorerApi?.type === 'etherscan'
     ? {
         type: project.explorerApi.type,
         apiKey: env.string([
-          `${ENV_NAME}_ETHERSCAN_API_KEY_FOR_ACTIVITY`,
-          `${ENV_NAME}_ETHERSCAN_API_KEY`,
+          Env.key(project.name, 'ETHERSCAN_API_KEY_FOR_ACTIVITY'),
+          Env.key(project.name, 'ETHERSCAN_API_KEY'),
         ]),
         url: project.explorerApi.url,
       }
@@ -86,19 +85,20 @@ export function getChainActivityConfig(
   env: Env,
   project: { id: ProjectId; transactionApi: ScalingProjectTransactionApi },
 ): ActivityTransactionConfig {
-  const ENV_NAME = project.id.toUpperCase().replace(/-/g, '_')
-
   if (project.transactionApi.type === 'rpc') {
     return {
       type: 'rpc',
       url: env.string(
-        [`${ENV_NAME}_RPC_URL_FOR_ACTIVITY`, `${ENV_NAME}_RPC_URL`],
+        [
+          Env.key(project.id, 'RPC_URL_FOR_ACTIVITY'),
+          Env.key(project.id, 'RPC_URL'),
+        ],
         project.transactionApi.defaultUrl,
       ),
       callsPerMinute: env.integer(
         [
-          `${ENV_NAME}_RPC_CALLS_PER_MINUTE_FOR_ACTIVITY`,
-          `${ENV_NAME}_RPC_CALLS_PER_MINUTE`,
+          Env.key(project.id, 'RPC_CALLS_PER_MINUTE_FOR_ACTIVITY'),
+          Env.key(project.id, 'RPC_CALLS_PER_MINUTE'),
         ],
         project.transactionApi.defaultCallsPerMinute ??
           DEFAULT_RPC_CALLS_PER_MINUTE,
@@ -118,13 +118,16 @@ export function getChainActivityConfig(
     return {
       type: project.transactionApi.type,
       url: env.string(
-        [`${ENV_NAME}_API_URL_FOR_ACTIVITY`, `${ENV_NAME}_API_URL`],
+        [
+          Env.key(project.id, 'API_URL_FOR_ACTIVITY'),
+          Env.key(project.id, 'API_URL'),
+        ],
         project.transactionApi.defaultUrl,
       ),
       callsPerMinute: env.integer(
         [
-          `${ENV_NAME}_API_CALLS_PER_MINUTE_FOR_ACTIVITY`,
-          `${ENV_NAME}_API_CALLS_PER_MINUTE`,
+          Env.key(project.id, 'API_CALLS_PER_MINUTE_FOR_ACTIVITY'),
+          Env.key(project.id, 'API_CALLS_PER_MINUTE'),
         ],
         project.transactionApi.defaultCallsPerMinute ??
           DEFAULT_RPC_CALLS_PER_MINUTE,

--- a/packages/config/src/projects/layer2s/polygonpos.ts
+++ b/packages/config/src/projects/layer2s/polygonpos.ts
@@ -270,4 +270,22 @@ export const polygonpos: Layer2 = {
       thumbnail: NUGGETS.THUMBNAILS.L2BEAT_03,
     },
   ],
+  chainConfig: {
+    name: 'polygonpos',
+    chainId: 137,
+    blockscoutV2ApiUrl: 'https://polygon.blockscout.com/api/v2',
+    explorerUrl: 'https://polygonscan.com',
+    explorerApi: {
+      url: 'https://api.polygonscan.com/api',
+      type: 'etherscan',
+    },
+    multicallContracts: [
+      {
+        address: EthereumAddress('0xcA11bde05977b3631167028862bE2a173976CA11'),
+        batchSize: 150,
+        sinceBlock: 25770160,
+        version: '3',
+      },
+    ],
+  },
 }

--- a/packages/config/src/projects/layer2s/polygonpos.ts
+++ b/packages/config/src/projects/layer2s/polygonpos.ts
@@ -270,22 +270,4 @@ export const polygonpos: Layer2 = {
       thumbnail: NUGGETS.THUMBNAILS.L2BEAT_03,
     },
   ],
-  chainConfig: {
-    name: 'polygonpos',
-    chainId: 137,
-    blockscoutV2ApiUrl: 'https://polygon.blockscout.com/api/v2',
-    explorerUrl: 'https://polygonscan.com',
-    explorerApi: {
-      url: 'https://api.polygonscan.com/api',
-      type: 'etherscan',
-    },
-    multicallContracts: [
-      {
-        address: EthereumAddress('0xcA11bde05977b3631167028862bE2a173976CA11'),
-        batchSize: 150,
-        sinceBlock: 25770160,
-        version: '3',
-      },
-    ],
-  },
 }


### PR DESCRIPTION
Currently depending on part of the code we could have:

- `POLYGONPOS_*`
- `POLYGON-POS_*`
- `POLYGON_POS_*`

after the fix everything will be unified to: `POLYGONPOS_*`