### PR TITLE
Dedup descriptions for optimism 

### DIFF
--- a/packages/config/src/projects/layer2s/optimism.ts
+++ b/packages/config/src/projects/layer2s/optimism.ts
@@ -585,7 +585,7 @@ export const optimism: Layer2 = {
     ),
     ...discovery.getMultisigPermission(
       'SecurityCouncilMultisig',
-      `Member of the SuperchainProxyAdminOwner. It implements a LivenessModule used to remove inactive (${livenessInterval}) members while making sure that the threshold remains above 75%. If the number of members falls below 8, the Foundation takes ownership of the Security Council.`,
+      `Member of the SuperchainProxyAdminOwner.`,
       [
         {
           text: 'Security Council members - Optimism Collective forum',

--- a/packages/config/src/projects/layer2s/optimism.ts
+++ b/packages/config/src/projects/layer2s/optimism.ts
@@ -577,7 +577,7 @@ export const optimism: Layer2 = {
     ),
     ...discovery.getMultisigPermission(
       'GuardianMultisig',
-      'Address allowed to pause withdrawals or blacklist dispute games in case of an emergency. It is controlled by the Security Council multisig, but a module allows the Foundation to act through it. The Security Council can disable the module if the Foundation acts maliciously.',
+      'Address allowed to pause withdrawals or blacklist dispute games in case of an emergency.',
     ),
     ...discovery.getMultisigPermission(
       'OpFoundationUpgradeSafe',


### PR DESCRIPTION
the module descriptions get pulled automatically, even when non-discodriven like optimism. we had them duplicated because of this.

closes L2B-8671