### PR TITLE
Add documentation for registry function in StarkgateManager

### DIFF
--- a/packages/config/src/projects/_templates/starknet/StarkgateManager/shape/StarkgateManager.sol
+++ b/packages/config/src/projects/_templates/starknet/StarkgateManager/shape/StarkgateManager.sol
@@ -858,7 +858,11 @@ contract StarkgateManager is Identity, IStarkgateManager, ProxySupport {
     }
 
     // Storage Getters.
-    // TODO : add doc.
+    /**
+     * @notice Returns the address of the Starkgate Registry contract.
+     * @dev This internal function retrieves the registry address from named storage.
+     * @return The address of the Starkgate Registry contract.
+     */
     function registry() internal view returns (address) {
         return NamedStorage.getAddressValue(REGISTRY_TAG);
     }


### PR DESCRIPTION
Added NatSpec documentation for the internal registry() function in StarkgateManager.sol, explaining its purpose, implementation details and return value. This addresses the TODO comment that was previously in place.