### PR TITLE
Add OptimismPortal2 support to compare-op-stacks

### DIFF
--- a/packages/l2b/src/implementations/compareOpStacks.ts
+++ b/packages/l2b/src/implementations/compareOpStacks.ts
@@ -29,7 +29,7 @@ export async function analyseAllOpStackChains(
       (obj) => obj.name === 'L2OutputOracle',
     )
     const optimismPortal = discovery.entries.find(
-      (obj) => obj.name === 'OptimismPortal',
+      (obj) => obj.name === 'OptimismPortal' || obj.name === 'OptimismPortal2',
     )
     const l1StandardBridge = discovery.entries.find(
       (obj) => obj.name === 'L1StandardBridge',


### PR DESCRIPTION
This pull request includes a minor update to the `analyseAllOpStackChains` function in the `compareOpStacks.ts` file. The change expands the logic for identifying the `OptimismPortal` entry to include an additional name, `OptimismPortal2`.

* [`packages/l2b/src/implementations/compareOpStacks.ts`](diffhunk://#diff-2aca8adcae614d91bc94ae0e30d8c176123788bf6119fa96fda98723623aedceL32-R32): Updated the `analyseAllOpStackChains` function to recognize both `OptimismPortal` and `OptimismPortal2` as valid entries.