### PR TITLE
Use sha2-256 instead of BLAKE2s256

### DIFF
--- a/packages/discovery/src/flatten/utils.ts
+++ b/packages/discovery/src/flatten/utils.ts
@@ -77,14 +77,14 @@ export function contractFlatteningHash(
 }
 
 export function flatteningHash(source: string): Hash256 {
-  const blake = createHash('blake2s256').update(source).digest('hex')
-  const cached = cache.get(blake)
+  const hashed = sha2_256bit(source)
+  const cached = cache.get(hashed)
   if (cached !== undefined) {
     return cached
   }
 
   const value = sha2_256bit(formatIntoHashable(source))
-  cache.set(blake, value)
+  cache.set(hashed, value)
   return value
 }
 


### PR DESCRIPTION
Initially I've used BLAKE2s256 because of the belief that it's faster than other similar functions offered by openssl. As it turns out computers don't care what you believe. 

clk: ~3.22 GHz
cpu: Apple M2 Pro
runtime: node 22.11.0 (arm64-darwin)

| benchmark  |              avg |         min |         p75 |         p99 |         max |
| ---------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| BLAKE2s256 | `284.53 ms/iter` | `277.47 ms` | `285.22 ms` | `291.16 ms` | `299.42 ms` |
| sha256     | `117.46 ms/iter` | `114.73 ms` | `118.06 ms` | `119.23 ms` | `119.34 ms` |

clk: ~0.78 GHz
cpu: Intel(R) Celeron(R) J4105 CPU @ 1.50GHz
runtime: node 22.13.1 (x64-linux)

| benchmark  |              avg |         min |         p75 |         p99 |         max |
| ---------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| BLAKE2s256 | `   1.02 s/iter` | `   1.01 s` | `   1.02 s` | `   1.02 s` | `   1.02 s` |
| sha256     | `620.55 ms/iter` | `616.94 ms` | `620.96 ms` | `624.91 ms` | `626.71 ms` |

Plus BLAKE2s256 is not supported by Bun and is generally more exotic which increases the chance that the OS of the user will not support it.