### PR TITLE
Archive Hyphen

### DIFF
--- a/packages/config/src/projects/hyphen/hyphen.ts
+++ b/packages/config/src/projects/hyphen/hyphen.ts
@@ -14,6 +14,8 @@ export const hyphen: Bridge = {
   display: {
     name: 'Hyphen',
     slug: 'hyphen',
+    warning:
+      'Hyphen has been decommissioned as of December 31, 2024. See the announcement [here](https://hyphen.biconomy.io).',
     category: 'Liquidity Network',
     links: {
       websites: ['https://hyphen.biconomy.io/'],


### PR DESCRIPTION
Hyphen has been decommissioned as of December 31, 2024.


<img width="1528" height="99" alt="image" src="https://github.com/user-attachments/assets/57e089d0-7219-4c97-8a09-c65f21e19b0a" />
