### PR TITLE
Fix broken Arbitrum security subsidy application link

### DIFF
--- a/packages/frontend/src/content/publications/governance-review-26.md
+++ b/packages/frontend/src/content/publications/governance-review-26.md
@@ -72,7 +72,7 @@ ImmutableLawyer [published a post on behalf of the ADPC](https://forum.arbitrum.
 * Guardian
 * Hacken
 
-For projects interested in security-service subsidies, please complete this expression of interest form: [Declaration of Interest—Subsidy Fund—NoteForms](https://noteforms.com/forms/declaration-of-interest-subsidy-fund-poiiqy).
+For projects interested in security-service subsidies, please complete this expression of interest form: [Declaration of Interest—Subsidy Fund—NoteForms](https://forum.arbitrum.foundation/t/apply-for-the-security-subsidy-fund/27040).
 
 
 ### **[ARDC] August Update**


### PR DESCRIPTION
Replaced the outdated NoteForms link for the Arbitrum security-service subsidy application with the current official forum application link, ensuring users can access the correct form.