### PR TITLE
Fix OPStack analyzer

### DIFF
--- a/packages/backend/src/modules/finality/analyzers/opStack/ChannelBank.ts
+++ b/packages/backend/src/modules/finality/analyzers/opStack/ChannelBank.ts
@@ -39,6 +39,9 @@ export class ChannelBank {
     this.dropOutdatedChannels(blockNumber)
 
     const channelIds = new Set(frames.map((f) => f.channelId))
+    if (channelIds.size === 0) {
+      return null
+    }
     assert(
       channelIds.size === 1,
       'All frames should belong to the same channel',

--- a/packages/backend/src/modules/finality/analyzers/opStack/OpStackT2IAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/opStack/OpStackT2IAnalyzer.ts
@@ -112,6 +112,10 @@ export class OpStackT2IAnalyzer extends BaseAnalyzer {
             tx.blockNumber,
           )
         if (blobs.length === 0) return []
+        const data = getRollupData(blobs)
+        if (Number(data.toString()) === 0) {
+          return []
+        }
         return getRollupData(blobs)
       }
       default:

--- a/packages/backend/src/modules/finality/analyzers/opStack/OpStackT2IAnalyzer.ts
+++ b/packages/backend/src/modules/finality/analyzers/opStack/OpStackT2IAnalyzer.ts
@@ -96,6 +96,9 @@ export class OpStackT2IAnalyzer extends BaseAnalyzer {
   async getRollupData(tx: EVMTransaction): Promise<Uint8Array[]> {
     switch (Number(tx.type)) {
       case 2:
+        if (tx.data === '0x') {
+          return []
+        }
         return [byteArrFromHexStr(tx.data)]
       case 3: {
         assert(

--- a/packages/database/scripts/db-restore/README.md
+++ b/packages/database/scripts/db-restore/README.md
@@ -15,5 +15,5 @@ DEV_REMOTE_DB_URL_READ_ONLY=
 ```
 3. Run the script
 ```
-./tvl-restore.sh <FEATURE>
+./db-restore.sh <FEATURE>
 ```


### PR DESCRIPTION
Resolves L2B-9399

2 issues fixed:
- there was [type 2 tx](https://etherscan.io/tx/0xf9f54ebf3d37a4dc88f302e1333f515d896973cea29426a73a3540c51ce53718) with no data: 
- there was [type 3 tx](https://etherscan.io/tx/0xbdf306d2843f8a511a45f1dbfae50a0a257e8aa482adb18a32dd00b15058982a) with 1 empty blob (unable to decode)