### PR TITLE
Remove delay from Timelock's ADMIN interact permission

### DIFF
--- a/packages/config/src/projects/_templates/orbitstack/Timelock/template.jsonc
+++ b/packages/config/src/projects/_templates/orbitstack/Timelock/template.jsonc
@@ -14,7 +14,6 @@
         "permissions": [
           {
             "type": "interact",
-            "delay": "{{getMinDelay}}",
             "description": "update the minimum delay and manage all access control roles of the timelock."
           }
         ]

--- a/packages/config/src/projects/arbitrum/ethereum/diffHistory.md
+++ b/packages/config/src/projects/arbitrum/ethereum/diffHistory.md
@@ -1,3 +1,114 @@
+Generated with discovered.json: 0xf2981e85d59eacef4706cc48609f84a6d5118868
+
+# Diff at Wed, 12 Mar 2025 16:12:48 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@83f499294acff3972f9246f27e07b7a531a5d4d2 block: 21892618
+- current block number: 21892618
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+Removed delay on Timelock's ADMIN interact permission.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 21892618 (main branch discovery), not current.
+
+```diff
+    contract Outbox (0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840) {
+    +++ description: Facilitates L2 to L1 contract calls: Messages initiated from L2 (for example withdrawal messages) eventually resolve in execution on L1. Is also used to relay governance action messages from Arbitrum One to Ethereum, allowing the L2Timelock and its Governance actors on L2 to act as this address and inherit all its listed permissions.
+      receivedPermissions.3.description:
+-        "propose transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      receivedPermissions.3.via.2:
++        {"address":"0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a"}
+      receivedPermissions.3.via.1:
++        {"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}
+      receivedPermissions.3.via.0.address:
+-        "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a"
++        "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
+      receivedPermissions.2.description:
+-        "cancel queued transactions."
++        "propose transactions."
+      receivedPermissions.2.via.2:
+-        {"address":"0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a"}
+      receivedPermissions.2.via.1:
+-        {"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}
+      receivedPermissions.2.via.0.address:
+-        "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"
++        "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a"
+      receivedPermissions.1.delay:
+-        259200
+      receivedPermissions.1.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
+```diff
+    contract UpgradeExecutor (0x3ffFbAdAF827559da092217e474760E2b2c3CeDd) {
+    +++ description: Central contract defining the access control permissions for upgrading the system contract implementations.
+      directlyReceivedPermissions.5.description:
+-        "cancel queued transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      directlyReceivedPermissions.4.delay:
+-        259200
+      directlyReceivedPermissions.4.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
+```diff
+    contract L1Timelock (0xE6841D92B0C345144506576eC13ECf5103aC7f49) {
+    +++ description: A timelock with access control. The current minimum delay is 3d. Proposals that passed their minimum delay can be executed by the anyone.
+      issuedPermissions.4.description:
+-        "cancel queued transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      issuedPermissions.3.delay:
+-        259200
+      issuedPermissions.3.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+      issuedPermissions.2.description:
+-        "propose transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      issuedPermissions.2.via.2:
++        {"address":"0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"}
+      issuedPermissions.2.via.1:
++        {"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}
+      issuedPermissions.1.description:
+-        "cancel queued transactions."
++        "propose transactions."
+      issuedPermissions.1.via.2:
+-        {"address":"0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"}
+      issuedPermissions.1.via.1:
+-        {"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}
+      issuedPermissions.0.delay:
+-        259200
+      issuedPermissions.0.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
+```diff
+    contract SecurityCouncil (0xF06E95eF589D9c38af242a8AAee8375f14023F85) {
+    +++ description: None
+      receivedPermissions.2.description:
+-        "cancel queued transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      receivedPermissions.1.delay:
+-        259200
+      receivedPermissions.1.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
 Generated with discovered.json: 0x3480e18612df53e760ea0d668dd67d5343120562
 
 # Diff at Wed, 12 Mar 2025 15:36:00 GMT:

--- a/packages/config/src/projects/arbitrum/ethereum/discovered.json
+++ b/packages/config/src/projects/arbitrum/ethereum/discovered.json
@@ -77,20 +77,6 @@
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock.",
-          "via": [
-            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" },
-            {
-              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-              "delay": 259200
-            },
-            { "address": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a" }
-          ]
-        },
-        {
-          "permission": "interact",
-          "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
           "description": "cancel queued transactions.",
           "via": [
             { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" },
@@ -106,6 +92,19 @@
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
           "description": "propose transactions.",
           "via": [{ "address": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a" }]
+        },
+        {
+          "permission": "interact",
+          "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
+          "description": "update the minimum delay and manage all access control roles of the timelock.",
+          "via": [
+            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" },
+            {
+              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
+              "delay": 259200
+            },
+            { "address": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a" }
+          ]
         },
         {
           "permission": "upgrade",
@@ -657,13 +656,12 @@
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock."
+          "description": "cancel queued transactions."
         },
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "description": "cancel queued transactions."
+          "description": "update the minimum delay and manage all access control roles of the timelock."
         },
         {
           "permission": "upgrade",
@@ -2032,20 +2030,6 @@
         {
           "permission": "interact",
           "to": "0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock.",
-          "via": [
-            { "address": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a" },
-            {
-              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-              "delay": 259200
-            },
-            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }
-          ]
-        },
-        {
-          "permission": "interact",
-          "to": "0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840",
           "description": "cancel queued transactions.",
           "via": [
             { "address": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a" },
@@ -2064,15 +2048,27 @@
         },
         {
           "permission": "interact",
-          "to": "0xF06E95eF589D9c38af242a8AAee8375f14023F85",
-          "delay": 259200,
+          "to": "0x0B9857ae2D4A3DBe74ffE1d7DF045bb7F96E4840",
           "description": "update the minimum delay and manage all access control roles of the timelock.",
-          "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
+          "via": [
+            { "address": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a" },
+            {
+              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
+              "delay": 259200
+            },
+            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }
+          ]
         },
         {
           "permission": "interact",
           "to": "0xF06E95eF589D9c38af242a8AAee8375f14023F85",
           "description": "cancel queued transactions.",
+          "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
+        },
+        {
+          "permission": "interact",
+          "to": "0xF06E95eF589D9c38af242a8AAee8375f14023F85",
+          "description": "update the minimum delay and manage all access control roles of the timelock.",
           "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
         },
         {
@@ -3833,14 +3829,13 @@
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock.",
+          "description": "cancel queued transactions.",
           "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
         },
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "description": "cancel queued transactions.",
+          "description": "update the minimum delay and manage all access control roles of the timelock.",
           "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
         },
         {
@@ -5132,7 +5127,7 @@
     "orbitstack/RollupProxyBoLD": "0xa3a864b1d3f2e11ba4ede1a3dc84af5767d2a68710787e9b4a39c71d0754c5cb",
     "orbitstack/SecurityCouncil": "0x5fd23279b0affcfd4d4a8e3c3df22ea5e85f5e5e72b2f6c99d65923ac9e0b1fa",
     "orbitstack/SequencerInbox": "0x585acad76f9fde6b4698ad27e253052208fc2887e5be409e531bb003f41753c1",
-    "orbitstack/Timelock": "0xef7d35a3d44e286c427681f05bea89b31593f88325d42e2fcaefaf70d00accc2",
+    "orbitstack/Timelock": "0x3548083a8f68fe20dc020b39ed8ed83cedf25667a3f77d5ef0d7f9f3a167e8b0",
     "orbitstack/UpgradeExecutor": "0x9e187e4b42cdad30207a7c9af974d6b0e877e557e911f614443b9cfab10bf757"
   }
 }

--- a/packages/config/src/projects/nova/ethereum/diffHistory.md
+++ b/packages/config/src/projects/nova/ethereum/diffHistory.md
@@ -1,3 +1,104 @@
+Generated with discovered.json: 0x96f15918c70e84d63ac24ad38d9af327bb9158ed
+
+# Diff at Wed, 12 Mar 2025 16:12:49 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@83f499294acff3972f9246f27e07b7a531a5d4d2 block: 21786859
+- current block number: 21786859
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+Removed delay on Timelock's ADMIN interact permission.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 21786859 (main branch discovery), not current.
+
+```diff
+    contract UpgradeExecutor (0x3ffFbAdAF827559da092217e474760E2b2c3CeDd) {
+    +++ description: Central contract defining the access control permissions for upgrading the system contract implementations.
+      directlyReceivedPermissions.5.description:
+-        "cancel queued transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      directlyReceivedPermissions.4.delay:
+-        259200
+      directlyReceivedPermissions.4.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
+```diff
+    contract ArbitrumBridge (0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a) {
+    +++ description: Contract used to relay governance action messages from Arbitrum One to Ethereum. It is also an escrow contract for the project's gas token (can be different from ETH). Keeps a list of allowed Inboxes and Outboxes for canonical bridge messaging.
+      receivedPermissions.2.description:
+-        "propose transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      receivedPermissions.2.via:
++        [{"address":"0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"},{"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}]
+      receivedPermissions.1.description:
+-        "cancel queued transactions."
++        "propose transactions."
+      receivedPermissions.1.via:
+-        [{"address":"0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"},{"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}]
+      receivedPermissions.0.delay:
+-        259200
+      receivedPermissions.0.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
+```diff
+    contract L1Timelock (0xE6841D92B0C345144506576eC13ECf5103aC7f49) {
+    +++ description: A timelock with access control. The current minimum delay is 3d. Proposals that passed their minimum delay can be executed by the anyone.
+      issuedPermissions.4.description:
+-        "cancel queued transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      issuedPermissions.3.delay:
+-        259200
+      issuedPermissions.3.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+      issuedPermissions.2.description:
+-        "propose transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      issuedPermissions.2.via.1:
++        {"address":"0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"}
+      issuedPermissions.2.via.0:
++        {"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}
+      issuedPermissions.1.description:
+-        "cancel queued transactions."
++        "propose transactions."
+      issuedPermissions.1.via.1:
+-        {"address":"0x3ffFbAdAF827559da092217e474760E2b2c3CeDd"}
+      issuedPermissions.1.via.0:
+-        {"address":"0xE6841D92B0C345144506576eC13ECf5103aC7f49","delay":259200}
+      issuedPermissions.0.delay:
+-        259200
+      issuedPermissions.0.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
+```diff
+    contract SecurityCouncil (0xF06E95eF589D9c38af242a8AAee8375f14023F85) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "cancel queued transactions."
++        "update the minimum delay and manage all access control roles of the timelock."
+      receivedPermissions.0.delay:
+-        259200
+      receivedPermissions.0.description:
+-        "update the minimum delay and manage all access control roles of the timelock."
++        "cancel queued transactions."
+    }
+```
+
 Generated with discovered.json: 0xaf572c852c2ad343d036dbe27a3fc599905aeb38
 
 # Diff at Wed, 12 Mar 2025 15:42:56 GMT:

--- a/packages/config/src/projects/nova/ethereum/discovered.json
+++ b/packages/config/src/projects/nova/ethereum/discovered.json
@@ -506,13 +506,12 @@
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock."
+          "description": "cancel queued transactions."
         },
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "description": "cancel queued transactions."
+          "description": "update the minimum delay and manage all access control roles of the timelock."
         },
         {
           "permission": "interact",
@@ -885,19 +884,6 @@
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock.",
-          "via": [
-            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" },
-            {
-              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-              "delay": 259200
-            }
-          ]
-        },
-        {
-          "permission": "interact",
-          "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
           "description": "cancel queued transactions.",
           "via": [
             { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" },
@@ -911,6 +897,18 @@
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
           "description": "propose transactions."
+        },
+        {
+          "permission": "interact",
+          "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
+          "description": "update the minimum delay and manage all access control roles of the timelock.",
+          "via": [
+            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" },
+            {
+              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
+              "delay": 259200
+            }
+          ]
         },
         {
           "permission": "interact",
@@ -2084,19 +2082,6 @@
         {
           "permission": "interact",
           "to": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock.",
-          "via": [
-            {
-              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-              "delay": 259200
-            },
-            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }
-          ]
-        },
-        {
-          "permission": "interact",
-          "to": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
           "description": "cancel queued transactions.",
           "via": [
             {
@@ -2114,15 +2099,26 @@
         },
         {
           "permission": "interact",
-          "to": "0xF06E95eF589D9c38af242a8AAee8375f14023F85",
-          "delay": 259200,
+          "to": "0x8315177aB297bA92A06054cE80a67Ed4DBd7ed3a",
           "description": "update the minimum delay and manage all access control roles of the timelock.",
-          "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
+          "via": [
+            {
+              "address": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
+              "delay": 259200
+            },
+            { "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }
+          ]
         },
         {
           "permission": "interact",
           "to": "0xF06E95eF589D9c38af242a8AAee8375f14023F85",
           "description": "cancel queued transactions.",
+          "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
+        },
+        {
+          "permission": "interact",
+          "to": "0xF06E95eF589D9c38af242a8AAee8375f14023F85",
+          "description": "update the minimum delay and manage all access control roles of the timelock.",
           "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
         },
         {
@@ -3732,14 +3728,13 @@
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "delay": 259200,
-          "description": "update the minimum delay and manage all access control roles of the timelock.",
+          "description": "cancel queued transactions.",
           "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
         },
         {
           "permission": "interact",
           "from": "0xE6841D92B0C345144506576eC13ECf5103aC7f49",
-          "description": "cancel queued transactions.",
+          "description": "update the minimum delay and manage all access control roles of the timelock.",
           "via": [{ "address": "0x3ffFbAdAF827559da092217e474760E2b2c3CeDd" }]
         },
         {
@@ -5222,7 +5217,7 @@
     "orbitstack/RollupProxy": "0x23008c1256ac001023fb7343b4740c018f305d7bf8596af189533f7cf7624f49",
     "orbitstack/SecurityCouncil": "0x5fd23279b0affcfd4d4a8e3c3df22ea5e85f5e5e72b2f6c99d65923ac9e0b1fa",
     "orbitstack/SequencerInbox": "0x585acad76f9fde6b4698ad27e253052208fc2887e5be409e531bb003f41753c1",
-    "orbitstack/Timelock": "0xef7d35a3d44e286c427681f05bea89b31593f88325d42e2fcaefaf70d00accc2",
+    "orbitstack/Timelock": "0x3548083a8f68fe20dc020b39ed8ed83cedf25667a3f77d5ef0d7f9f3a167e8b0",
     "orbitstack/UpgradeExecutor": "0x9e187e4b42cdad30207a7c9af974d6b0e877e557e911f614443b9cfab10bf757",
     "orbitstack/ValidatorUtils": "0x099391d8bd8ec1de8f5a2a24f61ea3318b95e82c320678c558f1ebae6b42b2ac"
   }


### PR DESCRIPTION
Resolves L2B-9578

Even though only a delay has been removed, the diff is quite big, because elements in issuedPermissions changed order.