### PR TITLE
Add easy rediscover prompt to DiscoUI

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/getCode.ts
+++ b/packages/l2b/src/implementations/discovery-ui/getCode.ts
@@ -45,15 +45,6 @@ export function getCode(
     address,
   )
 
-  const allFilesExist = codePaths.every(({ path }) => existsSync(path))
-
-  if (!allFilesExist) {
-    return {
-      entryName,
-      sources: [],
-    }
-  }
-
   return {
     entryName,
     sources: codePaths

--- a/packages/l2b/src/implementations/discovery-ui/getProject.ts
+++ b/packages/l2b/src/implementations/discovery-ui/getProject.ts
@@ -239,7 +239,6 @@ function contractFromDiscovery(
       address: toAddress(chain, address),
       entries: (abis[address] ?? []).map((e) => abiEntry(e)),
     })),
-    sources: [],
     implementationNames: contract.implementationNames,
   }
 }

--- a/packages/l2b/src/implementations/discovery-ui/types.ts
+++ b/packages/l2b/src/implementations/discovery-ui/types.ts
@@ -149,7 +149,6 @@ export interface ApiProjectContract extends ApiAddressEntry {
   proxyType?: string
   fields: Field[]
   abis: ApiAbi[]
-  sources: { name: string; code: string }[]
   implementationNames?: Record<string, string>
 }
 

--- a/packages/protocolbeat/src/api/types.ts
+++ b/packages/protocolbeat/src/api/types.ts
@@ -160,7 +160,6 @@ export interface ApiProjectContract extends ApiAddressEntry {
   proxyType?: string
   fields: Field[]
   abis: ApiAbi[]
-  sources: { name: string; code: string }[]
   implementationNames?: Record<string, string>
 }
 

--- a/packages/protocolbeat/src/common/findSelected.ts
+++ b/packages/protocolbeat/src/common/findSelected.ts
@@ -1,0 +1,39 @@
+import type { ApiProjectChain } from '../api/types'
+
+export function findSelected(
+  chains: ApiProjectChain[],
+  address: string | undefined,
+) {
+  if (!address) {
+    return
+  }
+  for (const chain of chains) {
+    for (const contract of chain.initialContracts) {
+      if (contract.address === address) {
+        return {
+          ...contract,
+          chain: chain.chain,
+          blockNumber: chain.blockNumber,
+        }
+      }
+    }
+    for (const contract of chain.discoveredContracts) {
+      if (contract.address === address) {
+        return {
+          ...contract,
+          chain: chain.chain,
+          blockNumber: chain.blockNumber,
+        }
+      }
+    }
+    for (const eoa of chain.eoas) {
+      if (eoa.address === address) {
+        return {
+          ...eoa,
+          chain: chain.chain,
+          blockNumber: chain.blockNumber,
+        }
+      }
+    }
+  }
+}

--- a/packages/protocolbeat/src/multi-view/PanelHeader.tsx
+++ b/packages/protocolbeat/src/multi-view/PanelHeader.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import { useParams } from 'react-router-dom'
 import { getCode, getProject } from '../api/api'
-import type { ApiProjectChain, ApiProjectContract } from '../api/types'
+import type { ApiProjectContract } from '../api/types'
 import { isReadOnly } from '../config'
 import { IconChatbot } from '../icons/IconChatbot'
 import { IconClose } from '../icons/IconClose'
@@ -9,6 +9,7 @@ import { IconFullscreen } from '../icons/IconFullscreen'
 import { IconFullscreenExit } from '../icons/IconFullscreenExit'
 import { usePanelStore } from '../store/store'
 import { PANEL_IDS, type PanelId, useMultiViewStore } from './store'
+import { findSelected } from '../common/findSelected'
 
 export function PanelHeader(props: { id: PanelId }) {
   const isFullScreen = useMultiViewStore(
@@ -134,29 +135,6 @@ const toClipboard = async (
       }
 
       navigator.clipboard.writeText([...fields, ...abis].join('\n'))
-    }
-  }
-}
-
-function findSelected(chains: ApiProjectChain[], address: string | undefined) {
-  if (!address) {
-    return
-  }
-  for (const chain of chains) {
-    for (const contract of chain.initialContracts) {
-      if (contract.address === address) {
-        return { contract, chain: chain }
-      }
-    }
-    for (const contract of chain.discoveredContracts) {
-      if (contract.address === address) {
-        return { contract, chain: chain }
-      }
-    }
-    for (const eoa of chain.eoas) {
-      if (eoa.address === address) {
-        return { contract: eoa, chain: chain }
-      }
     }
   }
 }

--- a/packages/protocolbeat/src/panel-code/CodePanel.tsx
+++ b/packages/protocolbeat/src/panel-code/CodePanel.tsx
@@ -3,12 +3,16 @@ import clsx from 'clsx'
 import { useEffect, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { getCode, getProject } from '../api/api'
+import type { ApiCodeResponse } from '../api/types'
 import { toShortenedAddress } from '../common/toShortenedAddress'
 import { IconCodeFile } from '../icons/IconCodeFile'
 import { useMultiViewStore } from '../multi-view/store'
 import { usePanelStore } from '../store/store'
 import { Editor } from './editor'
 import { type Range, useCodeStore } from './store'
+import { isReadOnly } from '../config'
+import { RediscoverPrompt } from './RediscoverPrompt'
+import { findSelected } from '../common/findSelected'
 
 export function CodePanel() {
   const { project } = useParams()
@@ -20,10 +24,21 @@ export function CodePanel() {
     queryFn: () => getProject(project),
   })
   const selectedAddress = usePanelStore((state) => state.selected)
+
+  const selected = projectResponse.data
+    ? findSelected(projectResponse.data.entries, selectedAddress)
+    : undefined
+
+  const hasCode: boolean =
+    selected !== undefined &&
+    'implementationNames' in selected &&
+    selected.implementationNames !== undefined
+
   const codeResponse = useQuery({
     queryKey: ['projects', project, 'code', selectedAddress],
-    enabled: selectedAddress !== undefined,
+    enabled: selectedAddress !== undefined && hasCode,
     queryFn: () => getCode(project, selectedAddress),
+    retry: 1,
   })
   const { getSourceIndex, setSourceIndex, range } = useCodeStore()
   useEffect(() => {
@@ -36,29 +51,48 @@ export function CodePanel() {
   }, [codeResponse.data])
   const sourceIndex = getSourceIndex(selectedAddress ?? 'Loading')
 
-  if (projectResponse.isError || codeResponse.isError) {
+  if (projectResponse.isPending || projectResponse.isError) {
     return <div>Error</div>
   }
 
+  if (selected === undefined) {
+    return <div>Select a contract</div>
+  }
+
+  let showRediscoverInfo = false
   const response = codeResponse.data?.sources ?? []
-  const sources =
-    response.length === 0
-      ? [
-          {
-            name: selectedAddress
-              ? toShortenedAddress(selectedAddress)
-              : 'Loading',
-            code: codeResponse.isPending
-              ? '// Loading'
-              : '// No code found - either the contract is not verified or the code is not available',
-          },
-        ]
-      : response
+  let sources: ApiCodeResponse['sources'] = []
+  if (!hasCode) {
+    sources = [
+      {
+        name: selectedAddress ? toShortenedAddress(selectedAddress) : 'Loading',
+        code: '// Entry has no code associated with it',
+      },
+    ]
+  } else if (codeResponse.isPending) {
+    sources = [
+      {
+        name: selectedAddress ? toShortenedAddress(selectedAddress) : 'Loading',
+        code: '// Loading',
+      },
+    ]
+  } else if (codeResponse.isError) {
+    showRediscoverInfo = !isReadOnly
+    sources = [
+      {
+        name: selectedAddress ? toShortenedAddress(selectedAddress) : 'Loading',
+        code: '// ERROR: Failed to find the code for this contract',
+      },
+    ]
+  } else {
+    sources = response
+  }
+
   const passedRange = codeResponse.isPending ? undefined : range
 
   return (
     <div className="flex h-full w-full select-none flex-col">
-      <div className="flex gap-1 overflow-x-auto border-b border-b-coffee-600 px-1 pt-1">
+      <div className="flex flex-shrink-0 flex-grow gap-1 overflow-x-auto border-b border-b-coffee-600 px-1 pt-1">
         {sources.map((x, i) => (
           <button
             key={i}
@@ -73,6 +107,7 @@ export function CodePanel() {
           </button>
         ))}
       </div>
+      {showRediscoverInfo && <RediscoverPrompt chain={selected.chain} />}
       <CodeView
         code={sources[sourceIndex ?? 0]?.code ?? '// No code'}
         range={passedRange}

--- a/packages/protocolbeat/src/panel-code/RediscoverPrompt.tsx
+++ b/packages/protocolbeat/src/panel-code/RediscoverPrompt.tsx
@@ -1,0 +1,45 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useTerminalStore } from '../panel-terminal/store'
+import { useParams } from 'react-router-dom'
+
+export interface RediscoverPromptProps {
+  chain: string
+}
+
+export function RediscoverPrompt({ chain }: RediscoverPromptProps) {
+  const { project } = useParams()
+  if (!project) {
+    throw new Error('Cannot use component outside of project page!')
+  }
+
+  const queryClient = useQueryClient()
+  const { command, discover, setChain, setDevMode } = useTerminalStore()
+
+  return (
+    <div className="flex h-1/3 flex-col items-center justify-center gap-4 border border-coffee-500 bg-coffee-900 px-8 py-6 text-center">
+      <div className="font-medium text-coffee-100 text-xl">
+        No source for this contract
+      </div>
+      <div className="text-coffee-300 text-sm">
+        Unable to find the flat file with source code.
+        <br />
+        Rediscovering should fix this issue.
+      </div>
+      <button
+        className="mt-2 rounded bg-autumn-300 px-6 py-2 font-medium text-black transition-colors hover:bg-autumn-300 disabled:opacity-50"
+        onClick={() => {
+          setChain(chain)
+          setDevMode(true)
+          discover(project).then(() => {
+            queryClient.invalidateQueries({
+              queryKey: ['projects', project],
+            })
+          })
+        }}
+        disabled={command.inFlight}
+      >
+        Rediscover contract
+      </button>
+    </div>
+  )
+}

--- a/packages/protocolbeat/src/panel-values/ValuesPanel.tsx
+++ b/packages/protocolbeat/src/panel-values/ValuesPanel.tsx
@@ -1,11 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 import { getProject } from '../api/api'
-import type {
-  ApiAddressEntry,
-  ApiProjectChain,
-  ApiProjectContract,
-} from '../api/types'
+import type { ApiAddressEntry, ApiProjectContract } from '../api/types'
 import { AddressIcon } from '../common/AddressIcon'
 import { isReadOnly } from '../config'
 import { usePanelStore } from '../store/store'
@@ -14,6 +10,7 @@ import { AddressDisplay } from './AddressDisplay'
 import { FieldDisplay } from './Field'
 import { Folder } from './Folder'
 import { TemplateDialog } from './template-dialog/TemplateDialog'
+import { findSelected } from '../common/findSelected'
 
 export function ValuesPanel() {
   const { project } = useParams()
@@ -47,41 +44,6 @@ export function ValuesPanel() {
       )}
     </div>
   )
-}
-
-function findSelected(chains: ApiProjectChain[], address: string | undefined) {
-  if (!address) {
-    return
-  }
-  for (const chain of chains) {
-    for (const contract of chain.initialContracts) {
-      if (contract.address === address) {
-        return {
-          ...contract,
-          chain: chain.chain,
-          blockNumber: chain.blockNumber,
-        }
-      }
-    }
-    for (const contract of chain.discoveredContracts) {
-      if (contract.address === address) {
-        return {
-          ...contract,
-          chain: chain.chain,
-          blockNumber: chain.blockNumber,
-        }
-      }
-    }
-    for (const eoa of chain.eoas) {
-      if (eoa.address === address) {
-        return {
-          ...eoa,
-          chain: chain.chain,
-          blockNumber: chain.blockNumber,
-        }
-      }
-    }
-  }
 }
 
 function Display({


### PR DESCRIPTION
Resolves L2B-10376

This also fixes additional things:

- in CodePanel tabs are set `grow-0` to fix the issue of tabs going _under_ the monaco editor
- remove `sources` field key from `ApiProjectContract` because it's always empty and not used
- do not make requests to the backend for sources for EOAs (EIP7702 should be handled fine)
- extract common logic of finding the selected contract