### PR TITLE
Scope controlsMajorityOfUpgradePermissions flag to a chain

### DIFF
--- a/packages/config/src/projects/_clingo/modelPermissions.lp
+++ b/packages/config/src/projects/_clingo/modelPermissions.lp
@@ -60,16 +60,17 @@ receivedUpgradePermissionsCount(Actor, ReceivedUpgradePermissions) :-
   address(Actor, _, _),
   ReceivedUpgradePermissions = #count{Giver: ultimatePermission(Actor, "upgrade", Giver, _, _, _, _, _, isFinal)}.
 
-% The maximum number of upgrade permissions received by any actor:
-maxReceivedUpgradePermissionsCount(Max) :-
-  Max = #max{C: receivedUpgradePermissionsCount(_, C)}.
+% The maximum number of upgrade permissions received by any actor (per chain):
+maxReceivedUpgradePermissionsCount(Max, Chain) :-
+  address(_, Chain, _),
+  Max = #max{ReceivedUpgradePermissions: receivedUpgradePermissionsCount(Actor, ReceivedUpgradePermissions), address(Actor, Chain, _)}.  
 
-% A potential EOA(s) that controls the maximum number of upgrade permissions:
+% A potential EOA(s) that controls the maximum number of upgrade permissions (per chain):
 eoaWithMajorityUpgradePermissions(Eoa) :-
-  address(Eoa, _, _),
+  address(Eoa, Chain, _),
   addressType(Eoa, eoa),
   receivedUpgradePermissionsCount(Eoa, ReceivedUpgradePermissions),
-  maxReceivedUpgradePermissionsCount(Max),
+  maxReceivedUpgradePermissionsCount(Max, Chain),
   Max > 0, % there are some projects that don't have any upgrade permissions
   ReceivedUpgradePermissions = Max.
 % END
@@ -82,6 +83,6 @@ eoaWithMajorityUpgradePermissions(Eoa) :-
 % #show transitivePermission/8.
 #show ultimatePermission/9.
 
-% #show maxReceivedUpgradePermissionsCount/1.
+% #show maxReceivedUpgradePermissionsCount/2.
 % #show receivedUpgradePermissionsCount/2.
 #show eoaWithMajorityUpgradePermissions/1.

--- a/packages/config/src/projects/nova/nova/diffHistory.md
+++ b/packages/config/src/projects/nova/nova/diffHistory.md
@@ -1,3 +1,29 @@
+Generated with discovered.json: 0x69517602bcbc3ef3d4113e9b436832a95251edb6
+
+# Diff at Wed, 14 May 2025 14:02:12 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@3e40b87963942c5b1b364373f150a7eda9e4eccd block: 83508934
+- current block number: 83508934
+
+## Description
+
+Max upgrade count flag updated (after change to algo to scope per chain).
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 83508934 (main branch discovery), not current.
+
+```diff
+    EOA L1Timelock (0xf7951D92B0C345144506576eC13Ecf5103aC905a) {
+    +++ description: None
+      controlsMajorityOfUpgradePermissions:
++        true
+    }
+```
+
 Generated with discovered.json: 0x6b8977576fc5a26adc8788df702f6ff1da4601b4
 
 # Diff at Thu, 08 May 2025 10:03:18 GMT:

--- a/packages/config/src/projects/nova/nova/discovered.json
+++ b/packages/config/src/projects/nova/nova/discovered.json
@@ -651,6 +651,7 @@
       "address": "0xf7951D92B0C345144506576eC13Ecf5103aC905a",
       "type": "EOA",
       "proxyType": "EOA",
+      "controlsMajorityOfUpgradePermissions": true,
       "receivedPermissions": [
         {
           "permission": "upgrade",

--- a/packages/config/src/projects/shared-zk-stack/zksync2/diffHistory.md
+++ b/packages/config/src/projects/shared-zk-stack/zksync2/diffHistory.md
@@ -1,3 +1,29 @@
+Generated with discovered.json: 0xb16ee2d99f3ae3cedb392f28d134aeadca98a709
+
+# Diff at Wed, 14 May 2025 14:02:05 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@3e40b87963942c5b1b364373f150a7eda9e4eccd block: 60151606
+- current block number: 60151606
+
+## Description
+
+Max upgrade count flag updated (after change to algo to scope per chain).
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 60151606 (main branch discovery), not current.
+
+```diff
+    EOA ProtocolUpgradeHandler_l2Alias_deprecated (0xA08b9912416E8aDc4D9C21Fae1415d3318A129A8) {
+    +++ description: None
+      controlsMajorityOfUpgradePermissions:
++        true
+    }
+```
+
 Generated with discovered.json: 0x0cb2d2c9b68b3e0d3747cb138cfbb16f908ab931
 
 # Diff at Fri, 09 May 2025 11:21:54 GMT:

--- a/packages/config/src/projects/shared-zk-stack/zksync2/discovered.json
+++ b/packages/config/src/projects/shared-zk-stack/zksync2/discovered.json
@@ -605,6 +605,7 @@
       "address": "0xA08b9912416E8aDc4D9C21Fae1415d3318A129A8",
       "type": "EOA",
       "proxyType": "EOA",
+      "controlsMajorityOfUpgradePermissions": true,
       "receivedPermissions": [
         {
           "permission": "upgrade",

--- a/packages/config/src/projects/tokens/base/diffHistory.md
+++ b/packages/config/src/projects/tokens/base/diffHistory.md
@@ -1,3 +1,45 @@
+Generated with discovered.json: 0x74d050bb2805c975663303aa49742e3192d680e9
+
+# Diff at Wed, 14 May 2025 14:02:09 GMT:
+
+- author: Adrian Adamiak (<adrian@adamiak.net>)
+- comparing to: main@3e40b87963942c5b1b364373f150a7eda9e4eccd block: 30000033
+- current block number: 30000033
+
+## Description
+
+Max upgrade count flag updated (after change to algo to scope per chain).
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 30000033 (main branch discovery), not current.
+
+```diff
+    EOA  (0x19b4B317E6Ea4643f1507c372630483092D0AbFf) {
+    +++ description: None
+      controlsMajorityOfUpgradePermissions:
++        true
+    }
+```
+
+```diff
+    EOA  (0x4fc7850364958d97B4d3f5A08f79db2493f8cA44) {
+    +++ description: None
+      controlsMajorityOfUpgradePermissions:
++        true
+    }
+```
+
+```diff
+    EOA  (0x88acF681fb9a1DFcE5ac83391991895C54CF24cc) {
+    +++ description: None
+      controlsMajorityOfUpgradePermissions:
++        true
+    }
+```
+
 Generated with discovered.json: 0x56abde3df0f324e57d99b3857374b0b30e20a7d8
 
 # Diff at Fri, 09 May 2025 11:17:02 GMT:

--- a/packages/config/src/projects/tokens/base/discovered.json
+++ b/packages/config/src/projects/tokens/base/discovered.json
@@ -58,6 +58,7 @@
       "address": "0x19b4B317E6Ea4643f1507c372630483092D0AbFf",
       "type": "EOA",
       "proxyType": "EOA",
+      "controlsMajorityOfUpgradePermissions": true,
       "receivedPermissions": [
         {
           "permission": "upgrade",
@@ -237,6 +238,7 @@
       "address": "0x4fc7850364958d97B4d3f5A08f79db2493f8cA44",
       "type": "EOA",
       "proxyType": "EOA",
+      "controlsMajorityOfUpgradePermissions": true,
       "receivedPermissions": [
         {
           "permission": "upgrade",
@@ -482,6 +484,7 @@
       "address": "0x88acF681fb9a1DFcE5ac83391991895C54CF24cc",
       "type": "EOA",
       "proxyType": "EOA",
+      "controlsMajorityOfUpgradePermissions": true,
       "receivedPermissions": [
         {
           "permission": "upgrade",


### PR DESCRIPTION
Resolves L2B-10186

The `controlsMajorityOfUpgradePermissions` flag is now calculated per chain since our update monitor doesn't handle cross-chain well yet. 