### PR TITLE
Add LivenessAggregating2 table & repo

### DIFF
--- a/packages/database/prisma/migrations/20250513105603_add_agg_liveness_2_again/migration.sql
+++ b/packages/database/prisma/migrations/20250513105603_add_agg_liveness_2_again/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "AggregatedLiveness2" (
+    "timestamp" TIMESTAMP(6) NOT NULL,
+    "projectId" VARCHAR(255) NOT NULL,
+    "subtype" VARCHAR(255) NOT NULL,
+    "min" INTEGER NOT NULL,
+    "avg" INTEGER NOT NULL,
+    "max" INTEGER NOT NULL,
+    "numberOfRecords" INTEGER NOT NULL,
+
+    CONSTRAINT "AggregatedLiveness2_pkey" PRIMARY KEY ("timestamp","projectId","subtype")
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -183,6 +183,18 @@ model AggregatedLiveness {
   @@id([timestamp, projectId, subtype])
 }
 
+model AggregatedLiveness2 {
+  timestamp       DateTime @db.Timestamp(6)
+  projectId       String   @db.VarChar(255)
+  subtype         String   @db.VarChar(255)
+  min             Int
+  avg             Int
+  max             Int
+  numberOfRecords Int
+
+  @@id([timestamp, projectId, subtype])
+}
+
 model Anomaly {
   timestamp DateTime @db.Timestamp(6)
   projectId String   @db.VarChar(255)

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -24,6 +24,7 @@ import { ProjectValueRepository } from './tvs/project-value/repository'
 import { TokenValueRepository } from './tvs/token-value/repository'
 import { IndexerConfigurationRepository } from './uif/indexer-configuration/repository'
 import { IndexerStateRepository } from './uif/indexer-state/repository'
+import { AggregatedLiveness2Repository } from './other/aggregated-liveness2/repository'
 
 export type Database = ReturnType<typeof createDatabase>
 export function createDatabase(config?: PoolConfig) {
@@ -59,6 +60,7 @@ export function createDatabase(config?: PoolConfig) {
     // #region Other
     aggregatedL2Cost: new AggregatedL2CostRepository(db),
     aggregatedLiveness: new AggregatedLivenessRepository(db),
+    aggregatedLiveness2: new AggregatedLiveness2Repository(db),
     anomalies: new AnomaliesRepository(db),
     finality: new FinalityRepository(db),
     l2Cost: new L2CostRepository(db),

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -11,6 +11,7 @@ import { UpdateNotifierRepository } from './discovery/update-notifier/repository
 import { DatabaseClient } from './kysely'
 import { AggregatedL2CostRepository } from './other/aggregated-l2-cost/repository'
 import { AggregatedLivenessRepository } from './other/aggregated-liveness/repository'
+import { AggregatedLiveness2Repository } from './other/aggregated-liveness2/repository'
 import { AnomaliesRepository } from './other/anomalies/repository'
 import { FinalityRepository } from './other/finality/repository'
 import { L2CostPriceRepository } from './other/l2-cost-price/repository'
@@ -24,7 +25,6 @@ import { ProjectValueRepository } from './tvs/project-value/repository'
 import { TokenValueRepository } from './tvs/token-value/repository'
 import { IndexerConfigurationRepository } from './uif/indexer-configuration/repository'
 import { IndexerStateRepository } from './uif/indexer-state/repository'
-import { AggregatedLiveness2Repository } from './other/aggregated-liveness2/repository'
 
 export type Database = ReturnType<typeof createDatabase>
 export function createDatabase(config?: PoolConfig) {

--- a/packages/database/src/other/aggregated-liveness2/entity.ts
+++ b/packages/database/src/other/aggregated-liveness2/entity.ts
@@ -1,0 +1,32 @@
+import { type TrackedTxsConfigSubtype, UnixTime } from '@l2beat/shared-pure'
+import type { Insertable, Selectable } from 'kysely'
+import type { AggregatedLiveness2 } from '../../kysely/generated/types'
+
+export interface AggregatedLiveness2Record {
+  timestamp: UnixTime
+  projectId: string
+  subtype: TrackedTxsConfigSubtype
+  min: number
+  avg: number
+  max: number
+  numberOfRecords: number
+}
+
+export function toRow(
+  record: AggregatedLiveness2Record,
+): Insertable<AggregatedLiveness2> {
+  return {
+    ...record,
+    timestamp: UnixTime.toDate(record.timestamp),
+  }
+}
+
+export function toRecord(
+  row: Selectable<AggregatedLiveness2>,
+): AggregatedLiveness2Record {
+  return {
+    ...row,
+    subtype: row.subtype as TrackedTxsConfigSubtype,
+    timestamp: UnixTime.fromDate(row.timestamp),
+  }
+}

--- a/packages/database/src/other/aggregated-liveness2/repository.test.ts
+++ b/packages/database/src/other/aggregated-liveness2/repository.test.ts
@@ -1,0 +1,219 @@
+import { ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { describeDatabase } from '../../test/database'
+import type { AggregatedLiveness2Record } from './entity'
+import { AggregatedLiveness2Repository } from './repository'
+
+describeDatabase(AggregatedLiveness2Repository.name, (db) => {
+  const repository = db.aggregatedLiveness2
+
+  const PROJECT_A = ProjectId('project-a')
+  const PROJECT_B = ProjectId('project-b')
+
+  const START = UnixTime.toStartOf(UnixTime.now(), 'hour')
+  const DATA: AggregatedLiveness2Record[] = [
+    // project A - batchSubmissions
+    {
+      projectId: PROJECT_A,
+      subtype: 'batchSubmissions',
+      min: 10,
+      avg: 20,
+      max: 30,
+      timestamp: START,
+      numberOfRecords: 1,
+    },
+    {
+      projectId: PROJECT_A,
+      subtype: 'batchSubmissions',
+      min: 20,
+      avg: 30,
+      max: 40,
+      timestamp: START - 1 * UnixTime.HOUR,
+      numberOfRecords: 4,
+    },
+    {
+      projectId: PROJECT_A,
+      subtype: 'batchSubmissions',
+      min: 30,
+      avg: 40,
+      max: 50,
+      timestamp: START - 2 * UnixTime.HOUR,
+      numberOfRecords: 3,
+    },
+    {
+      projectId: PROJECT_A,
+      subtype: 'batchSubmissions',
+      min: 40,
+      avg: 50,
+      max: 60,
+      timestamp: START - 3 * UnixTime.HOUR,
+      numberOfRecords: 2,
+    },
+    // project A - stateUpdates
+    {
+      projectId: PROJECT_A,
+      subtype: 'stateUpdates',
+      min: 30,
+      avg: 40,
+      max: 50,
+      timestamp: START - 1 * UnixTime.HOUR,
+      numberOfRecords: 2,
+    },
+    {
+      projectId: PROJECT_A,
+      subtype: 'stateUpdates',
+      min: 40,
+      avg: 50,
+      max: 60,
+      timestamp: START - 2 * UnixTime.HOUR,
+      numberOfRecords: 1,
+    },
+    // project B - stateUpdates
+    {
+      projectId: PROJECT_B,
+      subtype: 'stateUpdates',
+      min: 10,
+      avg: 10,
+      max: 10,
+      timestamp: START - 2 * UnixTime.HOUR,
+      numberOfRecords: 2,
+    },
+  ] as const satisfies AggregatedLiveness2Record[]
+
+  beforeEach(async function () {
+    this.timeout(10000)
+    await repository.deleteAll()
+    await repository.upsertMany(DATA)
+  })
+
+  describe(AggregatedLiveness2Repository.prototype.upsertMany.name, () => {
+    it('add new and update existing', async () => {
+      const newRows = [
+        // to update
+        {
+          projectId: PROJECT_A,
+          subtype: 'batchSubmissions',
+          min: 20,
+          avg: 20,
+          max: 20,
+          timestamp: START,
+          numberOfRecords: 4,
+        },
+        // to add
+        {
+          projectId: PROJECT_B,
+          subtype: 'stateUpdates',
+          min: 10,
+          avg: 10,
+          max: 10,
+          timestamp: START - 3 * UnixTime.HOUR,
+          numberOfRecords: 5,
+        },
+      ] as const satisfies AggregatedLiveness2Record[]
+
+      await repository.upsertMany(newRows)
+      const results = await repository.getAll()
+
+      expect(results).toEqualUnsorted([
+        newRows[0],
+        ...DATA.slice(1),
+        newRows[1],
+      ])
+    })
+
+    it('empty array', async () => {
+      await expect(repository.upsertMany([])).not.toBeRejected()
+    })
+  })
+
+  describe(AggregatedLiveness2Repository.prototype.getAll.name, () => {
+    it('should return all rows', async () => {
+      const results = await repository.getAll()
+
+      expect(results).toEqualUnsorted(
+        DATA.map((e) => ({
+          ...e,
+        })),
+      )
+    })
+  })
+
+  describe(AggregatedLiveness2Repository.prototype.getAggregatesByTimeRange
+    .name, () => {
+    it('returns aggregates with correctly calculated weighted averages for a given time range, grouped by project and subtype', async () => {
+      const results = await repository.getAggregatesByTimeRange([
+        START - 2 * UnixTime.HOUR,
+        START,
+      ])
+
+      expect(results).toEqualUnsorted([
+        {
+          projectId: PROJECT_A,
+          subtype: 'batchSubmissions',
+          min: 10,
+          avg: 32, // 1 * 20 + 4 * 30 + 3 * 40 / 1 + 4 + 3 = 32.5 but sql round it down
+          max: 50,
+        },
+        {
+          projectId: PROJECT_A,
+          subtype: 'stateUpdates',
+          min: 30,
+          avg: 43, // 2 * 40 + 1 * 50 / 2 + 1 = 43.(3) but sql round it down
+          max: 60,
+        },
+        {
+          projectId: PROJECT_B,
+          subtype: 'stateUpdates',
+          min: 10,
+          avg: 10,
+          max: 10,
+        },
+      ])
+    })
+
+    it('returns aggregates with null from', async () => {
+      await repository.deleteAll()
+      await repository.upsertMany([
+        {
+          projectId: PROJECT_A,
+          subtype: 'batchSubmissions',
+          min: 10,
+          avg: 20,
+          max: 30,
+          timestamp: START,
+          numberOfRecords: 1,
+        },
+        {
+          projectId: PROJECT_A,
+          subtype: 'batchSubmissions',
+          min: 20,
+          avg: 30,
+          max: 40,
+          timestamp: START - 1 * UnixTime.HOUR,
+          numberOfRecords: 4,
+        },
+      ])
+      const results = await repository.getAggregatesByTimeRange([null, START])
+
+      expect(results).toEqualUnsorted([
+        {
+          projectId: PROJECT_A,
+          subtype: 'batchSubmissions',
+          min: 10,
+          avg: 28, // 1 * 20 + 4 * 30/ 1 + 4 = 32.5 but sql round it down
+          max: 40,
+        },
+      ])
+    })
+  })
+
+  describe(AggregatedLiveness2Repository.prototype.deleteAll.name, () => {
+    it('should delete all rows', async () => {
+      await repository.deleteAll()
+
+      const results = await repository.getAll()
+
+      expect(results).toEqual([])
+    })
+  })
+})

--- a/packages/database/src/other/aggregated-liveness2/repository.ts
+++ b/packages/database/src/other/aggregated-liveness2/repository.ts
@@ -1,0 +1,81 @@
+import { type TrackedTxsConfigSubtype, UnixTime } from '@l2beat/shared-pure'
+import { sql } from 'kysely'
+import { BaseRepository } from '../../BaseRepository'
+import { type AggregatedLiveness2Record, toRecord, toRow } from './entity'
+import { selectAggregatedLiveness2 } from './select'
+
+export class AggregatedLiveness2Repository extends BaseRepository {
+  async upsertMany(records: AggregatedLiveness2Record[]): Promise<number> {
+    if (records.length === 0) return 0
+
+    const rows = records.map(toRow)
+    await this.batch(rows, 1_000, async (batch) => {
+      await this.db
+        .insertInto('AggregatedLiveness2')
+        .values(batch)
+        .onConflict((cb) =>
+          cb
+            .columns(['projectId', 'subtype', 'timestamp'])
+            .doUpdateSet((eb) => ({
+              min: eb.ref('excluded.min'),
+              avg: eb.ref('excluded.avg'),
+              max: eb.ref('excluded.max'),
+              numberOfRecords: eb.ref('excluded.numberOfRecords'),
+            })),
+        )
+        .execute()
+    })
+    return records.length
+  }
+
+  async deleteAll(): Promise<number> {
+    const result = await this.db
+      .deleteFrom('AggregatedLiveness2')
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
+  async getAll(): Promise<AggregatedLiveness2Record[]> {
+    const rows = await this.db
+      .selectFrom('AggregatedLiveness2')
+      .select(selectAggregatedLiveness2)
+      .execute()
+    return rows.map(toRecord)
+  }
+
+  async getAggregatesByTimeRange(
+    range: [UnixTime | null, UnixTime],
+  ): Promise<
+    Omit<AggregatedLiveness2Record, 'timestamp' | 'numberOfRecords'>[]
+  > {
+    const [from, to] = range
+
+    let query = this.db
+      .selectFrom('AggregatedLiveness2')
+      .select([
+        'projectId',
+        'subtype',
+        (eb) => eb.fn.min('min').as('min'),
+        (eb) =>
+          sql<number>`
+            SUM(${eb.ref('avg')} * ${eb.ref('numberOfRecords')})
+            / SUM(${eb.ref('numberOfRecords')})
+          `.as('avg'),
+        (eb) => eb.fn.max('max').as('max'),
+      ])
+      .where('timestamp', '<=', UnixTime.toDate(to))
+      .groupBy(['projectId', 'subtype'])
+
+    if (from) {
+      query = query.where('timestamp', '>=', UnixTime.toDate(from))
+    }
+
+    const rows = await query.execute()
+
+    return rows.map((row) => ({
+      ...row,
+      subtype: row.subtype as TrackedTxsConfigSubtype,
+      avg: Number(row.avg),
+    }))
+  }
+}

--- a/packages/database/src/other/aggregated-liveness2/select.ts
+++ b/packages/database/src/other/aggregated-liveness2/select.ts
@@ -1,0 +1,11 @@
+import type { AggregatedLiveness2 } from '../../kysely/generated/types'
+
+export const selectAggregatedLiveness2 = [
+  'timestamp',
+  'projectId',
+  'subtype',
+  'min',
+  'avg',
+  'max',
+  'numberOfRecords',
+] as const satisfies (keyof AggregatedLiveness2)[]


### PR DESCRIPTION
This PR is begging of refactoring liveness part again as we decided to change granularity to 1 hour aggregats. Unfortunatelly FE is already switched to new table, so we need to again create new table, new indexer, and after syncing switch FE to new one, and remove old one.