### PR TITLE
Use max block number instead of min block number

### DIFF
--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -67,8 +67,8 @@ export class ProjectDiscovery {
 
   get blockNumber(): number {
     return this.discoveries.reduce(
-      (min, d) => Math.min(min, d.blockNumber),
-      Infinity,
+      (min, d) => Math.max(min, d.blockNumber),
+      0,
     )
   }
 


### PR DESCRIPTION
Resolves L2B-10585

The code has wrong assumptions, this reduce was used to turn multiple shared discoveries and their block numbers into a single block number that is going to represent when a change could've occurred.

This was the right decision but instead of choosing the smallest block number we should've chosen the biggest.

   shared       change
   v            v
-----------------------
          ^
          project

There are to possibilities where the change can occur:

 - shared, handling that change the smallest block number will now point to the project block number. Since the change is higher than the project block number we're not going to invalidate it.
 - project, handling that change the smallest block number will still point to the shared block number. Again, not invalidating the change.

We come out of the assumption that the researcher will never do the following:

 - shared has HSC, discover project and not touch shared
 - project has HSC, discover shared and not touch project