### PR TITLE
Add challenge period to Outbox delay in Arbitrum model

### DIFF
--- a/packages/config/discovery/_templates/orbitstack/Outbox/model.lp
+++ b/packages/config/discovery/_templates/orbitstack/Outbox/model.lp
@@ -1,2 +1,6 @@
 permission(L2Entrypoint, "act", @self) :-
   l2Entrypoint(L2Entrypoint).
+
+permissionDelay(L2Entrypoint, "act", @self, Seconds) :-
+  challengePeriodSeconds(Seconds),
+  permission(L2Entrypoint, "act", @self).

--- a/packages/config/discovery/_templates/orbitstack/RollupProxyBoLD/model.lp
+++ b/packages/config/discovery/_templates/orbitstack/RollupProxyBoLD/model.lp
@@ -1,0 +1,2 @@
+challengePeriodSeconds(Seconds) :-
+  Seconds = #confirmPeriodBlocks * 12.  % from aribtrum.ts: assumedBlockTime = 12


### PR DESCRIPTION
Clingo model allows us to reference the challenge period when defining Outbox permission.

The block time needed for calculation is assumed to be 12s. This is how it's done in .ts config as well. In the future we need to find a better way to estimate it.