### PR TITLE
refactor: rename zksync type to zksynclite

### DIFF
--- a/packages/backend/src/config/chain/BlockApi.ts
+++ b/packages/backend/src/config/chain/BlockApi.ts
@@ -1,5 +1,5 @@
 interface BlockBasedApi {
-  type: 'rpc' | 'starknet' | 'zksync' | 'loopring' | 'degate3' | 'fuel'
+  type: 'rpc' | 'starknet' | 'zksynclite' | 'loopring' | 'degate3' | 'fuel'
   url: string
   callsPerMinute: number
   retryStrategy: 'RELIABLE' | 'UNRELIABLE'

--- a/packages/backend/src/config/chain/getChainConfig.ts
+++ b/packages/backend/src/config/chain/getChainConfig.ts
@@ -147,8 +147,7 @@ function getOtherChains(env: Env): ChainApi[] {
       indexerApis: [],
       blockApis: [
         {
-          // TODO: rename to zksynclite
-          type: 'zksync',
+          type: 'zksynclite',
           url: 'https://api.zksync.io/api/v0.2',
           callsPerMinute: 3_000,
           retryStrategy: 'RELIABLE',

--- a/packages/backend/src/providers/Clients.ts
+++ b/packages/backend/src/providers/Clients.ts
@@ -73,7 +73,7 @@ export function initClients(config: Config, logger: Logger): Clients {
           break
         }
 
-        case 'zksync': {
+        case 'zksynclite': {
           const zksyncLiteClient = new ZksyncLiteClient({
             sourceName: 'zksynclite',
             url: blockApi.url,


### PR DESCRIPTION
- Update BlockApi type from 'zksync' to 'zksynclite'
- Update case statement in Clients.ts
- Update type in getChainConfig.ts
- Remove TODO comment

This change improves code clarity by using a more specific name for the ZkSync Lite API type.