### PR TITLE
Update Shape docs URL to Gasback page

### DIFF
--- a/packages/config/src/projects/shape/shape.ts
+++ b/packages/config/src/projects/shape/shape.ts
@@ -26,7 +26,7 @@ export const shape: ScalingProject = opStackL2({
         'https://superbridge.app/shape-mainnet',
         'https://shape-mainnet.bridge.alchemy.com/',
       ],
-      documentation: ['https://docs.shape.network/documentation/introduction'],
+      documentation: ['https://docs.shape.network/building-on-shape/gasback'],
       explorers: ['https://shapescan.xyz/'],
       repositories: ['https://github.com/shape-network'],
       socialMedia: [


### PR DESCRIPTION
I replaced the outdated Shape Network documentation link with the correct Gasback page.
https://docs.shape.network/documentation/introduction - old
https://docs.shape.network/building-on-shape/gasback - new