### PR TITLE
Save sharedModules

### DIFF
--- a/packages/backend/discovery/apex/ethereum/diffHistory.md
+++ b/packages/backend/discovery/apex/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x7a6827f31d178614aac9c3b4e009541e8656e6cf
+Generated with discovered.json: 0x9efaa4125824a49cd3c3eba891f97f65c0d9b99f
 
 # Diff at Mon, 20 Jan 2025 11:09:15 GMT:
 

--- a/packages/backend/discovery/apex/ethereum/discovered.json
+++ b/packages/backend/discovery/apex/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 19825348,
   "configHash": "0x3d1fdfc99f2044bbaa42f4026f6f57fdfd74dfa5caa83cdc851bdf4d95b3eb36",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "AggregationRouterV4",

--- a/packages/backend/discovery/astarzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/astarzkevm/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x87fda66836b980612621d681b3af04aec35db16c
+Generated with discovered.json: 0xab3c0a75e7c9774b5a715df68694eec9ad18adf9
 
 # Diff at Mon, 20 Jan 2025 11:09:17 GMT:
 

--- a/packages/backend/discovery/astarzkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/astarzkevm/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 20325048,
   "configHash": "0x8c4ec9a89ad91e8b288f93a59283da5ca2019974864f0ab39fa4b9f53292b7e2",
+  "sharedModules": ["shared-polygon-cdk"],
   "contracts": [
     {
       "name": "AstarVerifier",

--- a/packages/backend/discovery/brine/ethereum/diffHistory.md
+++ b/packages/backend/discovery/brine/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xb3f7d8aa355f411b1963d446c58004945b1a2d21
+Generated with discovered.json: 0xe676b810d2c6f4b8ff9601b69d8960bdd7c1718a
 
 # Diff at Mon, 20 Jan 2025 11:09:21 GMT:
 

--- a/packages/backend/discovery/brine/ethereum/discovered.json
+++ b/packages/backend/discovery/brine/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 19825361,
   "configHash": "0x6d81b488e8f62481738c976e0f1919fc2ae2309a0a49094a92ab83e119ffd897",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "StarkExchange",

--- a/packages/backend/discovery/canvasconnect/ethereum/diffHistory.md
+++ b/packages/backend/discovery/canvasconnect/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x54c2eb77c8c01712cdf30477003c5eaa7978f1e6
+Generated with discovered.json: 0x941a7677e2a50eb0c2b6ac2cb520237bb006735f
 
 # Diff at Mon, 20 Jan 2025 11:09:21 GMT:
 

--- a/packages/backend/discovery/canvasconnect/ethereum/discovered.json
+++ b/packages/backend/discovery/canvasconnect/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 19825363,
   "configHash": "0x1186dd80cc3f9795816bb690b7faadee1864ab17eba5d25e1af47d50fa8f4def",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "GpsFactRegistryAdapter",

--- a/packages/backend/discovery/cronoszkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/cronoszkevm/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xe0cd4967c23c2f9e9be33cb5f0e793a33fbd39f2
+Generated with discovered.json: 0x5e8e0d515eadb4b77c41c006266778320ea52b99
 
 # Diff at Thu, 23 Jan 2025 09:37:44 GMT:
 

--- a/packages/backend/discovery/cronoszkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/cronoszkevm/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21686341,
   "configHash": "0xb9707df3aa255e90f3b4acd84a9ff8dffae09607c1c86bb89b01cbf7488a377b",
+  "sharedModules": ["shared-zk-stack"],
   "contracts": [
     {
       "name": "Verifier",

--- a/packages/backend/discovery/deversifi/ethereum/diffHistory.md
+++ b/packages/backend/discovery/deversifi/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x93f3ff8da78c4a5bab6d0d0e91584dd0216261e0
+Generated with discovered.json: 0xdd684683f170aba7a9fcfcc44fe2e42b02e9226b
 
 # Diff at Mon, 20 Jan 2025 11:09:25 GMT:
 

--- a/packages/backend/discovery/deversifi/ethereum/discovered.json
+++ b/packages/backend/discovery/deversifi/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 20640703,
   "configHash": "0x82d1fdd56e466cc4f9e75f941867b273933bb175c5b2d598cfb08ae9cdbbbfec",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "Committee",

--- a/packages/backend/discovery/eigenda/ethereum/diffHistory.md
+++ b/packages/backend/discovery/eigenda/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xd4f9f1f4c46984e287ab322a4c0b93a22d3fe85a
+Generated with discovered.json: 0xfdecefca0505b39cd2ee474098d469339feb25d1
 
 # Diff at Mon, 27 Jan 2025 08:44:35 GMT:
 

--- a/packages/backend/discovery/eigenda/ethereum/discovered.json
+++ b/packages/backend/discovery/eigenda/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21628459,
   "configHash": "0x3dc8d71e572dc96094cd0d5578d13579543d11933f3b4a2d76a317d315aa2c8b",
+  "sharedModules": ["shared-eigenlayer"],
   "contracts": [
     {
       "name": "StakeRegistry",

--- a/packages/backend/discovery/gpt/ethereum/diffHistory.md
+++ b/packages/backend/discovery/gpt/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xfefa2eea1f1591cc7d48c4d83ed641816edeba5f
+Generated with discovered.json: 0x20bd0ffd0c9b9e7795b3bc9c9774291626f20f85
 
 # Diff at Mon, 20 Jan 2025 11:09:33 GMT:
 

--- a/packages/backend/discovery/gpt/ethereum/discovered.json
+++ b/packages/backend/discovery/gpt/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21628462,
   "configHash": "0x492a276fe0e24cc14a7c4ac3b6e1d6d3427721121e25610066ea3c8bd8498ded",
+  "sharedModules": ["shared-polygon-cdk"],
   "contracts": [
     {
       "name": "Verifier",

--- a/packages/backend/discovery/grvt/ethereum/diffHistory.md
+++ b/packages/backend/discovery/grvt/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x332f9b98d8c5fd10db3ff8890dca23f240f438cd
+Generated with discovered.json: 0x8389fd0febf49490dfb76c31b368eb6fbf1d8530
 
 # Diff at Mon, 20 Jan 2025 11:09:34 GMT:
 

--- a/packages/backend/discovery/grvt/ethereum/discovered.json
+++ b/packages/backend/discovery/grvt/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21629172,
   "configHash": "0xc17359dda03f1eda182b4bffe4a7993bcfadd5f27f81ec5c9616759b9ddd1e25",
+  "sharedModules": ["shared-zk-stack"],
   "contracts": [
     {
       "name": "GrvtChainAdminMultisig",

--- a/packages/backend/discovery/immutablex/ethereum/diffHistory.md
+++ b/packages/backend/discovery/immutablex/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x97e5279e959eb2e772c14be6234d447e46e863b9
+Generated with discovered.json: 0x578ad983ad1e920e972e8e745308c2ba122d4f40
 
 # Diff at Mon, 20 Jan 2025 11:09:36 GMT:
 

--- a/packages/backend/discovery/immutablex/ethereum/discovered.json
+++ b/packages/backend/discovery/immutablex/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21387345,
   "configHash": "0x312dd075dbcf3dc3ea19d8c0640bfed25bd5a3d8fb79a3d010924543a10dccf3",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "Committee",

--- a/packages/backend/discovery/layer2financezk/ethereum/diffHistory.md
+++ b/packages/backend/discovery/layer2financezk/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xba72cddecce686150b195cd33bc0a439426b42ef
+Generated with discovered.json: 0x51bc15d6dbdceaec2269107c28dc6213a72831b7
 
 # Diff at Mon, 20 Jan 2025 11:09:40 GMT:
 

--- a/packages/backend/discovery/layer2financezk/ethereum/discovered.json
+++ b/packages/backend/discovery/layer2financezk/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 19825376,
   "configHash": "0xf6fc170779218c98b89f20a4ec74c9e049ebffe128074f7567887679a758f64f",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "OrderRegistry",

--- a/packages/backend/discovery/myria/ethereum/diffHistory.md
+++ b/packages/backend/discovery/myria/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xc9fd30041ffebfec1fb53663f78ef32beb874dfe
+Generated with discovered.json: 0x692a8273fb1be8fe1333860c99ae135d56a61444
 
 # Diff at Mon, 20 Jan 2025 11:09:47 GMT:
 

--- a/packages/backend/discovery/myria/ethereum/discovered.json
+++ b/packages/backend/discovery/myria/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 19825378,
   "configHash": "0xda8c7387c100cb2461cf5680dfd15bd075a42d7fb763a4c55b73ceeb97a6f380",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "Committee",

--- a/packages/backend/discovery/optimism/ethereum/diffHistory.md
+++ b/packages/backend/discovery/optimism/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x87efb2585e13b00ac3aae3268faa047ddcfe14a3
+Generated with discovered.json: 0xfe4f950cc9481767f7f4d17684d9295c599d211a
 
 # Diff at Tue, 21 Jan 2025 11:19:15 GMT:
 

--- a/packages/backend/discovery/optimism/ethereum/discovered.json
+++ b/packages/backend/discovery/optimism/ethereum/discovered.json
@@ -318,7 +318,7 @@
       "values": {
         "$immutable": true,
         "safe": "0xc2819DC788505Aac350142A7A707BF9D03E3Bd03",
-        "timeSinceLastL2beatInteraction": "9d 16h",
+        "timeSinceLastL2beatInteraction": "9d 17h",
         "version": "1.0.0"
       },
       "derivedName": "LivenessGuard"

--- a/packages/backend/discovery/paradex/ethereum/diffHistory.md
+++ b/packages/backend/discovery/paradex/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x2d8ed074a98b6921ca5b8c5aa2a2a873a6fff42d
+Generated with discovered.json: 0x7543e3797229957078655ecd9be43d97603a96ef
 
 # Diff at Mon, 20 Jan 2025 11:09:53 GMT:
 

--- a/packages/backend/discovery/paradex/ethereum/discovered.json
+++ b/packages/backend/discovery/paradex/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21629810,
   "configHash": "0xaa0aa74ef8fd5b854c9bdc4faf84f21c2f051ce5ee9549d332769fbbf7617fda",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "ParadexImplementationGovernorMultisig",

--- a/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
+++ b/packages/backend/discovery/polygonzkevm/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xaf1789d5aa68cdb95fdbced8505a71d082d6b9d3
+Generated with discovered.json: 0xf75a5eb2457d27bc6bf4f0c93ba7130daee9f7d4
 
 # Diff at Mon, 20 Jan 2025 11:09:55 GMT:
 

--- a/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
+++ b/packages/backend/discovery/polygonzkevm/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21630127,
   "configHash": "0xceb4cee1478e471326f07e709db9d05e23b7736b3ed527306f8292bcc92cc522",
+  "sharedModules": ["shared-polygon-cdk"],
   "contracts": [
     {
       "name": "daiBridge",

--- a/packages/backend/discovery/reddioex/ethereum/diffHistory.md
+++ b/packages/backend/discovery/reddioex/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x1f921f53080ce1afbe2e86c15ee4a8183a83d969
+Generated with discovered.json: 0x3eaee540f9209ace5924e0e769ae18059d33d122
 
 # Diff at Mon, 20 Jan 2025 11:09:58 GMT:
 

--- a/packages/backend/discovery/reddioex/ethereum/discovered.json
+++ b/packages/backend/discovery/reddioex/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 19825385,
   "configHash": "0x52fd208c42da4bb6c8289925e32c4fc4d9a65cbf653f16bf3398570f09b7c047",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "Committee",

--- a/packages/backend/discovery/silicon/ethereum/diffHistory.md
+++ b/packages/backend/discovery/silicon/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x6d0e061c9405d036a0af0ec1c2123438eda83e85
+Generated with discovered.json: 0xcd5e6c347866f9b8b557e681f526ac57d516b5e9
 
 # Diff at Mon, 20 Jan 2025 11:10:06 GMT:
 

--- a/packages/backend/discovery/silicon/ethereum/discovered.json
+++ b/packages/backend/discovery/silicon/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21628488,
   "configHash": "0xa49ef0af233380c9e6c9a7a34d9551533568ffa4fa19a55168386920098d0578",
+  "sharedModules": ["shared-polygon-cdk"],
   "contracts": [
     {
       "name": "Verifier",

--- a/packages/backend/discovery/sophon/ethereum/diffHistory.md
+++ b/packages/backend/discovery/sophon/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x58a5ad3c6d5983fe0f2d1a9f12b354e06c7125e7
+Generated with discovered.json: 0x5eb22ac8d74bc92d3dbf90a46549a36c36d4706c
 
 # Diff at Wed, 22 Jan 2025 12:22:26 GMT:
 

--- a/packages/backend/discovery/sophon/ethereum/discovered.json
+++ b/packages/backend/discovery/sophon/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21679920,
   "configHash": "0x70ff044e340894fa64468e6c90090d30f3a9e7f2b2deb9c0b460b487bd10dede",
+  "sharedModules": ["shared-zk-stack"],
   "contracts": [
     {
       "name": "SophonZkEvm",

--- a/packages/backend/discovery/sorare/ethereum/diffHistory.md
+++ b/packages/backend/discovery/sorare/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x47d4a4e8c7606ccd508752730dfa097f43f91dfd
+Generated with discovered.json: 0x27954a37dd949dd2df85ccc240885179573f5185
 
 # Diff at Mon, 20 Jan 2025 11:10:10 GMT:
 

--- a/packages/backend/discovery/sorare/ethereum/discovered.json
+++ b/packages/backend/discovery/sorare/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 19825381,
   "configHash": "0x94773065d0f1386ec8c6c632e5c85c118e13e5372c3ce6ce016a1b3d1e364b7d",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "OrderRegistry",

--- a/packages/backend/discovery/starknet/ethereum/diffHistory.md
+++ b/packages/backend/discovery/starknet/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xe1a151087c3ce613b22d4e8c7f7f5000aa0fb778
+Generated with discovered.json: 0xb9503031051fa02f99e862e89799c59f17f066ff
 
 # Diff at Mon, 20 Jan 2025 11:10:12 GMT:
 

--- a/packages/backend/discovery/starknet/ethereum/discovered.json
+++ b/packages/backend/discovery/starknet/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21635833,
   "configHash": "0xe11ed7f0d9d30e7453bd2e5c94bedc50fb87eb26adac42d7dfda9fd01b41ca1b",
+  "sharedModules": ["shared-sharp-verifier"],
   "contracts": [
     {
       "name": "BridgeMultisig",

--- a/packages/backend/discovery/treasure/ethereum/diffHistory.md
+++ b/packages/backend/discovery/treasure/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xc04b8f4486721901d4ec338ed71da8a2fa993519
+Generated with discovered.json: 0x9ccc58c9872fd26aaf70224eff95e611fe660852
 
 # Diff at Thu, 09 Jan 2025 06:58:54 GMT:
 

--- a/packages/backend/discovery/treasure/ethereum/discovered.json
+++ b/packages/backend/discovery/treasure/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21585285,
   "configHash": "0xe86eefbfd9fd6ebe3b8959529e759963b9b19a4a4d584b775ad63dc521b2afe1",
+  "sharedModules": ["shared-zk-stack"],
   "contracts": [
     {
       "name": "TreasureChainAdminMultisig",

--- a/packages/backend/discovery/wirex/ethereum/diffHistory.md
+++ b/packages/backend/discovery/wirex/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x5d14ed154ff97a54cc3da8cbcbef1ae7b498fd3c
+Generated with discovered.json: 0xfb73a1a9b97e5619b3a87225bc6aa537141c27b2
 
 # Diff at Mon, 20 Jan 2025 11:10:20 GMT:
 

--- a/packages/backend/discovery/wirex/ethereum/discovered.json
+++ b/packages/backend/discovery/wirex/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21628493,
   "configHash": "0x95215c58c4c6019694e41ef1dcd739b866744e9c8ac48521603f973baf351506",
+  "sharedModules": ["shared-polygon-cdk"],
   "contracts": [
     {
       "name": "Verifier",

--- a/packages/backend/discovery/witness/ethereum/diffHistory.md
+++ b/packages/backend/discovery/witness/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xaecb72b56f4253812a7f9aa24d19de3d1e66a9e2
+Generated with discovered.json: 0xf62412de983d39a423fea62956f99ee7593c1cb0
 
 # Diff at Mon, 20 Jan 2025 11:10:20 GMT:
 

--- a/packages/backend/discovery/witness/ethereum/discovered.json
+++ b/packages/backend/discovery/witness/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 20491473,
   "configHash": "0x271dae2021804d278c07a38d665fb6d6a92123fc674159d78c7580ec08dc83df",
+  "sharedModules": ["shared-polygon-cdk"],
   "contracts": [
     {
       "name": "FflonkVerifier",

--- a/packages/backend/discovery/xlayer/ethereum/diffHistory.md
+++ b/packages/backend/discovery/xlayer/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x750011224acc0426108e062745e9f260a8b59a24
+Generated with discovered.json: 0x840195c017aacfa4b6a66094bc3d25659296fc17
 
 # Diff at Mon, 20 Jan 2025 12:06:34 GMT:
 

--- a/packages/backend/discovery/xlayer/ethereum/discovered.json
+++ b/packages/backend/discovery/xlayer/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21665594,
   "configHash": "0x5fe03ef944f620355c5cb07ebd60481d7b318a35bf013a954856a9dd5d02b06e",
+  "sharedModules": ["shared-polygon-cdk"],
   "contracts": [
     {
       "name": "XLayerValidiumDAC",

--- a/packages/backend/discovery/zeronetwork/ethereum/diffHistory.md
+++ b/packages/backend/discovery/zeronetwork/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x056eb47d3a636fbda5fffd20b0031ffa242bc03c
+Generated with discovered.json: 0x096276bf47fe0662e7b13e891c951db44428de7c
 
 # Diff at Fri, 17 Jan 2025 08:39:46 GMT:
 

--- a/packages/backend/discovery/zeronetwork/ethereum/discovered.json
+++ b/packages/backend/discovery/zeronetwork/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21643075,
   "configHash": "0xae3571bf0f2057047d38992f61cb101942750148ec69ffb5041f29a52a71e70d",
+  "sharedModules": ["shared-zk-stack"],
   "contracts": [
     {
       "name": "Verifier",

--- a/packages/backend/discovery/zksync2/ethereum/diffHistory.md
+++ b/packages/backend/discovery/zksync2/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xbe786efbf76e30a304dd44b399b0d5fc4780a788
+Generated with discovered.json: 0x36b8c6d9ead866cfaf46cdf38330c2c22943315b
 
 # Diff at Wed, 15 Jan 2025 13:55:12 GMT:
 

--- a/packages/backend/discovery/zksync2/ethereum/discovered.json
+++ b/packages/backend/discovery/zksync2/ethereum/discovered.json
@@ -3,6 +3,7 @@
   "chain": "ethereum",
   "blockNumber": 21630311,
   "configHash": "0x5efac1da459f0fa120737787953023f6c76cead01e8535293567aea8dac40602",
+  "sharedModules": ["shared-zk-stack"],
   "contracts": [
     {
       "name": "Verifier",

--- a/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
+++ b/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
@@ -52,13 +52,7 @@ export class DiscoveryRunner {
 
     setDiscoveryMetrics(this.allProviders.getStats(config.chain), config.chain)
 
-    const discovery = toDiscoveryOutput(
-      config.name,
-      config.chain,
-      config.hash,
-      blockNumber,
-      result,
-    )
+    const discovery = toDiscoveryOutput(config, blockNumber, result)
 
     const flatSources = flattenDiscoveredSources(result, DiscoveryLogger.SILENT)
 

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -61,10 +61,10 @@ export class ProjectDiscovery {
     public readonly chain: string = 'ethereum',
     configReader = new ConfigReader(join(process.cwd(), '../backend')),
   ) {
-    const config = configReader.readConfig(projectName, chain)
+    const discovery = configReader.readDiscovery(projectName, chain)
     this.discoveries = [
-      configReader.readDiscovery(projectName, chain),
-      ...config.sharedModules.map((module) =>
+      discovery,
+      ...(discovery.sharedModules ?? []).map((module) =>
         configReader.readDiscovery(module, chain),
       ),
     ]

--- a/packages/discovery-types/src/Discovery.ts
+++ b/packages/discovery-types/src/Discovery.ts
@@ -29,6 +29,7 @@ export interface DiscoveryOutput {
   eoas: EoaParameters[]
   abis: Record<string, string[]>
   configHash: Hash256
+  sharedModules?: string[]
   usedTemplates: Record<string, Hash256>
 }
 

--- a/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
+++ b/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
@@ -45,13 +45,7 @@ async function saveDiscoveredJson(
   blockNumber: number,
   options: SaveDiscoveryResultOptions,
 ): Promise<void> {
-  const project = toDiscoveryOutput(
-    config.name,
-    config.chain,
-    config.hash,
-    blockNumber,
-    results,
-  )
+  const project = toDiscoveryOutput(config, blockNumber, results)
   const json = await toPrettyJson(project)
   const discoveryFilename = options.discoveryFilename ?? 'discovered.json'
   await writeFile(posix.join(rootPath, discoveryFilename), json)

--- a/packages/discovery/src/discovery/output/toDiscoveryOutput.ts
+++ b/packages/discovery/src/discovery/output/toDiscoveryOutput.ts
@@ -6,6 +6,7 @@ import type {
 import type { Hash256 } from '@l2beat/shared-pure'
 
 import type { Analysis, AnalyzedContract } from '../analysis/AddressAnalyzer'
+import type { DiscoveryConfig } from '../config/DiscoveryConfig'
 import { resolveAnalysis } from '../permission-resolving/resolveAnalysis'
 import {
   transformToIssued,
@@ -14,20 +15,19 @@ import {
 import { neuterErrors } from './errors'
 
 export function toDiscoveryOutput(
-  name: string,
-  chain: string,
-  configHash: Hash256,
+  config: DiscoveryConfig,
   blockNumber: number,
   results: Analysis[],
 ): DiscoveryOutput {
-  return {
-    name,
-    chain,
+  return withoutUndefinedKeys({
+    name: config.name,
+    chain: config.chain,
     blockNumber,
-    configHash,
+    configHash: config.hash,
+    sharedModules: undefinedIfEmpty(config.sharedModules),
     ...processAnalysis(results),
     usedTemplates: collectUsedTemplatesWithHashes(results),
-  }
+  })
 }
 
 function collectUsedTemplatesWithHashes(

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -129,13 +129,7 @@ async function justDiscover(
     http,
     overwriteCache,
   )
-  return toDiscoveryOutput(
-    config.name,
-    config.chain,
-    config.hash,
-    blockNumber,
-    result,
-  )
+  return toDiscoveryOutput(config, blockNumber, result)
 }
 
 export async function discover(


### PR DESCRIPTION
Removes the need to read the config in ProjectDiscovery, saves time but not running Zod validation.
Tested with `hyperfine --warmup 5 "echo echo 'require("@l2beat/config")' | node"`

Before:

```
Benchmark 1: Config read
  Time (mean ± σ):      1.450 s ±  0.029 s    [User: 1.609 s, System: 0.205 s]
  Range (min … max):    1.417 s …  1.498 s    10 runs
```

After
```
Benchmark 1: Just discovery
  Time (mean ± σ):      1.185 s ±  0.028 s    [User: 1.261 s, System: 0.158 s]
  Range (min … max):    1.157 s …  1.237 s    10 runs
```