### PR TITLE
Remove unused flag in modelPermissions

### DIFF
--- a/packages/l2b/src/implementations/discovery/updateDiffHistory.ts
+++ b/packages/l2b/src/implementations/discovery/updateDiffHistory.ts
@@ -220,6 +220,9 @@ async function performDiscoveryOnPreviousBlockButWithCurrentConfigs(
       blockNumber = discoveryFromMainBranch.blockNumber
     }
     if (blockNumber === undefined) {
+      // We rediscover on the past block number, but with current configs and dependencies.
+      // Those dependencies might not have been referenced in the old discovery.
+      // In that case we don't fail - the diff will show all those "added".
       console.log(
         `No block number found for dependency ${dependency.project} on ${dependency.chain}, skipping its rediscovery.`,
       )
@@ -245,10 +248,6 @@ async function performDiscoveryOnPreviousBlockButWithCurrentConfigs(
     discoveryPaths,
     {
       debug: false,
-      // We rediscover on the past block number, but with current configs and dependencies.
-      // Those dependencies might not have been referenced in the old discovery.
-      // In that case we don't fail - the diff will show all those "added".
-      ignoreMissingDependencies: true,
     },
   )
 


### PR DESCRIPTION
The flag `ignoreMissingDependencies` passed to `modelPermissions()` is an unnecessary left-over from the time when modelPermissions checked if passed arguments matched requirements for a given project.

In the current, more simple and generic approach, `modelPermissions()` is unaware of what project it's modelling. It simply takes discoveries and models permissions between them. 

This PR removes this unnecessary flag.