### PR TITLE
Fix article usage in multiple files

### DIFF
--- a/packages/config/src/projects/bridges/pNetwork.ts
+++ b/packages/config/src/projects/bridges/pNetwork.ts
@@ -152,7 +152,7 @@ export const pNetwork: Bridge = {
     {
       name: 'PNETWORK',
       description:
-        'A set of EOA addresses (different ones for different Vault contracts) that can transfer tokens and perform admin functions. It is supposed to be controlled by a group of Validator nodes in a MPC network.',
+        'A set of EOA addresses (different ones for different Vault contracts) that can transfer tokens and perform admin functions. It is supposed to be controlled by a group of Validator nodes in an MPC network.',
       accounts: [
         discovery.getPermissionedAccount('ERC20 Vault V2', 'PNETWORK'),
         discovery.getPermissionedAccount('ERC20 Vault V1', 'PNETWORK'),

--- a/packages/config/src/projects/bridges/symbiosis.ts
+++ b/packages/config/src/projects/bridges/symbiosis.ts
@@ -64,7 +64,7 @@ export const symbiosis: Bridge = {
     principleOfOperation: {
       name: 'Principle of operation',
       description:
-        'Symbiosis uses a MPC relayer network to facilitate cross-chain transfers. An AMM on BOBA BNB is used to perform swaps.',
+        'Symbiosis uses an MPC relayer network to facilitate cross-chain transfers. An AMM on BOBA BNB is used to perform swaps.',
       references: [],
       risks: [],
     },

--- a/packages/config/src/projects/layer2s/canto.ts
+++ b/packages/config/src/projects/layer2s/canto.ts
@@ -9,7 +9,7 @@ export const canto: Layer2 = upcomingL2({
     name: 'Canto',
     slug: 'canto',
     description:
-      "Canto is the L1 which will migrate to a Ethereum L2 scaling solution powered by Polygon's CDK dedicated to Real World Assets.",
+      "Canto is the L1 which will migrate to an Ethereum L2 scaling solution powered by Polygon's CDK dedicated to Real World Assets.",
     purposes: ['Universal'],
     category: 'ZK Rollup',
     provider: 'Polygon',

--- a/packages/config/src/projects/layer2s/fuse.ts
+++ b/packages/config/src/projects/layer2s/fuse.ts
@@ -9,7 +9,7 @@ export const fuse: Layer2 = upcomingL2({
     name: 'Fuse',
     slug: 'fuse',
     description:
-      'Fuse announced a strategic move to integrate with the Ethereum ecosystem as an Polygon CDK L2.',
+      'Fuse announced a strategic move to integrate with the Ethereum ecosystem as a Polygon CDK L2.',
     purposes: ['Universal'],
     category: 'ZK Rollup',
     provider: 'Polygon',

--- a/packages/config/src/projects/layer2s/hermez.ts
+++ b/packages/config/src/projects/layer2s/hermez.ts
@@ -105,7 +105,7 @@ export const hermez: Layer2 = {
     operator: {
       ...OPERATOR.DECENTRALIZED_OPERATOR,
       description:
-        'The system runs an auction in which anyone can bid to become the operator for a set number of blocks. The operator will be able to propose blocks and collect fees during this window. Hermez will also run a operator known as boot coordinator that will propose blocks in case no one bids in the auction. This operator can be removed by the governance.',
+        'The system runs an auction in which anyone can bid to become the operator for a set number of blocks. The operator will be able to propose blocks and collect fees during this window. Hermez will also run an operator known as boot coordinator that will propose blocks in case no one bids in the auction. This operator can be removed by the governance.',
       references: [
         {
           text: 'Forging Consensus Protocol - Hermez documentation',

--- a/packages/config/src/projects/layer2s/polygonzkevm.ts
+++ b/packages/config/src/projects/layer2s/polygonzkevm.ts
@@ -36,7 +36,7 @@ export const polygonzkevm: Layer2 = polygonCDKStack({
     slug: 'polygonzkevm',
     warning: 'The forced transaction mechanism is currently disabled.',
     description:
-      'Polygon zkEVM is a EVM-compatible ZK Rollup built by Polygon Labs.',
+      'Polygon zkEVM is an EVM-compatible ZK Rollup built by Polygon Labs.',
     links: {
       websites: ['https://polygon.technology/polygon-zkevm'],
       apps: ['https://bridge.zkevm-rpc.com'],

--- a/packages/config/src/tvl/amounts/aggLayerL2Tokens.ts
+++ b/packages/config/src/tvl/amounts/aggLayerL2Tokens.ts
@@ -34,7 +34,7 @@ export function getAggLayerL2TokenEntry(
     : (escrow.includeInTotal ?? true)
   const isAssociated = !!project.associatedTokens?.includes(token.symbol)
 
-  // We are hardcoding assetId because aggLayerL2Token is an canonical token
+  // We are hardcoding assetId because aggLayerL2Token is a canonical token
   const assetId = AssetId.create(ethereum.name, token.address)
   const type = 'aggLayerL2Token'
   const originNetwork = 0

--- a/packages/config/src/tvl/amounts/aggLayerNativeEtherWrapped.ts
+++ b/packages/config/src/tvl/amounts/aggLayerNativeEtherWrapped.ts
@@ -20,7 +20,7 @@ export function getAggLayerNativeEtherWrappedEntry(
   assert(escrow.sharedEscrow.wethAddress, 'WETH address is required')
   assert(l1WETH.address, 'Ethereum WETH token not found')
 
-  // We are hardcoding assetId because aggLayerNativeEtherWrapped is an canonical token
+  // We are hardcoding assetId because aggLayerNativeEtherWrapped is a canonical token
   const assetId = AssetId.create(ethereum.name, l1WETH.address)
   const type = 'aggLayerNativeEtherWrapped'
   const dataSource = `${chain.name}_agglayer`

--- a/packages/config/src/tvl/amounts/elasticChainL2Tokens.ts
+++ b/packages/config/src/tvl/amounts/elasticChainL2Tokens.ts
@@ -34,7 +34,7 @@ export function getElasticChainL2TokenEntry(
     : (escrow.includeInTotal ?? true)
   const isAssociated = !!project.associatedTokens?.includes(token.symbol)
 
-  // We are hardcoding assetId because elasticChainL2Token is an canonical token
+  // We are hardcoding assetId because elasticChainL2Token is a canonical token
   const assetId = AssetId.create(ethereum.name, token.address)
   const type = 'elasticChainL2Token'
   const dataSource = `${project.projectId}_elastic_chain`

--- a/packages/frontend/src/app/api/trpc/[trpc]/route.ts
+++ b/packages/frontend/src/app/api/trpc/[trpc]/route.ts
@@ -7,7 +7,7 @@ import { createTRPCContext } from '~/server/api/trpc'
 
 /**
  * This wraps the `createTRPCContext` helper and provides the required context for the tRPC API when
- * handling a HTTP request (e.g. when you make requests from Client Components).
+ * handling an HTTP request (e.g. when you make requests from Client Components).
  */
 const createContext = (req: NextRequest) => {
   return createTRPCContext({


### PR DESCRIPTION
## Changes:
- Fixed article usage in other files like `hermez.ts`, `polygonzkevm.ts`, and `aggLayerL2Tokens.ts`.
- Replaced "a" with "an" before "MPC" in `pNetwork.ts` and `symbiosis.ts`.
- Replaced "a" with "an" before "Ethereum" in `canto.ts` and `ethereum.ts`.
- Replaced "an" with "a" before "Polygon" in `fuse.ts`.
