### PR TITLE
Fix spelling errors

### DIFF
--- a/packages/backend/discovery/silicon/ethereum/discovered.json
+++ b/packages/backend/discovery/silicon/ethereum/discovered.json
@@ -48,7 +48,7 @@
         "$upgradeCount": 1,
         "committeeHash": "0x6a72452343c27af9cfd36812714ec5c293ae843cac115b41f7b422f8e237c83f",
         "getAmountOfMembers": 3,
-        "getProcotolName": "DataAvailabilityCommittee",
+        "getProtocolName": "DataAvailabilityCommittee",
         "members": [
           [
             "http://silicon-mainnet-da-3.nodeinfra.com:8444",
@@ -333,7 +333,7 @@
       "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
       "function committeeHash() view returns (bytes32)",
       "function getAmountOfMembers() view returns (uint256)",
-      "function getProcotolName() pure returns (string)",
+      "function getProtocolName() pure returns (string)",
       "function initialize()",
       "function members(uint256) view returns (string url, address addr)",
       "function owner() view returns (address)",

--- a/packages/l2b/src/commands/Init.ts
+++ b/packages/l2b/src/commands/Init.ts
@@ -17,7 +17,7 @@ export const Init = command({
     chain,
     initialAddresses: restPositionals({
       type: EthereumAddressValue,
-      displayName: 'initalAddresses',
+      displayName: 'initialAddresses',
       description: 'a list of initial addresses',
     }),
   },

--- a/packages/l2b/src/commands/InitTemplate.ts
+++ b/packages/l2b/src/commands/InitTemplate.ts
@@ -1,5 +1,5 @@
 import { command, positional, string } from 'cmd-ts'
-import { initTempalte } from '../implementations/initTemplate'
+import { initTemplate } from '../implementations/initTemplate'
 
 export const InitTemplate = command({
   name: 'init-template',
@@ -13,6 +13,6 @@ export const InitTemplate = command({
     }),
   },
   handler: (args) => {
-    initTempalte(args.name)
+    initTemplate(args.name)
   },
 })

--- a/packages/l2b/src/implementations/common/ResponseProgress.ts
+++ b/packages/l2b/src/implementations/common/ResponseProgress.ts
@@ -12,7 +12,7 @@ export interface ProgressEvent {
   eta: number
 }
 
-interface EmitedEvents {
+interface EmittedEvents {
   progress: (progress: ProgressEvent) => void
   finish: (progress: ProgressEvent) => void
 }
@@ -22,16 +22,16 @@ export class ResponseProgress extends EventEmitter {
   private done: number
   private startedAt: number
 
-  override emit<K extends keyof EmitedEvents>(
+  override emit<K extends keyof EmittedEvents>(
     event: K,
-    ...args: Parameters<EmitedEvents[K]>
+    ...args: Parameters<EmittedEvents[K]>
   ): boolean {
     return super.emit(event, ...args)
   }
 
-  override on<K extends keyof EmitedEvents>(
+  override on<K extends keyof EmittedEvents>(
     event: K,
-    listener: EmitedEvents[K],
+    listener: EmittedEvents[K],
   ): this {
     return super.on(event, listener)
   }

--- a/packages/l2b/src/implementations/init.ts
+++ b/packages/l2b/src/implementations/init.ts
@@ -7,7 +7,7 @@ import { readConfig } from '../config/readConfig'
 export function initDiscovery(
   project: string,
   chain: string,
-  initalAddresses: EthereumAddress[],
+  initialAddresses: EthereumAddress[],
 ) {
   const config = readConfig()
   assert(config.discoveryPath, '.l2b does not specify the discovery path')
@@ -16,7 +16,7 @@ export function initDiscovery(
   mkdirSync(projectPath, { recursive: true })
 
   const configPath = path.join(projectPath, 'config.jsonc')
-  createEmptyConfig(configPath, project, chain, initalAddresses)
+  createEmptyConfig(configPath, project, chain, initialAddresses)
 }
 
 function createEmptyConfig(

--- a/packages/l2b/src/implementations/initTemplate.ts
+++ b/packages/l2b/src/implementations/initTemplate.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import { assert } from '@l2beat/shared-pure'
 import { readConfig } from '../config/readConfig'
 
-export function initTempalte(name: string) {
+export function initTemplate(name: string) {
   const config = readConfig()
   assert(config.projectRootPath, '.l2b file not found')
   assert(config.discoveryPath, '.l2b does not specify the discovery path')

--- a/packages/shared/src/uops/protocols/gnosisSafe/isGnosisSafe.ts
+++ b/packages/shared/src/uops/protocols/gnosisSafe/isGnosisSafe.ts
@@ -8,7 +8,7 @@ import {
 export function isGnosisSafe(tx: Transaction): boolean {
   assert(
     tx.data && !isArray(tx.data),
-    `Only EVM Transcations are allowed: ${tx.hash}`,
+    `Only EVM Transactions are allowed: ${tx.hash}`,
   )
   const selector = tx.data.slice(0, 10)
 

--- a/packages/uops-dashboard/src/components/statsForm.tsx
+++ b/packages/uops-dashboard/src/components/statsForm.tsx
@@ -67,7 +67,7 @@ export function StatsForm({
     getStats(chainId, blockCount)
   }
 
-  const getStats = async (chainId: ChainId, overideBlockCount: number) => {
+  const getStats = async (chainId: ChainId, overrideBlockCount: number) => {
     setIsLoading(true)
 
     const chain = SUPPORTED_CHAINS.find((c) => c.id === chainId)
@@ -77,7 +77,7 @@ export function StatsForm({
     }
 
     let currentBatchSize = chain.batchSize || 10
-    let blocksLeftToFetch = overideBlockCount ?? blockCount
+    let blocksLeftToFetch = overrideBlockCount ?? blockCount
     let currentLastFetched = lastFetched
 
     try {


### PR DESCRIPTION
- Fixed `overide` to `override`.
- Corrected `Tempalte` to `Template`.
- Changed `Emited` to `Emitted`.
- Corrected `inital` to `initial`.
- Fixed `Procotol` to `Protocol`.
- Corrected `Transcations` to `Transactions`.
