### PR TITLE
Display DA members under L3's permissions section

### DIFF
--- a/packages/frontend/src/server/features/scaling/project/utils/get-l3-project-details.ts
+++ b/packages/frontend/src/server/features/scaling/project/utils/get-l3-project-details.ts
@@ -357,12 +357,15 @@ export async function getL3ProjectDetails({
   }
 
   if (permissionsSection) {
+    const permissionedEntities = project.customDa?.dac?.knownMembers
+
     items.push({
       type: 'PermissionsSection',
       props: {
         ...permissionsSection,
         id: 'permissions',
         title: 'Permissions',
+        permissionedEntities,
       },
     })
   }


### PR DESCRIPTION
Resolves L2B-9359

We've omitted that completely during refactoring.