### PR TITLE
Create index on ProjectValue

### DIFF
--- a/packages/database/prisma/migrations/20250516140307_index_project_value/migration.sql
+++ b/packages/database/prisma/migrations/20250516140307_index_project_value/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "ProjectValue_type_timestamp_idx" ON "ProjectValue"("type", "timestamp");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -271,6 +271,7 @@ model ProjectValue {
   associated Float    @db.Real
 
   @@id([timestamp, project, type])
+  @@index([type, timestamp])
 }
 
 model UpdateDiff {


### PR DESCRIPTION
Removes a sequential scan.

The size of the index is 11MB. This table is used in the slowest query right now on the frontend.

Before:

```
 Nested Loop  (cost=27943.96..27952.02 rows=1 width=57)
   ->  GroupAggregate  (cost=27943.53..27943.56 rows=1 width=25)
         Group Key: "ProjectValue".project, "ProjectValue".type
         ->  Sort  (cost=27943.53..27943.54 rows=1 width=25)
               Sort Key: "ProjectValue".project
               ->  Gather  (cost=1000.00..27943.52 rows=1 width=25)
                     Workers Planned: 2
                     ->  Parallel Seq Scan on "ProjectValue"  (cost=0.00..26943.42 rows=1 width=25)
                           Filter: (("timestamp" <= '2025-05-16 15:31:21+02'::timestamp with time zone) AND ((type)::text = 'tvl'::text))
   ->  Index Scan using "ProjectValue_pkey" on "ProjectValue" pv  (cost=0.43..8.45 rows=1 width=57)
         Index Cond: (("timestamp" = (max("ProjectValue"."timestamp"))) AND ((type)::text = ("ProjectValue".type)::text) AND ((project)::text = ("ProjectValue".project)::t
ext))
```

After:

```
 Nested Loop  (cost=8.31..16.38 rows=1 width=1072)
   ->  GroupAggregate  (cost=8.17..8.20 rows=1 width=1040)
         Group Key: "ProjectValue".project, "ProjectValue".type
         ->  Sort  (cost=8.17..8.18 rows=1 width=1040)
               Sort Key: "ProjectValue".project
               ->  Index Scan using "ProjectValue_type_timestamp_idx" on "ProjectValue"  (cost=0.14..8.16 rows=1 width=1040)
                     Index Cond: (((type)::text = 'tvl'::text) AND ("timestamp" <= '2025-05-16 15:31:21+02'::timestamp with time zone))
   ->  Index Scan using "ProjectValue_type_timestamp_idx" on "ProjectValue" pv  (cost=0.14..8.16 rows=1 width=1072)
         Index Cond: (((type)::text = ("ProjectValue".type)::text) AND ("timestamp" = (max("ProjectValue"."timestamp"))))
         Filter: (("ProjectValue".project)::text = (project)::text)
```