### PR TITLE
fixed 404 link in avail.ts

### DIFF
--- a/packages/config/src/projects/avail/avail.ts
+++ b/packages/config/src/projects/avail/avail.ts
@@ -85,7 +85,7 @@ App-specific data can be reconstructed by app clients, which request and assembl
       references: [
         {
           title: 'Avail Documentation',
-          url: 'https://docs.availproject.org/docs/learn-about-avail/consensus/npos',
+          url: 'https://docs.availproject.org/docs/glossary#nominated-proof-of-stake',
         },
         {
           title: 'Avail Light Client - Source Code',


### PR DESCRIPTION
`packages/config/src/projects/avail/avail.ts`

https://docs.availproject.org/docs/learn-about-avail/consensus/npos - old link
https://docs.availproject.org/docs/glossary#nominated-proof-of-stake - new link 