### PR TITLE
Fix used in icons look misaligned when too many

### DIFF
--- a/packages/frontend/src/components/projects/sections/permissions/used-in-project.tsx
+++ b/packages/frontend/src/components/projects/sections/permissions/used-in-project.tsx
@@ -23,10 +23,8 @@ export function UsedInProjectEntry({
 }: { label: string; implementations: UsedInProject[] }) {
   return (
     <div className="mt-2 flex flex-row items-center">
-      <p className="text-gray-850 dark:text-gray-400">
-        <strong className="text-primary">{label}: </strong>
-      </p>
-      <div className="flex flex-row items-center">
+      <div className="flex flex-row flex-wrap items-center">
+        <strong className="whitespace-nowrap text-primary">{label}: </strong>
         {implementations.map((project, i) => (
           <Tooltip key={i}>
             <TooltipTrigger disabledOnMobile>
@@ -40,7 +38,7 @@ export function UsedInProjectEntry({
                   key={i}
                   src={project.icon}
                   alt="Project icon"
-                  className="mx-1 inline"
+                  className="mx-1 inline min-h-5 min-w-5"
                 />
               </LinkWithOnHoverPrefetch>
             </TooltipTrigger>


### PR DESCRIPTION
Resolves L2B-10240
Before: 
<img width="395" alt="81462" src="https://github.com/user-attachments/assets/298d87b6-d701-4ce5-a92c-3e5ffb353f1d" />

After: 
<img width="400" alt="87165" src="https://github.com/user-attachments/assets/cfa2a9c9-5b75-4636-a491-364cfa218c2f" />
