### PR TITLE
Enable cross-chain for arbitrum, fix ProjectDiscovery

### DIFF
--- a/packages/config/src/discovery/ProjectDiscovery.ts
+++ b/packages/config/src/discovery/ProjectDiscovery.ts
@@ -47,6 +47,8 @@ const paths = getDiscoveryPaths()
 
 export class ProjectDiscovery {
   private readonly discoveries: DiscoveryOutput[]
+  private readonly dependentDiscoveries: DiscoveryOutput[]
+  private readonly projectAndDependentDiscoveries: DiscoveryOutput[]
   private eoaIDMap: Record<string, string> = {}
   private permissionRegistry: PermissionRegistry
 
@@ -61,12 +63,18 @@ export class ProjectDiscovery {
       ...(discovery.sharedModules ?? []).map((module) =>
         configReader.readDiscovery(module, chain),
       ),
+    ]
+    this.dependentDiscoveries = [
       ...Object.entries(discovery.dependentDiscoveries ?? {}).flatMap(
         ([projectName, chains]) =>
           Object.keys(chains).map((chain) =>
             configReader.readDiscovery(projectName, chain),
           ),
       ),
+    ]
+    this.projectAndDependentDiscoveries = [
+      ...this.discoveries,
+      ...this.dependentDiscoveries,
     ]
     this.permissionRegistry = new PermissionsFromDiscovery(this)
   }
@@ -573,31 +581,24 @@ export class ProjectDiscovery {
     }
   }
 
-  getAllContractAddresses(): EthereumAddress[] {
-    const contracts = this.getContracts()
-    const addressesWithinUpgradeability = contracts.flatMap((contract) =>
-      get$Implementations(contract.values),
-    )
-
-    return addressesWithinUpgradeability.filter((addr) => !this.isEOA(addr))
-  }
-
   getContractByAddress(address: EthereumAddress): EntryParameters | undefined {
-    const contracts = this.getContracts()
+    const contracts = this.getContracts({ includeDependentDiscoveries: true })
     return contracts.find((contract) => contract.address === address)
   }
 
   getContractByChainSpecificAddress(
     address: ChainSpecificAddress,
   ): EntryParameters | undefined {
-    const contracts = this.getPrefixedContracts()
+    const contracts = this.getPrefixedContracts({
+      includeDependentDiscoveries: true,
+    })
     return contracts[address]
   }
 
   getEOAByAddress(
     address: string | EthereumAddress,
   ): EntryParameters | undefined {
-    const eoas = this.discoveries
+    const eoas = this.projectAndDependentDiscoveries
       .flatMap((discovery) => discovery.entries)
       .filter((e) => e.type === 'EOA')
     return eoas.find(
@@ -609,11 +610,12 @@ export class ProjectDiscovery {
     chainSpecificAddress: ChainSpecificAddress,
   ): EntryParameters | undefined {
     const [chain, address] = chainSpecificAddress.toString().split(':')
-    const entries = this.discoveries
+    const entries = this.projectAndDependentDiscoveries
       .filter((discovery) => discovery.chain === chain)
       .flatMap((discovery) => discovery.entries)
     return entries.find((entry) => entry.address === address)
   }
+
   getEntryByAddress(address: EthereumAddress): EntryParameters | undefined {
     const entries = this.discoveries.flatMap((discovery) => discovery.entries)
     return entries.find(
@@ -622,14 +624,14 @@ export class ProjectDiscovery {
   }
 
   private getContractByName(name: string): EntryParameters[] {
-    const contracts = this.discoveries.flatMap((discovery) =>
+    const contracts = this.projectAndDependentDiscoveries.flatMap((discovery) =>
       discovery.entries.filter((e) => e.type === 'Contract'),
     )
     return contracts.filter((contract) => contract.name === name)
   }
 
   private getEOAByName(name: string): EntryParameters[] {
-    const eoas = this.discoveries
+    const eoas = this.projectAndDependentDiscoveries
       .flatMap((discovery) => discovery.entries)
       .filter((e) => e.type === 'EOA')
 
@@ -640,9 +642,14 @@ export class ProjectDiscovery {
     return this.discoveries.flatMap((discovery) => discovery.entries)
   }
 
-  getPrefixedContracts(): { [chainSpecificAddress: string]: EntryParameters } {
+  getPrefixedContracts(options?: { includeDependentDiscoveries?: boolean }): {
+    [chainSpecificAddress: string]: EntryParameters
+  } {
     const result: { [chainSpecificAddress: string]: EntryParameters } = {}
-    this.discoveries.forEach((discovery) => {
+    const discoveries = options?.includeDependentDiscoveries
+      ? this.projectAndDependentDiscoveries
+      : this.discoveries
+    discoveries.forEach((discovery) => {
       discovery.entries.forEach((e) => {
         if (e.type === 'Contract') {
           const chainSpecificAddress = ChainSpecificAddress(
@@ -660,14 +667,24 @@ export class ProjectDiscovery {
     return result
   }
 
-  getContracts(): EntryParameters[] {
-    return this.discoveries
+  getContracts(options?: {
+    includeDependentDiscoveries?: boolean
+  }): EntryParameters[] {
+    const discoveries = options?.includeDependentDiscoveries
+      ? this.projectAndDependentDiscoveries
+      : this.discoveries
+    return discoveries
       .flatMap((discovery) => discovery.entries)
       .filter((e) => e.type === 'Contract')
   }
 
-  getEoas(): EntryParameters[] {
-    return this.discoveries
+  getEoas(options?: {
+    includeDependentDiscoveries?: boolean
+  }): EntryParameters[] {
+    const discoveries = options?.includeDependentDiscoveries
+      ? this.projectAndDependentDiscoveries
+      : this.discoveries
+    return discoveries
       .flatMap((discovery) => discovery.entries)
       .filter((e) => e.type === 'EOA')
   }

--- a/packages/config/src/projects/arbitrum/arbitrum/diffHistory.md
+++ b/packages/config/src/projects/arbitrum/arbitrum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x2aa467ebf1e2ea7c7778f71b5fdb9b753fb6a4e9
+Generated with discovered.json: 0xc692917dd7ed14bfabfb49bbb9c134bc60529a32
 
 # Diff at Tue, 27 May 2025 08:31:02 GMT:
 

--- a/packages/config/src/projects/arbitrum/arbitrum/discovered.json
+++ b/packages/config/src/projects/arbitrum/arbitrum/discovered.json
@@ -2972,5 +2972,8 @@
     "orbitstack/layer2/TreasuryTimelock": "0x980b51e8fac48051f563d3246b01c151b043c4bd3e252b27a5f4a301a0a3fad3",
     "orbitstack/layer2/UpgradeExecRouteBuilder": "0xf345ec40fe1222ef7f4a526c7eb6312670077f7d9b24d7f9f82c517103b02639"
   },
-  "permissionsConfigHash": "0x05265449bcc3f5ce73501b4299c69ba90e3648cf6d6a467c294b0ecf9925101f"
+  "permissionsConfigHash": "0x05265449bcc3f5ce73501b4299c69ba90e3648cf6d6a467c294b0ecf9925101f",
+  "dependentDiscoveries": {
+    "arbitrum": { "ethereum": { "blockNumber": 22730549 } }
+  }
 }

--- a/packages/config/src/projects/arbitrum/config.jsonc
+++ b/packages/config/src/projects/arbitrum/config.jsonc
@@ -2,6 +2,7 @@
   "$schema": "../../../../discovery/schemas/config.v2.schema.json",
   "name": "arbitrum",
   "import": ["../globalConfig.jsonc"],
+  "modelCrossChainPermissions": true,
   "chains": {
     "arbitrum": {
       "initialAddresses": [

--- a/packages/config/src/projects/arbitrum/ethereum/diffHistory.md
+++ b/packages/config/src/projects/arbitrum/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x82b394cb06ec2300d0a4a18347c88dd73233700c
+Generated with discovered.json: 0xe9aa951eca6c639966105a468ccd1aae733105ca
 
 # Diff at Wed, 18 Jun 2025 09:51:53 GMT:
 

--- a/packages/config/src/projects/arbitrum/ethereum/discovered.json
+++ b/packages/config/src/projects/arbitrum/ethereum/discovered.json
@@ -5227,5 +5227,8 @@
     "orbitstack/Timelock": "0x04f942abdcad9d7b2cb8d4a7d7ae99eb81b76e7872285ce0148c8cf27034a39c",
     "orbitstack/UpgradeExecutor": "0xf65e73e609a464b657011e80920c1852ae19b0e3d493e4678f74b99052ee87fe"
   },
-  "permissionsConfigHash": "0x05265449bcc3f5ce73501b4299c69ba90e3648cf6d6a467c294b0ecf9925101f"
+  "permissionsConfigHash": "0x05265449bcc3f5ce73501b4299c69ba90e3648cf6d6a467c294b0ecf9925101f",
+  "dependentDiscoveries": {
+    "arbitrum": { "arbitrum": { "blockNumber": 348602301 } }
+  }
 }


### PR DESCRIPTION
Enables "modelCrossChainPermissions" flag for arbitrum (even though it doesn't have any cross-chain permissions set up yet), to make sure discovery and ui works in this mode.

Fixes issue in ProjectDiscovery which needs to load all dependent discoveries, but shouldn't return those dependent contracts in e.g. "getContracts()". 