### PR TITLE
fix: Deduplicate project links in DA project view

### DIFF
--- a/packages/frontend/src/server/features/data-availability/project/get-da-project-entry.ts
+++ b/packages/frontend/src/server/features/data-availability/project/get-da-project-entry.ts
@@ -170,7 +170,7 @@ export async function getDaProjectEntry(
     header: {
       links: getProjectLinks(
         layer.display.links,
-        ...bridges.map((x) => x.display.links),
+        ...bridges.filter((x) => x.id !== layer.id).map((x) => x.display.links),
       ),
       daLayerGrissiniValues: layerGrissiniValues,
       daBridgeGrissiniValues: bridgeGrissiniValues,

--- a/packages/frontend/src/utils/project/get-project-links.ts
+++ b/packages/frontend/src/utils/project/get-project-links.ts
@@ -3,13 +3,13 @@ import { compact } from 'lodash'
 import type { ProjectLink } from '~/components/projects/links/types'
 
 export function getProjectLinks(...links: ProjectLinks[]): ProjectLink[] {
-  const websites = links.flatMap((links) => links.websites ?? [])
-  const apps = links.flatMap((links) => links.apps ?? [])
-  const docs = links.flatMap((links) => links.documentation ?? [])
-  const explorers = links.flatMap((links) => links.explorers ?? [])
-  const repositories = links.flatMap((links) => links.repositories ?? [])
-  const social = links.flatMap((links) => links.socialMedia ?? [])
-  const rollupCodes = links.flatMap((links) => links.rollupCodes ?? [])
+  const websites = [...new Set(links.flatMap((links) => links.websites ?? []))]
+  const apps = [...new Set(links.flatMap((links) => links.apps ?? []))]
+  const docs = [...new Set(links.flatMap((links) => links.documentation ?? []))]
+  const explorers = [...new Set(links.flatMap((links) => links.explorers ?? []))]
+  const repositories = [...new Set(links.flatMap((links) => links.repositories ?? []))]
+  const social = [...new Set(links.flatMap((links) => links.socialMedia ?? []))]
+  const rollupCodes = [...new Set(links.flatMap((links) => links.rollupCodes ?? []))]
 
   return compact([
     websites.length !== 0 && { name: 'Website', links: websites },

--- a/packages/frontend/src/utils/project/get-project-links.ts
+++ b/packages/frontend/src/utils/project/get-project-links.ts
@@ -3,19 +3,13 @@ import { compact } from 'lodash'
 import type { ProjectLink } from '~/components/projects/links/types'
 
 export function getProjectLinks(...links: ProjectLinks[]): ProjectLink[] {
-  const websites = [...new Set(links.flatMap((links) => links.websites ?? []))]
-  const apps = [...new Set(links.flatMap((links) => links.apps ?? []))]
-  const docs = [...new Set(links.flatMap((links) => links.documentation ?? []))]
-  const explorers = [
-    ...new Set(links.flatMap((links) => links.explorers ?? [])),
-  ]
-  const repositories = [
-    ...new Set(links.flatMap((links) => links.repositories ?? [])),
-  ]
-  const social = [...new Set(links.flatMap((links) => links.socialMedia ?? []))]
-  const rollupCodes = [
-    ...new Set(links.flatMap((links) => links.rollupCodes ?? []))
-  ]
+  const websites = links.flatMap((links) => links.websites ?? [])
+  const apps = links.flatMap((links) => links.apps ?? [])
+  const docs = links.flatMap((links) => links.documentation ?? [])
+  const explorers = links.flatMap((links) => links.explorers ?? [])
+  const repositories = links.flatMap((links) => links.repositories ?? [])
+  const social = links.flatMap((links) => links.socialMedia ?? [])
+  const rollupCodes = links.flatMap((links) => links.rollupCodes ?? [])
 
   return compact([
     websites.length !== 0 && { name: 'Website', links: websites },

--- a/packages/frontend/src/utils/project/get-project-links.ts
+++ b/packages/frontend/src/utils/project/get-project-links.ts
@@ -6,10 +6,16 @@ export function getProjectLinks(...links: ProjectLinks[]): ProjectLink[] {
   const websites = [...new Set(links.flatMap((links) => links.websites ?? []))]
   const apps = [...new Set(links.flatMap((links) => links.apps ?? []))]
   const docs = [...new Set(links.flatMap((links) => links.documentation ?? []))]
-  const explorers = [...new Set(links.flatMap((links) => links.explorers ?? []))]
-  const repositories = [...new Set(links.flatMap((links) => links.repositories ?? []))]
+  const explorers = [
+    ...new Set(links.flatMap((links) => links.explorers ?? [])),
+  ]
+  const repositories = [
+    ...new Set(links.flatMap((links) => links.repositories ?? [])),
+  ]
   const social = [...new Set(links.flatMap((links) => links.socialMedia ?? []))]
-  const rollupCodes = [...new Set(links.flatMap((links) => links.rollupCodes ?? []))]
+  const rollupCodes = [
+    ...new Set(links.flatMap((links) => links.rollupCodes ?? []))
+  ]
 
   return compact([
     websites.length !== 0 && { name: 'Website', links: websites },


### PR DESCRIPTION

## Problem
The Data Availability (DA) project view currently shows duplicate links because the same links are being combined from both layer and bridges sources. This occurs in `getProjectLinks` where we merge links from both the DA layer and all bridge configurations.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/f362279d-913a-4b10-99e9-46d9fffe2827" />


