### PR TITLE
Migrate from Routescan to Blockscan

### DIFF
--- a/packages/discovery/src/config/chains.ts
+++ b/packages/discovery/src/config/chains.ts
@@ -188,8 +188,8 @@ export const chains: ChainConfig[] = [
     shortName: 'mantle',
     multicall: getMulticall3Config(304717),
     explorer: {
-      type: 'routescan',
-      url: 'https://api.routescan.io/v2/network/mainnet/evm/5000/etherscan/api',
+      type: 'blockscout',
+      url: 'https://explorer.mantle.xyz/api',
     },
   },
   {


### PR DESCRIPTION
Part of L2B-10546

Routescan for Mantle has been deprecated.