### PR TITLE
Add katana chain config

### DIFF
--- a/packages/discovery/src/config/chains.ts
+++ b/packages/discovery/src/config/chains.ts
@@ -308,4 +308,14 @@ export const chains: ChainConfig[] = [
       chainId: 48900,
     },
   },
+  {
+    name: 'katana',
+    chainId: 747474,
+    shortName: 'katana',
+    multicall: undefined,
+    explorer: {
+      type: 'blockscout',
+      url: 'https://explorer.katanarpc.com/api',
+    },
+  },
 ] as const satisfies ChainConfig[]


### PR DESCRIPTION
This pull request adds support for a new blockchain network, "katana," to the `chains` configuration file.

### Blockchain network addition:

* [`packages/discovery/src/config/chains.ts`](diffhunk://#diff-95722e96f8c024cc9e7834f3a6b765d1ccc7abe21bbbe64eb28782ba6e65c6e5R311-R320): Added the "katana" blockchain network to the `chains` array, including its name, `chainId`, `shortName`, and explorer configuration.