### PR TITLE
Show "can be upgraded by" in Disco UI

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/getPreview.ts
+++ b/packages/l2b/src/implementations/discovery-ui/getPreview.ts
@@ -103,6 +103,7 @@ function getContractsPreview(
         addresses: [toAddressFieldValue(c.address, chain, metaPerChain)],
         name: c.name,
         description: c.description ?? '',
+        upgradableBy: c.upgradableBy,
       }
     }),
   }))

--- a/packages/l2b/src/implementations/discovery-ui/types.ts
+++ b/packages/l2b/src/implementations/discovery-ui/types.ts
@@ -32,6 +32,7 @@ export interface ApiPreviewContract {
   addresses: AddressFieldValue[]
   name: string
   description: string
+  upgradableBy: UpgradeabilityActor[] | undefined
 }
 
 export interface ApiProjectChain {
@@ -146,4 +147,9 @@ export interface ApiAbiEntry {
 
 export interface ApiCodeResponse {
   sources: { name: string; code: string }[]
+}
+
+export interface UpgradeabilityActor {
+  name: string
+  delay: string
 }

--- a/packages/protocolbeat/src/api/types.ts
+++ b/packages/protocolbeat/src/api/types.ts
@@ -32,6 +32,7 @@ export interface ApiPreviewContract {
   addresses: AddressFieldValue[]
   name: string
   description: string
+  upgradableBy: UpgradeabilityActor[] | undefined
 }
 
 export interface ApiProjectChain {
@@ -146,4 +147,9 @@ export interface ApiAbiEntry {
 
 export interface ApiCodeResponse {
   sources: { name: string; code: string }[]
+}
+
+export interface UpgradeabilityActor {
+  name: string
+  delay: string
 }

--- a/packages/protocolbeat/src/panel-preview/PreviewPanel.tsx
+++ b/packages/protocolbeat/src/panel-preview/PreviewPanel.tsx
@@ -7,6 +7,7 @@ import type {
   AddressFieldValue,
   ApiPreviewContract,
   ApiPreviewPermissions,
+  UpgradeabilityActor,
 } from '../api/types'
 import { AddressDisplay } from '../panel-values/AddressDisplay'
 import { usePanelStore } from '../store/store'
@@ -164,6 +165,7 @@ function ContractsPreview(props: {
               addresses={contract.addresses}
               description={contract.description}
               isHighlighted={isSelected}
+              upgradableBy={contract.upgradableBy}
             />
           )
         })}
@@ -177,6 +179,7 @@ function PreviewItem(props: {
   multisigParticipants?: AddressFieldValue[]
   description: string
   isHighlighted: boolean
+  upgradableBy?: UpgradeabilityActor[]
 }) {
   return (
     <div
@@ -210,6 +213,17 @@ function PreviewItem(props: {
           {a}
         </div>
       ))}
+      {props.upgradableBy && (
+        <div className="ml-2 italic">
+          <b>Can be upgraded by:</b>{' '}
+          {props.upgradableBy.map((actor, idx) => (
+            <span key={idx}>
+              {idx > 0 && ', '}
+              {actor.name} with {actor.delay} delay
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Adds "Can be upgraded by" under smart contracts in Discovery UI / Preview Panel:

![image](https://github.com/user-attachments/assets/97a63a49-5107-4da5-a6a7-169829eee5cb)
