### PR TITLE
Fix broken link to prover.rs in RISC Zero catalog description

### DIFF
--- a/packages/frontend/src/content/zk-catalog-descriptions/risczero.md
+++ b/packages/frontend/src/content/zk-catalog-descriptions/risczero.md
@@ -4,7 +4,7 @@ RISC Zero allows to prove with ZK the computation of a RISC-V program. The archi
 - The aggregation circuit;
 - The STARK to SNARK wrapper.
 
-The repo containing the circuits code can be found [here](https://github.com/risc0/risc0/tree/main). The prover implementation can be found [here]('https://github.com/risc0/risc0/blob/main/risc0/zkp/src/prove/prover.rs').
+The repo containing the circuits code can be found [here](https://github.com/risc0/risc0/tree/main). The prover implementation can be found [here](https://github.com/risc0/risc0/blob/main/risc0/zkp/src/prove/prover.rs).
 
 The wrapper uses Groth16 as the proof system, and therefore requires a circuit specific trusted setup. The ceremony can be found [here](https://ceremony.pse.dev/projects/RISC%20Zero%20STARK-to-SNARK%20Prover). A high level guide on how to verify the setup can be found [here](https://www.risczero.com/blog/verifying-risc-zeros-trusted-setup-ceremony), while the full guide can be found [here](https://dev.risczero.com/api/trusted-setup-ceremony).
 


### PR DESCRIPTION
- Fixed a broken link to prover.rs in the RISC Zero catalog description (removed extra quotes around the URL).
- The link now correctly points to the source file in the risc0/risc0 repository.
