### PR TITLE
Make executor non-permissioned for layerZerov2 and stargatev2

### DIFF
--- a/packages/config/src/projects/bridges/layerzerov2oft.ts
+++ b/packages/config/src/projects/bridges/layerzerov2oft.ts
@@ -140,6 +140,8 @@ export const layerzerov2oft: Bridge = {
       These can be set by the Oapp / OFT owner or a delegate that they can define in the EndpointV2 contract.
       Additionally, the OFT owner can often use other admin functions on the OFT contract that are specific to the ERC-20 implementation (similar to other ERC-20 tokens, like arbitrary minting or pausing functions) and not related to LayerZero.
       
+      In the case of the Executor failing to deliver the bridge message, the user can try to deliver the message to the destination themselves, either if it was already verified or if the user has access to the signed verifier message (e.g. through layerzeroscan.com).
+      
       OFTs can either be natively multichain or they can use an adapter. Native OFTs are burned at their origin and minted at their destination when bridging. 
       Adapter OFTs have a main chain, where they are locked in an adapter escrow. This mints a 'native' OFT version of the locked token that can then be bridged on all chains by burn-minting. 
       To receive the original locked token back, a user would have to return to the main chain and unlock it from the adapter escrow.`,
@@ -177,7 +179,7 @@ export const layerzerov2oft: Bridge = {
       risks: [
         {
           category: 'Users can be censored if',
-          text: 'the executor or all required verifiers fail to facilitate the transfer.',
+          text: 'any required verifiers fail to approve the transfer.',
         },
         {
           category: 'Funds can be stolen if',

--- a/packages/config/src/projects/bridges/layerzerov2oft.ts
+++ b/packages/config/src/projects/bridges/layerzerov2oft.ts
@@ -179,11 +179,11 @@ export const layerzerov2oft: Bridge = {
       risks: [
         {
           category: 'Users can be censored if',
-          text: 'any required verifiers fail to approve the transfer.',
+          text: 'any required Verifiers fail to approve the transfer.',
         },
         {
           category: 'Funds can be stolen if',
-          text: 'the Executor and the Verifiers collude to submit fraudulent block hash and relay fraudulent transfer.',
+          text: 'all required Verifiers collude to approve and relay a fraudulent transfer.',
         },
         {
           category: 'Funds can be stolen if',

--- a/packages/config/src/projects/bridges/stargatev2.ts
+++ b/packages/config/src/projects/bridges/stargatev2.ts
@@ -107,16 +107,22 @@ export const stargatev2: Bridge = {
       name: 'Principle of operation',
       description: `
       On chains where assets are available through other bridges, Stargate acts as a Liquidity Bridge. This requires Stargate liquidity pools for assets at the sources and destinations.
-
+      
+      
       While liquidity providers need to keep all pools buffered with assets, users can deposit into a pool on their chosen source chain and quickly receive the equivalent asset at the destination through an Executor.
       Users can choose between an economical batched bridge mode ('bus') or an individual fast 'taxi' mode that delivers the bridging message as soon as the user deposits.
-
+      
+      
       The Executor is a permissioned actor that withdraws the asset from the liquidity pool at the destination directly to the user.
       They are only a relayer and depend on LayerZero DVNs (distributed validator networks) to verify the message coming from the source chain. These DVNs can be freely configured by the OApp owner (Stargate) for each pair of endpoints.
       Stargatev2 currently has two DVNs configured: Stargate and Nethermind. From the viewpoint of the LayerZero message protocol, each DVN is a single signer and the current threshold for verification is 2.
-
+      
+      
       Just like the assets themselves, so-called *credits* are bridged among the supported pools in the Stargate v2 system. Credits can be seen as claims on assets, so a liquidity pool needs credits for a remote pool to be able to bridge there.
-      These credits can be moved and rebalanced (but not minted) by a permissioned Planner.`,
+      These credits can be moved and rebalanced (but not minted) by a permissioned Planner.
+      
+      
+      In the case of the Executor failing to deliver the bridge message, the user can try to deliver the message to the destination themselves, either if it was already verified or if the user has access to the signed verifier message (e.g. through layerzeroscan.com).`,
       references: [
         {
           title: 'Stargate Docs: Modes of transport',
@@ -148,7 +154,7 @@ export const stargatev2: Bridge = {
         name: 'LayerZero messaging',
         description:
           'The LayerZero message protocol is used: For validation of messages from Stargate over LayerZero, two DVNs are currently configured: Nethermind and Stargate.\
-        If both DVNs agree on a message, it is verified and can be executed by a permissioned Executor at the destination. This configuration can be changed at any time by the StargateMultisig.',
+        If both DVNs agree on a message, it is verified and can be executed by an Executor at the destination. This configuration can be changed at any time by the StargateMultisig.',
         references: [
           {
             title: 'LayerZero Docs: Security Stack',
@@ -158,7 +164,7 @@ export const stargatev2: Bridge = {
         risks: [
           {
             category: 'Users can be censored if',
-            text: 'both whitelisted DVNs or the LayerZero Executor fail to facilitate the transaction.',
+            text: 'any of the two whitelisted DVNs fail to approve the transaction.',
           },
           {
             category: 'Funds can be stolen if',

--- a/packages/config/src/projects/bridges/stargatev2.ts
+++ b/packages/config/src/projects/bridges/stargatev2.ts
@@ -357,7 +357,7 @@ export const stargatev2: Bridge = {
     risks: [
       {
         category: 'Funds can be stolen if',
-        text: 'the OApp owner changes the configuration of the OApp to malicious DVNs and executors.',
+        text: 'the OApp owner changes the configuration of the OApp to a malicious DVN.',
       },
       {
         category: 'Funds can be frozen if',


### PR DESCRIPTION
ultimately the DVN decides whether the executor is permissioned or not, but in practice all executors i looked at are permissionless

the user just needs gas at the destiantion and the DVN has to sign onchain or somehow broadcast their sig to the user