### PR TITLE
fix: correct fluence network URL

### DIFF
--- a/packages/config/src/projects/fluence/fluence.ts
+++ b/packages/config/src/projects/fluence/fluence.ts
@@ -22,7 +22,7 @@ export const fluence: ScalingProject = orbitStackL2({
     description:
       'Fluence is an Optimium on Ethereum, built on the Orbit stack. It enables a decentralized serverless platform & computing marketplace powered by blockchain economics.',
     links: {
-      websites: ['https://luence.network/'],
+      websites: ['https://fluence.network/'],
       apps: ['https://bridge.fluence.network/bridge/fluence'],
       documentation: ['https://fluence.dev/docs/learn/overview'],
       explorers: ['https://blockscout.mainnet.fluence.dev/'],


### PR DESCRIPTION
Corrected the URL for `Fluence` Network from `https://luence.network` to `https://fluence.network/`. This fixes a typo in the website link.