### PR TITLE
Bump clingo version

### DIFF
--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -26,7 +26,7 @@
     "@mradomski/fast-solidity-parser": "0.1.1",
     "bignumber.js": "^9.1.2",
     "chalk": "^4.1.2",
-    "clingo-wasm": "0.1.1",
+    "clingo-wasm": "0.3.2",
     "cmd-ts": "^0.13.0",
     "deep-diff": "^1.0.2",
     "ethers": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -358,8 +358,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       clingo-wasm:
-        specifier: 0.1.1
-        version: 0.1.1
+        specifier: 0.3.2
+        version: 0.3.2
       cmd-ts:
         specifier: ^0.13.0
         version: 0.13.0
@@ -2802,8 +2802,8 @@ packages:
   '@radix-ui/react-switch@1.1.2':
     resolution: {integrity: sha512-zGukiWHjEdBCRyXvKR6iXAQG6qXm2esuAD6kDOi9Cn+1X6ev3ASo4+CsYaD6Fov9r/AQFekqnD/7+V0Cs6/98g==}
     peerDependencies:
-      '@types/react': 19.0.8
-      '@types/react-dom': 19.0.3
+      '@types/react': '*'
+      '@types/react-dom': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
@@ -4183,8 +4183,8 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
-  clingo-wasm@0.1.1:
-    resolution: {integrity: sha512-Y3OhhL5Vnwh3m03M3XRx2gLpYlJHsUj6FjMdI/dMF8YvQpdm8s3kNtohAql1cvASyb3kQP0IX/s/tX1FwF/1Mw==}
+  clingo-wasm@0.3.2:
+    resolution: {integrity: sha512-0ZdaGgekZaO8hLF3PE0fcs4FjR+GAdVeMTTzVgm8L1OuCl4A8+/H1V8urBMJYlV6+HH+gAweDxFq1MVgM4lDKQ==}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -11518,7 +11518,7 @@ snapshots:
 
   client-only@0.0.1: {}
 
-  clingo-wasm@0.1.1:
+  clingo-wasm@0.3.2:
     dependencies:
       '@types/emscripten': 1.40.0
 


### PR DESCRIPTION
Resolves L2B-10109

We used a very old version of `clingo-wasm` which was compiled by an older version of `emscripten` where the default setting for `NODEJS_CATCH_EXIT` was `1`. In result it would register a listener on the `process` for any `uncaughtException` and it would rethrow it causing the entire source to reprinted. Using version `0.3.2` solves this problem because it was compiled with newer version of `emscripten` where the default for `NODEJS_CATCH_EXIT` is `0`.

I've reran all discoveries to make sure everything is fine and found no error, no changes.