### PR TITLE
chore: replace reference OP/ZK

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -1048,7 +1048,7 @@ function getTechnologyExitMechanism(
     references: [
       {
         title: 'Forced withdrawal from an OP Stack blockchain',
-        url: 'https://stack.optimism.io/docs/security/forced-withdrawal/',
+        url: 'https://docs.optimism.io/stack/transactions/forced-transaction',
       },
     ],
   })

--- a/packages/config/src/templates/zkStack.ts
+++ b/packages/config/src/templates/zkStack.ts
@@ -510,7 +510,7 @@ ZKsync Era's Chain Admin differs from the others as it also has the above *ZK cl
         {
           title: 'Prover Architecture',
           description:
-            'ZKsync Era proof system Boojum can be found [here](https://github.com/matter-labs/era-boojum/tree/main) and contains essential tools like the Prover, the Verifier, and other backend components. The specs of the system can be found [here](https://github.com/matter-labs/zksync-era/tree/main/docs/specs/prover).',
+            'ZKsync Era proof system Boojum can be found [here](https://github.com/matter-labs/era-boojum/tree/main) and contains essential tools like the Prover, the Verifier, and other backend components. The specs of the system can be found [here](https://github.com/matter-labs/zksync-era/tree/main/prover).',
         },
         {
           title: 'ZK Circuits',


### PR DESCRIPTION
Hi, I fixed broken links in the documentation and replaced them with working ones.

`packages/config/src/templates/opStack.ts`
https://stack.optimism.io/docs/security/forced-withdrawal/ - dead link
https://docs.optimism.io/stack/transactions/forced-transaction - new link

`packages/config/src/templates/zkStack.ts`
https://github.com/matter-labs/zksync-era/tree/main/docs/specs/prover - dead link 
https://github.com/matter-labs/zksync-era/tree/main/prover- new link