### PR TITLE
Add ModelIdRegistry to easily query for addresses in Clingo models

### DIFF
--- a/packages/discovery/src/discovery/modelling/ModelIdRegistry.test.ts
+++ b/packages/discovery/src/discovery/modelling/ModelIdRegistry.test.ts
@@ -1,0 +1,221 @@
+import { expect } from 'earl'
+import { KnowledgeBase } from './KnowledgeBase'
+import { ModelIdRegistry } from './ModelIdRegistry'
+import type { ClingoFact } from './factTypes'
+
+describe(ModelIdRegistry.name, () => {
+  let registry: ModelIdRegistry
+  beforeEach(() => {
+    const knowledgeBase = new KnowledgeBase(facts)
+    registry = new ModelIdRegistry(knowledgeBase)
+  })
+
+  describe(ModelIdRegistry.prototype.getModelIdOrUndefined.name, () => {
+    it('returns undefined when address is not found', () => {
+      expect(
+        registry.getModelIdOrUndefined(
+          'ethereum',
+          '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ),
+      ).toEqual(undefined)
+    })
+
+    it('returns id when found', () => {
+      expect(
+        registry.getModelId(
+          'ethereum',
+          '0x000000000000000000000000000000000000ccc1',
+        ),
+      ).toEqual('contractA_ethereum_0x000000000000000000000000000000000000ccc1')
+    })
+  })
+
+  describe(ModelIdRegistry.prototype.getModelId.name, () => {
+    it('throws when no id is found', () => {
+      expect(() =>
+        registry.getModelId(
+          'ethereum',
+          '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        ),
+      ).toThrow(
+        'No id found for ethereum:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      )
+    })
+  })
+
+  describe(ModelIdRegistry.prototype.getAddressData.name, () => {
+    it('returns address data', () => {
+      expect(
+        registry.getAddressData(
+          'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+        ),
+      ).toEqual({
+        modelId:
+          'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+        chain: 'ethereum',
+        address: '0x000000000000000000000000000000000000ccc1',
+        name: 'ContractA',
+        type: 'contract',
+        description: 'Description of ContractA',
+      })
+
+      expect(
+        registry.getAddressData(
+          'eoaA_ethereum_0x000000000000000000000000000000000000eee1',
+        ),
+      ).toEqual({
+        modelId: 'eoaA_ethereum_0x000000000000000000000000000000000000eee1',
+        chain: 'ethereum',
+        address: '0x000000000000000000000000000000000000eee1',
+        name: 'Special EOA',
+        type: 'eoa',
+      })
+    })
+
+    it('throws when address is not found', () => {
+      expect(() => registry.getAddressData('abc')).toThrow(
+        'No address data found for modelId abc',
+      )
+    })
+  })
+
+  describe(ModelIdRegistry.prototype.getAddressDataOrUndefined.name, () => {
+    it('returns undefined when address is not found', () => {
+      expect(registry.getAddressDataOrUndefined('abc')).toEqual(undefined)
+    })
+  })
+
+  describe(ModelIdRegistry.prototype.replaceIdsWithNames.name, () => {
+    it('correctly replaces ids with names', () => {
+      const result = registry.replaceIdsWithNames(
+        'Contract @@contractA_ethereum_0x000000000000000000000000000000000000ccc1, eoa @@eoaA_ethereum_0x000000000000000000000000000000000000eee1, unknown @@a_b_c',
+      )
+      expect(result).toEqual(
+        'Contract ContractA, eoa Special EOA, unknown a_b_c',
+      )
+    })
+  })
+})
+
+const facts: ClingoFact[] = [
+  {
+    atom: 'address',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'ethereum',
+      '0x000000000000000000000000000000000000ccc1',
+    ],
+  },
+  {
+    atom: 'addressName',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'ContractA',
+    ],
+  },
+  {
+    atom: 'addressType',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'contract',
+    ],
+  },
+  {
+    atom: 'addressDescription',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'Description of ContractA',
+    ],
+  },
+  {
+    atom: 'permission',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'act',
+      'eoaA_ethereum_0x000000000000000000000000000000000000eee1',
+    ],
+  },
+  {
+    atom: 'permissionDescription',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'act',
+      'eoaA_ethereum_0x000000000000000000000000000000000000eee1',
+      'Description of Permission 2',
+    ],
+  },
+  {
+    atom: 'permissionDelay',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'act',
+      'eoaA_ethereum_0x000000000000000000000000000000000000eee1',
+      3600,
+    ],
+  },
+  {
+    atom: 'permission',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'upgrade',
+      'contractB_ethereum_0x000000000000000000000000000000000000ccc2',
+    ],
+  },
+  {
+    atom: 'permissionDescription',
+    params: [
+      'contractA_ethereum_0x000000000000000000000000000000000000ccc1',
+      'upgrade',
+      'contractB_ethereum_0x000000000000000000000000000000000000ccc2',
+      'Description of Permission 1',
+    ],
+  },
+  {
+    atom: 'address',
+    params: [
+      'contractB_ethereum_0x000000000000000000000000000000000000ccc2',
+      'ethereum',
+      '0x000000000000000000000000000000000000ccc2',
+    ],
+  },
+  {
+    atom: 'addressName',
+    params: [
+      'contractB_ethereum_0x000000000000000000000000000000000000ccc2',
+      'ContractB',
+    ],
+  },
+  {
+    atom: 'addressType',
+    params: [
+      'contractB_ethereum_0x000000000000000000000000000000000000ccc2',
+      'contract',
+    ],
+  },
+  {
+    atom: 'addressDescription',
+    params: [
+      'contractB_ethereum_0x000000000000000000000000000000000000ccc2',
+      'Description of ContractB',
+    ],
+  },
+  {
+    atom: 'address',
+    params: [
+      'eoaA_ethereum_0x000000000000000000000000000000000000eee1',
+      'ethereum',
+      '0x000000000000000000000000000000000000eee1',
+    ],
+  },
+  {
+    atom: 'addressType',
+    params: ['eoaA_ethereum_0x000000000000000000000000000000000000eee1', 'eoa'],
+  },
+  {
+    atom: 'addressName',
+    params: [
+      'eoaA_ethereum_0x000000000000000000000000000000000000eee1',
+      'Special EOA',
+    ],
+  },
+]

--- a/packages/discovery/src/discovery/modelling/ModelIdRegistry.ts
+++ b/packages/discovery/src/discovery/modelling/ModelIdRegistry.ts
@@ -1,0 +1,85 @@
+import type { KnowledgeBase } from './KnowledgeBase'
+import type { ClingoFact } from './factTypes'
+
+interface AddressData {
+  modelId: string
+  chain: string
+  address: string
+  name?: string
+  description?: string
+  type: string
+}
+
+export class ModelIdRegistry {
+  private readonly dataByAddress: Record<string, AddressData> = {}
+  private readonly dataById: Record<string, AddressData> = {}
+  constructor(public readonly knowledgeBase: KnowledgeBase) {
+    this.buildMaps()
+  }
+
+  buildMaps() {
+    const addressFacts = this.knowledgeBase.getFacts('address', [])
+    addressFacts.forEach((fact) => {
+      const modelId = String(fact.params[0])
+      const chain = String(fact.params[1])
+      const address = String(fact.params[2])
+      const data: AddressData = {
+        modelId,
+        address,
+        chain,
+        type: 'unknown',
+      }
+      this.dataByAddress[`${chain}:${address}`] = data
+      this.dataById[modelId] = data
+    })
+    const updateData = (fact: ClingoFact, field: keyof AddressData) => {
+      const modelId = String(fact.params[0])
+      const value = String(fact.params[1])
+      const data = this.dataById[modelId]
+      if (data === undefined) {
+        throw new Error(`No address data found for modelId ${modelId}`)
+      }
+      data[field] = value
+    }
+    this.knowledgeBase
+      .getFacts('addressName', [])
+      .forEach((fact) => updateData(fact, 'name'))
+    this.knowledgeBase
+      .getFacts('addressType', [])
+      .forEach((fact) => updateData(fact, 'type'))
+    this.knowledgeBase
+      .getFacts('addressDescription', [])
+      .forEach((fact) => updateData(fact, 'description'))
+  }
+
+  getModelIdOrUndefined(chain: string, address: string): string | undefined {
+    return this.dataByAddress[`${chain}:${address.toLowerCase()}`]?.modelId
+  }
+
+  getModelId(chain: string, address: string): string {
+    const id = this.getModelIdOrUndefined(chain, address)
+    if (id === undefined) {
+      throw new Error(`No id found for ${chain}:${address}`)
+    }
+    return id
+  }
+
+  getAddressDataOrUndefined(modelId: string): AddressData | undefined {
+    return this.dataById[modelId]
+  }
+
+  getAddressData(modelId: string): AddressData {
+    const data = this.getAddressDataOrUndefined(modelId)
+    if (data === undefined) {
+      throw new Error(`No address data found for modelId ${modelId}`)
+    }
+    return data
+  }
+
+  replaceIdsWithNames(s: string): string {
+    return s.replace(
+      /@@([a-zA-Z0-9_]+)/g,
+      (_, id) => this.getAddressDataOrUndefined(id)?.name ?? id,
+    )
+  }
+}


### PR DESCRIPTION
Part of L2B-9400

Introduces Model ID Registry, to easily query about address data, name, type and description. It uses KnowledgeBase to find relevant facts in Clingo model.