### PR TITLE
Update broken orbiter links

### DIFF
--- a/packages/config/src/projects/orbiter/orbiter.ts
+++ b/packages/config/src/projects/orbiter/orbiter.ts
@@ -89,11 +89,11 @@ export const orbiter: Bridge = {
       references: [
         {
           title: 'Documentation - Maker System',
-          url: 'https://docs.orbiter.finance/makersystem',
+          url: 'https://docs.orbiter.finance/welcome/maker-system',
         },
         {
           title: 'Documentation - Technology',
-          url: 'https://docs.orbiter.finance/technology',
+          url: 'https://docs.orbiter.finance/welcome/bridge-protocol',
         },
       ],
       risks: [],
@@ -105,7 +105,7 @@ export const orbiter: Bridge = {
       references: [
         {
           title: 'Documentation - Maker System',
-          url: 'https://docs.orbiter.finance/makersystem',
+          url: 'https://docs.orbiter.finance/welcome/maker-system',
         },
       ],
       risks: [


### PR DESCRIPTION
Hey devs!

`https://docs.orbiter.finance/makersystem` - `https://docs.orbiter.finance/welcome/maker-system` --x2
`https://docs.orbiter.finance/technology` - `https://docs.orbiter.finance/welcome/bridge-protocol`