### PR TITLE
Update link and fix typographical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We believe in knowledge sharing and open access. Our code is and will remain ope
 
 Some of the sub-packages are published to NPM. We use a tool called [changesets](https://github.com/changesets/changesets) to manage versioning, cross-dependency versioning and publishing new versions to NPM.  When you make a change, before merging to master:
 
-- run `pnpm changeset` and mark the packages you wish to publish, select what kind of a change it is (major,minor,patch) and provide the summary of the changes
+- run `pnpm changeset` and mark the packages you wish to publish, select what kind of change it is (major,minor,patch) and provide the summary of the changes
 
 When you want to publish all previous changes to NPM:
 

--- a/packages/backend/discovery/_templates/opstack/FaultDisputeGame/shape/FaultDisputeGame.sol
+++ b/packages/backend/discovery/_templates/opstack/FaultDisputeGame/shape/FaultDisputeGame.sol
@@ -522,7 +522,7 @@ library FixedPointMathLib {
     /// @dev Calculates `floor(x * y / d)` with full precision, rounded up.
     /// Throws if result overflows a uint256 or when `d` is zero.
     /// Credit to Uniswap-v3-core under MIT license:
-    /// https://github.com/Uniswap/v3-core/blob/contracts/libraries/FullMath.sol
+    /// https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol
     function fullMulDivUp(uint256 x, uint256 y, uint256 d) internal pure returns (uint256 result) {
         result = fullMulDiv(x, y, d);
         /// @solidity memory-safe-assembly

--- a/packages/backend/discovery/_templates/orbitstack/RollupEventInbox/shape/ERC20RollupEventInbox_apechain.sol
+++ b/packages/backend/discovery/_templates/orbitstack/RollupEventInbox/shape/ERC20RollupEventInbox_apechain.sol
@@ -14,10 +14,10 @@ interface IRollupEventInbox {
 }
 
 interface IDelayedMessageProvider {
-    /// @dev event emitted when a inbox message is added to the Bridge's delayed accumulator
+    /// @dev event emitted when an inbox message is added to the Bridge's delayed accumulator
     event InboxMessageDelivered(uint256 indexed messageNum, bytes data);
 
-    /// @dev event emitted when a inbox message is added to the Bridge's delayed accumulator
+    /// @dev event emitted when an inbox message is added to the Bridge's delayed accumulator
     /// same as InboxMessageDelivered but the batch data is available in tx.input
     event InboxMessageDeliveredFromOrigin(uint256 indexed messageNum);
 }

--- a/packages/backend/discovery/_templates/orbitstack/RollupEventInbox/shape/RollupEventInbox_parallel.sol
+++ b/packages/backend/discovery/_templates/orbitstack/RollupEventInbox/shape/RollupEventInbox_parallel.sol
@@ -14,10 +14,10 @@ interface IRollupEventInbox {
 }
 
 interface IDelayedMessageProvider {
-    /// @dev event emitted when a inbox message is added to the Bridge's delayed accumulator
+    /// @dev event emitted when an inbox message is added to the Bridge's delayed accumulator
     event InboxMessageDelivered(uint256 indexed messageNum, bytes data);
 
-    /// @dev event emitted when a inbox message is added to the Bridge's delayed accumulator
+    /// @dev event emitted when an inbox message is added to the Bridge's delayed accumulator
     /// same as InboxMessageDelivered but the batch data is available in tx.input
     event InboxMessageDeliveredFromOrigin(uint256 indexed messageNum);
 }

--- a/packages/config/src/tvl/amounts/aggLayerL2Tokens.ts
+++ b/packages/config/src/tvl/amounts/aggLayerL2Tokens.ts
@@ -34,7 +34,7 @@ export function getAggLayerL2TokenEntry(
     : (escrow.includeInTotal ?? true)
   const isAssociated = !!project.associatedTokens?.includes(token.symbol)
 
-  // We are hardcoding assetId because aggLayerL2Token is an canonical token
+  // We are hardcoding assetId because aggLayerL2Token is a canonical token
   const assetId = AssetId.create(ethereum.name, token.address)
   const type = 'aggLayerL2Token'
   const originNetwork = 0

--- a/packages/discovery/src/discovery/permission-resolving/resolvePermissions.ts
+++ b/packages/discovery/src/discovery/permission-resolving/resolvePermissions.ts
@@ -13,7 +13,7 @@ import { Permission } from '../config/RawDiscoveryConfig'
 // operation with some additional baseline delay.
 //
 // Edges link two nodes together and define the action that can take place on
-// that link. Each action can have a execution delay which is additive to the
+// that link. Each action can have an execution delay which is additive to the
 // node on which that action can take place.
 //
 // Multisigs are modeled as a link between the multisig and the owner with the


### PR DESCRIPTION
This pull request resolves several typographical errors and updates a broken link in various files. 
These changes improve the accuracy and readability of the code and documentation.

## Changes
1. **README.md**
   - Corrected grammar in the description of `pnpm changeset`.
   - Fixed "what kind of a change" to "what kind of change".

2. **FaultDisputeGame.sol**
   - Updated the Uniswap link to point to the correct URL:  
     From: `https://github.com/Uniswap/v3-core/blob/contracts/libraries/FullMath.sol`  
     To: `https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol`

3. **ERC20RollupEventInbox_apechain.sol** and **RollupEventInbox_parallel.sol**
   - Corrected grammar in comments from "a inbox" to "an inbox".

4. **aggLayerL2Tokens.ts**
   - Fixed "an canonical" to "a canonical".

5. **resolvePermissions.ts**
   - Corrected grammar from "a execution delay" to "an execution delay".