### PR TITLE
[L2B-9368] Update finality genesis timestamp for Kroma

### DIFF
--- a/packages/config/src/projects/layer2s/kroma.ts
+++ b/packages/config/src/projects/layer2s/kroma.ts
@@ -198,7 +198,7 @@ export const kroma: Layer2 = {
       // timestamp of the first blob tx
       minTimestamp: new UnixTime(1714032407),
       l2BlockTimeSeconds: 2,
-      genesisTimestamp: new UnixTime(1693880389),
+      genesisTimestamp: new UnixTime(1693880387),
       lag: 0,
       stateUpdate: 'disabled',
     },


### PR DESCRIPTION
The genesis block timestamp was taken from block 1 instead of block 0 resulting in 2s offset for finality calculations