### PR TITLE
fix: broken Moonchain URL (add www subdomain)

### DIFF
--- a/packages/config/src/projects/moonchain/moonchain.ts
+++ b/packages/config/src/projects/moonchain/moonchain.ts
@@ -17,7 +17,7 @@ export const moonchain: ScalingProject = underReviewL3({
     purposes: ['Universal'],
     category: 'Optimistic Rollup',
     links: {
-      websites: ['https://moonchain.com'],
+      websites: ['https://www.moonchain.com'],
       bridges: [
         'https://bridge.moonchain.com/',
         'https://mns.moonchain.com/',


### PR DESCRIPTION
Just a small fix — the https://moonchain.com/ link doesn’t load, but https://www.moonchain.com/ works fine.