### PR TITLE
Fix not showed 0 seconds liveness

### DIFF
--- a/packages/frontend/src/app/(side-nav)/scaling/liveness/_components/liveness-duration-cell.tsx
+++ b/packages/frontend/src/app/(side-nav)/scaling/liveness/_components/liveness-duration-cell.tsx
@@ -16,7 +16,7 @@ export function LivenessDurationCell(props: { durationInSeconds: number }) {
         ? `${getDurationText(hours, 'hour')} ${getDurationText(remainingMinutes, 'minute')}`
         : minutes > 0
           ? `${getDurationText(minutes, 'minute')}`
-          : `${getDurationText(seconds, 'second')}`
+          : `${seconds} ${pluralize(seconds, 'second')}`
 
   const colorClassName = getDurationColorClassName(seconds)
 


### PR DESCRIPTION
Before:
<img width="491" alt="Screenshot 2025-05-14 at 12 55 30" src="https://github.com/user-attachments/assets/ca3159f6-bc1a-43b8-a81d-2408e2167b27" />
After:
<img width="491" alt="Screenshot 2025-05-14 at 12 55 49" src="https://github.com/user-attachments/assets/3f0e74be-a8c1-4992-928e-eb6412e00925" />
