### PR TITLE
chore(honeypot): archive honeypot v1

### DIFF
--- a/packages/config/src/projects/honeypot/honeypot.ts
+++ b/packages/config/src/projects/honeypot/honeypot.ts
@@ -21,6 +21,7 @@ import { getDiscoveryInfo } from '../../templates/getDiscoveryInfo'
 const discovery = new ProjectDiscovery('honeypot')
 
 export const honeypot: ScalingProject = {
+  archivedAt: UnixTime(1751987762), // 2025-07-08T15:16:02Z
   type: 'layer2',
   id: ProjectId('honeypot'),
   capability: 'appchain',
@@ -241,6 +242,13 @@ export const honeypot: ScalingProject = {
       url: 'https://x.com/cartesiproject/status/1706685141421047982',
       date: '2023-09-26T00:00:00Z',
       description: 'Honeypot launched on mainnet.',
+      type: 'general',
+    },
+    {
+      title: 'Honeypot archived',
+      url: 'https://x.com/cartesiproject/status/1940757477844455765',
+      date: '2025-07-08T00:00:00Z',
+      description: 'Honeypot funds withdrawn, and validator turned off.',
       type: 'general',
     },
   ],


### PR DESCRIPTION
With PRT Honeypot running on Ethereum mainnet to test the fraud-proof system, the old Honeypot journey has come to an end. The funds have been withdrawn, and the validator has been turned off.

This PR archives Honeypot V1.