### PR TITLE
[L2B-9443] Add error handling for TvsPriceIndexer

### DIFF
--- a/packages/backend/src/modules/tvs/indexers/TvsPriceIndexer.ts
+++ b/packages/backend/src/modules/tvs/indexers/TvsPriceIndexer.ts
@@ -67,14 +67,21 @@ export class TvsPriceIndexer extends ManagedMultiIndexer<PriceConfig> {
 
             return optimizedRecords
           } catch (error) {
-            this.logger.warn(
-              `Failed to fetch prices for ${configuration.properties.priceId}`,
-              {
-                priceId: configuration.properties.priceId,
-                error,
-              },
-            )
-            return []
+            if (
+              error instanceof Error &&
+              error.message.startsWith('Insufficient data in response')
+            ) {
+              this.logger.warn(
+                `Failed to fetch prices for ${configuration.properties.priceId}`,
+                {
+                  priceId: configuration.properties.priceId,
+                  error,
+                },
+              )
+              return []
+            }
+
+            throw error
           }
         }),
       )


### PR DESCRIPTION
In case of error in price fetching we want to log warn and continue syncing
![image](https://github.com/user-attachments/assets/ebe66b2e-460a-4f38-8db6-1d26668765bd)