### PR TITLE
Catch-all express path for serving UI

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/main.ts
+++ b/packages/l2b/src/implementations/discovery-ui/main.ts
@@ -103,17 +103,6 @@ export function runDiscoveryUi({ readonly }: { readonly: boolean }) {
     res.json(response)
   })
 
-  app.get('/', (_req, res) => {
-    res.redirect('/ui')
-  })
-
-  app.get(
-    ['/ui', '/ui/*', '/diff', '/diff/*', '/address', '/address/*'],
-    (_req, res) => {
-      res.sendFile(join(STATIC_ROOT, 'index.html'))
-    },
-  )
-
   app.get('/api/projects/:project/code/:address', (req, res) => {
     const paramsValidation = projectAddressParamsSchema.safeParse(req.params)
     if (!paramsValidation.success) {
@@ -224,6 +213,10 @@ export function runDiscoveryUi({ readonly }: { readonly: boolean }) {
       )
     })
   }
+
+  app.get('*', (_req, res) => {
+    res.sendFile(join(STATIC_ROOT, 'index.html'))
+  })
 
   const server = app.listen(port, () => {
     console.log(`Discovery UI live on http://localhost:${port}/ui`)


### PR DESCRIPTION
Resolves L2B-10724 (I promise)
Tested locally, both regular and docker runtime.