### PR TITLE
revert token definition removal and make tokens custom

### DIFF
--- a/packages/config/src/projects/real/real.ts
+++ b/packages/config/src/projects/real/real.ts
@@ -62,6 +62,7 @@ export const real: ScalingProject = orbitStackL2({
       { type: 'blockscout', url: 'https://explorer.re.al/api' },
     ],
   },
+  associatedTokens: ['RWA'], // native reETH not on CG
   isNodeAvailable: 'UnderReview',
   bridge: discovery.getContract('Bridge'),
   rollupProxy: discovery.getContract('RollupProxy'),

--- a/packages/config/src/tokens/generated.json
+++ b/packages/config/src/tokens/generated.json
@@ -13209,6 +13209,28 @@
       }
     },
     {
+      "name": "arcUSD",
+      "coingeckoId": "arcana-2",
+      "address": "0xAEC9e50e3397f9ddC635C6c429C8C7eca418a143",
+      "symbol": "arcUSD",
+      "decimals": 18,
+      "deploymentTimestamp": 1715634151,
+      "coingeckoListingTimestamp": 1717632000,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38490/large/USDa.png?1717688209",
+      "chainId": 111188,
+      "source": "native",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Layer Zero",
+            "slug": "omnichain"
+          }
+        ]
+      }
+    },
+    {
       "name": "MORE",
       "coingeckoId": "stack-2",
       "address": "0x25ea98ac87A38142561eA70143fd44c4772A16b6",
@@ -13232,6 +13254,42 @@
       }
     },
     {
+      "name": "Pearl",
+      "coingeckoId": "pearl",
+      "address": "0xCE1581d7b4bA40176f0e219b2CaC30088Ad50C7A",
+      "symbol": "PEARL",
+      "decimals": 18,
+      "deploymentTimestamp": 1715394373,
+      "coingeckoListingTimestamp": 1687478400,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/30799/large/Yp9H3agr_400x400.jpg?1696529660",
+      "chainId": 111188,
+      "source": "native",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Layer Zero",
+            "slug": "omnichain"
+          }
+        ]
+      }
+    },
+    {
+      "name": "re.al",
+      "coingeckoId": "re-al",
+      "address": "0x4644066f535Ead0cde82D209dF78d94572fCbf14",
+      "symbol": "RWA",
+      "decimals": 18,
+      "deploymentTimestamp": 1715799306,
+      "coingeckoListingTimestamp": 1720483200,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38626/large/RWA_200x200.png?1718168632",
+      "chainId": 111188,
+      "source": "native",
+      "supply": "totalSupply"
+    },
+    {
       "name": "UK Real Estate",
       "coingeckoId": "uk-real-estate",
       "address": "0x835d3E1C0aA079C6164AAd21DCb23E60eb71AF48",
@@ -13245,6 +13303,28 @@
       "chainId": 111188,
       "source": "native",
       "supply": "totalSupply"
+    },
+    {
+      "name": "US T-Bill",
+      "coingeckoId": "real-us-t-bill",
+      "address": "0x83feDBc0B85c6e29B589aA6BdefB1Cc581935ECD",
+      "symbol": "USTB",
+      "decimals": 18,
+      "deploymentTimestamp": 1713200024,
+      "coingeckoListingTimestamp": 1717459200,
+      "category": "other",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38174/large/ustb.png?1716780607",
+      "chainId": 111188,
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Layer Zero",
+            "slug": "omnichain"
+          }
+        ]
+      }
     },
     {
       "name": "USD Coin",

--- a/packages/config/src/tokens/tokens.jsonc
+++ b/packages/config/src/tokens/tokens.jsonc
@@ -5344,6 +5344,58 @@
   ],
   "real": [
     {
+      "symbol": "RWA",
+      "address": "0x4644066f535Ead0cde82D209dF78d94572fCbf14",
+      "source": "native",
+      "supply": "totalSupply",
+      "coingeckoId": "re-al"
+    },
+    {
+      "symbol": "USTB",
+      "address": "0x83fedbc0b85c6e29b589aa6bdefb1cc581935ecd",
+      "source": "external",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Layer Zero",
+            "slug": "omnichain"
+          }
+        ]
+      },
+      "coingeckoId": "real-us-t-bill"
+    },
+    {
+      "symbol": "PEARL",
+      "address": "0xce1581d7b4ba40176f0e219b2cac30088ad50c7a",
+      "source": "native",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Layer Zero",
+            "slug": "omnichain"
+          }
+        ]
+      },
+      "coingeckoId": "pearl"
+    },
+    {
+      "symbol": "arcUSD",
+      "address": "0xaec9e50e3397f9ddc635c6c429c8c7eca418a143",
+      "source": "native",
+      "supply": "totalSupply",
+      "bridgedUsing": {
+        "bridges": [
+          {
+            "name": "Layer Zero",
+            "slug": "omnichain"
+          }
+        ]
+      },
+      "coingeckoId": "arcana-2"
+    },
+    {
       "symbol": "UKRE",
       "address": "0x835d3E1C0aA079C6164AAd21DCb23E60eb71AF48",
       "source": "native",

--- a/packages/config/src/tvs/json/real.json
+++ b/packages/config/src/tvs/json/real.json
@@ -3,6 +3,24 @@
   "projectId": "real",
   "tokens": [
     {
+      "mode": "custom",
+      "id": "real-arcUSD",
+      "priceId": "arcana-2",
+      "symbol": "arcUSD",
+      "name": "arcUSD",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38490/large/USDa.png?1717688209",
+      "amount": {
+        "type": "totalSupply",
+        "address": "0xAEC9e50e3397f9ddC635C6c429C8C7eca418a143",
+        "chain": "real",
+        "decimals": 18,
+        "sinceTimestamp": 1717632000
+      },
+      "category": "other",
+      "source": "native",
+      "isAssociated": false
+    },
+    {
       "mode": "auto",
       "id": "real-cbBTC",
       "priceId": "coinbase-wrapped-btc",
@@ -20,6 +38,42 @@
       "category": "other",
       "source": "canonical",
       "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "real-PEARL",
+      "priceId": "pearl",
+      "symbol": "PEARL",
+      "name": "Pearl",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/30799/large/Yp9H3agr_400x400.jpg?1696529660",
+      "amount": {
+        "type": "totalSupply",
+        "address": "0xCE1581d7b4bA40176f0e219b2CaC30088Ad50C7A",
+        "chain": "real",
+        "decimals": 18,
+        "sinceTimestamp": 1715394373
+      },
+      "category": "other",
+      "source": "native",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "real-RWA",
+      "priceId": "re-al",
+      "symbol": "RWA",
+      "name": "re.al",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38626/large/RWA_200x200.png?1718168632",
+      "amount": {
+        "type": "totalSupply",
+        "address": "0x4644066f535Ead0cde82D209dF78d94572fCbf14",
+        "chain": "real",
+        "decimals": 18,
+        "sinceTimestamp": 1720483200
+      },
+      "category": "other",
+      "source": "native",
+      "isAssociated": true
     },
     {
       "mode": "auto",
@@ -94,6 +148,24 @@
       },
       "category": "stablecoin",
       "source": "canonical",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "real-USTB",
+      "priceId": "real-us-t-bill",
+      "symbol": "USTB",
+      "name": "US T-Bill",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/38174/large/ustb.png?1716780607",
+      "amount": {
+        "type": "totalSupply",
+        "address": "0x83feDBc0B85c6e29B589aA6BdefB1Cc581935ECD",
+        "chain": "real",
+        "decimals": 18,
+        "sinceTimestamp": 1717459200
+      },
+      "category": "other",
+      "source": "external",
       "isAssociated": false
     },
     {


### PR DESCRIPTION
try with `pnpm tvs:execute real --timestamp 1730954729` (ts is ~ the peak of their tvs), it shows 0$

is this because coingecko stopped reporting **any** data, even historical, for those 4 tokens? or is the tvs logic assuming 0 because current price is unavailable?

current prod tvs without the tokens:
![image](https://github.com/user-attachments/assets/f05d589c-897c-4572-9622-edaa4cdfda44)

tvs before removing them:
![image](https://github.com/user-attachments/assets/8412fad7-9e18-441e-b4b4-dd56be1db78b)
