### PR TITLE
Bump tinyerc55 version to 0.1.2

### DIFF
--- a/packages/shared-pure/package.json
+++ b/packages/shared-pure/package.json
@@ -16,7 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mradomski/tinyerc55": "^0.1.1",
+    "@mradomski/tinyerc55": "^0.1.2",
     "chalk": "^4.1.2",
     "ethers": "^5.7.2",
     "zod": "^3.22.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,8 +929,8 @@ importers:
   packages/shared-pure:
     dependencies:
       '@mradomski/tinyerc55':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.1.2
+        version: 0.1.2
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -2596,8 +2596,8 @@ packages:
   '@mradomski/fast-solidity-parser@0.1.1':
     resolution: {integrity: sha512-BnX+UKswinYed/yFgH9zwYNNBvUXJu32vJkxwnkZuPcV/YR9TDzMgjAOhiq8Vj77wDcfHHhyA0/MdIMhkd92PQ==}
 
-  '@mradomski/tinyerc55@0.1.1':
-    resolution: {integrity: sha512-cMsweutjiqWSazlBN5YgRWPe6Sy9Z/ZPQ8MyVqNsxsZodH5i0L74FydvIASIQFLYWKhk0mktRaJ/VDDf/+AFbg==}
+  '@mradomski/tinyerc55@0.1.2':
+    resolution: {integrity: sha512-BmNoaq23Ni8VfYKstqsgYok1HP7rGpNjQ62ti2/vPX5xnnh1oonsBXMCrGQbK2UNz9G+ADAsULXA1xB/bTmxlA==}
 
   '@mrleebo/prisma-ast@0.7.0':
     resolution: {integrity: sha512-GTPkYf1meO2UXXIrz/SIDFWz+P4kXo2PTt36LYh/oNxV1PieYi7ZgenQk4IV0ut71Je3Z8ZoNZ8Tr7v2c1X1pg==}
@@ -11025,7 +11025,7 @@ snapshots:
 
   '@mradomski/fast-solidity-parser@0.1.1': {}
 
-  '@mradomski/tinyerc55@0.1.1': {}
+  '@mradomski/tinyerc55@0.1.2': {}
 
   '@mrleebo/prisma-ast@0.7.0':
     dependencies:


### PR DESCRIPTION
Version v0.1.2 of tinyerc55 has a performance gain of 20%-25% over version v0.1.1.

| benchmark      |              avg |         min |         p75 |         p99 |         max |
| -------------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| single ethers  | `  4.72 µs/iter` | `  4.25 µs` | `  4.54 µs` | `  8.25 µs` | `147.08 µs` |
| single v0.1.1 | `346.98 ns/iter` | `318.87 ns` | `350.18 ns` | `379.48 ns` | `389.28 ns` |
| single v0.1.2 | `279.37 ns/iter` | `263.81 ns` | `280.85 ns` | `318.54 ns` | `336.70 ns` |

|      benchmark       |              avg |         min |         p75 |         p99 |         max |
| ----------- | ---------------- | ----------- | ----------- | ----------- | ----------- |
| 100 ethers  | `490.47 µs/iter` | `460.54 µs` | `491.50 µs` | `638.79 µs` | `898.50 µs` |
| 100 v0.1.1 | ` 37.26 µs/iter` | ` 36.87 µs` | ` 37.26 µs` | ` 37.50 µs` | ` 39.09 µs` |
| 100 v0.1.2 | ` 30.73 µs/iter` | ` 30.47 µs` | ` 30.82 µs` | ` 30.95 µs` | ` 31.04 µs` |

This translates to around 10-20ms speed up in loading the config, tested with `hyperfine --warmup 5 "echo echo 'require("@l2beat/config")' | node"`. 

```
Benchmark 1: v0.1.1
  Time (mean ± σ):     751.2 ms ±  24.5 ms    [User: 845.3 ms, System: 136.4 ms]
  Range (min … max):   731.0 ms … 791.2 ms    10 runs

Benchmark 1: v0.1.2
  Time (mean ± σ):     733.4 ms ±  15.0 ms    [User: 835.4 ms, System: 134.8 ms]
  Range (min … max):   717.5 ms … 763.8 ms    10 runs
```