### PR TITLE
Cache flattening hash calls

### DIFF
--- a/packages/discovery/src/discovery/analysis/TemplateService.ts
+++ b/packages/discovery/src/discovery/analysis/TemplateService.ts
@@ -5,6 +5,7 @@ import { hashJson } from '@l2beat/shared'
 import { EthereumAddress, type Hash256, type json } from '@l2beat/shared-pure'
 import {
   flattenFirstSource,
+  flatteningHash,
   formatIntoHashable,
   sha2_256bit,
 } from '../../flatten/utils'
@@ -144,7 +145,7 @@ export class TemplateService {
     const allTemplates = this.listAllTemplates()
     for (const [templateId, shapeFilePaths] of Object.entries(allTemplates)) {
       const haystackHashes = shapeFilePaths.paths.map((p) =>
-        sha2_256bit(formatIntoHashable(readFileSync(p, 'utf8'))),
+        flatteningHash(readFileSync(p, 'utf8')),
       )
       result[templateId] = {
         criteria: shapeFilePaths.criteria,

--- a/packages/discovery/src/discovery/source/SourceCodeService.ts
+++ b/packages/discovery/src/discovery/source/SourceCodeService.ts
@@ -1,7 +1,7 @@
 import type { EthereumAddress } from '@l2beat/shared-pure'
 import { zip } from 'lodash'
 
-import { flatteningHash, sha2_256bit } from '../../flatten/utils'
+import { contractFlatteningHash, sha2_256bit } from '../../flatten/utils'
 import type { ContractSource } from '../../utils/IEtherscanClient'
 import type { IProvider } from '../provider/IProvider'
 import { deduplicateAbi } from './deduplicateAbi'
@@ -93,7 +93,7 @@ export class SourceCodeService {
     item: ContractSource,
     manualSourcePath: string | undefined,
   ): string | undefined {
-    const hash = flatteningHash(item)
+    const hash = contractFlatteningHash(item)
     if (hash === undefined && manualSourcePath !== undefined) {
       return sha2_256bit(manualSourcePath)
     }


### PR DESCRIPTION
Before:

```
pnpm refresh-discovery --all -y  102.94s user 18.95s system 102% cpu 1:58.98 total
```

After:

```
pnpm refresh-discovery --all -y  65.31s user 18.28s system 100% cpu 1:22.94 total
```