### PR TITLE
Correctly differentiate EOAs fom Contracts in modelling

### DIFF
--- a/packages/discovery/src/discovery/modelling/interpolate.ts
+++ b/packages/discovery/src/discovery/modelling/interpolate.ts
@@ -58,17 +58,11 @@ export function normalizeId(s: string) {
 export function contractValuesForInterpolation(
   contract: ContractParameters | EoaParameters,
 ): Record<string, ContractValue | undefined> {
-  const values = isContract(contract) ? contract.values : {}
+  const values = 'values' in contract ? (contract.values ?? {}) : {}
   return {
     '$.address': contract.address.toLowerCase(),
     '$.name': contract.name ?? '',
     '$.description': contract.description,
     ...values,
   }
-}
-
-export function isContract(
-  contractOrEoa: ContractParameters | EoaParameters,
-): contractOrEoa is ContractParameters {
-  return 'values' in contractOrEoa
 }


### PR DESCRIPTION
This is a small refactoring of clingo modelling code.

Previously, to differentiate between contracts and EOAs, it checked if `.values` field existed. This is not a future-proof approach. Current refactoring simply assigns flag isEOA if data comes from `discovered.json -> eoas`. 

(There's also one place where we don't need to know if address is a Contract or an EOA, so checking for `.values` there is ok)