### PR TITLE
Add Fuel Ignition's Security Council ref

### DIFF
--- a/packages/backend/discovery/fuel/ethereum/config.jsonc
+++ b/packages/backend/discovery/fuel/ethereum/config.jsonc
@@ -8,7 +8,7 @@
   ],
   "names": {
     "0xa4cA04d02bfdC3A2DF56B9b6994520E69dF43F67": "FuelERC20Gateway",
-    "0x32da601374b38154f05904B16F44A1911Aa6f314": "FuelMultisig",
+    "0x32da601374b38154f05904B16F44A1911Aa6f314": "FuelSecurityCouncil",
     "0xAEB0c00D0125A8a788956ade4f4F12Ead9f65DDf": "FuelMessagePortal",
     "0xf3D20Db1D16A4D0ad2f280A5e594FF3c7790f130": "FuelChainState",
     "0xEA0337EFC12e98AB118948dA570C07691E8E4b37": "Sequencer"
@@ -49,6 +49,14 @@
           }
         }
       }
+    },
+    "FuelSecurityCouncil": {
+      "references": [
+        {
+          "text": "Security Council members - Fuel Ignition docs",
+          "href": "https://docs.fuel.network/docs/verified-addresses/security-council/#fuel-bridge-security-council"
+        }
+      ]
     }
   }
 }

--- a/packages/backend/discovery/fuel/ethereum/diffHistory.md
+++ b/packages/backend/discovery/fuel/ethereum/diffHistory.md
@@ -1,3 +1,32 @@
+Generated with discovered.json: 0xa058729c55a2acd8b130353199774c9186993b78
+
+# Diff at Wed, 15 Jan 2025 14:14:10 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@6fd163e76ba309fea8e407a192deb4ec99f21cb3 block: 21242136
+- current block number: 21630407
+
+## Description
+
+Provide description of changes. This section will be preserved.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 21242136 (main branch discovery), not current.
+
+```diff
+    contract FuelSecurityCouncil (0x32da601374b38154f05904B16F44A1911Aa6f314) {
+    +++ description: None
+      name:
+-        "FuelMultisig"
++        "FuelSecurityCouncil"
+      references:
++        [{"text":"Security Council members - Fuel Ignition docs","href":"https://docs.fuel.network/docs/verified-addresses/security-council/#fuel-bridge-security-council"}]
+    }
+```
+
 Generated with discovered.json: 0x0aa7eda5ee0e248498c60090e58c072b12ce9d7c
 
 # Diff at Tue, 10 Dec 2024 10:38:55 GMT:

--- a/packages/backend/discovery/fuel/ethereum/discovered.json
+++ b/packages/backend/discovery/fuel/ethereum/discovered.json
@@ -1,11 +1,11 @@
 {
   "name": "fuel",
   "chain": "ethereum",
-  "blockNumber": 21242136,
-  "configHash": "0x7ee2ae0e7ba0d97eafbf9768cea8a382c341485e3e89653ce61b973f1e0afac0",
+  "blockNumber": 21630407,
+  "configHash": "0x27f59892160590243c2b4b7ab0cf96a9e4b163e5ecec20ae04cf96ee48b0a1f5",
   "contracts": [
     {
-      "name": "FuelMultisig",
+      "name": "FuelSecurityCouncil",
       "address": "0x32da601374b38154f05904B16F44A1911Aa6f314",
       "template": "GnosisSafe",
       "sourceHashes": [
@@ -38,10 +38,16 @@
         "getChainId": 1,
         "GnosisSafe_modules": [],
         "multisigThreshold": "10 of 13 (77%)",
-        "nonce": 39,
+        "nonce": 42,
         "VERSION": "1.3.0"
       },
-      "derivedName": "GnosisSafe"
+      "derivedName": "GnosisSafe",
+      "references": [
+        {
+          "text": "Security Council members - Fuel Ignition docs",
+          "href": "https://docs.fuel.network/docs/verified-addresses/security-council/#fuel-bridge-security-council"
+        }
+      ]
     },
     {
       "name": "Safe",
@@ -66,7 +72,7 @@
         "getChainId": 1,
         "GnosisSafe_modules": [],
         "multisigThreshold": "1 of 2 (50%)",
-        "nonce": 4,
+        "nonce": 7,
         "VERSION": "1.4.1"
       }
     },
@@ -196,15 +202,15 @@
             "members": ["0x32da601374b38154f05904B16F44A1911Aa6f314"]
           }
         },
-        "currentPeriodAmount": "85079029443000000000",
-        "currentPeriodEnd": 1732584167,
+        "currentPeriodAmount": "81122095978000000000",
+        "currentPeriodEnd": 1737429947,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "depositLimitGlobal": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
         "ETH_DECIMALS": 18,
         "FUEL_BASE_ASSET_DECIMALS": 9,
         "fuelBaseAssetDecimals": 9,
         "fuelChainStateContract": "0xf3D20Db1D16A4D0ad2f280A5e594FF3c7790f130",
-        "getNextOutgoingMessageNonce": 219765,
+        "getNextOutgoingMessageNonce": 245380,
         "limitAmount": "7829000000000000000000",
         "MAX_MESSAGE_DATA_SIZE": 65536,
         "paused": false,
@@ -213,7 +219,7 @@
         "RATE_LIMIT_DURATION": 604800,
         "rateLimitEnabled": true,
         "SET_RATE_LIMITER_ROLE": "0x7e5b1c957d4df4bad29cdaceffe50f28f282a0d5096601b958917550d4b2e016",
-        "totalDeposited": "19131428798708000000000",
+        "totalDeposited": "14452843843978000000000",
         "withdrawalsPaused": false
       },
       "derivedName": "FuelMessagePortalV3"

--- a/packages/config/src/projects/layer2s/fuel.ts
+++ b/packages/config/src/projects/layer2s/fuel.ts
@@ -279,7 +279,7 @@ export const fuel: Layer2 = {
       ),
     },
     ...discovery.getMultisigPermission(
-      'FuelMultisig',
+      'FuelSecurityCouncil',
       'Can upgrade the FuelERC20Gateway, FuelMessagePortal and FuelChainState contracts, potentially gaining access to all funds. It can unpause contracts and remove L2->L1 messages from the blacklist. It can also limit the tokens that can be bridged to L2.',
     ),
   ],
@@ -287,18 +287,18 @@ export const fuel: Layer2 = {
     addresses: [
       discovery.getContractDetails('FuelERC20Gateway', {
         description: `Standard gateway to deposit and withdraw ERC20 tokens. It implements rate limits and a whitelist for tokens. The whitelist is currently ${isErc20whitelistActive ? 'active' : 'inactive'}.`,
-        upgradableBy: ['FuelMultisig'],
+        upgradableBy: ['FuelSecurityCouncil'],
         upgradeDelay: 'None',
       }),
       discovery.getContractDetails('FuelMessagePortal', {
         description: `Contract that allows to send and receive arbitrary messages to and from L2. It implements a max deposit limit for ETH, currently set to ${depositLimitGlobal} ETH, and rate limits withdrawals. Pausers are allowed to blacklist L2->L1 messages.`,
-        upgradableBy: ['FuelMultisig'],
+        upgradableBy: ['FuelSecurityCouncil'],
         upgradeDelay: 'None',
       }),
       discovery.getContractDetails('FuelChainState', {
         description:
           'Contract that allows state root submissions and settlement.',
-        upgradableBy: ['FuelMultisig'],
+        upgradableBy: ['FuelSecurityCouncil'],
         upgradeDelay: 'None',
       }),
     ],


### PR DESCRIPTION
Resolves L2B-8781. It is currently not considered a properly set up Security Council as the entity-centric threshold is 6/9