### PR TITLE
Fix order of "used by" on Ethereum entry

### DIFF
--- a/packages/frontend/src/server/features/data-availability/summary/get-da-summary-entries.ts
+++ b/packages/frontend/src/server/features/data-availability/summary/get-da-summary-entries.ts
@@ -157,7 +157,9 @@ function getEthereumEntry(
     nameSecondLine: kindToType(ethereumDaLayer.kind),
     href: `/data-availability/projects/${ethereumDaLayer.display.slug}/${ethereumDaLayer.bridges[0].display.slug}`,
     statuses: {},
-    usedIn: ethereumDaLayer.bridges.flatMap((bridge) => bridge.usedIn),
+    usedIn: ethereumDaLayer.bridges
+      .flatMap((bridge) => bridge.usedIn)
+      .sort((a, b) => getTvs([b.id]) - getTvs([a.id])),
     economicSecurity: economicSecurity[ethereumDaLayer.id],
     bridge: ethereumDaLayer.bridges[0].display.name,
     tvs: getTvs(


### PR DESCRIPTION
The "used by" section on the Ethereum entry was not being displayed in the correct order. This pull request fixes the issue by sorting the "used by" entries based on their TVS.