### PR TITLE
Use `&` instead of `#` for field access in Clingo templates

### DIFF
--- a/packages/config/discovery/_templates/GnosisSafe/model.lp
+++ b/packages/config/discovery/_templates/GnosisSafe/model.lp
@@ -1,4 +1,4 @@
-msig(@self, #$threshold).
+msig(@self, &$threshold).
 member(@self, 
-  #$members
+  &$members
 ).

--- a/packages/config/discovery/_templates/orbitstack/SecurityCouncil/model.lp
+++ b/packages/config/discovery/_templates/orbitstack/SecurityCouncil/model.lp
@@ -1,4 +1,4 @@
-msig(@self, #$threshold).
+msig(@self, &$threshold).
 member(@self, 
-  #$members
+  &$members
 ).

--- a/packages/config/discovery/_templates/orbitstack/Timelock/model.lp
+++ b/packages/config/discovery/_templates/orbitstack/Timelock/model.lp
@@ -1,2 +1,2 @@
 l2Entrypoint(L2Timelock) :-
-  address(L2Timelock, "arbitrum", "#l2Timelock|lower").
+  address(L2Timelock, "arbitrum", "&l2Timelock|lower").

--- a/packages/config/discovery/_templates/orbitstack/layer2/L2SecurityCouncilEmergency/model.lp
+++ b/packages/config/discovery/_templates/orbitstack/layer2/L2SecurityCouncilEmergency/model.lp
@@ -1,4 +1,4 @@
-msig(@self, #$threshold).
+msig(@self, &$threshold).
 member(@self, 
-  #$members
+  &$members
 ).

--- a/packages/config/discovery/_templates/orbitstack/layer2/L2SecurityCouncilPropose/model.lp
+++ b/packages/config/discovery/_templates/orbitstack/layer2/L2SecurityCouncilPropose/model.lp
@@ -1,4 +1,4 @@
-msig(@self, #$threshold).
+msig(@self, &$threshold).
 member(@self, 
-  #$members
+  &$members
 ).

--- a/packages/discovery/src/discovery/modelling/interpolate.test.ts
+++ b/packages/discovery/src/discovery/modelling/interpolate.test.ts
@@ -38,13 +38,13 @@ describe(tryCastingToName.name, () => {
 describe(interpolateModelTemplate.name, () => {
   it('properly interpolates the model file', () => {
     const modelTemplate = `
-      msig(@self, #$threshold).
+      msig(@self, &$threshold).
       member(@self, 
-        #$members
+        &$members
       ).
-      myAddr(#$.address, "#$.address:raw").
-      myName("#$.name").
-      myDescription("#$.description")
+      myAddr(&$.address, "&$.address:raw").
+      myName("&$.name").
+      myDescription("&$.description")
     `
     const contract: EntryParameters = {
       type: 'Contract',
@@ -85,7 +85,7 @@ describe(interpolateModelTemplate.name, () => {
   })
 
   it('properly casts to lowercase', () => {
-    const modelTemplate = `msg1("#msg|lower").msg2("#msg:raw|lower").`
+    const modelTemplate = `msg1("&msg|lower").msg2("&msg:raw|lower").`
     const contract: EntryParameters = {
       type: 'Contract',
       address: EthereumAddress.from('0x123'),
@@ -103,8 +103,8 @@ describe(interpolateModelTemplate.name, () => {
 
   it('fails for missing values', () => {
     const modelTemplate = `
-      one(#one).
-      two(#two).
+      one(&one).
+      two(&two).
     `
     const contract: EntryParameters = {
       type: 'Contract',

--- a/packages/discovery/src/discovery/modelling/interpolate.ts
+++ b/packages/discovery/src/discovery/modelling/interpolate.ts
@@ -11,7 +11,7 @@ export function interpolateModelTemplate(
     tryCastingToName(String(values['$.address']), addressToNameMap, false),
   )
   const withValuesReplaced = withSelfReplaced.replace(
-    /#([a-zA-Z0-9_$.]+)(:raw)?(\|lower)?/g,
+    /&([a-zA-Z0-9_$.]+)(:raw)?(\|lower)?/g,
     (_match, key, raw, lower) => {
       const leaveRaw = raw !== undefined
       const toLower = lower !== undefined

--- a/packages/discovery/src/discovery/modelling/relations.ts
+++ b/packages/discovery/src/discovery/modelling/relations.ts
@@ -21,15 +21,15 @@ const addressTemplate: InlineTemplate = {
   content: `
 address(
   @self,
-  "#$.chain",
-  "#$.address:raw").`,
+  "&$.chain",
+  "&$.address:raw").`,
   when: () => true,
 }
 const addressNameTemplate: InlineTemplate = {
   content: `
 addressName(
   @self,
-  "#$.name").`,
+  "&$.name").`,
   when: (c) => c.name !== undefined,
 }
 const addressTypeContractTemplate: InlineTemplate = {
@@ -50,33 +50,33 @@ const addressDescriptionTemplate: InlineTemplate = {
   content: `
 addressDescription(
   @self,
-  "#$.description").`,
+  "&$.description").`,
   when: (c) => c.description !== undefined,
 }
 const permissionTemplate: InlineTemplate = {
   content: `
 permission(
   @self,
-  "#permission.type",
-  #permission.giver).`,
+  "&permission.type",
+  &permission.giver).`,
   when: () => true,
 }
 const permissionDescriptionTemplate: InlineTemplate = {
   content: `
 permissionDescription(
   @self,
-  "#permission.type",
-  #permission.giver,
-  "#permission.description").`,
+  "&permission.type",
+  &permission.giver,
+  "&permission.description").`,
   when: (_, p) => p?.description !== undefined,
 }
 const permissionDelayTemplate: InlineTemplate = {
   content: `
 permissionDelay(
   @self,
-  "#permission.type",
-  #permission.giver,
-  #permission.delay).`,
+  "&permission.type",
+  &permission.giver,
+  &permission.delay).`,
   when: (_, p) => p?.delay !== undefined && p.delay !== 0,
 }
 


### PR DESCRIPTION
Originally I selected `#` as a field accessor in Clingo templates, e.g.:

`permission(#receiver, "upgrade")` <-- accessing values.receiver

but Clingo uses `#` for directives, like `#include`, `#count`, `#min`, `#max`, `#show`, etc. which I need to use in many places.

This PR replaces `#` with `&` so the example above becomes:

`permission(&receiver, "upgrade")` <-- accessing values.receiver
