### PR TITLE
 Update Delegate Link in Governance Review

### DIFF
--- a/packages/frontend/src/content/publications/governance-review-26.md
+++ b/packages/frontend/src/content/publications/governance-review-26.md
@@ -383,7 +383,7 @@ The Constitution provides comprehensive information on voting, the Security Coun
 
 ### **Delegate to L2BEAT**
 
-If you’re holding $LSK and want to delegate your voting power, you must stake it to receive $vLSK. You can stake your tokens on the [Lisk Portal](https://portal.lisk.com/), and then you can delegate the $vLSK you’ll receive [on Tally](https://www.tally.xyz/gov/lisk/delegate/l2beatcom.eth).
+If you’re holding $LSK and want to delegate your voting power, you must stake it to receive $vLSK. You can stake your tokens on the [Lisk Portal](https://portal.lisk.com/), and then you can delegate the $vLSK you’ll receive [on Tally](https://www.tally.xyz/gov/lisk/delegate/0x1b686ee8e31c5959d9f5bbd8122a58682788eead).
 
 **Discuss with L2BEAT**
 


### PR DESCRIPTION

## Changes Made
File: `packages/frontend/src/content/publications/governance-review-26.md`

- Old (broken) link: `https://www.tally.xyz/gov/lisk/delegate/l2beatcom.eth` (404 error)
- New (working) link: `https://www.tally.xyz/gov/lisk/delegate/0x1b686ee8e31c595b09f5bbd8122a586827B8eead`

## Reason for Change
The old ENS-based delegation link was returning a 404 error. Updated to use direct Ethereum address to fix the broken link and ensure users can access the delegation page correctly.

## Impact
Users can now successfully access the delegation page to stake their $vLSK tokens.