### PR TITLE
[L2B-9864] Add USDC as custom tokens

### DIFF
--- a/packages/config/src/projects/lens/lens.ts
+++ b/packages/config/src/projects/lens/lens.ts
@@ -63,7 +63,7 @@ export const lens: ScalingProject = zkStackL2({
   nonTemplateEscrows: [
     discovery.getEscrowDetails({
       address: bridge.address,
-      tokens: ['LGHO', 'ETH', 'USDC'],
+      tokens: ['LGHO', 'ETH'],
       description:
         'Shared bridge for depositing tokens to Lens and other ZK stack chains.',
       sharedEscrow: {

--- a/packages/config/src/projects/sophon/sophon.ts
+++ b/packages/config/src/projects/sophon/sophon.ts
@@ -90,7 +90,6 @@ export const sophon: ScalingProject = zkStackL2({
         'stAZUR',
         'stAVAIL',
         'OPN',
-        'USDC',
       ], // 'SOPH' not on CG yet
       description:
         'Shared bridge for depositing tokens to Treasure and other ZK stack chains.',

--- a/packages/config/src/tvs/json/lens.json
+++ b/packages/config/src/tvs/json/lens.json
@@ -40,7 +40,7 @@
       "isAssociated": false
     },
     {
-      "mode": "auto",
+      "mode": "custom",
       "id": "lens-USDC",
       "priceId": "usd-coin",
       "symbol": "USDC",
@@ -51,10 +51,10 @@
       "isAssociated": false,
       "amount": {
         "type": "totalSupply",
-        "address": "0xFc20fbf81928D495575B02D13c99ea1f1Ac4b272",
+        "address": "0x88F08E304EC4f90D644Cec3Fb69b8aD414acf884",
         "chain": "lens",
         "decimals": 6,
-        "sinceTimestamp": 1740140786
+        "sinceTimestamp": 1743699600
       }
     }
   ]

--- a/packages/config/src/tvs/json/sophon.json
+++ b/packages/config/src/tvs/json/sophon.json
@@ -147,6 +147,24 @@
       }
     },
     {
+      "mode": "custom",
+      "id": "sophon-USDC",
+      "priceId": "usd-coin",
+      "symbol": "USDC",
+      "name": "USD Coin",
+      "iconUrl": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696506694",
+      "category": "stablecoin",
+      "source": "canonical",
+      "isAssociated": false,
+      "amount": {
+        "type": "totalSupply",
+        "address": "0x9Aa0F72392B5784Ad86c6f3E899bCc053D00Db4F",
+        "chain": "sophon",
+        "decimals": 6,
+        "sinceTimestamp": 1733169600
+      }
+    },
+    {
       "mode": "auto",
       "id": "sophon-USDT",
       "priceId": "tether",


### PR DESCRIPTION
As long as we need to support two versions of the feature (TVL and TVS) it is not feasible to add custom code to automatically support this kind of setups. Thus we will configureUSDC as custom for now.

USDC:
lens: $0.04 => $66,665.80
sophon: $0.0 => $4,737,144.34