### PR TITLE
Fix percent format

### DIFF
--- a/packages/frontend/src/components/breakdown/TokenBreakdown.tsx
+++ b/packages/frontend/src/components/breakdown/TokenBreakdown.tsx
@@ -1,5 +1,6 @@
 import type { WarningWithSentiment } from '@l2beat/config'
 import { RoundedWarningIcon } from '~/icons/RoundedWarning'
+import { formatPercent } from '~/utils/calculatePercentageChange'
 import { cn } from '~/utils/cn'
 import { languageJoin } from '~/utils/languageJoin'
 import { Square } from '../Square'
@@ -88,7 +89,7 @@ export function TokenBreakdownTooltipContent({
                     </span>
                   </span>
                   <span className="font-medium text-label-value-15">
-                    {((v.value / total) * 100).toFixed(2)}%
+                    {formatPercent(v.value / total)}
                   </span>
                 </div>
               ),

--- a/packages/frontend/src/components/breakdown/ValueSecuredBreakdown.tsx
+++ b/packages/frontend/src/components/breakdown/ValueSecuredBreakdown.tsx
@@ -1,5 +1,6 @@
 import type { WarningWithSentiment } from '@l2beat/config'
 import { RoundedWarningIcon } from '~/icons/RoundedWarning'
+import { formatPercent } from '~/utils/calculatePercentageChange'
 import { cn } from '~/utils/cn'
 import { WarningBar, sentimentToWarningBarColor } from '../WarningBar'
 import { Breakdown } from './Breakdown'
@@ -84,7 +85,7 @@ export function ValueSecuredBreakdownTooltipContent({
                   <span>{v.title}</span>
                 </span>
                 <span className="font-medium">
-                  {((v.value / total) * 100).toFixed(2)}%
+                  {formatPercent(v.value / total)}
                 </span>
               </div>
             ),

--- a/packages/frontend/src/utils/calculatePercentageChange.test.ts
+++ b/packages/frontend/src/utils/calculatePercentageChange.test.ts
@@ -36,6 +36,17 @@ describe('formatPercent', () => {
     expect(formatPercent(1)).toEqual('100%')
   })
 
+  it('formats close values correctly', () => {
+    const values = [
+      { value: 0.9999943793529054, expected: '99.9%' },
+      { value: 0.0999943793529054, expected: '9.99%' },
+    ]
+
+    for (const { value, expected } of values) {
+      expect(formatPercent(value)).toEqual(expected)
+    }
+  })
+
   it('formats values greater than or equal to 10 with one decimal place', () => {
     expect(formatPercent(0.15)).toEqual('15.0%')
   })

--- a/packages/frontend/src/utils/calculatePercentageChange.ts
+++ b/packages/frontend/src/utils/calculatePercentageChange.ts
@@ -26,5 +26,7 @@ export function formatPercent(value: number) {
 }
 
 function fixedPercent(value: number, digits: number) {
-  return value.toFixed(digits).slice(0, 4)
+  return (Math.floor(value * 10 ** digits) / 10 ** digits)
+    .toFixed(digits)
+    .slice(0, 4)
 }


### PR DESCRIPTION
Before (value = 0.9999943793529054:)
<img width="588" height="335" alt="PixelSnap 2025-07-11 at 15 17 29" src="https://github.com/user-attachments/assets/98b11f77-8547-4165-9aae-7102ffe38ebb" />
After (value = 0.9999943793529054)
<img width="544" height="302" alt="PixelSnap 2025-07-11 at 15 17 34" src="https://github.com/user-attachments/assets/d22cb6ae-ec73-4ae9-b84b-96c3efeed8d3" />
