### PR TITLE
chore: Fix typo in Degen project's diff history

### DIFF
--- a/packages/config/src/projects/degen/base/diffHistory.md
+++ b/packages/config/src/projects/degen/base/diffHistory.md
@@ -1968,7 +1968,7 @@ Generated with discovered.json: 0x4dc1e62f8d759083d693975e0570bbb5e477dc3a
 
 ## Description
 
-A new OFT adapter contract (for the DEGEN token) is added as allowed Outbox to the main bridge. This gives the OFT adapter the permission to make any calls as the bridge (including sending all tokens from the bridge). See the Sanko L3 on Arbitrum for a similar contruction. The LayerZero AMB now has access to the canonically escrowed funds and the bridge escrow serves doubly as a canonical escrow and OFT adapter lockbox.
+A new OFT adapter contract (for the DEGEN token) is added as allowed Outbox to the main bridge. This gives the OFT adapter the permission to make any calls as the bridge (including sending all tokens from the bridge). See the Sanko L3 on Arbitrum for a similar construction. The LayerZero AMB now has access to the canonically escrowed funds and the bridge escrow serves doubly as a canonical escrow and OFT adapter lockbox.
 
 ## Watched changes
 

--- a/packages/tools-api/src/modules/decoder-module/domain/plugins/whitebitBatchPlugin.ts
+++ b/packages/tools-api/src/modules/decoder-module/domain/plugins/whitebitBatchPlugin.ts
@@ -92,7 +92,7 @@ function decodeBatch(
               ? {
                   type: 'address',
                   value: `${chain.shortName}:${token}`,
-                  explorerLink: `${chain.explorerUrl}/adddress/${token}`,
+                  explorerLink: `${chain.explorerUrl}/address/${token}`,
                 }
               : {
                   type: 'string',
@@ -106,7 +106,7 @@ function decodeBatch(
             decoded: {
               type: 'address',
               value: `${chain.shortName}:${address}`,
-              explorerLink: `${chain.explorerUrl}/adddress/${address}`,
+              explorerLink: `${chain.explorerUrl}/address/${address}`,
             },
           },
           amountValue,


### PR DESCRIPTION
This PR corrects a minor typo in the `diffHistory.md` file for the Degen project.

- Corrected "contruction" to "construction".