### PR TITLE
Typo fix in diffHistory.md

### DIFF
--- a/packages/backend/discovery/shared-eigenlayer/ethereum/diffHistory.md
+++ b/packages/backend/discovery/shared-eigenlayer/ethereum/diffHistory.md
@@ -2439,7 +2439,7 @@ Generated with discovered.json: 0x15b53e5d1d63506e73b32bb5cecc4f309c7d46bd
 
 ## Description
 
-One signer changed, threshold decreased in EigenLayerTokenMultisig. Unverified strat deployed through the Factory.
+One signer changed, threshold decreased in EigenLayerTokenMultisig. Unverified start deployed through the Factory.
 
 ## Watched changes
 


### PR DESCRIPTION
# Fix Typo in diffHistory.md

## Description
This pull request corrects a typo in the `diffHistory.md` file. The word **"strat"** was replaced with **"start"** to improve clarity and correctness.

## Changes Made
- Corrected "strat" to "start" in the relevant section of `diffHistory.md`.

## Why This Change?
Clear and accurate documentation is critical for users and contributors to effectively understand the project. Fixing this typo ensures professionalism and reduces confusion.

## Checklist
- [x] Typo has been corrected.
- [x] Documentation is now clear and error-free.
- [x] Ready for review and merge.

---

Let me know if there are any further adjustments needed!
