### PR TITLE
remove ARDC event from governance page

### DIFF
--- a/packages/frontend/src/content/events/ardc-office-hours.json
+++ b/packages/frontend/src/content/events/ardc-office-hours.json
@@ -3,6 +3,7 @@
   "title": "Office Hours",
   "subtitle": "Arbitrum Research and Development Committee (ARDC)",
   "sinceDate": "2024-03-15",
+  "tillDate": "2024-12-30",
   "futureEventsCount": 3,
   "dayOfWeek": 1,
   "startDate": {

--- a/packages/frontend/src/content/events/polygon-starknet-office-hours.json
+++ b/packages/frontend/src/content/events/polygon-starknet-office-hours.json
@@ -3,6 +3,7 @@
   "title": "Office Hours",
   "subtitle": "Polygon, Starknet",
   "sinceDate": "2023-08-01",
+  "tillDate": "2025-01-02",
   "futureEventsCount": 3,
   "dayOfWeek": 5,
   "startDate": {


### PR DESCRIPTION
Remove ARDC event from governance page, and also remove the Polygo and Starknet office hours