### PR TITLE
Fix Typos in Documentation and Source Code

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -31,7 +31,7 @@ online.
 Alternatively you can simply run `./scripts/start_db.sh` which will always do what's needed.
 
 To update database schema to the latest version run `pnpm dev:migrate`. That way you will have the
-lastest schema in your local database.
+latest schema in your local database.
 
 ### Third party services
 

--- a/packages/config/src/projects/synapse/ethereum/diffHistory.md
+++ b/packages/config/src/projects/synapse/ethereum/diffHistory.md
@@ -537,7 +537,7 @@ discovery. Values are for block 21387773 (main branch discovery), not current.
     contract SynapseBridge (0x2796317b0fF8538F253012862c06787Adfb8cEb6) {
     +++ description: None
       fieldMeta:
-+        {"accessControl":{"severity":"MEDIUM","description":"Roles: GOVERNANCE_ROLE can set fees, pause and unpause; NODEGROUP_ROLE can call bridging funtions; ADMIN_ROLE can setWethAddress()","type":"PERMISSION"}}
++        {"accessControl":{"severity":"MEDIUM","description":"Roles: GOVERNANCE_ROLE can set fees, pause and unpause; NODEGROUP_ROLE can call bridging functions; ADMIN_ROLE can setWethAddress()","type":"PERMISSION"}}
     }
 ```
 
@@ -1093,7 +1093,7 @@ Generated with discovered.json: 0x318ed27da4a4ee3c26b9a1b4767fea204abb68fe
 ## Description
 
 New EOA is given the GOVERNANCE_ROLE in the bridge contract.
-Roles: GOVERNANCE_ROLE can set fees, pause and unpause; NODEGROUP_ROLE can call bridging funtions; ADMIN_ROLE can setWethAddress()
+Roles: GOVERNANCE_ROLE can set fees, pause and unpause; NODEGROUP_ROLE can call bridging functions; ADMIN_ROLE can setWethAddress()
 
 ## Watched changes
 

--- a/packages/discovery/src/flatten/format.ts
+++ b/packages/discovery/src/flatten/format.ts
@@ -195,7 +195,7 @@ function AssemblyIf(node: AST.AssemblyIf, out: OutputStream) {
   // parser and now the hashes in the shapes expect that the output will
   // contain this bug artifact.
   // This can be removed once we have a script that goes over all the shapes
-  // and updates their hash with the new flattener verison.
+  // and updates their hash with the new flattener version.
   //
   // @ts-ignore: This can be Identifier, the types are wrong
   if (node.condition.type === 'Identifier') {


### PR DESCRIPTION


**Description:**  
This pull request corrects several typographical errors across documentation and source files:
- Fixed "lastest" → "latest" in backend README.
- Fixed "funtions" → "functions" in SynapseBridge descriptions.
- Fixed "verison" → "version" in flattener script comments.
