### PR TITLE
Rename `OPStack-blob` finality type

### DIFF
--- a/packages/backend/src/modules/finality/FinalityModule.ts
+++ b/packages/backend/src/modules/finality/FinalityModule.ts
@@ -116,7 +116,7 @@ function initializeConfigurations(
             minTimestamp: configuration.minTimestamp,
             stateUpdateMode: configuration.stateUpdate,
           }
-        case 'OPStack-blob':
+        case 'OPStack':
           return {
             projectId: configuration.projectId,
             analyzers: {

--- a/packages/config/src/projects/layer2s/base.ts
+++ b/packages/config/src/projects/layer2s/base.ts
@@ -205,7 +205,7 @@ export const base: Layer2 = {
       assessCount: subtractOneAfterBlockInclusive(1),
     },
     finality: {
-      type: 'OPStack-blob',
+      type: 'OPStack',
       minTimestamp: new UnixTime(1710375515),
       genesisTimestamp: new UnixTime(1686789347),
       l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/blast.ts
+++ b/packages/config/src/projects/layer2s/blast.ts
@@ -91,7 +91,7 @@ export const blast: Layer2 = opStackL2({
     ],
   },
   finality: {
-    type: 'OPStack-blob',
+    type: 'OPStack',
     // timestamp of the first blob tx
     minTimestamp: new UnixTime(1716846455),
     l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/ink.ts
+++ b/packages/config/src/projects/layer2s/ink.ts
@@ -192,7 +192,7 @@ export const ink: Layer2 = {
       assessCount: subtractOneAfterBlockInclusive(1),
     },
     finality: {
-      type: 'OPStack-blob',
+      type: 'OPStack',
       minTimestamp: new UnixTime(1733502012),
       genesisTimestamp: new UnixTime(1733498411),
       l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/kroma.ts
+++ b/packages/config/src/projects/layer2s/kroma.ts
@@ -215,7 +215,7 @@ export const kroma: Layer2 = {
       },
     ],
     finality: {
-      type: 'OPStack-blob',
+      type: 'OPStack',
       // timestamp of the first blob tx
       minTimestamp: new UnixTime(1714032407),
       l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/lisk.ts
+++ b/packages/config/src/projects/layer2s/lisk.ts
@@ -42,7 +42,7 @@ export const lisk: Layer2 = opStackL2({
   l1StandardBridgePremintedTokens: ['LSK'],
   nonTemplateExcludedTokens: ['USDC'],
   finality: {
-    type: 'OPStack-blob',
+    type: 'OPStack',
     genesisTimestamp: new UnixTime(1714728791),
     minTimestamp: new UnixTime(1714746983), // first blob
     l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/mode.ts
+++ b/packages/config/src/projects/layer2s/mode.ts
@@ -72,7 +72,7 @@ export const mode: Layer2 = opStackL2({
     },
   ],
   finality: {
-    type: 'OPStack-blob',
+    type: 'OPStack',
     l2BlockTimeSeconds: 2,
     minTimestamp: new UnixTime(1710386375),
     genesisTimestamp: new UnixTime(1700167583),

--- a/packages/config/src/projects/layer2s/optimism.ts
+++ b/packages/config/src/projects/layer2s/optimism.ts
@@ -260,7 +260,7 @@ export const optimism: Layer2 = {
       assessCount: subtractOneAfterBlockInclusive(105235064),
     },
     finality: {
-      type: 'OPStack-blob',
+      type: 'OPStack',
       // timestamp of the first blob tx
       minTimestamp: new UnixTime(1710375155),
       l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/polynomial.ts
+++ b/packages/config/src/projects/layer2s/polynomial.ts
@@ -33,7 +33,7 @@ export const polynomial: Layer2 = opStackL2({
   },
   rpcUrl: 'https://rpc.polynomial.fi',
   finality: {
-    type: 'OPStack-blob',
+    type: 'OPStack',
     genesisTimestamp: new UnixTime(1718038175),
     minTimestamp: new UnixTime(1718049059),
     l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/superlumio.ts
+++ b/packages/config/src/projects/layer2s/superlumio.ts
@@ -34,7 +34,7 @@ export const superlumio: Layer2 = opStackL2({
   rpcUrl: 'https://mainnet.lumio.io',
   genesisTimestamp: new UnixTime(1708984633),
   finality: {
-    type: 'OPStack-blob',
+    type: 'OPStack',
     genesisTimestamp: new UnixTime(1708984631),
     minTimestamp: new UnixTime(1708984751),
     l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/swell.ts
+++ b/packages/config/src/projects/layer2s/swell.ts
@@ -203,7 +203,7 @@ export const swell: Layer2 = {
       assessCount: subtractOneAfterBlockInclusive(1),
     },
     finality: {
-      type: 'OPStack-blob',
+      type: 'OPStack',
       minTimestamp: new UnixTime(1732701647),
       genesisTimestamp: new UnixTime(1732696703),
       l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/thebinaryholdings.ts
+++ b/packages/config/src/projects/layer2s/thebinaryholdings.ts
@@ -38,7 +38,7 @@ export const thebinaryholdings: Layer2 = opStackL2({
   rpcUrl: 'https://rpc.zero.thebinaryholdings.com',
   genesisTimestamp: new UnixTime(1719397465),
   finality: {
-    type: 'OPStack-blob',
+    type: 'OPStack',
     genesisTimestamp: new UnixTime(1719397463),
     minTimestamp: new UnixTime(1719397465),
     l2BlockTimeSeconds: 2,

--- a/packages/config/src/projects/layer2s/types/Layer2FinalityConfig.ts
+++ b/packages/config/src/projects/layer2s/types/Layer2FinalityConfig.ts
@@ -27,7 +27,7 @@ export type Layer2FinalityConfig =
       stateUpdate: StateUpdateMode
     }
   | {
-      type: 'OPStack-blob'
+      type: 'OPStack'
       minTimestamp: UnixTime
       lag: number
       // https://specs.optimism.io/protocol/holocene/derivation.html#span-batches

--- a/packages/config/src/projects/layer2s/zora.ts
+++ b/packages/config/src/projects/layer2s/zora.ts
@@ -39,7 +39,7 @@ export const zora: Layer2 = opStackL2({
   },
   rpcUrl: 'https://rpc.zora.energy',
   finality: {
-    type: 'OPStack-blob',
+    type: 'OPStack',
     genesisTimestamp: new UnixTime(1686693839),
     minTimestamp: new UnixTime(1710386579),
     l2BlockTimeSeconds: 2,


### PR DESCRIPTION
This PR renames `OPStack-blob` finality type to just `OPStack` because after https://github.com/l2beat/l2beat/pull/6272 OPStack analyzer is able to decode blob tx as well as type 2 tx.