### PR TITLE
typo fix in diffHistory.md

### DIFF
--- a/packages/backend/discovery/eigenda/ethereum/diffHistory.md
+++ b/packages/backend/discovery/eigenda/ethereum/diffHistory.md
@@ -2261,7 +2261,7 @@ Generated with discovered.json: 0x8e81bf69871f9c75df3876cc95e439c7edc13416
 
 ## Description
 
-A third quorum is added. (added config) This new quorum uses a yet unverified strategy to count its stake. (Probbaly related to restaked ALT)
+A third quorum is added. (added config) This new quorum uses a yet unverified strategy to count its stake. (Probably related to restaked ALT)
 
 source: [StakeRegistry.strategyParams(2,0)](https://etherscan.io/address/0x006124Ae7976137266feeBFb3F4D2BE4C073139D#readProxyContract#F20)
 


### PR DESCRIPTION
### Title: Typo Fix in `diffHistory.md`

**Description**:  
This pull request fixes a typo in the `diffHistory.md` file. The word **"Probbaly"** has been corrected to **"Probably"**.

---

**Changes Made**:
1. **Fixed Typo**:
   - **"Probbaly"** → **"Probably"**


