### PR TITLE
ix typos in diffHistory.md files

### DIFF
--- a/packages/config/src/projects/optopia/ethereum/diffHistory.md
+++ b/packages/config/src/projects/optopia/ethereum/diffHistory.md
@@ -244,7 +244,7 @@ Generated with discovered.json: 0x94a5d2cd04288907be23c4060534370420d05aee
 
 ## Description
 
-For some reason the ERC20Factory has a EOA as the implementation contract. Ignored as it shows as implementation unverified on frontend and it's unusuable anyway.
+For some reason the ERC20Factory has a EOA as the implementation contract. Ignored as it shows as implementation unverified on frontend and it's unusable anyway.
 
 ## Config/verification related changes
 

--- a/packages/config/src/projects/reya/ethereum/diffHistory.md
+++ b/packages/config/src/projects/reya/ethereum/diffHistory.md
@@ -1327,7 +1327,7 @@ Generated with discovered.json: 0x6c2987f2fd2f0d30409924f65b1807ff9fddb32b
 
 ## Description
 
-Reya socket vault admin transfered to a new EOA (previous was socketadmin.eth, current one is funded by it).
+Reya socket vault admin transferred to a new EOA (previous was socketadmin.eth, current one is funded by it).
 
 ## Watched changes
 


### PR DESCRIPTION


### Description

This PR fixes minor typos in the diffHistory.md files for two projects:

** Optopia/Ethereum**
- Fixed typo in ERC20Factory description: `unusable` → `unusable` (corrected spelling)

** Reya/Ethereum** 
- Fixed typo in socket vault admin description: `transfered` → `transferred` (corrected spelling)

### Changes
-  `packages/config/src/projects/optopia/ethereum/diffHistory.md`
-  `packages/config/src/projects/reya/ethereum/diffHistory.md`


---

