### PR TITLE
Do not save negative values for Finality to db

### DIFF
--- a/packages/backend/src/modules/finality/FinalityIndexer.test.ts
+++ b/packages/backend/src/modules/finality/FinalityIndexer.test.ts
@@ -139,6 +139,25 @@ describe(FinalityIndexer.name, () => {
         averageStateUpdate: 0,
       })
     })
+
+    it('throws an error if data is negative', async () => {
+      const start = UnixTime.now().toStartOf('day')
+      const from = start.toNumber()
+      const to = start.add(1, 'days').toNumber()
+      const finalityIndexer = getMockFinalityIndexer({})
+      finalityIndexer.isConfigurationSynced = mockFn().resolvesToOnce(false)
+      finalityIndexer.getFinalityData = mockFn().resolvesToOnce({
+        projectId: ProjectId('project'),
+        timestamp: start.add(1, 'days'),
+        averageTimeToInclusion: -1,
+        minimumTimeToInclusion: -2,
+        maximumTimeToInclusion: 4,
+      })
+
+      expect(
+        async () => await finalityIndexer.update(from + 1, to),
+      ).toBeRejectedWith(`Finality data cannot be negative: project`)
+    })
   })
 
   describe(FinalityIndexer.prototype.isConfigurationSynced.name, () => {

--- a/packages/backend/src/modules/finality/FinalityIndexer.ts
+++ b/packages/backend/src/modules/finality/FinalityIndexer.ts
@@ -84,7 +84,7 @@ export class FinalityIndexer extends ChildIndexer {
           finalityData.averageTimeToInclusion > 0 &&
           finalityData.maximumTimeToInclusion > 0 &&
           (finalityData.averageStateUpdate === null ||
-            finalityData.averageStateUpdate > 0),
+            finalityData.averageStateUpdate >= 0),
         `Finality data cannot be negative: ${this.configuration.projectId}`,
       )
 

--- a/packages/backend/src/modules/finality/FinalityIndexer.ts
+++ b/packages/backend/src/modules/finality/FinalityIndexer.ts
@@ -77,6 +77,17 @@ export class FinalityIndexer extends ChildIndexer {
     )
 
     if (finalityData) {
+      // Sometimes if finality is wrongly configured we get negative values,
+      // we do not want to save those data to db
+      assert(
+        finalityData.minimumTimeToInclusion > 0 &&
+          finalityData.averageTimeToInclusion > 0 &&
+          finalityData.maximumTimeToInclusion > 0 &&
+          (finalityData.averageStateUpdate === null ||
+            finalityData.averageStateUpdate > 0),
+        `Finality data cannot be negative: ${this.configuration.projectId}`,
+      )
+
       await this.db.finality.insert(finalityData)
     }
 


### PR DESCRIPTION
Resolves L2B-9077
This PR prevents from saving negative values to the db and throws an error to investigate the given project configuration.