### PR TITLE
Use tinyerc55 to validate EthereumAddress

### DIFF
--- a/packages/shared-pure/package.json
+++ b/packages/shared-pure/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mradomski/tinyerc55": "^0.1.0",
+    "@mradomski/tinyerc55": "^0.1.1",
     "chalk": "^4.1.2",
     "ethers": "^5.7.2",
     "zod": "^3.22.2"

--- a/packages/shared-pure/package.json
+++ b/packages/shared-pure/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@mradomski/tinyerc55": "^0.1.0",
     "chalk": "^4.1.2",
     "ethers": "^5.7.2",
     "zod": "^3.22.2"

--- a/packages/shared-pure/src/types/EthereumAddress.ts
+++ b/packages/shared-pure/src/types/EthereumAddress.ts
@@ -1,3 +1,4 @@
+import { validateAddress } from '@mradomski/tinyerc55'
 import { constants, utils } from 'ethers'
 
 export type EthereumAddress = string & {
@@ -5,11 +6,12 @@ export type EthereumAddress = string & {
 }
 
 export function EthereumAddress(value: string): EthereumAddress {
-  try {
-    return utils.getAddress(value) as unknown as EthereumAddress
-  } catch {
+  const result = validateAddress(value)
+  if (!result.valid) {
     throw new TypeError('Invalid EthereumAddress')
   }
+
+  return result.address as unknown as EthereumAddress
 }
 
 EthereumAddress.ZERO = EthereumAddress(constants.AddressZero)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,6 +928,9 @@ importers:
 
   packages/shared-pure:
     dependencies:
+      '@mradomski/tinyerc55':
+        specifier: ^0.1.0
+        version: 0.1.0
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -2592,6 +2595,9 @@ packages:
 
   '@mradomski/fast-solidity-parser@0.1.1':
     resolution: {integrity: sha512-BnX+UKswinYed/yFgH9zwYNNBvUXJu32vJkxwnkZuPcV/YR9TDzMgjAOhiq8Vj77wDcfHHhyA0/MdIMhkd92PQ==}
+
+  '@mradomski/tinyerc55@0.1.0':
+    resolution: {integrity: sha512-1Sxb0MaWQLQoUEGkJ73NygHnhEOjifxVbw1z3qkU1zfm5Ub0LHjtLl/Zj6HeixX9O5SjZZbS138TvIE6QiKVkw==}
 
   '@mrleebo/prisma-ast@0.7.0':
     resolution: {integrity: sha512-GTPkYf1meO2UXXIrz/SIDFWz+P4kXo2PTt36LYh/oNxV1PieYi7ZgenQk4IV0ut71Je3Z8ZoNZ8Tr7v2c1X1pg==}
@@ -9301,7 +9307,7 @@ snapshots:
       '@babel/traverse': 7.25.9
       '@babel/types': 7.26.0
       convert-source-map: 2.0.0
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -9360,7 +9366,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -10022,7 +10028,7 @@ snapshots:
       '@babel/parser': 7.26.1
       '@babel/template': 7.25.9
       '@babel/types': 7.26.0
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -10494,7 +10500,7 @@ snapshots:
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -10504,7 +10510,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -11018,6 +11024,8 @@ snapshots:
       react: 18.3.1
 
   '@mradomski/fast-solidity-parser@0.1.1': {}
+
+  '@mradomski/tinyerc55@0.1.0': {}
 
   '@mrleebo/prisma-ast@0.7.0':
     dependencies:
@@ -12637,7 +12645,7 @@ snapshots:
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.95.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(esbuild@0.20.2))':
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       endent: 2.1.0
       find-cache-dir: 3.3.2
       flat-cache: 3.2.0
@@ -13232,7 +13240,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.12.2
       '@typescript-eslint/visitor-keys': 8.12.2
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -13429,7 +13437,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14336,10 +14344,6 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
-  debug@4.3.7:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.3.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -14700,7 +14704,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.20.2):
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       esbuild: 0.20.2
     transitivePeerDependencies:
       - supports-color
@@ -15035,7 +15039,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -15728,7 +15732,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -15753,7 +15757,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -17792,7 +17796,7 @@ snapshots:
   socks-proxy-agent@6.2.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@8.1.1)
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,8 +929,8 @@ importers:
   packages/shared-pure:
     dependencies:
       '@mradomski/tinyerc55':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -2596,8 +2596,8 @@ packages:
   '@mradomski/fast-solidity-parser@0.1.1':
     resolution: {integrity: sha512-BnX+UKswinYed/yFgH9zwYNNBvUXJu32vJkxwnkZuPcV/YR9TDzMgjAOhiq8Vj77wDcfHHhyA0/MdIMhkd92PQ==}
 
-  '@mradomski/tinyerc55@0.1.0':
-    resolution: {integrity: sha512-1Sxb0MaWQLQoUEGkJ73NygHnhEOjifxVbw1z3qkU1zfm5Ub0LHjtLl/Zj6HeixX9O5SjZZbS138TvIE6QiKVkw==}
+  '@mradomski/tinyerc55@0.1.1':
+    resolution: {integrity: sha512-cMsweutjiqWSazlBN5YgRWPe6Sy9Z/ZPQ8MyVqNsxsZodH5i0L74FydvIASIQFLYWKhk0mktRaJ/VDDf/+AFbg==}
 
   '@mrleebo/prisma-ast@0.7.0':
     resolution: {integrity: sha512-GTPkYf1meO2UXXIrz/SIDFWz+P4kXo2PTt36LYh/oNxV1PieYi7ZgenQk4IV0ut71Je3Z8ZoNZ8Tr7v2c1X1pg==}
@@ -11025,7 +11025,7 @@ snapshots:
 
   '@mradomski/fast-solidity-parser@0.1.1': {}
 
-  '@mradomski/tinyerc55@0.1.0': {}
+  '@mradomski/tinyerc55@0.1.1': {}
 
   '@mrleebo/prisma-ast@0.7.0':
     dependencies:


### PR DESCRIPTION
Tested with `hyperfine --warmup 5 "echo echo 'require("@l2beat/config")' | node"`

Before:
```
Benchmark 1: ethers
  Time (mean ± σ):      1.442 s ±  0.036 s    [User: 1.588 s, System: 0.208 s]
  Range (min … max):    1.413 s …  1.528 s    10 runs
```

After:
```
Benchmark 1: tinyerc55
  Time (mean ± σ):     975.7 ms ±   9.9 ms    [User: 1137.3 ms, System: 192.4 ms]
  Range (min … max):   966.3 ms … 1000.0 ms    10 runs
```