### PR TITLE
Fix bug where controlling EOA lost flag

### DIFF
--- a/packages/config/src/projects/_clingo/modelPermissions.lp
+++ b/packages/config/src/projects/_clingo/modelPermissions.lp
@@ -58,7 +58,7 @@ ultimatePermission(Receiver, OriginalPermission, Giver, OriginalDelay, OriginalD
 % The number of upgrade permissions received for every actor
 receivedUpgradePermissionsCount(Actor, ReceivedUpgradePermissions) :-
   address(Actor, _, _),
-  ReceivedUpgradePermissions = #count{Giver: ultimatePermission(Actor, "upgrade", Giver, _, _, _, _, _, isFinal)}.
+  ReceivedUpgradePermissions = #count{Giver: ultimatePermission(Actor, "upgrade", Giver, _, _, _, _, _, _, isFinal)}.
 
 % The maximum number of upgrade permissions received by any actor (per chain):
 maxReceivedUpgradePermissionsCount(Max, Chain) :-

--- a/packages/discovery/src/discovery/modelling/combinePermissionsIntoDiscovery.ts
+++ b/packages/discovery/src/discovery/modelling/combinePermissionsIntoDiscovery.ts
@@ -54,13 +54,13 @@ export async function combinePermissionsIntoDiscovery(
               ),
             )
       updateRelevantField(entry, key, permissions)
-      if (
+
+      entry.controlsMajorityOfUpgradePermissions =
         permissionsOutput.eoasWithMajorityUpgradePermissions?.includes(
           entry.address,
         )
-      ) {
-        entry.controlsMajorityOfUpgradePermissions = true
-      }
+          ? true
+          : undefined
     }
   }
 }


### PR DESCRIPTION
There are two fixes here.
* a simple parameter mismatch in Clingo
* properly erasing existing flag in discovered.json during `l2b model-permissions` if it's no longer `true`
