### PR TITLE
Add OPCM upgrade function sig to calldata decoder

### DIFF
--- a/packages/tools/src/decoder/Decoded.tsx
+++ b/packages/tools/src/decoder/Decoded.tsx
@@ -77,6 +77,9 @@ export function Decoded(props: DecodedProps) {
               <option value="(address, address, uint256, uint256, uint256, bytes)">
                 scheduleBatch
               </option>
+              <option value="function upgrade((address, address, bytes32)[])">
+                OPCM upgrade
+              </option>
             </select>
           </div>
           {customAbi ? (


### PR DESCRIPTION
<img width="856" alt="image" src="https://github.com/user-attachments/assets/e194e99c-b33d-46cd-857f-0e8317ee1cc7" />

<img width="813" alt="image" src="https://github.com/user-attachments/assets/f0a881e0-418a-419f-8786-ce4db159a5e8" />

<img width="804" alt="image" src="https://github.com/user-attachments/assets/3814847d-ff1b-49f7-841e-cfb6d1a0e5dd" />

https://etherscan.deth.net/address/0x3a1f523a4bc09cd344a2745a108bb0398288094f

tested with

```
0x82ad56cb000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000020000000000000000000000000026b2f158255beac46c1e7c6b8bbf29a4b6a7b76000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000164ff2dd5a100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003000000000000000000000000229047fed2591dbec1ef1118d64f7af3db9eb290000000000000000000000000543ba4aadbab8f9025686bd03993043599c6fb04039facea52b20c605c05efb0a33560a92de7074218998f75bcdf61e8989cb5d90000000000000000000000007a8ed66b319911a0f3e7288bddab30d9c0c875c300000000000000000000000089889b569c3a505f3640ee1bd0ac1d557f436d2a039facea52b20c605c05efb0a33560a92de7074218998f75bcdf61e8989cb5d900000000000000000000000062c0a111929fa32cec2f76adba54c16afb6e8364000000000000000000000000d56045e68956fce2576e680c95a4750cf8241f79039facea52b20c605c05efb0a33560a92de7074218998f75bcdf61e8989cb5d900000000000000000000000000000000000000000000000000000000
```
which is taken from here https://gov.optimism.io/t/upgrade-proposal-13-opcm-and-incident-response-improvements/9739
