### PR TITLE
Fix typos and improve clarity in documentation and tests

### DIFF
--- a/docs/mdbook/specs/code_walkthroughs/scroll/sequencing.md
+++ b/docs/mdbook/specs/code_walkthroughs/scroll/sequencing.md
@@ -22,7 +22,7 @@ The block time is set at 3 seconds and maintained on a best-effort basis, not en
 
 ## Forced transactions
 
-Messages appended to the message queue (`L1MessageQueueV2`) are expected to be included into a bundle by the centralized operator. Messages in the queue cannot be skipped or dropped, but the sequencer can choose to finalize a bundle without processing any queued messaged. Should a permissioned sequencer not process any queued messages within the `SystemConfig.maxDelayMessageQueue`, anyone can include queue messages as commiting and finalizing bundles becomes permissionless.
+Messages appended to the message queue (`L1MessageQueueV2`) are expected to be included into a bundle by the centralized operator. Messages in the queue cannot be skipped or dropped, but the sequencer can choose to finalize a bundle without processing any queued messaged. Should a permissioned sequencer not process any queued messages within the `SystemConfig.maxDelayMessageQueue`, anyone can include queue messages as committing and finalizing bundles becomes permissionless.
 
 
 ### High-level flow

--- a/docs/mdbook/specs/l2b_specs/contracts.md
+++ b/docs/mdbook/specs/l2b_specs/contracts.md
@@ -16,7 +16,7 @@ The goal of the contracts section is to list all contracts in the system that ar
 
 ## Single contract view
 
-For each contract, the basic information to be shown is the name and the address. If a contract is a proxy, the implementation contract(s) should also be shown. Optionally, a category can be shown. If a contract has any field with a defined "interact" or "act" permission, the direct permission receiver should be shown. Note that these permisions might not be ultimate permissions. Optionally, if the design allows, the ultimate permission receiver can be shown too. Upgrade permissions should be presented more distinctly, with the ultimate permission receiver shown, and its associated ultimate delay.
+For each contract, the basic information to be shown is the name and the address. If a contract is a proxy, the implementation contract(s) should also be shown. Optionally, a category can be shown. If a contract has any field with a defined "interact" or "act" permission, the direct permission receiver should be shown. Note that these permissions might not be ultimate permissions. Optionally, if the design allows, the ultimate permission receiver can be shown too. Upgrade permissions should be presented more distinctly, with the ultimate permission receiver shown, and its associated ultimate delay.
 
 Let's pick some Arbitrum One's contracts to present an implementation proposal that only shows direct permissions for "interact" and "act" permissions:
 

--- a/packages/shared-pure/src/utils/formatAsciiBorder.test.ts
+++ b/packages/shared-pure/src/utils/formatAsciiBorder.test.ts
@@ -12,7 +12,7 @@ describe(formatAsciiBorder.name, () => {
     )
   })
 
-  it('should print a border where mutliple widths', () => {
+  it('should print a border where multiple widths', () => {
     const lines = ['line 1', 'line 23', 'line 345']
     const withBorder = formatAsciiBorder(lines)
     expect(withBorder).toEqual(


### PR DESCRIPTION


**Description:**  
- Corrected minor typos in documentation files (`contracts.md`, `sequencing.md`)
- Improved wording for better clarity and consistency
- Updated test description in `formatAsciiBorder.test.ts` for accuracy

