### PR TITLE
Errors to improve

### DIFF
--- a/packages/backend/discovery/_templates/orbitstack/OneStepProverHostIo_Celestia/shape/OneStepProverHostIo.sol
+++ b/packages/backend/discovery/_templates/orbitstack/OneStepProverHostIo_Celestia/shape/OneStepProverHostIo.sol
@@ -1171,7 +1171,7 @@ library CelestiaBatchVerifier {
      * @notice Given some batch data with the structre of `BlobPointer`, verifyBatch validates:
      * 1. The Celestia Height for the batch data is in blobsream.
      * 2. The user supplied proof's data root exists in Blobstream.
-     * 2. The the data root from the batch data and the valid user supplied proof match, and the
+     * 2. The data root from the batch data and the valid user supplied proof match, and the
      *    span of shares for the batch data is available (i.e the start + length of a blob does not
      *    go outside the bounds of the origianal celestia data square for the given height)
      *

--- a/packages/backend/discovery/_templates/transporter/OfframpV2/shape/EVM2EVMOffRamp.sol
+++ b/packages/backend/discovery/_templates/transporter/OfframpV2/shape/EVM2EVMOffRamp.sol
@@ -2008,7 +2008,7 @@ abstract contract OCR2Abstract is ITypeAndVersion {
   /// @param report serialized report, which the signatures are signing.
   /// @param rs ith element is the R components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
   /// @param ss ith element is the S components of the ith signature on report. Must have at most MAX_NUM_ORACLES entries
-  /// @param rawVs ith element is the the V component of the ith signature
+  /// @param rawVs ith element is the V component of the ith signature
   function transmit(
     // NOTE: If these parameters are changed, expectedMsgDataLength and/or
     // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly
@@ -2658,7 +2658,7 @@ contract AggregateRateLimiter is OwnerIsCreator {
 }
 
 interface IAny2EVMOffRamp {
-  /// @notice Returns the the current nonce for a receiver.
+  /// @notice Returns the current nonce for a receiver.
   /// @param sender The sender address
   /// @return nonce The nonce value belonging to the sender address.
   function getSenderNonce(address sender) external view returns (uint64 nonce);

--- a/packages/backend/discovery/ronin/ethereum/config.jsonc
+++ b/packages/backend/discovery/ronin/ethereum/config.jsonc
@@ -41,7 +41,7 @@
         "checkThreshold",
         "globalProposalRelayed",
         "round",
-        "getFullBridgeOperatorInfos" // this method returns operators, their indidual weights and asosciated governors with each operator. We skip becase there are other methods to get operators/governors
+        "getFullBridgeOperatorInfos" // this method returns operators, their individual weights and associated governors with each operator. We skip becase there are other methods to get operators/governors
       ],
       "fields": {
         "accessControl": {


### PR DESCRIPTION
Fix typos in documentation and comments

Changes:
1. packages/backend/discovery/config.jsonc:
- "indidual" weights and "asosciated"
+ "individual" weights and "associated"

2. packages/backend/discovery_templates/transporter/OFTFeeV2/shape/EVMOLVMOFTFeev2.sol:
- the the 
+ the 

Why:
Fixed spelling errors to improve code readability and maintain documentation standards. No functional changes, text-only fixes.