### PR TITLE
Enable DA Tracking for ZK and Polygon stack chains

### DIFF
--- a/packages/config/src/projects/abstract/abstract.ts
+++ b/packages/config/src/projects/abstract/abstract.ts
@@ -66,6 +66,7 @@ export const abstract: ScalingProject = zkStackL2({
       },
     }),
   ],
+  usesEthereumBlobs: true,
   nonTemplateTrackedTxs: [
     {
       uses: [{ type: 'l2costs', subtype: 'batchSubmissions' }],

--- a/packages/config/src/projects/arbitrum/arbitrum.ts
+++ b/packages/config/src/projects/arbitrum/arbitrum.ts
@@ -96,7 +96,7 @@ export const arbitrum: ScalingProject = orbitStackL2({
   bridge: discovery.getContract('Bridge'),
   rollupProxy: discovery.getContract('RollupProxy'),
   sequencerInbox: discovery.getContract('SequencerInbox'),
-  usesBlobs: true,
+  usesEthereumBlobs: true,
   display: {
     name: 'Arbitrum One',
     slug: 'arbitrum',

--- a/packages/config/src/projects/facet/facet.ts
+++ b/packages/config/src/projects/facet/facet.ts
@@ -105,7 +105,7 @@ export const facet: ScalingProject = opStackL2({
       type: 'general',
     },
   ],
-  usesBlobs: false, // uses calldata
+  usesEthereumBlobs: false, // uses calldata
   isNodeAvailable: true,
   nodeSourceLink: 'https://github.com/0xFacet/facet-node',
 })

--- a/packages/config/src/projects/kinto/kinto.ts
+++ b/packages/config/src/projects/kinto/kinto.ts
@@ -102,7 +102,7 @@ export const kinto: ScalingProject = orbitStackL2({
   bridge: discovery.getContract('Bridge'),
   rollupProxy: discovery.getContract('RollupProxy'),
   sequencerInbox: discovery.getContract('SequencerInbox'),
-  usesBlobs: true,
+  usesEthereumBlobs: true,
   nonTemplateRiskView: {
     exitWindow: {
       value: 'None',
@@ -185,7 +185,7 @@ The Appchain designation of Kinto is mainly due to a modified L2 node, which que
 This makes the KintoAppRegistry contract a critical system contract and any change to its configuration equivalent to an upgrade of the Layer 2 system.
 The KintoAppRegistry contract is also governed via the AccessManager by the Security Council or the Kinto Multisig 2 with a ${formatSeconds(l2critDelay)} delay.
 
-Another critical contract on the Appchain is called KintoID. Permissioned actors with the 'KYC provider' role in the KintoID contract can 'sanction' (freeze) user smart wallets, preventing them from transacting. 
+Another critical contract on the Appchain is called KintoID. Permissioned actors with the 'KYC provider' role in the KintoID contract can 'sanction' (freeze) user smart wallets, preventing them from transacting.
 To protect users from this role which is mostly held by EOAs, a sanction expires if not confirmed by the Security Council within ${formatSeconds(sanctionExpirySeconds)}.
 An expired sanction guarantees the user a ${formatSeconds(l2discovery.getContractValue<number>('KintoID', 'EXIT_WINDOW_PERIOD') - sanctionExpirySeconds)} cooldown window during which they cannot be sanctioned again.
 
@@ -199,11 +199,11 @@ The permissioned sanctions logic by KYC providers necessitates at least an ${for
       {
         name: 'Enforced smart wallets and KYC',
         description: `
-      The Kinto L2 node is a fork of Arbitrum's geth implementation with notable changes to the state transition function. 
-      A valid state transition in Kinto [disallows all transactions by EOAs](https://github.com/KintoXYZ/kinto-go-ethereum/blob/7aba9b812a82d9339d29a2345946c3d7030a0377/core/kinto_hardfork_7.go#L58) and new contract creation, unless specifically whitelisted. 
+      The Kinto L2 node is a fork of Arbitrum's geth implementation with notable changes to the state transition function.
+      A valid state transition in Kinto [disallows all transactions by EOAs](https://github.com/KintoXYZ/kinto-go-ethereum/blob/7aba9b812a82d9339d29a2345946c3d7030a0377/core/kinto_hardfork_7.go#L58) and new contract creation, unless specifically whitelisted.
       The current whitelist is sourced directly from the KintoAppRegistry smart contract on Kinto L2, and can be modified by the L2 governance.
       This setup effectively enforces smart wallet use because the auxiliary contracts of the standard KintoWallet smart wallet (like the EntryPoint and the KintoWalletFactory) are whitelisted.
-        
+
       The KYC validation is part of the KintoWallet signature verification. Since all users must use the same implementation of this smart wallet, all user transactions on Kinto check for an up-to-date KYC flag, and are dropped in case the check fails.`,
         risks: [
           {

--- a/packages/config/src/projects/zeronetwork/zeronetwork.ts
+++ b/packages/config/src/projects/zeronetwork/zeronetwork.ts
@@ -53,6 +53,7 @@ export const zeronetwork: ScalingProject = zkStackL2({
     ],
   },
   diamondContract: discovery.getContract('ZeroNetworkZkEvm'),
+  usesEthereumBlobs: true,
   nonTemplateTrackedTxs: [
     {
       uses: [{ type: 'l2costs', subtype: 'batchSubmissions' }],

--- a/packages/config/src/projects/zksync2/zksync2.ts
+++ b/packages/config/src/projects/zksync2/zksync2.ts
@@ -144,6 +144,7 @@ export const zksync2: ScalingProject = zkStackL2({
         'Legacy bridge for depositing ERC20 tokens to ZKsync Era. Forwards deposits and withdrawals to the BridgeHub.',
     }),
   ],
+  usesEthereumBlobs: true,
   nonTemplateTrackedTxs: [
     {
       uses: [{ type: 'l2costs', subtype: 'batchSubmissions' }],

--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -148,7 +148,6 @@ interface OpStackConfigCommon {
   nodeSourceLink?: string
   chainConfig?: ChainConfig
   hasProperSecurityCouncil?: boolean
-  usesBlobs?: boolean
   isUnderReview?: boolean
   stage?: ProjectScalingStage
   additionalBadges?: Badge[]
@@ -162,6 +161,8 @@ interface OpStackConfigCommon {
   display: Omit<ProjectScalingDisplay, 'provider' | 'category' | 'purposes'> & {
     category?: ProjectScalingCategory
   }
+  /** Set to true if projects posts blobs to Ethereum */
+  usesEthereumBlobs?: boolean
   /** Configure to enable DA metrics tracking for chain using Celestia DA */
   celestiaDa?: {
     namespace: string
@@ -355,7 +356,7 @@ function getDaTracking(
   }
 
   const usesBlobs =
-    templateVars.usesBlobs ??
+    templateVars.usesEthereumBlobs ??
     templateVars.discovery.getContractValue<{
       isSequencerSendingBlobTx: boolean
     }>('SystemConfig', 'opStackDA').isSequencerSendingBlobTx
@@ -816,7 +817,7 @@ function getTechnology(
   const portal = getOptimismPortal(templateVars)
 
   const usesBlobs =
-    templateVars.usesBlobs ??
+    templateVars.usesEthereumBlobs ??
     templateVars.discovery.getContractValue<{
       isSequencerSendingBlobTx: boolean
     }>('SystemConfig', 'opStackDA').isSequencerSendingBlobTx
@@ -1144,7 +1145,7 @@ function getDAProvider(
   hostChainDA?: DAProvider,
 ): DAProvider {
   const postsToCelestia =
-    templateVars.usesBlobs ??
+    templateVars.usesEthereumBlobs ??
     templateVars.discovery.getContractValue<{
       isUsingCelestia: boolean
     }>('SystemConfig', 'opStackDA').isUsingCelestia
@@ -1161,7 +1162,7 @@ function getDAProvider(
 
   if (daProvider === undefined) {
     const usesBlobs =
-      templateVars.usesBlobs ??
+      templateVars.usesEthereumBlobs ??
       templateVars.discovery.getContractValue<{
         isSequencerSendingBlobTx: boolean
       }>('SystemConfig', 'opStackDA').isSequencerSendingBlobTx
@@ -1314,7 +1315,7 @@ function getTrackedTxs(
 
 function postsToEthereum(templateVars: OpStackConfigCommon): boolean {
   const postsToCelestia =
-    templateVars.usesBlobs ??
+    templateVars.usesEthereumBlobs ??
     templateVars.discovery.getContractValue<{
       isUsingCelestia: boolean
     }>('SystemConfig', 'opStackDA').isUsingCelestia

--- a/packages/config/src/templates/orbitStack.ts
+++ b/packages/config/src/templates/orbitStack.ts
@@ -145,7 +145,6 @@ interface OrbitStackConfigCommon {
   milestones?: Milestone[]
   trackedTxs?: Layer2TxConfig[]
   chainConfig?: ChainConfig
-  usesBlobs?: boolean
   additionalBadges?: Badge[]
   stage?: ProjectScalingStage
   stateValidation?: ProjectScalingStateValidation
@@ -159,6 +158,8 @@ interface OrbitStackConfigCommon {
   customDa?: ProjectCustomDa
   hasAtLeastFiveExternalChallengers?: boolean
   reasonsForBeingOther?: ReasonForBeingInOther[]
+  /** Set to true if projects posts blobs to Ethereum */
+  usesEthereumBlobs?: boolean
   /** Configure to enable DA metrics tracking for chain using Celestia DA */
   celestiaDa?: {
     namespace: string
@@ -826,7 +827,7 @@ function getDaTracking(
     return templateVars.nonTemplateDaTracking
   }
 
-  const usesBlobs = templateVars.usesBlobs ?? false
+  const usesBlobs = templateVars.usesEthereumBlobs ?? false
 
   const batchPosters = templateVars.discovery.getContractValue<string[]>(
     'SequencerInbox',
@@ -995,7 +996,7 @@ function getDAProvider(
 
   if (postsToEthereum(templateVars)) {
     const usesBlobs =
-      templateVars.usesBlobs ??
+      templateVars.usesEthereumBlobs ??
       templateVars.discovery.getContractValueOrUndefined(
         'SequencerInbox',
         'postsBlobs',

--- a/packages/config/src/templates/polygonCDKStack.ts
+++ b/packages/config/src/templates/polygonCDKStack.ts
@@ -482,44 +482,47 @@ function getDaTracking(
     return templateVars.nonTemplateDaTracking
   }
 
-  const inbox = templateVars.discovery.getContract('PolygonZkEVM')
-
-  const sequencers = [
-    templateVars.discovery.getContractValue<string>(
+  if (templateVars.usesEthereumBlobs) {
+    const polygonContract = templateVars.discovery.getContract('PolygonZkEVM')
+    const sequencer = templateVars.discovery.getContractValue<string>(
       'PolygonZkEVM',
       'trustedSequencer',
-    ),
-  ]
+    )
 
-  return templateVars.usesEthereumBlobs
-    ? [
-        {
-          type: 'ethereum',
-          daLayer: ProjectId('ethereum'),
-          sinceBlock: inbox.sinceBlock ?? 0,
-          inbox: inbox.address,
-          sequencers,
-        },
-      ]
-    : templateVars.celestiaDa
-      ? [
-          {
-            type: 'celestia',
-            daLayer: ProjectId('celestia'),
-            // TODO: update to value from discovery
-            sinceBlock: templateVars.celestiaDa.sinceBlock,
-            namespace: templateVars.celestiaDa.namespace,
-          },
-        ]
-      : templateVars.availDa
-        ? [
-            {
-              type: 'avail',
-              daLayer: ProjectId('avail'),
-              // TODO: update to value from discovery
-              sinceBlock: templateVars.availDa.sinceBlock,
-              appId: templateVars.availDa.appId,
-            },
-          ]
-        : undefined
+    return [
+      {
+        type: 'ethereum',
+        daLayer: ProjectId('ethereum'),
+        sinceBlock: polygonContract.sinceBlock ?? 0,
+        inbox: polygonContract.address,
+        sequencers: [sequencer],
+      },
+    ]
+  }
+
+  if (templateVars.celestiaDa) {
+    return [
+      {
+        type: 'celestia',
+        daLayer: ProjectId('celestia'),
+        // TODO: update to value from discovery
+        sinceBlock: templateVars.celestiaDa.sinceBlock,
+        namespace: templateVars.celestiaDa.namespace,
+      },
+    ]
+  }
+
+  if (templateVars.availDa) {
+    return [
+      {
+        type: 'avail',
+        daLayer: ProjectId('avail'),
+        // TODO: update to value from discovery
+        sinceBlock: templateVars.availDa.sinceBlock,
+        appId: templateVars.availDa.appId,
+      },
+    ]
+  }
+
+  return undefined
 }

--- a/packages/config/src/templates/polygonCDKStack.ts
+++ b/packages/config/src/templates/polygonCDKStack.ts
@@ -94,7 +94,7 @@ export interface PolygonCDKStackConfig {
   reasonsForBeingOther?: ReasonForBeingInOther[]
   architectureImage?: string
   scopeOfAssessment?: ProjectScalingScopeOfAssessment
-  /** Set to true if projects post blobs to Ethereum */
+  /** Set to true if projects posts blobs to Ethereum */
   usesEthereumBlobs?: boolean
   /** Configure to enable DA metrics tracking for chain using Celestia DA */
   celestiaDa?: {

--- a/packages/config/src/templates/zkStack.ts
+++ b/packages/config/src/templates/zkStack.ts
@@ -593,50 +593,57 @@ function technologyDA(DA: DAProvider | undefined): ProjectTechnologyChoice {
 function getDaTracking(
   templateVars: ZkStackConfigCommon,
 ): ProjectDaTrackingConfig[] | undefined {
+  // Return non-template tracking if it exists
   if (templateVars.nonTemplateDaTracking) {
     return templateVars.nonTemplateDaTracking
   }
 
-  const validatorTimelock =
-    templateVars.discovery.getContractDetails('ValidatorTimelock').address
+  if (templateVars.usesEthereumBlobs) {
+    const validatorTimelock =
+      templateVars.discovery.getContractDetails('ValidatorTimelock').address
 
-  const validatorsVTL = templateVars.discovery.getContractValue<string[]>(
-    'ValidatorTimelock',
-    'validatorsVTL',
-  )
+    const validatorsVTL = templateVars.discovery.getContractValue<string[]>(
+      'ValidatorTimelock',
+      'validatorsVTL',
+    )
 
-  const inboxDeploymentBlockNumber =
-    templateVars.discovery.getContract('ValidatorTimelock').sinceBlock ?? 0
+    const inboxDeploymentBlockNumber =
+      templateVars.discovery.getContract('ValidatorTimelock').sinceBlock ?? 0
 
-  return templateVars.usesEthereumBlobs
-    ? [
-        {
-          type: 'ethereum',
-          daLayer: ProjectId('ethereum'),
-          sinceBlock: inboxDeploymentBlockNumber,
-          inbox: validatorTimelock,
-          sequencers: validatorsVTL,
-        },
-      ]
-    : templateVars.celestiaDa
-      ? [
-          {
-            type: 'celestia',
-            daLayer: ProjectId('celestia'),
-            // TODO: update to value from discovery
-            sinceBlock: templateVars.celestiaDa.sinceBlock,
-            namespace: templateVars.celestiaDa.namespace,
-          },
-        ]
-      : templateVars.availDa
-        ? [
-            {
-              type: 'avail',
-              daLayer: ProjectId('avail'),
-              // TODO: update to value from discovery
-              sinceBlock: templateVars.availDa.sinceBlock,
-              appId: templateVars.availDa.appId,
-            },
-          ]
-        : undefined
+    return [
+      {
+        type: 'ethereum',
+        daLayer: ProjectId('ethereum'),
+        sinceBlock: inboxDeploymentBlockNumber,
+        inbox: validatorTimelock,
+        sequencers: validatorsVTL,
+      },
+    ]
+  }
+
+  if (templateVars.celestiaDa) {
+    return [
+      {
+        type: 'celestia',
+        daLayer: ProjectId('celestia'),
+        // TODO: update to value from discovery
+        sinceBlock: templateVars.celestiaDa.sinceBlock,
+        namespace: templateVars.celestiaDa.namespace,
+      },
+    ]
+  }
+
+  if (templateVars.availDa) {
+    return [
+      {
+        type: 'avail',
+        daLayer: ProjectId('avail'),
+        // TODO: update to value from discovery
+        sinceBlock: templateVars.availDa.sinceBlock,
+        appId: templateVars.availDa.appId,
+      },
+    ]
+  }
+
+  return undefined
 }

--- a/packages/config/src/templates/zkStack.ts
+++ b/packages/config/src/templates/zkStack.ts
@@ -103,7 +103,7 @@ export interface ZkStackConfigCommon {
   nonTemplateTechnology?: Partial<ProjectScalingTechnology>
   reasonsForBeingOther?: ReasonForBeingInOther[]
   ecosystemInfo?: ProjectEcosystemInfo
-  /** Set to true if projects post blobs to Ethereum */
+  /** Set to true if projects posts blobs to Ethereum */
   usesEthereumBlobs?: boolean
   /** Configure to enable DA metrics tracking for chain using Celestia DA */
   celestiaDa?: {

--- a/packages/config/src/templates/zkStack.ts
+++ b/packages/config/src/templates/zkStack.ts
@@ -93,7 +93,6 @@ export interface ZkStackConfigCommon {
   isNodeAvailable?: boolean | 'UnderReview'
   nodeSourceLink?: string
   chainConfig?: ChainConfig
-  usesBlobs?: boolean
   isUnderReview?: boolean
   stage?: ProjectScalingStage
   additionalBadges?: Badge[]
@@ -104,6 +103,8 @@ export interface ZkStackConfigCommon {
   nonTemplateTechnology?: Partial<ProjectScalingTechnology>
   reasonsForBeingOther?: ReasonForBeingInOther[]
   ecosystemInfo?: ProjectEcosystemInfo
+  /** Set to true if projects post blobs to Ethereum */
+  usesEthereumBlobs?: boolean
   /** Configure to enable DA metrics tracking for chain using Celestia DA */
   celestiaDa?: {
     namespace: string
@@ -607,7 +608,7 @@ function getDaTracking(
   const inboxDeploymentBlockNumber =
     templateVars.discovery.getContract('ValidatorTimelock').sinceBlock ?? 0
 
-  return templateVars.usesBlobs
+  return templateVars.usesEthereumBlobs
     ? [
         {
           type: 'ethereum',


### PR DESCRIPTION
Resolves L2B-9903

- rename `usesBlobs` flag to `usesEthereumBlobs` for more explicit configuration
- add daTracking to PolygonCDK
- configure missing projects (ZkSync Era, ZERO, Abstract)
- refactored functions for readability

![image](https://github.com/user-attachments/assets/99d970c6-2a35-4244-8a68-51a746663c80)

This PR results in adding 3 Ethereum DA configurations

<img width="459" alt="image" src="https://github.com/user-attachments/assets/6545ac70-7bd7-4f5b-870b-522f85c193ac" />
