### PR TITLE
Update withdrawals wording to messaging

### DIFF
--- a/packages/config/src/common/exits.ts
+++ b/packages/config/src/common/exits.ts
@@ -1,24 +1,49 @@
 import { formatSeconds } from '@l2beat/shared-pure'
 import type { ProjectTechnologyChoice, ScalingProjectRisk } from '../types'
 
-function REGULAR(
+function REGULAR_WITHDRAWAL(
   type: 'zk' | 'optimistic',
-  proof: 'no proof' | 'merkle proof',
   timeSeconds?: number,
 ): ProjectTechnologyChoice {
-  const finalized = type === 'zk' ? 'proven' : 'finalized'
-  const requires = proof === 'no proof' ? 'does not require' : 'requires'
-  const timeString =
+  // optimistic specific considerations
+  const delay =
     timeSeconds !== undefined
       ? `takes a challenge period of ${formatSeconds(timeSeconds)}`
       : 'usually takes several days'
-  const time =
+  const optimisticConsideration =
     type === 'optimistic'
-      ? ` The process of block finalization ${timeString} to complete.`
+      ? ` The process of settling a block ${delay} to complete.`
       : ''
+  // zk specific considerations
+  const zkConsideration =
+    type === 'zk' ? 'ZK proofs are required to settle blocks.' : ''
   return {
     name: 'Regular exit',
-    description: `The user initiates the withdrawal by submitting a regular transaction on this chain. When the block containing that transaction is ${finalized} the funds become available for withdrawal on L1.${time} Finally the user submits an L1 transaction to claim the funds. This transaction ${requires} a merkle proof.`,
+    description: `The user initiates the withdrawal by submitting a regular transaction on this chain. When the block containing that transaction is settled the funds become available for withdrawal on L1.${optimisticConsideration}${zkConsideration} Finally the user submits an L1 transaction to claim the funds.`,
+    risks: [],
+    references: [],
+  }
+}
+
+function REGULAR_MESSAGING(
+  type: 'zk' | 'optimistic',
+  timeSeconds?: number,
+): ProjectTechnologyChoice {
+  // optimistic specific considerations
+  const delay =
+    timeSeconds !== undefined
+      ? `takes a challenge period of ${formatSeconds(timeSeconds)}`
+      : 'usually takes several days'
+  const optimisticConsideration =
+    type === 'optimistic'
+      ? ` The process of block finalization ${delay} to complete.`
+      : ''
+  // zk specific considerations
+  const zkConsideration =
+    type === 'zk' ? ' ZK proofs are required to settle blocks.' : ''
+  return {
+    name: 'Regular messaging',
+    description: `The user initiates L2->L1 messages by submitting a regular transaction on this chain. When the block containing that transaction is settled, the message becomes available for processing on L1.${optimisticConsideration}${zkConsideration}`,
     risks: [],
     references: [],
   }
@@ -28,7 +53,6 @@ function REGULAR_YIELDING(
   type: 'zk' | 'optimistic',
   timeSeconds?: number,
 ): ProjectTechnologyChoice {
-  const finalized = type === 'zk' ? 'proven' : 'finalized'
   const timeString =
     timeSeconds !== undefined
       ? `takes a challenge period of ${formatSeconds(timeSeconds)}`
@@ -39,7 +63,7 @@ function REGULAR_YIELDING(
       : ''
   return {
     name: 'Regular exit',
-    description: `The user initiates the withdrawal by submitting a regular transaction on this chain. When the block containing that transaction is ${finalized} the funds become available for withdrawal on L1.${time} Once funds are added to the withdrawal queue, operator must ensure there is enough liquidity for withdrawals. If not, they need to reclaim tokens from Yield Providers.`,
+    description: `The user initiates the withdrawal by submitting a regular transaction on this chain. When the block containing that transaction is settled the funds become available for withdrawal on L1.${time} Once funds are added to the withdrawal queue, operator must ensure there is enough liquidity for withdrawals. If not, they need to reclaim tokens from Yield Providers.`,
     risks: [],
     references: [],
   }
@@ -93,7 +117,7 @@ function EMERGENCY(
 }
 
 const STARKEX_REGULAR_PERPETUAL: ProjectTechnologyChoice = {
-  ...REGULAR('zk', 'no proof'),
+  ...REGULAR_WITHDRAWAL('zk'),
   references: [
     {
       title: 'Withdrawal - StarkEx documentation',
@@ -103,9 +127,9 @@ const STARKEX_REGULAR_PERPETUAL: ProjectTechnologyChoice = {
 }
 
 const STARKEX_REGULAR_SPOT: ProjectTechnologyChoice = {
-  ...REGULAR('zk', 'no proof'),
+  ...REGULAR_WITHDRAWAL('zk'),
   description:
-    REGULAR('zk', 'no proof').description +
+    REGULAR_WITHDRAWAL('zk').description +
     ' When withdrawing NFTs they are minted on L1.',
   references: [
     {
@@ -163,10 +187,10 @@ const OPERATOR_CENSORS_WITHDRAWAL: ScalingProjectRisk = {
 }
 
 const STARKNET_REGULAR: ProjectTechnologyChoice = {
-  ...REGULAR('zk', 'no proof'),
+  ...REGULAR_MESSAGING('zk'),
   description:
-    REGULAR('zk', 'no proof').description +
-    ' Note that the withdrawal request can be censored by the Sequencer.',
+    REGULAR_MESSAGING('zk').description +
+    ' Note that the message request can be censored by the Sequencer.',
   references: [
     {
       title:
@@ -238,7 +262,8 @@ export const RISK_LACK_OF_LIQUIDITY: ScalingProjectRisk = {
 }
 
 export const EXITS = {
-  REGULAR,
+  REGULAR_WITHDRAWAL,
+  REGULAR_MESSAGING,
   REGULAR_YIELDING,
   FORCED,
   EMERGENCY,

--- a/packages/config/src/common/exits.ts
+++ b/packages/config/src/common/exits.ts
@@ -69,7 +69,7 @@ function REGULAR_YIELDING(
   }
 }
 
-function FORCED(
+function FORCED_WITHDRAWAL(
   orHalt?: 'forced-withdrawals' | 'all-withdrawals',
 ): ProjectTechnologyChoice {
   let orHaltString = ''
@@ -77,7 +77,7 @@ function FORCED(
     switch (orHalt) {
       case 'forced-withdrawals':
         orHaltString =
-          ' or halt all messages from L1, including all forced withdrawals and deposits'
+          ' or halt all withdrawals from L1, including all forced withdrawals and deposits'
         break
       case 'all-withdrawals':
         orHaltString =
@@ -88,6 +88,30 @@ function FORCED(
   return {
     name: 'Forced exit',
     description: `If the user experiences censorship from the operator with regular exit they can submit their withdrawal requests directly on L1. The system is then obliged to service this request${orHaltString}. Once the force operation is submitted and if the request is serviced, the operation follows the flow of a regular exit.`,
+    risks: [],
+    references: [],
+  }
+}
+
+function FORCED_MESSAGING(
+  orHalt?: 'forced-messages' | 'all-messages',
+): ProjectTechnologyChoice {
+  let orHaltString = ''
+  if (orHalt) {
+    switch (orHalt) {
+      case 'forced-messages':
+        orHaltString =
+          ' or halt all messages from L1, including all forced withdrawals and deposits'
+        break
+      case 'all-messages':
+        orHaltString =
+          ' or halt all messages, including forced withdrawals from L1 and regular messages initiated on L2'
+        break
+    }
+  }
+  return {
+    name: 'Forced messaging',
+    description: `If the user experiences censorship from the operator with regular L2->L1 messaging they can submit their messages directly on L1. The system is then obliged to service this request${orHaltString}. Once the force operation is submitted and if the request is serviced, the operation follows the flow of a regular message.`,
     risks: [],
     references: [],
   }
@@ -140,7 +164,7 @@ const STARKEX_REGULAR_SPOT: ProjectTechnologyChoice = {
 }
 
 const STARKEX_FORCED_PERPETUAL: ProjectTechnologyChoice = {
-  ...FORCED(),
+  ...FORCED_WITHDRAWAL(),
   references: [
     {
       title: 'Forced Operations - StarkEx documentation',
@@ -158,7 +182,7 @@ const STARKEX_FORCED_PERPETUAL: ProjectTechnologyChoice = {
 }
 
 const STARKEX_FORCED_SPOT: ProjectTechnologyChoice = {
-  ...FORCED(),
+  ...FORCED_WITHDRAWAL(),
   references: [
     {
       title: 'Forced Operations - StarkEx documentation',
@@ -265,7 +289,8 @@ export const EXITS = {
   REGULAR_WITHDRAWAL,
   REGULAR_MESSAGING,
   REGULAR_YIELDING,
-  FORCED,
+  FORCED_WITHDRAWAL,
+  FORCED_MESSAGING,
   EMERGENCY,
   AUTONOMOUS,
   STARKEX_PERPETUAL: [

--- a/packages/config/src/projects/layer2s/base.ts
+++ b/packages/config/src/projects/layer2s/base.ts
@@ -390,7 +390,7 @@ export const base: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED('all-withdrawals'),
+        ...EXITS.FORCED_MESSAGING('all-messages'),
         references: [
           {
             title: 'Forced withdrawal from an OP Stack blockchain',

--- a/packages/config/src/projects/layer2s/blast.ts
+++ b/packages/config/src/projects/layer2s/blast.ts
@@ -61,7 +61,7 @@ export const blast: Layer2 = opStackL2({
         risks: [EXITS.RISK_REHYPOTHECATED_ASSETS, EXITS.RISK_LACK_OF_LIQUIDITY],
       },
       {
-        ...EXITS.FORCED('all-withdrawals'),
+        ...EXITS.FORCED_MESSAGING('all-messages'),
         references: [
           {
             title: 'Forced withdrawal from an OP Stack blockchain',

--- a/packages/config/src/projects/layer2s/degate.ts
+++ b/packages/config/src/projects/layer2s/degate.ts
@@ -208,7 +208,7 @@ export const degate: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         references: [
           {
             title: 'Withdraw - DeGate design doc',

--- a/packages/config/src/projects/layer2s/degate.ts
+++ b/packages/config/src/projects/layer2s/degate.ts
@@ -217,7 +217,7 @@ export const degate: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED(),
+        ...EXITS.FORCED_WITHDRAWAL(),
         references: [
           {
             title: 'Forced Request Handling - DeGate design doc',

--- a/packages/config/src/projects/layer2s/degate2.ts
+++ b/packages/config/src/projects/layer2s/degate2.ts
@@ -212,7 +212,7 @@ export const degate2: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED(),
+        ...EXITS.FORCED_WITHDRAWAL(),
         references: [
           {
             title: 'Forced Request Handling - DeGate design doc',

--- a/packages/config/src/projects/layer2s/degate2.ts
+++ b/packages/config/src/projects/layer2s/degate2.ts
@@ -203,7 +203,7 @@ export const degate2: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         references: [
           {
             title: 'Withdraw - DeGate design doc',

--- a/packages/config/src/projects/layer2s/degate3.ts
+++ b/packages/config/src/projects/layer2s/degate3.ts
@@ -267,7 +267,7 @@ export const degate3: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED(),
+        ...EXITS.FORCED_WITHDRAWAL(),
         references: [
           {
             title: 'Forced Request Handling - DeGate design doc',

--- a/packages/config/src/projects/layer2s/degate3.ts
+++ b/packages/config/src/projects/layer2s/degate3.ts
@@ -258,7 +258,7 @@ export const degate3: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         references: [
           {
             title: 'Withdraw - DeGate design doc',

--- a/packages/config/src/projects/layer2s/fuel.ts
+++ b/packages/config/src/projects/layer2s/fuel.ts
@@ -217,7 +217,7 @@ export const fuel: Layer2 = {
       ],
     },
     exitMechanisms: [
-      EXITS.REGULAR('optimistic', 'merkle proof'),
+      EXITS.REGULAR_MESSAGING('optimistic'),
       EXITS.FORCED('all-withdrawals'),
     ],
     otherConsiderations: [

--- a/packages/config/src/projects/layer2s/fuel.ts
+++ b/packages/config/src/projects/layer2s/fuel.ts
@@ -218,7 +218,7 @@ export const fuel: Layer2 = {
     },
     exitMechanisms: [
       EXITS.REGULAR_MESSAGING('optimistic'),
-      EXITS.FORCED('all-withdrawals'),
+      EXITS.FORCED_MESSAGING('all-messages'),
     ],
     otherConsiderations: [
       {

--- a/packages/config/src/projects/layer2s/fuelv1.ts
+++ b/packages/config/src/projects/layer2s/fuelv1.ts
@@ -146,7 +146,7 @@ export const fuelv1: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('optimistic', 'merkle proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('optimistic'),
         references: [
           {
             title: 'Withdraw.yulp#L40 - Fuel documentation',

--- a/packages/config/src/projects/layer2s/hermez.ts
+++ b/packages/config/src/projects/layer2s/hermez.ts
@@ -130,9 +130,9 @@ export const hermez: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'merkle proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         description:
-          EXITS.REGULAR('zk', 'merkle proof').description +
+          EXITS.REGULAR_WITHDRAWAL('zk').description +
           ' This operation cannot be performed if the withdrawal exceeds certain threshold.',
         risks: [],
         references: [

--- a/packages/config/src/projects/layer2s/honeypot.ts
+++ b/packages/config/src/projects/layer2s/honeypot.ts
@@ -172,7 +172,7 @@ export const honeypot: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('optimistic', 'merkle proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('optimistic'),
         references: [],
         risks: [EXITS.RISK_CENTRALIZED_VALIDATOR],
       },

--- a/packages/config/src/projects/layer2s/ink.ts
+++ b/packages/config/src/projects/layer2s/ink.ts
@@ -352,7 +352,7 @@ export const ink: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED('all-withdrawals'),
+        ...EXITS.FORCED_MESSAGING('all-messages'),
         references: [
           {
             title: 'Forced withdrawal from an OP Stack blockchain',

--- a/packages/config/src/projects/layer2s/kroma.ts
+++ b/packages/config/src/projects/layer2s/kroma.ts
@@ -352,7 +352,7 @@ export const kroma: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('optimistic', 'merkle proof', finalizationPeriod),
+        ...EXITS.REGULAR_MESSAGING('optimistic', finalizationPeriod),
         references: [
           {
             title:

--- a/packages/config/src/projects/layer2s/linea.ts
+++ b/packages/config/src/projects/layer2s/linea.ts
@@ -472,9 +472,9 @@ export const linea: Layer2 = {
     forceTransactions: FORCE_TRANSACTIONS.SEQUENCER_NO_MECHANISM,
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'merkle proof'),
+        ...EXITS.REGULAR_MESSAGING('zk'),
         description:
-          EXITS.REGULAR('zk', 'merkle proof').description +
+          EXITS.REGULAR_MESSAGING('zk').description +
           ' Note that withdrawal requests can be censored by the Sequencer. ' +
           withdrawalLimitString +
           ' Users can (eventually, after 6 months of inactivity from the centralized Operator) exit by replacing the Operator. In such a case they need to self-propose and prove their new state on the base layer with the required software which is currently not made available.',

--- a/packages/config/src/projects/layer2s/loopring.ts
+++ b/packages/config/src/projects/layer2s/loopring.ts
@@ -268,7 +268,7 @@ export const loopring: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED(),
+        ...EXITS.FORCED_WITHDRAWAL(),
         references: [
           {
             title: 'Forced Request Handling - Loopring design doc',

--- a/packages/config/src/projects/layer2s/loopring.ts
+++ b/packages/config/src/projects/layer2s/loopring.ts
@@ -259,7 +259,7 @@ export const loopring: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         references: [
           {
             title: 'Withdraw - Loopring design doc',

--- a/packages/config/src/projects/layer2s/metis.ts
+++ b/packages/config/src/projects/layer2s/metis.ts
@@ -182,7 +182,7 @@ export const metis: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('optimistic', 'merkle proof'),
+        ...EXITS.REGULAR_MESSAGING('optimistic'),
         references: [
           {
             title: 'Withdrawing from Metis - Metis documentation',

--- a/packages/config/src/projects/layer2s/metis.ts
+++ b/packages/config/src/projects/layer2s/metis.ts
@@ -191,7 +191,7 @@ export const metis: Layer2 = {
         ],
         risks: [EXITS.RISK_CENTRALIZED_VALIDATOR],
       },
-      EXITS.FORCED('forced-withdrawals'),
+      EXITS.FORCED_MESSAGING('forced-messages'),
     ],
     otherConsiderations: [
       {

--- a/packages/config/src/projects/layer2s/morph.ts
+++ b/packages/config/src/projects/layer2s/morph.ts
@@ -230,7 +230,7 @@ export const morph: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('optimistic', 'merkle proof', challengeWindow),
+        ...EXITS.REGULAR_MESSAGING('optimistic', challengeWindow),
         risks: [EXITS.OPERATOR_CENSORS_WITHDRAWAL],
         references: [
           {

--- a/packages/config/src/projects/layer2s/optimism.ts
+++ b/packages/config/src/projects/layer2s/optimism.ts
@@ -435,7 +435,7 @@ export const optimism: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED('all-withdrawals'),
+        ...EXITS.FORCED_MESSAGING('all-messages'),
         references: [
           {
             title: 'Forced withdrawal from an OP Stack blockchain',

--- a/packages/config/src/projects/layer2s/scroll.ts
+++ b/packages/config/src/projects/layer2s/scroll.ts
@@ -385,7 +385,7 @@ export const scroll: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_MESSAGING('zk'),
         risks: [EXITS.OPERATOR_CENSORS_WITHDRAWAL],
         references: [
           {

--- a/packages/config/src/projects/layer2s/templates/opStack.ts
+++ b/packages/config/src/projects/layer2s/templates/opStack.ts
@@ -1060,7 +1060,7 @@ function getTechnologyExitMechanism(
   }
 
   result.push({
-    ...EXITS.FORCED('all-withdrawals'),
+    ...EXITS.FORCED_MESSAGING('all-messages'),
     references: [
       {
         title: 'Forced withdrawal from an OP Stack blockchain',

--- a/packages/config/src/projects/layer2s/templates/opStack.ts
+++ b/packages/config/src/projects/layer2s/templates/opStack.ts
@@ -984,9 +984,8 @@ function getTechnologyExitMechanism(
         templateVars.discovery.getContract('L2OutputOracle')
 
       result.push({
-        ...EXITS.REGULAR(
+        ...EXITS.REGULAR_MESSAGING(
           'optimistic',
-          'merkle proof',
           getFinalizationPeriod(templateVars),
         ),
         references: explorerReferences(explorerUrl, [

--- a/packages/config/src/projects/layer2s/templates/orbitStack.ts
+++ b/packages/config/src/projects/layer2s/templates/orbitStack.ts
@@ -508,7 +508,7 @@ function orbitStackCommon(
       },
       exitMechanisms: templateVars.nonTemplateTechnology?.exitMechanisms ?? [
         {
-          ...EXITS.REGULAR('optimistic', 'merkle proof'),
+          ...EXITS.REGULAR_MESSAGING('optimistic'),
           references: [
             {
               title: 'Transaction lifecycle - Arbitrum documentation',

--- a/packages/config/src/projects/layer2s/templates/polygonCDKStack.ts
+++ b/packages/config/src/projects/layer2s/templates/polygonCDKStack.ts
@@ -441,7 +441,7 @@ export function polygonCDKStack(templateVars: PolygonCDKStackConfig): Layer2 {
       },
       exitMechanisms: templateVars.nonTemplateTechnology?.exitMechanisms ?? [
         {
-          ...EXITS.REGULAR('zk', 'merkle proof'),
+          ...EXITS.REGULAR_MESSAGING('zk'),
           references: explorerReferences(explorerUrl, [
             {
               title:

--- a/packages/config/src/projects/layer2s/templates/zkStack.ts
+++ b/packages/config/src/projects/layer2s/templates/zkStack.ts
@@ -380,7 +380,7 @@ export function zkStackL2(templateVars: ZkStackConfigCommon): Layer2 {
       },
       exitMechanisms: templateVars.nonTemplateTechnology?.exitMechanisms ?? [
         {
-          ...EXITS.REGULAR('zk', 'merkle proof'),
+          ...EXITS.REGULAR_MESSAGING('zk'),
           references: [
             {
               title: 'Withdrawing funds - ZKsync documentation',

--- a/packages/config/src/projects/layer2s/templates/zkStack.ts
+++ b/packages/config/src/projects/layer2s/templates/zkStack.ts
@@ -388,7 +388,7 @@ export function zkStackL2(templateVars: ZkStackConfigCommon): Layer2 {
             },
           ],
         },
-        EXITS.FORCED('forced-withdrawals'),
+        EXITS.FORCED_MESSAGING('forced-messages'),
       ],
     },
     upgradesAndGovernance: (() => {

--- a/packages/config/src/projects/layer2s/termstructure.ts
+++ b/packages/config/src/projects/layer2s/termstructure.ts
@@ -250,7 +250,7 @@ export const termstructure: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED(),
+        ...EXITS.FORCED_WITHDRAWAL(),
         references: [
           {
             title:

--- a/packages/config/src/projects/layer2s/termstructure.ts
+++ b/packages/config/src/projects/layer2s/termstructure.ts
@@ -236,7 +236,7 @@ export const termstructure: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         references: [
           {
             title:

--- a/packages/config/src/projects/layer2s/zkfair.ts
+++ b/packages/config/src/projects/layer2s/zkfair.ts
@@ -249,7 +249,7 @@ export const zkfair: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'merkle proof'),
+        ...EXITS.REGULAR_MESSAGING('zk'),
         references: [
           {
             title:

--- a/packages/config/src/projects/layer2s/zkswap.ts
+++ b/packages/config/src/projects/layer2s/zkswap.ts
@@ -125,7 +125,7 @@ export const zkswap: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         references: [
           {
             title: 'Make Transaction',

--- a/packages/config/src/projects/layer2s/zkswap.ts
+++ b/packages/config/src/projects/layer2s/zkswap.ts
@@ -134,7 +134,7 @@ export const zkswap: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED(),
+        ...EXITS.FORCED_WITHDRAWAL(),
         references: [
           {
             title: 'ZkSync.sol#L404 - ZKSwap source code',

--- a/packages/config/src/projects/layer2s/zksynclite.ts
+++ b/packages/config/src/projects/layer2s/zksynclite.ts
@@ -292,7 +292,7 @@ export const zksynclite: Layer2 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('zk', 'no proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('zk'),
         references: [
           {
             title: 'Withdrawing funds - ZKsync documentation',

--- a/packages/config/src/projects/layer2s/zksynclite.ts
+++ b/packages/config/src/projects/layer2s/zksynclite.ts
@@ -301,7 +301,7 @@ export const zksynclite: Layer2 = {
         ],
       },
       {
-        ...EXITS.FORCED(),
+        ...EXITS.FORCED_WITHDRAWAL(),
         references: [
           {
             title: 'Withdrawing funds - ZKsync documentation',

--- a/packages/config/src/projects/layer3s/bugbuster.ts
+++ b/packages/config/src/projects/layer3s/bugbuster.ts
@@ -142,7 +142,7 @@ export const bugbuster: Layer3 = {
     },
     exitMechanisms: [
       {
-        ...EXITS.REGULAR('optimistic', 'merkle proof'),
+        ...EXITS.REGULAR_WITHDRAWAL('optimistic'),
         references: [],
         risks: [EXITS.RISK_CENTRALIZED_VALIDATOR],
       },

--- a/packages/config/src/projects/layer3s/zklinknova.ts
+++ b/packages/config/src/projects/layer3s/zklinknova.ts
@@ -444,7 +444,7 @@ export const zklinknova: Layer3 = {
       references: [],
     },
     exitMechanisms: [
-      EXITS.REGULAR('zk', 'merkle proof'),
+      EXITS.REGULAR_MESSAGING('zk'),
       EXITS.FORCED('forced-withdrawals'),
     ],
     otherConsiderations: [

--- a/packages/config/src/projects/layer3s/zklinknova.ts
+++ b/packages/config/src/projects/layer3s/zklinknova.ts
@@ -445,7 +445,7 @@ export const zklinknova: Layer3 = {
     },
     exitMechanisms: [
       EXITS.REGULAR_MESSAGING('zk'),
-      EXITS.FORCED('forced-withdrawals'),
+      EXITS.FORCED_MESSAGING('forced-messages'),
     ],
     otherConsiderations: [
       {


### PR DESCRIPTION
Resolves L2B-8989. In the withdrawals section, chains that have an AMB now use the messaging wording, while chains that don't use the old withdrawals centric wording. This is a temporary solution (so don't expect it to be perfect) as we're likely to do some bigger refactoring of these sections