### PR TITLE
Fix token address parsing and simplify condition in `getStage.ts`

### DIFF
--- a/packages/backend/scripts/discover-tokens/index.ts
+++ b/packages/backend/scripts/discover-tokens/index.ts
@@ -164,7 +164,8 @@ async function main() {
             })
           }
 
-          const rawAddress = tokenFromLog.split(':')[1]
+          const [chain, rawAddress] = tokenFromLog.split(':') 
+          assert(rawAddress, `Invalid token format: ${tokenFromLog}`)
 
           try {
             const [balance, decimals] = await Promise.all([

--- a/packages/config/src/projects/layer2s/common/stages/getStage.ts
+++ b/packages/config/src/projects/layer2s/common/stages/getStage.ts
@@ -18,7 +18,7 @@ export const getStage = (
   const rollupNode = isSatisfied(
     blueprintChecklist.stage0.rollupNodeSourceAvailable,
   )
-  if (rollupNode === true && !opts?.rollupNodeLink) {
+  if (rollupNode && !opts?.rollupNodeLink) {
     throw new Error('Rollup node link is required')
   }
 


### PR DESCRIPTION
- **Fixed token address parsing** in `index.ts`:
  - Replaced `tokenFromLog.split(':')[1]` with a safer `[chain, rawAddress] = tokenFromLog.split(':')`
  - Added an `assert` to handle invalid token formats.
  
- **Simplified conditional check** in `getStage.ts`:
  - Removed redundant `=== true` comparison in `if (rollupNode === true && !opts?.rollupNodeLink)`, making it `if (rollupNode && !opts?.rollupNodeLink)`
  
  ## Why?
- **Prevents potential crashes** when a token log doesn't contain `":"`.
- **Improves readability and robustness** of the `getStage` function.
