### PR TITLE
Add LivenessAggregatingIndexer2

### DIFF
--- a/packages/backend/src/modules/tracked-txs/TrackedTxsModule.ts
+++ b/packages/backend/src/modules/tracked-txs/TrackedTxsModule.ts
@@ -19,6 +19,7 @@ import { L2CostsPricesIndexer } from './modules/l2-costs/indexers/L2CostsPricesI
 import { createLivenessModule } from './modules/liveness/LivenessModule'
 import { AnomaliesIndexer } from './modules/liveness/indexers/AnomaliesIndexer'
 import { LivenessAggregatingIndexer } from './modules/liveness/indexers/LivenessAggregatingIndexer'
+import { LivenessAggregatingIndexer2 } from './modules/liveness/indexers/LivenessAggregatingIndexer2'
 
 export function createTrackedTxsModule(
   config: Config,
@@ -111,10 +112,20 @@ export function createTrackedTxsModule(
   }
 
   let livenessAggregatingIndexer: LivenessAggregatingIndexer | undefined
+  let livenessAggregatingIndexer2: LivenessAggregatingIndexer2 | undefined
   let anomaliesIndexer: AnomaliesIndexer | undefined
 
   if (config.trackedTxsConfig.uses.liveness) {
     livenessAggregatingIndexer = new LivenessAggregatingIndexer({
+      db: peripherals.database,
+      projects: config.trackedTxsConfig.projects,
+      parents: [trackedTxsIndexer],
+      indexerService,
+      minHeight: config.trackedTxsConfig.minTimestamp,
+      logger: logger.tag({ feature: 'liveness' }),
+    })
+
+    livenessAggregatingIndexer2 = new LivenessAggregatingIndexer2({
       db: peripherals.database,
       projects: config.trackedTxsConfig.projects,
       parents: [trackedTxsIndexer],
@@ -145,6 +156,7 @@ export function createTrackedTxsModule(
     await l2CostPricesIndexer?.start()
     await l2CostsAggregatorIndexer?.start()
     await livenessAggregatingIndexer?.start()
+    await livenessAggregatingIndexer2?.start()
     await anomaliesIndexer?.start()
   }
 

--- a/packages/backend/src/modules/tracked-txs/modules/liveness/indexers/LivenessAggregatingIndexer2.test.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/liveness/indexers/LivenessAggregatingIndexer2.test.ts
@@ -1,0 +1,437 @@
+import { Logger } from '@l2beat/backend-tools'
+import type { Database, LivenessRecord } from '@l2beat/database'
+import type { AggregatedLiveness2Record } from '@l2beat/database/dist/other/aggregated-liveness2/entity'
+import { type TrackedTxConfigEntry, createTrackedTxId } from '@l2beat/shared'
+import {
+  ProjectId,
+  type SavedConfiguration,
+  UnixTime,
+} from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import type { TrackedTxProject } from '../../../../../config/Config'
+import type { IndexerService } from '../../../../../tools/uif/IndexerService'
+import type { LivenessRecordWithConfig } from '../services/LivenessWithConfigService'
+import { LivenessAggregatingIndexer2 } from './LivenessAggregatingIndexer2'
+
+const NOW = UnixTime.now()
+
+const MOCK_CONFIGURATION_ID = createTrackedTxId.random()
+const MOCK_CONFIGURATION_TYPE = 'batchSubmissions'
+
+const MOCK_PROJECTS: TrackedTxProject[] = [
+  {
+    id: ProjectId('mocked-project'),
+    isArchived: false,
+    configurations: [
+      mockObject<TrackedTxConfigEntry>({
+        id: MOCK_CONFIGURATION_ID,
+        type: 'liveness',
+        subtype: MOCK_CONFIGURATION_TYPE,
+        untilTimestamp: UnixTime.now(),
+        projectId: ProjectId('mocked-project'),
+      }),
+    ],
+  },
+]
+
+const MOCK_CONFIGURATIONS = [
+  mockObject<Omit<SavedConfiguration<TrackedTxConfigEntry>, 'properties'>>({
+    id: MOCK_CONFIGURATION_ID,
+    maxHeight: null,
+    currentHeight: 1,
+  }),
+]
+
+const MOCK_LIVENESS: LivenessRecord[] = [
+  mockObject<LivenessRecord>({
+    configurationId: MOCK_CONFIGURATION_ID,
+    timestamp: NOW - 1 * UnixTime.HOUR,
+  }),
+  mockObject<LivenessRecord>({
+    configurationId: MOCK_CONFIGURATION_ID,
+    timestamp: NOW - 3 * UnixTime.HOUR,
+  }),
+  mockObject<LivenessRecord>({
+    configurationId: MOCK_CONFIGURATION_ID,
+    timestamp: NOW - 7 * UnixTime.HOUR,
+  }),
+]
+
+describe(LivenessAggregatingIndexer2.name, () => {
+  describe(LivenessAggregatingIndexer2.prototype.update.name, () => {
+    it('use correct time range when backfilling, on midnight', async () => {
+      const indexer = createIndexer({ tag: 'update-backfill-midnight' })
+      const mockGenerateLiveness = mockFn().resolvesTo([])
+      indexer.generateLiveness = mockGenerateLiveness
+
+      // 00:00:00 someday
+      const safeHeight = UnixTime.toStartOf(NOW, 'day') - 30 * UnixTime.DAY
+      const parentSafeHeight = NOW
+
+      const result = await indexer.update(safeHeight, parentSafeHeight)
+
+      // 00:00:00 same day as safeHeight
+      const expectedFrom = safeHeight
+      // 00:01:00 same day as safeHeight
+      const expectedTo = safeHeight + 1 * UnixTime.HOUR
+
+      expect(mockGenerateLiveness).toHaveBeenCalledWith(
+        expectedFrom,
+        expectedTo,
+      )
+      expect(result).toEqual(expectedTo)
+    })
+
+    it('use correct time range when backfilling, on middle of the day', async () => {
+      const indexer = createIndexer({ tag: 'update-backfill-middle-of-day' })
+      const mockGenerateLiveness = mockFn().resolvesTo([])
+      indexer.generateLiveness = mockGenerateLiveness
+
+      // 12:00:00 someday
+      const safeHeight =
+        UnixTime.toStartOf(NOW, 'day') - 30 * UnixTime.DAY + 12 * UnixTime.HOUR
+      const parentSafeHeight = NOW
+
+      const result = await indexer.update(safeHeight, parentSafeHeight)
+
+      // same as safeHeight
+      const expectedFrom = safeHeight
+      // 13:00:00 same day as safeHeight
+      const expectedTo = expectedFrom + 1 * UnixTime.HOUR
+
+      expect(mockGenerateLiveness).toHaveBeenCalledWith(
+        expectedFrom,
+        expectedTo,
+      )
+      expect(result).toEqual(expectedTo)
+    })
+
+    it('use correct time range when fully synced, on middle of the day', async () => {
+      const indexer = createIndexer({ tag: 'update-synced-middle-of-day' })
+      const mockGenerateLiveness = mockFn().resolvesTo([])
+      indexer.generateLiveness = mockGenerateLiveness
+
+      // round hour
+      const parentSafeHeight = UnixTime.toStartOf(NOW, 'hour')
+      // round hour - 1 hour as not yet synced
+      const safeHeight = parentSafeHeight - 1 * UnixTime.HOUR
+
+      const result = await indexer.update(safeHeight, parentSafeHeight)
+
+      const expectedFrom = safeHeight
+      const expectedTo = parentSafeHeight
+
+      expect(mockGenerateLiveness).toHaveBeenCalledWith(
+        expectedFrom,
+        expectedTo,
+      )
+      expect(result).toEqual(expectedTo)
+    })
+
+    it('use correct time range when fully synced, on midnight', async () => {
+      const indexer = createIndexer({ tag: 'update-synced-midnight' })
+      const mockGenerateLiveness = mockFn().resolvesTo([])
+      indexer.generateLiveness = mockGenerateLiveness
+
+      // 00:00:00 of current day
+      const safeHeight = UnixTime.toStartOf(NOW, 'day')
+      // 01:00:00 of current day
+      const parentSafeHeight = safeHeight + 1 * UnixTime.HOUR
+
+      const result = await indexer.update(safeHeight, parentSafeHeight)
+
+      const expectedFrom = safeHeight
+      const expectedTo = parentSafeHeight
+
+      expect(mockGenerateLiveness).toHaveBeenCalledWith(
+        expectedFrom,
+        expectedTo,
+      )
+      expect(result).toEqual(expectedTo)
+    })
+
+    it('handles time range with min height', async () => {
+      // 12:30:00 of some day
+      const minHeight =
+        UnixTime.toStartOf(NOW, 'day') -
+        30 * UnixTime.DAY +
+        12 * UnixTime.HOUR +
+        30 * UnixTime.MINUTE
+      const indexer = createIndexer({
+        tag: 'update-min-height',
+        minHeight,
+      })
+      const mockGenerateLiveness = mockFn().resolvesTo([])
+      indexer.generateLiveness = mockGenerateLiveness
+
+      const parentSafeHeight = NOW
+
+      const result = await indexer.update(
+        minHeight - 1 * UnixTime.DAY,
+        parentSafeHeight,
+      )
+
+      // 12:30:00 of some day - we do not round it to start of day
+      const expectedFrom = minHeight
+      // 13:00:00 of same day
+      const expectedTo = minHeight + 30 * UnixTime.MINUTE
+
+      expect(mockGenerateLiveness).toHaveBeenCalledWith(
+        expectedFrom,
+        expectedTo,
+      )
+      expect(result).toEqual(expectedTo)
+    })
+
+    it('should save data to db', async () => {
+      const mockAggregatedLivenessRepository = mockObject<
+        Database['aggregatedLiveness']
+      >({
+        upsertMany: mockFn().resolvesTo(1),
+      })
+      const indexer = createIndexer({
+        tag: 'update-save-to-db',
+        aggregatedLivenessRepository: mockAggregatedLivenessRepository,
+      })
+      const mockAggregatedLiveness: AggregatedLiveness2Record[] = [
+        mockObject<AggregatedLiveness2Record>({
+          min: 10,
+          avg: 20,
+          max: 30,
+          timestamp: NOW,
+        }),
+        mockObject<AggregatedLiveness2Record>({
+          min: 20,
+          avg: 30,
+          max: 40,
+          timestamp: NOW,
+        }),
+      ]
+      indexer.generateLiveness = mockFn().resolvesTo(mockAggregatedLiveness)
+
+      const parentSafeHeight = UnixTime.toStartOf(NOW, 'hour')
+      const safeHeight = parentSafeHeight - 1 * UnixTime.HOUR
+
+      const result = await indexer.update(safeHeight, parentSafeHeight)
+
+      expect(mockAggregatedLivenessRepository.upsertMany).toHaveBeenCalledWith(
+        mockAggregatedLiveness,
+      )
+      expect(result).toEqual(parentSafeHeight)
+    })
+  })
+
+  describe(LivenessAggregatingIndexer2.prototype.invalidate.name, () => {
+    it('should return new safeHeigh and not delete data', async () => {
+      const livenessRepositoryMock = mockObject<Database['liveness']>({
+        deleteAll: mockFn().resolvesTo(1),
+      })
+
+      const targetHeight = UnixTime.now()
+
+      const indexer = createIndexer({
+        tag: 'invalidate',
+        livenessRepository: livenessRepositoryMock,
+      })
+
+      const result = await indexer.invalidate(targetHeight)
+
+      expect(livenessRepositoryMock.deleteAll).not.toHaveBeenCalled()
+
+      expect(result).toEqual(targetHeight)
+    })
+  })
+
+  describe(LivenessAggregatingIndexer2.prototype.generateLiveness.name, () => {
+    it('should generate aggregated liveness', async () => {
+      const mockLivenessRepository = mockObject<Database['liveness']>({
+        getRecordsInRangeWithLatestBefore: mockFn().resolvesTo(MOCK_LIVENESS),
+      })
+
+      const mockIndexerService = mockObject<IndexerService>({
+        getSavedConfigurations: mockFn().resolvesTo(MOCK_CONFIGURATIONS),
+      })
+
+      const indexer = createIndexer({
+        tag: 'generate-liveness',
+        livenessRepository: mockLivenessRepository,
+        indexerService: mockIndexerService,
+      })
+
+      const result = await indexer.generateLiveness(
+        NOW - 3 * UnixTime.HOUR,
+        NOW,
+      )
+
+      expect(
+        mockLivenessRepository.getRecordsInRangeWithLatestBefore,
+      ).toHaveBeenCalledWith(
+        [MOCK_CONFIGURATION_ID],
+        NOW - 3 * UnixTime.HOUR,
+        NOW,
+      )
+
+      expect(result).toEqual([
+        {
+          avg: 3 * UnixTime.HOUR,
+          max: 4 * UnixTime.HOUR,
+          min: 2 * UnixTime.HOUR,
+          projectId: 'mocked-project',
+          subtype: 'batchSubmissions',
+          timestamp: NOW - 3 * UnixTime.HOUR,
+          numberOfRecords: 2,
+        },
+      ])
+    })
+  })
+
+  describe(LivenessAggregatingIndexer2.prototype.aggregateRecords.name, () => {
+    it('should aggregate records', async () => {
+      const indexer = createIndexer({ tag: 'aggregate-records' })
+
+      const result = indexer.aggregateRecords(
+        MOCK_PROJECTS[0].id,
+        'batchSubmissions',
+        MOCK_LIVENESS.map((record) => ({
+          ...record,
+          id: MOCK_CONFIGURATION_ID,
+          subtype: MOCK_CONFIGURATION_TYPE,
+        })),
+        NOW - 7 * UnixTime.HOUR,
+      )
+
+      expect(result).toEqual({
+        avg: ((4 + 2) / 2) * UnixTime.HOUR,
+        max: 4 * UnixTime.HOUR,
+        min: 2 * UnixTime.HOUR,
+        projectId: 'mocked-project',
+        subtype: 'batchSubmissions',
+        timestamp: NOW - 7 * UnixTime.HOUR,
+        numberOfRecords: 2,
+      })
+    })
+
+    it('should use only latest before timestamp, and filter out all before', async () => {
+      const indexer = createIndexer({ tag: 'aggregate-only-one-latest' })
+
+      const start = UnixTime.toStartOf(NOW, 'day')
+
+      const result = indexer.aggregateRecords(
+        MOCK_PROJECTS[0].id,
+        'batchSubmissions',
+        [
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start + 5 * UnixTime.HOUR,
+          }),
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start + 2 * UnixTime.HOUR,
+          }),
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start,
+          }),
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start - 1 * UnixTime.HOUR,
+          }),
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start - 2 * UnixTime.HOUR,
+          }),
+        ],
+        start,
+      )
+
+      expect(result).toEqual({
+        avg: 2 * UnixTime.HOUR,
+        max: 3 * UnixTime.HOUR,
+        min: 1 * UnixTime.HOUR,
+        projectId: 'mocked-project',
+        subtype: 'batchSubmissions',
+        timestamp: start,
+        numberOfRecords: 3,
+      })
+    })
+
+    it('should still calculate if no records before start', async () => {
+      const indexer = createIndexer({ tag: 'aggregate-if-no-records-before' })
+
+      const start = UnixTime.toStartOf(NOW, 'day')
+
+      const result = indexer.aggregateRecords(
+        MOCK_PROJECTS[0].id,
+        'batchSubmissions',
+        [
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start + 5 * UnixTime.HOUR,
+          }),
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start + 2 * UnixTime.HOUR,
+          }),
+          mockObject<LivenessRecordWithConfig>({
+            configurationId: MOCK_CONFIGURATION_ID,
+            timestamp: start,
+          }),
+        ],
+        start,
+      )
+
+      expect(result).toEqual({
+        avg: 2.5 * UnixTime.HOUR,
+        max: 3 * UnixTime.HOUR,
+        min: 2 * UnixTime.HOUR,
+        projectId: 'mocked-project',
+        subtype: 'batchSubmissions',
+        timestamp: start,
+        numberOfRecords: 2,
+      })
+    })
+
+    it('should skip if no data to calculate intervals', async () => {
+      const indexer = createIndexer({ tag: 'skip-if-no-data' })
+
+      const result = indexer.aggregateRecords(
+        MOCK_PROJECTS[0].id,
+        'batchSubmissions',
+        MOCK_LIVENESS.slice(0, 1).map((record) => ({
+          ...record,
+          id: MOCK_CONFIGURATION_ID,
+          subtype: MOCK_CONFIGURATION_TYPE,
+        })),
+        NOW,
+      )
+
+      expect(result).toEqual(undefined)
+    })
+  })
+})
+
+function createIndexer(options: {
+  tag: string
+  livenessRepository?: Database['liveness']
+  aggregatedLivenessRepository?: Database['aggregatedLiveness2']
+  indexerService?: IndexerService
+  minHeight?: number
+}) {
+  return new LivenessAggregatingIndexer2({
+    tags: { tag: options.tag },
+    indexerService: options.indexerService ?? mockObject<IndexerService>(),
+    logger: Logger.SILENT,
+    minHeight: options.minHeight ?? 0,
+    parents: [],
+    db: mockObject<Database>({
+      liveness:
+        options.livenessRepository ?? mockObject<Database['liveness']>(),
+      aggregatedLiveness2:
+        options.aggregatedLivenessRepository ??
+        mockObject<Database['aggregatedLiveness2']>({
+          upsertMany: mockFn().resolvesTo(1),
+        }),
+    }),
+    projects: MOCK_PROJECTS,
+  })
+}

--- a/packages/backend/src/modules/tracked-txs/modules/liveness/indexers/LivenessAggregatingIndexer2.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/liveness/indexers/LivenessAggregatingIndexer2.ts
@@ -1,0 +1,174 @@
+import type { Database } from '@l2beat/database'
+import {
+  ProjectId,
+  type TrackedTxsConfigSubtype,
+  UnixTime,
+} from '@l2beat/shared-pure'
+import groupBy from 'lodash/groupBy'
+import type { TrackedTxProject } from '../../../../../config/Config'
+import {
+  ManagedChildIndexer,
+  type ManagedChildIndexerOptions,
+} from '../../../../../tools/uif/ManagedChildIndexer'
+import {
+  type LivenessRecordWithConfig,
+  LivenessWithConfigService,
+} from '../services/LivenessWithConfigService'
+import { calculateIntervals } from '../utils/calculateIntervals'
+import { calculateStats } from '../utils/calculateStats'
+import { getActiveConfigurations } from '../utils/getActiveConfigurations'
+import { groupByType } from '../utils/groupByType'
+import type { AggregatedLiveness2Record } from '@l2beat/database/dist/other/aggregated-liveness2/entity'
+
+export interface LivenessAggregatingIndexer2Deps
+  extends Omit<ManagedChildIndexerOptions, 'name'> {
+  db: Database
+  projects: TrackedTxProject[]
+}
+
+export class LivenessAggregatingIndexer2 extends ManagedChildIndexer {
+  constructor(private readonly $: LivenessAggregatingIndexer2Deps) {
+    super({ ...$, name: 'liveness_aggregating_2' })
+  }
+
+  override async update(
+    safeHeight: number,
+    parentSafeHeight: number,
+  ): Promise<number> {
+    const from =
+      safeHeight <= this.$.minHeight
+        ? this.$.minHeight
+        : UnixTime.toStartOf(safeHeight, 'hour')
+    const endOfHour = UnixTime.toStartOf(from, 'hour') + UnixTime.HOUR
+
+    const to = parentSafeHeight > endOfHour ? endOfHour : parentSafeHeight
+
+    const updatedLivenessRecords = await this.generateLiveness(from, to)
+
+    await this.$.db.aggregatedLiveness2.upsertMany(updatedLivenessRecords)
+    return to
+  }
+
+  override async invalidate(targetHeight: number): Promise<number> {
+    // no need to remove data
+    // safeHeight will be updated to this value
+    return await Promise.resolve(targetHeight)
+  }
+
+  async generateLiveness(
+    from: UnixTime,
+    to: UnixTime,
+  ): Promise<AggregatedLiveness2Record[]> {
+    const aggregatedRecords: (AggregatedLiveness2Record | undefined)[] = []
+
+    const configurations = await this.$.indexerService.getSavedConfigurations(
+      'tracked_txs_indexer',
+    )
+
+    const allProjectConfigs = this.$.projects
+      .flatMap((p) => getActiveConfigurations(p, configurations))
+      .filter((c) => c !== undefined)
+
+    const livenessWithConfig = new LivenessWithConfigService(
+      allProjectConfigs,
+      this.$.db,
+    )
+
+    // for every considered time range we also take latest record before `from`
+    // for each configuration to calculate interval for first record in time range
+    const livenessRecords =
+      await livenessWithConfig.getWithinTimeRangeWithLatestBeforeFrom(from, to)
+
+    const groupedConfigs = groupBy(allProjectConfigs, (c) => c.projectId)
+
+    for (const project of Object.keys(groupedConfigs)) {
+      const projectConfigs = groupedConfigs[project]
+
+      if (projectConfigs.length === 0) {
+        continue
+      }
+
+      const activeConfigIds = projectConfigs.map((c) => c.id)
+      const projectLivenessRecords = livenessRecords.filter((r) =>
+        activeConfigIds.includes(r.id),
+      )
+
+      if (projectLivenessRecords.length === 0) {
+        this.logger.debug('No records found for project', {
+          projectId: project,
+        })
+        continue
+      }
+
+      this.logger.debug('Liveness records loaded', {
+        projectId: project,
+        count: livenessRecords.length,
+      })
+
+      const [batchSubmissions, stateUpdates, proofSubmissions] = groupByType(
+        projectLivenessRecords,
+      )
+
+      aggregatedRecords.push(
+        this.aggregateRecords(
+          ProjectId(project),
+          'batchSubmissions',
+          batchSubmissions,
+          from,
+        ),
+      )
+      aggregatedRecords.push(
+        this.aggregateRecords(
+          ProjectId(project),
+          'stateUpdates',
+          stateUpdates,
+          from,
+        ),
+      )
+      aggregatedRecords.push(
+        this.aggregateRecords(
+          ProjectId(project),
+          'proofSubmissions',
+          proofSubmissions,
+          from,
+        ),
+      )
+    }
+
+    return aggregatedRecords.filter((r) => r !== undefined)
+  }
+
+  aggregateRecords(
+    projectId: ProjectId,
+    subtype: TrackedTxsConfigSubtype,
+    livenessRecords: LivenessRecordWithConfig[],
+    timestamp: UnixTime,
+  ): AggregatedLiveness2Record | undefined {
+    // here we have few records before timestamp as we take one for each configuration
+    // so here we need to filter out all and leave only the latest before timestamp
+    const timeRangeStartIndex = livenessRecords.findIndex(
+      (r) => r.timestamp < timestamp,
+    )
+    const timeRangeRecords =
+      timeRangeStartIndex === -1
+        ? livenessRecords
+        : livenessRecords.slice(0, timeRangeStartIndex + 1)
+
+    // if <= 1 record, than we can't calculate intervals
+    if (timeRangeRecords.length <= 1) return
+    const intervals = calculateIntervals(timeRangeRecords)
+    const stats = calculateStats(intervals)
+
+    return {
+      projectId: projectId,
+      subtype,
+      min: stats.minimumInSeconds,
+      avg: stats.averageInSeconds,
+      max: stats.maximumInSeconds,
+      timestamp,
+      // We are saving the number of records to later correctly calculate the average for a given time range.
+      // This ensures we calculate the correct average from all records, not just from daily aggregations.
+      numberOfRecords: intervals.length,
+    }
+  }
+}

--- a/packages/backend/src/modules/tracked-txs/modules/liveness/indexers/LivenessAggregatingIndexer2.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/liveness/indexers/LivenessAggregatingIndexer2.ts
@@ -1,4 +1,5 @@
 import type { Database } from '@l2beat/database'
+import type { AggregatedLiveness2Record } from '@l2beat/database/dist/other/aggregated-liveness2/entity'
 import {
   ProjectId,
   type TrackedTxsConfigSubtype,
@@ -18,7 +19,6 @@ import { calculateIntervals } from '../utils/calculateIntervals'
 import { calculateStats } from '../utils/calculateStats'
 import { getActiveConfigurations } from '../utils/getActiveConfigurations'
 import { groupByType } from '../utils/groupByType'
-import type { AggregatedLiveness2Record } from '@l2beat/database/dist/other/aggregated-liveness2/entity'
 
 export interface LivenessAggregatingIndexer2Deps
   extends Omit<ManagedChildIndexerOptions, 'name'> {


### PR DESCRIPTION
This PR is next step in rewritng LivenessAggregatingIndexer to hourly granularity. It makes copy of current indexer with small change of time range logic. After merging it will start syncing data. Next step will be to switch scaling/liveness page to new table.