### PR TITLE
Fix l2b failing to start due to missing folder

### DIFF
--- a/packages/l2b/src/implementations/common/GetProvider.ts
+++ b/packages/l2b/src/implementations/common/GetProvider.ts
@@ -1,3 +1,4 @@
+import { mkdirSync } from 'fs'
 import path from 'path'
 import {
   AllProviders,
@@ -22,11 +23,9 @@ export async function getProvider(
   let cache: DiscoveryCache = new NoCache()
   const config = readConfig()
   if (config.projectRootPath !== undefined) {
-    const globalCachePath = path.join(
-      config.projectRootPath,
-      'cache',
-      'l2b.sqlite',
-    )
+    const cacheDir = path.join(config.projectRootPath, 'cache')
+    mkdirSync(cacheDir, { recursive: true }) // Make sure the cache directory exists
+    const globalCachePath = path.join(cacheDir, 'l2b.sqlite')
     const sqliteCache = new SQLiteCache(globalCachePath)
     await sqliteCache.init()
     cache = sqliteCache


### PR DESCRIPTION
Turns out that "/cache" folder is required for l2b to start, or else it fails with a cryptic error: 

```
[Error: SQLITE_CANTOPEN: unable to open database file
Emitted 'error' event on Database instance at:
] {
  errno: 14,
  code: 'SQLITE_CANTOPEN'
}
```