### PR TITLE
Require correct category for associated tokens 

### DIFF
--- a/packages/config/src/processing/getProjects.test.ts
+++ b/packages/config/src/processing/getProjects.test.ts
@@ -596,4 +596,18 @@ describe('getProjects', () => {
       })
     }
   })
+
+  describe('associated tokens can only have category other', () => {
+    for (const project of projects) {
+      if (!project.tvsConfig) {
+        continue
+      }
+      const associated = project.tvsConfig?.filter((t) => t.isAssociated)
+      for (const a of associated) {
+        it(`${project.name}: ${a.id}`, () => {
+          expect(a.category).toEqual('other')
+        })
+      }
+    }
+  })
 })

--- a/packages/config/src/projects/fraxferry/fraxferry.ts
+++ b/packages/config/src/projects/fraxferry/fraxferry.ts
@@ -36,15 +36,7 @@ export const fraxferry: Bridge = {
     category: 'Liquidity Network',
   },
   config: {
-    associatedTokens: [
-      'FRAX.legacy',
-      'FRAX',
-      'frxETH',
-      'sfrxETH',
-      'FPI',
-      'FPIS',
-      'sFRAX.legacy',
-    ],
+    associatedTokens: ['FRAX', 'FPIS'],
     escrows: [
       {
         address: EthereumAddress('0x85c5f05Ae4CB68190C695a22b292C3bA90696128'),

--- a/packages/config/src/tvs/json/fraxferry.json
+++ b/packages/config/src/tvs/json/fraxferry.json
@@ -73,7 +73,7 @@
       },
       "category": "other",
       "source": "canonical",
-      "isAssociated": true
+      "isAssociated": false
     },
     {
       "mode": "auto",
@@ -380,7 +380,7 @@
       },
       "category": "stablecoin",
       "source": "canonical",
-      "isAssociated": true
+      "isAssociated": false
     },
     {
       "mode": "auto",
@@ -469,7 +469,7 @@
       },
       "category": "ether",
       "source": "canonical",
-      "isAssociated": true
+      "isAssociated": false
     },
     {
       "mode": "auto",
@@ -534,7 +534,7 @@
       },
       "category": "other",
       "source": "canonical",
-      "isAssociated": true
+      "isAssociated": false
     },
     {
       "mode": "auto",
@@ -631,7 +631,7 @@
       },
       "category": "ether",
       "source": "canonical",
-      "isAssociated": true
+      "isAssociated": false
     }
   ]
 }


### PR DESCRIPTION
Resolves L2B-10809

<img width="796" height="479" alt="image" src="https://github.com/user-attachments/assets/bdd85aad-7571-4a2c-b83f-0c8731a17f58" />

There was an issue with Frax Ferry token breakdown calculation. After investigation it turned out we had wrong configuration for associated tokens. Config has been fixed.

Test has been added to ensure **associated tokens can only have category "other"**