### PR TITLE
Refactor ProjectDiscovery into multiple files

### DIFF
--- a/packages/config/src/discovery/PermissionRegistry.ts
+++ b/packages/config/src/discovery/PermissionRegistry.ts
@@ -1,0 +1,10 @@
+import type { ContractParameters, EoaParameters } from '@l2beat/discovery'
+
+export interface PermissionRegistry {
+  getPermissionedContracts(): ContractParameters[]
+  getPermissionedEoas(): EoaParameters[]
+  describePermissions(
+    contractOrEoa: ContractParameters | EoaParameters,
+    includeDirectPermissions: boolean,
+  ): string[]
+}

--- a/packages/config/src/discovery/PermissionsFromDiscovery.ts
+++ b/packages/config/src/discovery/PermissionsFromDiscovery.ts
@@ -1,0 +1,191 @@
+import type {
+  ContractParameters,
+  EoaParameters,
+  Permission,
+  ReceivedPermission,
+  ResolvedPermissionPath,
+} from '@l2beat/discovery'
+import { notUndefined } from '@l2beat/shared-pure'
+import { groupBy } from 'lodash'
+import type { PermissionRegistry } from './PermissionRegistry'
+import type { ProjectDiscovery } from './ProjectDiscovery'
+import {
+  DirectPermissionToPrefix,
+  UltimatePermissionToPrefix,
+} from './descriptions'
+import {
+  formatPermissionCondition,
+  formatPermissionDelay,
+  formatPermissionDescription,
+  isMultisigLike,
+} from './utils'
+
+export class PermissionsFromDiscovery implements PermissionRegistry {
+  constructor(private readonly projectDiscovery: ProjectDiscovery) {}
+
+  getPermissionedContracts(): ContractParameters[] {
+    const contracts = this.projectDiscovery.getContracts()
+
+    return [
+      ...contracts.filter(
+        (contract) => contract.receivedPermissions !== undefined,
+      ),
+      // We show multisigs even without ultimate permissions,
+      // because they can be members of msigs with permissions.
+      // We can also assume that msigs are always permissioned.
+      // But we show them last.
+      ...contracts.filter(
+        (contract) =>
+          contract.receivedPermissions === undefined &&
+          isMultisigLike(contract),
+      ),
+    ]
+      .filter((e) => (e.category?.priority ?? 0) >= 0)
+      .sort((a, b) => {
+        return this.getPermissionPriority(b) - this.getPermissionPriority(a)
+      })
+  }
+
+  getPermissionedEoas(): EoaParameters[] {
+    return this.projectDiscovery
+      .getEoas()
+      .filter((e) => (e.category?.priority ?? 0) >= 0)
+      .sort((a, b) => {
+        return this.getPermissionPriority(b) - this.getPermissionPriority(a)
+      })
+  }
+  describePermissions(
+    contractOrEoa: ContractParameters | EoaParameters,
+    includeDirectPermissions: boolean = true,
+  ) {
+    return [
+      ...(includeDirectPermissions
+        ? this.describeDirectlyReceivedPermissions(contractOrEoa)
+        : []),
+      ...this.describeUltimatelyReceivedPermissions(contractOrEoa),
+    ].filter(notUndefined)
+  }
+
+  getPermissionPriority(entry: ContractParameters | EoaParameters): number {
+    if (entry.receivedPermissions === undefined) {
+      return 0
+    }
+
+    const permissions = entry.receivedPermissions.map((p) => p.from)
+    const priority = permissions.reduce((acc, permission) => {
+      return (
+        acc +
+        (this.projectDiscovery.getEntryByAddress(permission)?.category
+          ?.priority ?? 0)
+      )
+    }, 0)
+
+    return priority
+  }
+
+  describeDirectlyReceivedPermissions(
+    contractOrEoa: ContractParameters | EoaParameters,
+  ): string[] {
+    return Object.entries(
+      groupBy(
+        contractOrEoa.directlyReceivedPermissions ?? [],
+        (value: ReceivedPermission) =>
+          [
+            value.permission,
+            value.description ?? '',
+            value.condition ?? '',
+            value.delay?.toString() ?? '',
+          ].join('►'),
+      ),
+    ).map(([key, entries]) => {
+      const permission = key.split('►')[0] as Permission
+      const description = key.split('►')[1] ?? ''
+      const condition = key.split('►')[2] ?? ''
+      const delay = key.split('►')[3] ?? ''
+      const permissionsRequiringTarget: Permission[] = [
+        'interact',
+        'upgrade',
+        'act',
+      ]
+      const showTargets = permissionsRequiringTarget.includes(permission)
+      const addressesString = showTargets
+        ? entries
+            .map(
+              (entry) =>
+                this.projectDiscovery.getContract(entry.from.toString()).name,
+            )
+            .join(', ')
+        : ''
+
+      return `${[
+        DirectPermissionToPrefix[permission],
+        addressesString,
+        formatPermissionDescription(description),
+        formatPermissionCondition(condition),
+        delay === '' ? '' : formatPermissionDelay(Number(delay)),
+      ]
+        .filter((s) => s !== '')
+        .join(' ')
+        .trim()}.`
+    })
+  }
+
+  describeUltimatelyReceivedPermissions(
+    contractOrEoa: ContractParameters | EoaParameters,
+  ): string[] {
+    const formatVia = (via: ResolvedPermissionPath[]) =>
+      `- acting via ${via.map((p) => this.projectDiscovery.formatViaPath(p)).join(', ')}`
+
+    return Object.entries(
+      groupBy(
+        contractOrEoa.receivedPermissions ?? [],
+        (value: ReceivedPermission) => {
+          return [
+            value.permission,
+            value.via !== undefined ? formatVia(value.via) : '',
+            value.description ?? '',
+            value.condition ?? '',
+            value.delay?.toString() ?? '',
+          ].join('►')
+        },
+      ),
+    ).map(([key, entries]) => {
+      const permission = key.split('►')[0] as Permission
+      const via = key.split('►')[1] ?? ''
+      const description = key.split('►')[2] ?? ''
+      const condition = key.split('►')[3] ?? ''
+      const delay = key.split('►')[4] ?? ''
+      const prefix = UltimatePermissionToPrefix[permission]
+      if (prefix === undefined) {
+        return ''
+      }
+
+      const permissionsRequiringTarget: Permission[] = [
+        'interact',
+        'upgrade',
+        'act',
+      ]
+      const showTargets = permissionsRequiringTarget.includes(permission)
+      const addressesString = showTargets
+        ? entries
+            .map(
+              (entry) =>
+                this.projectDiscovery.getContract(entry.from.toString()).name,
+            )
+            .join(', ')
+        : ''
+
+      return `${[
+        UltimatePermissionToPrefix[permission as Permission],
+        addressesString,
+        formatPermissionDescription(description),
+        formatPermissionCondition(condition),
+        delay === '' ? '' : formatPermissionDelay(Number(delay)),
+        via,
+      ]
+        .filter((s) => s !== '')
+        .join(' ')
+        .trim()}.`
+    })
+  }
+}

--- a/packages/config/src/discovery/ProjectDiscovery.test.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.test.ts
@@ -7,11 +7,7 @@ import {
   type RawDiscoveryConfig,
 } from '@l2beat/discovery'
 import { contractStub, discoveredJsonStub } from '../test/stubs/discoveredJson'
-import {
-  ProjectDiscovery,
-  formatAsBulletPoints,
-  trimTrailingDots,
-} from './ProjectDiscovery'
+import { ProjectDiscovery, formatAsBulletPoints } from './ProjectDiscovery'
 
 describe(ProjectDiscovery.name, () => {
   const projectName = 'ExampleProject'
@@ -141,20 +137,6 @@ describe(formatAsBulletPoints.name, () => {
     const description = ['Single point']
     const formatted = formatAsBulletPoints(description)
     expect(formatted).toEqual('Single point')
-  })
-})
-
-describe(trimTrailingDots.name, () => {
-  it('should remove trailing dots', () => {
-    const description = 'Some description...'
-    const trimmed = trimTrailingDots(description)
-    expect(trimmed).toEqual('Some description')
-  })
-
-  it('should not remove trailing dots if there are no dots', () => {
-    const description = 'Some description'
-    const trimmed = trimTrailingDots(description)
-    expect(trimmed).toEqual(description)
   })
 })
 

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -43,14 +43,14 @@ import {
 export class ProjectDiscovery {
   private readonly discoveries: DiscoveryOutput[]
   private eoaIDMap: Record<string, string> = {}
-  private permissionsRegistry: PermissionRegistry
+  private permissionRegistry: PermissionRegistry
   constructor(
     public readonly projectName: string,
     public readonly chain: string = 'ethereum',
     configReader = new ConfigReader(join(process.cwd(), '../config')),
   ) {
     const discovery = configReader.readDiscovery(projectName, chain)
-    this.permissionsRegistry = new PermissionsFromDiscovery(this)
+    this.permissionRegistry = new PermissionsFromDiscovery(this)
     this.discoveries = [
       discovery,
       ...(discovery.sharedModules ?? []).map((module) =>
@@ -740,7 +740,7 @@ export class ProjectDiscovery {
     return [
       contractOrEoa.description,
       ...this.describeGnosisSafeMembership(contractOrEoa),
-      ...this.permissionsRegistry.describePermissions(
+      ...this.permissionRegistry.describePermissions(
         contractOrEoa,
         includeDirectPermissions,
       ),
@@ -761,9 +761,8 @@ export class ProjectDiscovery {
   }
 
   getDiscoveredPermissions(): ProjectPermissions {
-    const relevantContracts =
-      this.permissionsRegistry.getPermissionedContracts()
-    const eoas = this.permissionsRegistry.getPermissionedEoas()
+    const relevantContracts = this.permissionRegistry.getPermissionedContracts()
+    const eoas = this.permissionRegistry.getPermissionedEoas()
     const allActors: ProjectPermission[] = []
     for (const contract of relevantContracts) {
       const descriptions = this.describeContractOrEoa(contract, true)

--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -5,8 +5,6 @@ import type {
   ContractValue,
   DiscoveryOutput,
   EoaParameters,
-  Permission,
-  ReceivedPermission,
   ResolvedPermissionPath,
 } from '@l2beat/discovery'
 import {
@@ -18,7 +16,7 @@ import {
   notUndefined,
 } from '@l2beat/shared-pure'
 import { utils } from 'ethers'
-import { groupBy, isString, sum, uniq } from 'lodash'
+import { isString, sum, uniq } from 'lodash'
 import { EXPLORER_URLS } from '../projects/chains/explorerUrls'
 import type {
   ProjectContract,
@@ -31,17 +29,28 @@ import type {
   ScalingProjectUpgradeability,
   SharedEscrow,
 } from '../types'
+import type { PermissionRegistry } from './PermissionRegistry'
+import { PermissionsFromDiscovery } from './PermissionsFromDiscovery'
+import { RoleDescriptions } from './descriptions'
 import { get$Admins, get$Implementations, toAddressArray } from './extractors'
+import {
+  formatPermissionCondition,
+  formatPermissionDelay,
+  isMultisigLike,
+  trimTrailingDots,
+} from './utils'
 
 export class ProjectDiscovery {
   private readonly discoveries: DiscoveryOutput[]
   private eoaIDMap: Record<string, string> = {}
+  private permissionsRegistry: PermissionRegistry
   constructor(
     public readonly projectName: string,
     public readonly chain: string = 'ethereum',
     configReader = new ConfigReader(join(process.cwd(), '../config')),
   ) {
     const discovery = configReader.readDiscovery(projectName, chain)
+    this.permissionsRegistry = new PermissionsFromDiscovery(this)
     this.discoveries = [
       discovery,
       ...(discovery.sharedModules ?? []).map((module) =>
@@ -592,12 +601,16 @@ export class ProjectDiscovery {
     return eoas.filter((eoa) => eoa.name === name)
   }
 
+  getContracts(): ContractParameters[] {
+    return this.discoveries.flatMap((discovery) => discovery.contracts)
+  }
+
+  getEoas(): EoaParameters[] {
+    return this.discoveries.flatMap((discovery) => discovery.eoas)
+  }
+
   getContractsAndEoas(): (ContractParameters | EoaParameters)[] {
-    const contracts = this.discoveries.flatMap(
-      (discovery) => discovery.contracts,
-    )
-    const eoas = this.discoveries.flatMap((discovery) => discovery.eoas)
-    return [...contracts, ...eoas]
+    return [...this.getContracts(), ...this.getEoas()]
   }
 
   getPermissionsByRole(
@@ -659,7 +672,7 @@ export class ProjectDiscovery {
       )
 
       const finalDescription = [
-        descriptions[0] ?? roleDescriptions[role].description,
+        descriptions[0] ?? RoleDescriptions[role].description,
       ]
 
       for (const c of matching) {
@@ -693,7 +706,7 @@ export class ProjectDiscovery {
       }
 
       result.push({
-        ...roleDescriptions[role],
+        ...RoleDescriptions[role],
         description: finalDescription.join('\n'),
         accounts: this.formatPermissionedAccounts(addresses),
         chain: this.chain,
@@ -720,152 +733,6 @@ export class ProjectDiscovery {
     return result.join(' ')
   }
 
-  describeUltimatelyReceivedPermissions(
-    contractOrEoa: ContractParameters | EoaParameters,
-  ): string[] {
-    const ultimatePermissionToPrefix: {
-      [key in Permission]: string | undefined
-    } = {
-      interact: 'Is allowed to interact with',
-      upgrade: 'Can upgrade the implementation of',
-      act: undefined,
-      guard: 'A Guardian',
-      challenge: 'A Challenger',
-      propose: 'A Proposer',
-      sequence: 'A Sequencer',
-      validate: 'A Validator',
-      operateLinea: 'An Operator',
-      fastconfirm: 'A FastConfirmer',
-      validateZkStack: 'A Validator',
-      relay: 'A Relayer',
-      validateBridge: 'A Validator',
-      validateBridge2: 'A Validator',
-      aggregatePolygon: 'A trusted Aggregator',
-      operateStarknet: 'An Operator',
-      governStarknet: 'A Governor',
-      member: 'Is a member of',
-    }
-
-    const formatVia = (via: ResolvedPermissionPath[]) =>
-      `- acting via ${via.map((p) => this.formatViaPath(p)).join(', ')}`
-
-    return Object.entries(
-      groupBy(
-        contractOrEoa.receivedPermissions ?? [],
-        (value: ReceivedPermission) => {
-          return [
-            value.permission,
-            value.via !== undefined ? formatVia(value.via) : '',
-            value.description ?? '',
-            value.condition ?? '',
-            value.delay?.toString() ?? '',
-          ].join('►')
-        },
-      ),
-    ).map(([key, entries]) => {
-      const permission = key.split('►')[0] as Permission
-      const via = key.split('►')[1] ?? ''
-      const description = key.split('►')[2] ?? ''
-      const condition = key.split('►')[3] ?? ''
-      const delay = key.split('►')[4] ?? ''
-      const prefix = ultimatePermissionToPrefix[permission]
-      if (prefix === undefined) {
-        return ''
-      }
-
-      const permissionsRequiringTarget: Permission[] = [
-        'interact',
-        'upgrade',
-        'act',
-      ]
-      const showTargets = permissionsRequiringTarget.includes(permission)
-      const addressesString = showTargets
-        ? entries
-            .map((entry) => this.getContract(entry.from.toString()).name)
-            .join(', ')
-        : ''
-
-      return `${[
-        ultimatePermissionToPrefix[permission as Permission],
-        addressesString,
-        formatPermissionDescription(description),
-        formatPermissionCondition(condition),
-        delay === '' ? '' : formatPermissionDelay(Number(delay)),
-        via,
-      ]
-        .filter((s) => s !== '')
-        .join(' ')
-        .trim()}.`
-    })
-  }
-
-  describeDirectlyReceivedPermissions(
-    contractOrEoa: ContractParameters | EoaParameters,
-  ): string[] {
-    const directPermissionToPrefix: {
-      [key in Permission]: string | undefined
-    } = {
-      interact: 'Can be used to interact with',
-      upgrade: 'Can be used to upgrade implementation of',
-      act: 'Can act on behalf of',
-      guard: 'Can act as a Guardian',
-      challenge: 'Can act as a Challenger',
-      propose: 'Can act as a Proposer',
-      sequence: 'Can act as a Sequencer',
-      validate: 'Can act as a Validator',
-      operateLinea: 'Can act as an Operator',
-      fastconfirm: 'Can act as a FastConfirmer',
-      validateZkStack: 'Can act as a Validator',
-      relay: 'Can act as a Relayer',
-      validateBridge: 'Can act as a Validator',
-      validateBridge2: 'Can act as a Validator',
-      aggregatePolygon: 'Can act as a trusted Aggregator',
-      operateStarknet: 'Can act as an Operator',
-      governStarknet: 'Can act as a Governor',
-      member: 'Is a member of',
-    }
-
-    return Object.entries(
-      groupBy(
-        contractOrEoa.directlyReceivedPermissions ?? [],
-        (value: ReceivedPermission) =>
-          [
-            value.permission,
-            value.description ?? '',
-            value.condition ?? '',
-            value.delay?.toString() ?? '',
-          ].join('►'),
-      ),
-    ).map(([key, entries]) => {
-      const permission = key.split('►')[0] as Permission
-      const description = key.split('►')[1] ?? ''
-      const condition = key.split('►')[2] ?? ''
-      const delay = key.split('►')[3] ?? ''
-      const permissionsRequiringTarget: Permission[] = [
-        'interact',
-        'upgrade',
-        'act',
-      ]
-      const showTargets = permissionsRequiringTarget.includes(permission)
-      const addressesString = showTargets
-        ? entries
-            .map((entry) => this.getContract(entry.from.toString()).name)
-            .join(', ')
-        : ''
-
-      return `${[
-        directPermissionToPrefix[permission],
-        addressesString,
-        formatPermissionDescription(description),
-        formatPermissionCondition(condition),
-        delay === '' ? '' : formatPermissionDelay(Number(delay)),
-      ]
-        .filter((s) => s !== '')
-        .join(' ')
-        .trim()}.`
-    })
-  }
-
   describeContractOrEoa(
     contractOrEoa: ContractParameters | EoaParameters,
     includeDirectPermissions: boolean = true,
@@ -873,10 +740,10 @@ export class ProjectDiscovery {
     return [
       contractOrEoa.description,
       ...this.describeGnosisSafeMembership(contractOrEoa),
-      ...(includeDirectPermissions
-        ? this.describeDirectlyReceivedPermissions(contractOrEoa)
-        : []),
-      ...this.describeUltimatelyReceivedPermissions(contractOrEoa),
+      ...this.permissionsRegistry.describePermissions(
+        contractOrEoa,
+        includeDirectPermissions,
+      ),
     ].filter(notUndefined)
   }
 
@@ -893,50 +760,10 @@ export class ProjectDiscovery {
     return s
   }
 
-  getPermissionPriority(entry: ContractParameters | EoaParameters): number {
-    if (entry.receivedPermissions === undefined) {
-      return 0
-    }
-
-    const permissions = entry.receivedPermissions.map((p) => p.from)
-    const priority = permissions.reduce((acc, permission) => {
-      return acc + (this.getEntryByAddress(permission)?.category?.priority ?? 0)
-    }, 0)
-
-    return priority
-  }
-
   getDiscoveredPermissions(): ProjectPermissions {
-    const contracts = this.discoveries.flatMap(
-      (discovery) => discovery.contracts,
-    )
-
-    const relevantContracts = [
-      ...contracts.filter(
-        (contract) => contract.receivedPermissions !== undefined,
-      ),
-      // We show multisigs even without ultimate permissions,
-      // because they can be members of msigs with permissions.
-      // We can also assume that msigs are always permissioned.
-      // But we show them last.
-      ...contracts.filter(
-        (contract) =>
-          contract.receivedPermissions === undefined &&
-          isMultisigLike(contract),
-      ),
-    ]
-      .filter((e) => (e.category?.priority ?? 0) >= 0)
-      .sort((a, b) => {
-        return this.getPermissionPriority(b) - this.getPermissionPriority(a)
-      })
-
-    const eoas = this.discoveries
-      .flatMap((discovery) => discovery.eoas)
-      .filter((e) => (e.category?.priority ?? 0) >= 0)
-      .sort((a, b) => {
-        return this.getPermissionPriority(b) - this.getPermissionPriority(a)
-      })
-
+    const relevantContracts =
+      this.permissionsRegistry.getPermissionedContracts()
+    const eoas = this.permissionsRegistry.getPermissionedEoas()
     const allActors: ProjectPermission[] = []
     for (const contract of relevantContracts) {
       const descriptions = this.describeContractOrEoa(contract, true)
@@ -1165,117 +992,10 @@ function isNonNullable<T>(
   return value !== null && value !== undefined
 }
 
-const roleDescriptions: {
-  [key in (typeof RolePermissionEntries)[number]]: {
-    name: string
-    description: string
-  }
-} = {
-  sequence: {
-    name: 'Sequencer',
-    description:
-      'Allowed to commit transactions from the current layer to the host chain.',
-  },
-  propose: {
-    name: 'Proposer',
-    description:
-      'Allowed to post new state roots of the current layer to the host chain.',
-  },
-  challenge: {
-    name: 'Challenger',
-    description:
-      'Allowed to challenge or delete state roots proposed by a Proposer.',
-  },
-  guard: {
-    name: 'Guardian',
-    description: 'Allowed to pause deposits and withdrawals.',
-  },
-  validate: {
-    // ORBIT specific
-    name: 'Validator',
-    description:
-      'Orbit stack specific Proposer and Challenger role. Can propose new state roots (called nodes) and challenge state roots on the host chain.',
-  },
-  operateLinea: {
-    // LINEA specific
-    name: 'Operator',
-    description:
-      'Allowed to prove blocks and post the corresponding transaction data.',
-  },
-  fastconfirm: {
-    name: 'AnyTrust FastConfirmer',
-    description:
-      'Can finalize a state root before the challenge period has passed. This allows withdrawing from the bridge based on the state root.',
-  },
-  validateZkStack: {
-    // ZK stack specific
-    name: 'Validator',
-    description:
-      'Permissioned to call the functions to commit, prove, execute and revert L2 batches through the ValidatorTimelock in the main Diamond contract.',
-  },
-  validateBridge: {
-    name: 'Validator',
-    description:
-      'Permissoned to sign messages (state roots) encoding transfer information or governance actions such as updates to a new validator set, which are decoded onchain with signature checks.',
-  },
-  validateBridge2: {
-    name: 'Validator',
-    description:
-      'Permissoned to sign crosschain messages encoding transfer information, which are decoded onchain with signature checks. The validators listed here are the default validators for Ethereum and can be overridden by a custom configuration.',
-  },
-  relay: {
-    name: 'Relayer',
-    description:
-      'Permissioned to relay messages that are then verified onchain.',
-  },
-  aggregatePolygon: {
-    name: 'Trusted Aggregator (Proposer)',
-    description:
-      'Permissioned to post new state roots and global exit roots accompanied by ZK proofs.', // and accounting proofs for CDK sovereign (others) chains
-  },
-  operateStarknet: {
-    name: 'Operator',
-    description:
-      'Permissioned to regularly update and prove the state of the L2 on L1.',
-  },
-  governStarknet: {
-    name: 'Governor',
-    description:
-      'Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.',
-  },
-}
-
 export function formatAsBulletPoints(description: string[]): string {
   return description.length > 1
     ? description.map((s) => `* ${s}\n`).join('')
     : description.join(' ')
-}
-
-export function trimTrailingDots(s: string): string {
-  return s.replace(/\.*$/, '')
-}
-
-function formatPermissionDescription(description: string): string {
-  return description !== '' ? `- ${trimTrailingDots(description)}` : ''
-}
-
-function formatPermissionCondition(condition: string): string {
-  return condition !== '' ? `if ${trimTrailingDots(condition)}` : ''
-}
-
-function formatPermissionDelay(delay: number): string {
-  return ` with ${formatSeconds(delay)} delay`
-}
-
-function isMultisigLike(contract: ContractParameters | undefined): boolean {
-  if (contract === undefined) {
-    return false
-  }
-
-  const hasMembers = contract.values?.['$members'] !== undefined
-  const hasThreshold = contract.values?.['$threshold'] !== undefined
-
-  return hasMembers && hasThreshold
 }
 
 function isEntryVerified(entry: ContractParameters | EoaParameters): boolean {

--- a/packages/config/src/discovery/descriptions.ts
+++ b/packages/config/src/discovery/descriptions.ts
@@ -1,0 +1,127 @@
+import type { Permission, RolePermissionEntries } from '@l2beat/discovery'
+
+export const DirectPermissionToPrefix: {
+  [key in Permission]: string | undefined
+} = {
+  interact: 'Can be used to interact with',
+  upgrade: 'Can be used to upgrade implementation of',
+  act: 'Can act on behalf of',
+  guard: 'Can act as a Guardian',
+  challenge: 'Can act as a Challenger',
+  propose: 'Can act as a Proposer',
+  sequence: 'Can act as a Sequencer',
+  validate: 'Can act as a Validator',
+  operateLinea: 'Can act as an Operator',
+  fastconfirm: 'Can act as a FastConfirmer',
+  validateZkStack: 'Can act as a Validator',
+  relay: 'Can act as a Relayer',
+  validateBridge: 'Can act as a Validator',
+  validateBridge2: 'Can act as a Validator',
+  aggregatePolygon: 'Can act as a trusted Aggregator',
+  operateStarknet: 'Can act as an Operator',
+  governStarknet: 'Can act as a Governor',
+  member: 'Is a member of',
+}
+
+export const UltimatePermissionToPrefix: {
+  [key in Permission]: string | undefined
+} = {
+  interact: 'Is allowed to interact with',
+  upgrade: 'Can upgrade the implementation of',
+  act: undefined,
+  guard: 'A Guardian',
+  challenge: 'A Challenger',
+  propose: 'A Proposer',
+  sequence: 'A Sequencer',
+  validate: 'A Validator',
+  operateLinea: 'An Operator',
+  fastconfirm: 'A FastConfirmer',
+  validateZkStack: 'A Validator',
+  relay: 'A Relayer',
+  validateBridge: 'A Validator',
+  validateBridge2: 'A Validator',
+  aggregatePolygon: 'A trusted Aggregator',
+  operateStarknet: 'An Operator',
+  governStarknet: 'A Governor',
+  member: 'Is a member of',
+}
+
+export const RoleDescriptions: {
+  [key in (typeof RolePermissionEntries)[number]]: {
+    name: string
+    description: string
+  }
+} = {
+  sequence: {
+    name: 'Sequencer',
+    description:
+      'Allowed to commit transactions from the current layer to the host chain.',
+  },
+  propose: {
+    name: 'Proposer',
+    description:
+      'Allowed to post new state roots of the current layer to the host chain.',
+  },
+  challenge: {
+    name: 'Challenger',
+    description:
+      'Allowed to challenge or delete state roots proposed by a Proposer.',
+  },
+  guard: {
+    name: 'Guardian',
+    description: 'Allowed to pause deposits and withdrawals.',
+  },
+  validate: {
+    // ORBIT specific
+    name: 'Validator',
+    description:
+      'Orbit stack specific Proposer and Challenger role. Can propose new state roots (called nodes) and challenge state roots on the host chain.',
+  },
+  operateLinea: {
+    // LINEA specific
+    name: 'Operator',
+    description:
+      'Allowed to prove blocks and post the corresponding transaction data.',
+  },
+  fastconfirm: {
+    name: 'AnyTrust FastConfirmer',
+    description:
+      'Can finalize a state root before the challenge period has passed. This allows withdrawing from the bridge based on the state root.',
+  },
+  validateZkStack: {
+    // ZK stack specific
+    name: 'Validator',
+    description:
+      'Permissioned to call the functions to commit, prove, execute and revert L2 batches through the ValidatorTimelock in the main Diamond contract.',
+  },
+  validateBridge: {
+    name: 'Validator',
+    description:
+      'Permissoned to sign messages (state roots) encoding transfer information or governance actions such as updates to a new validator set, which are decoded onchain with signature checks.',
+  },
+  validateBridge2: {
+    name: 'Validator',
+    description:
+      'Permissoned to sign crosschain messages encoding transfer information, which are decoded onchain with signature checks. The validators listed here are the default validators for Ethereum and can be overridden by a custom configuration.',
+  },
+  relay: {
+    name: 'Relayer',
+    description:
+      'Permissioned to relay messages that are then verified onchain.',
+  },
+  aggregatePolygon: {
+    name: 'Trusted Aggregator (Proposer)',
+    description:
+      'Permissioned to post new state roots and global exit roots accompanied by ZK proofs.', // and accounting proofs for CDK sovereign (others) chains
+  },
+  operateStarknet: {
+    name: 'Operator',
+    description:
+      'Permissioned to regularly update and prove the state of the L2 on L1.',
+  },
+  governStarknet: {
+    name: 'Governor',
+    description:
+      'Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.',
+  },
+}

--- a/packages/config/src/discovery/utils.test.ts
+++ b/packages/config/src/discovery/utils.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'earl'
+import { trimTrailingDots } from './utils'
+
+describe(trimTrailingDots.name, () => {
+  it('should remove trailing dots', () => {
+    const description = 'Some description...'
+    const trimmed = trimTrailingDots(description)
+    expect(trimmed).toEqual('Some description')
+  })
+
+  it('should not remove trailing dots if there are no dots', () => {
+    const description = 'Some description'
+    const trimmed = trimTrailingDots(description)
+    expect(trimmed).toEqual(description)
+  })
+})

--- a/packages/config/src/discovery/utils.ts
+++ b/packages/config/src/discovery/utils.ts
@@ -1,0 +1,31 @@
+import type { ContractParameters } from '@l2beat/discovery'
+import { formatSeconds } from '@l2beat/shared-pure'
+
+export function isMultisigLike(
+  contract: ContractParameters | undefined,
+): boolean {
+  if (contract === undefined) {
+    return false
+  }
+
+  const hasMembers = contract.values?.['$members'] !== undefined
+  const hasThreshold = contract.values?.['$threshold'] !== undefined
+
+  return hasMembers && hasThreshold
+}
+
+export function formatPermissionDescription(description: string): string {
+  return description !== '' ? `- ${trimTrailingDots(description)}` : ''
+}
+
+export function trimTrailingDots(s: string): string {
+  return s.replace(/\.*$/, '')
+}
+
+export function formatPermissionCondition(condition: string): string {
+  return condition !== '' ? `if ${trimTrailingDots(condition)}` : ''
+}
+
+export function formatPermissionDelay(delay: number): string {
+  return ` with ${formatSeconds(delay)} delay`
+}


### PR DESCRIPTION
Part of L2B-9400

In order to render project data using Clingo facts it's necessary to refactor ProjectDiscovery into smaller chunks, so that e.g. part responsible for displaying permissions can be swapped from discovery-based to clingo-model-based.

This PR is only about breaking ProjectDiscovery into smaller files. It doesn't introduce any new or limit any functionality.