### PR TITLE
fix: Correct typo in canvasconnect diffHistory

### DIFF
--- a/packages/config/src/projects/canvasconnect/ethereum/diffHistory.md
+++ b/packages/config/src/projects/canvasconnect/ethereum/diffHistory.md
@@ -481,7 +481,7 @@ discovery. Values are for block 19825363 (main branch discovery), not current.
     contract StarkExchange (0x7A7f9c8fe871cd50f6Ce935d7c7caD2e89987f9d) {
     +++ description: Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.
       issuedPermissions:
--        [{"permission":"governStarknet","to":"0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A","via":[]},{"permission":"interact","to":"0x3e10FD04BfCE4dBF496d72F39172347Bf887ac1D","description":"Can regsiter new tokens for deposits and withdrawals.","via":[]},{"permission":"interact","to":"0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A","description":"manage the token admin role.","via":[]},{"permission":"operateStarkEx","to":"0x107691bD4F590270B9793c807cB912DD278e8cB5","via":[]},{"permission":"operateStarkEx","to":"0x5751a83170BeA11fE7CdA5D599B04153C021f21A","via":[]},{"permission":"upgrade","to":"0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A","via":[]}]
+-        [{"permission":"governStarknet","to":"0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A","via":[]},{"permission":"interact","to":"0x3e10FD04BfCE4dBF496d72F39172347Bf887ac1D","description":"Can register new tokens for deposits and withdrawals.","via":[]},{"permission":"interact","to":"0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A","description":"manage the token admin role.","via":[]},{"permission":"operateStarkEx","to":"0x107691bD4F590270B9793c807cB912DD278e8cB5","via":[]},{"permission":"operateStarkEx","to":"0x5751a83170BeA11fE7CdA5D599B04153C021f21A","via":[]},{"permission":"upgrade","to":"0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A","via":[]}]
     }
 ```
 
@@ -661,7 +661,7 @@ discovery. Values are for block 19825363 (main branch discovery), not current.
       issuedPermissions.2:
 +        {"permission":"interact","to":"0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A","description":"manage the token admin role.","via":[]}
       issuedPermissions.1:
-+        {"permission":"interact","to":"0x3e10FD04BfCE4dBF496d72F39172347Bf887ac1D","description":"Can regsiter new tokens for deposits and withdrawals.","via":[]}
++        {"permission":"interact","to":"0x3e10FD04BfCE4dBF496d72F39172347Bf887ac1D","description":"Can register new tokens for deposits and withdrawals.","via":[]}
       issuedPermissions.0.permission:
 -        "upgrade"
 +        "governStarknet"

--- a/packages/config/src/projects/deversifi/ethereum/diffHistory.md
+++ b/packages/config/src/projects/deversifi/ethereum/diffHistory.md
@@ -952,7 +952,7 @@ Generated with discovered.json: 0xbe7aa9d6888202e6db6653cea361e9478929504c
 
 ### Update on 10 Mar 2025:
 
-Rhino.fi upgrades their core contract to a simple withdraw contract that [transfered all funds to a multisig](https://etherscan.io/tx/0x9c1692398b107161c7af2c1c02316d449bdf03b15e84b69170373b2864dba754) (labeled Rhino.fi treasury on etherscan). The current app.rhino.fi frontend points to new onchain escrows which act as simple EOA bridge escrows.
+Rhino.fi upgrades their core contract to a simple withdraw contract that [transferred all funds to a multisig](https://etherscan.io/tx/0x9c1692398b107161c7af2c1c02316d449bdf03b15e84b69170373b2864dba754) (labeled Rhino.fi treasury on etherscan). The current app.rhino.fi frontend points to new onchain escrows which act as simple EOA bridge escrows.
 
 On telegram their team promises a withdraw-only function to be deployed later today. We will keep the projects page up until we can link there.
 

--- a/packages/config/src/projects/kroma/ethereum/diffHistory.md
+++ b/packages/config/src/projects/kroma/ethereum/diffHistory.md
@@ -6080,7 +6080,7 @@ Previously, validators could only withdraw funds to themselves. Now, with the wi
 
 ### 2. Change in block header hash function for Colosseum
 
-With the Shanghai upgrade on the Kroma mainnet, a withdrawalsRoot field has been added to the block header. Accordingly, the hash function for obtaining the block header in Colosseum has been modified. Implemenatation contract address: `0x311b4A33b6dC4e080eE0d98caAaf8dF86C833066`
+With the Shanghai upgrade on the Kroma mainnet, a withdrawalsRoot field has been added to the block header. Accordingly, the hash function for obtaining the block header in Colosseum has been modified. Implementation contract address: `0x311b4A33b6dC4e080eE0d98caAaf8dF86C833066`
 
 ### Current Context
 


### PR DESCRIPTION
##  Fix

- **Typo correction** - Fixed "regsiters" → "register"
- **Typo correction** - Fixed "transfered" → "transferred" 
- **Typo correction** - Fixed "Implemenatation" → "Implementation"

