### PR TITLE
Typo fix in diffHistory.md

### DIFF
--- a/packages/backend/discovery/parallel/ethereum/diffHistory.md
+++ b/packages/backend/discovery/parallel/ethereum/diffHistory.md
@@ -2919,7 +2919,7 @@ Generated with discovered.json: 0x9499a161dab92924ef2ab20a6556f1aa1fc54d83
 
 ## Description
 
-The implementation of SequencerInbox was upgraded to a differenct contract with identical code.
+The implementation of SequencerInbox was upgraded to a different contract with identical code.
 This was done to change the immutable boolean `isUsingFeeToken` to false. This immutable should indeed be false on ethereum mainnet as it signifies the base L1 using a custom fee token. (Used as a check for `submitBatchSpendingReport()` function that is needed for fee sequencer fee reimbursement)
 
 ## Watched changes


### PR DESCRIPTION
# Title:
Typo Fix in `diffHistory.md`

# Description:
This pull request fixes a typo in the `diffHistory.md` file. The word **"differenct"** was corrected to **"different"**.

# Changes:
- Corrected the typo **"differenct"** to **"different"** in the description of the SequencerInbox contract upgrade.



