### PR TITLE
docs: Fix typo in function name Update README.md

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -123,7 +123,7 @@ The tvl feature is configured via the following environment variables:
 
 ### `tracked-txs` feature
 
-The tracked-txx feature is configured via the following environment variables:
+The tracked-txs feature is configured via the following environment variables:
 
 - `BIGQUERY_CLIENT_EMAIL` - BigQuery credentials
 - `BIGQUERY_PRIVATE_KEY` - BigQuery credentials


### PR DESCRIPTION
### Description 
I noticed a typo in the function name where `tracked-txs` was mistakenly written as `tracked-txx`.
This PR corrects the typo to ensure consistency and avoid potential issues in the codebase.