### PR TITLE
Allow adding Clingo model for specific project

### DIFF
--- a/packages/config/src/projects/.gitignore
+++ b/packages/config/src/projects/.gitignore
@@ -2,6 +2,7 @@
 .code@*
 .flat
 .flat@*
-**/*.lp
-!_templates/**/*.lp
-!_clingo/**/*.lp
+
+# Clingo debug files
+**/clingo.input.lp
+**/clingo.output.lp

--- a/packages/config/src/projects/optimism/ethereum/diffHistory.md
+++ b/packages/config/src/projects/optimism/ethereum/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0xe42a65ea4e402017d72e9491ccc0a93e7f985b9a
+Generated with discovered.json: 0xfe912c1d8f5490d961db6c84c8f3ad22ae3f84fe
 
 # Diff at Mon, 14 Jul 2025 12:47:06 GMT:
 

--- a/packages/config/src/projects/optimism/ethereum/discovered.json
+++ b/packages/config/src/projects/optimism/ethereum/discovered.json
@@ -3100,5 +3100,5 @@
     "opstack/SuperchainConfig": "0xeb14939081b4e8063f0b74396af70ab91d44b37fbac0e77fa06c8f48eed71b6c",
     "opstack/SystemConfig": "0x499f136cde0c11e214b4e9ef6ee1149701d33e15d10cb3284d703257956f96d3"
   },
-  "permissionsConfigHash": "0x9baefa04b737b0ada473a054b7e7684e7334cdc9dbb1f2f4ec103b87657aa138"
+  "permissionsConfigHash": "0xa58aa1a8b6a23b6cb4bccc29902c96e9d8dd04202d915c918585af40a8e22180"
 }

--- a/packages/config/src/projects/optimism/model.lp
+++ b/packages/config/src/projects/optimism/model.lp
@@ -1,0 +1,1 @@
+project(optimism).

--- a/packages/config/src/projects/optimism/optimism/diffHistory.md
+++ b/packages/config/src/projects/optimism/optimism/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x05af4fcb92bb689767f6095182f8ff41e97dffa8
+Generated with discovered.json: 0x78d8aa35a98d696d48a1b8a47b8d5b98b8cad54f
 
 # Diff at Mon, 14 Jul 2025 12:47:06 GMT:
 

--- a/packages/config/src/projects/optimism/optimism/discovered.json
+++ b/packages/config/src/projects/optimism/optimism/discovered.json
@@ -1528,5 +1528,5 @@
     "opstack/Layer2/SchemaRegistry": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
     "opstack/Layer2/SequencerFeeVault": "0x356a6cb706ffd52cc68d7a5c06197e72a7388bb32090967ad5ce5a683b508aa4"
   },
-  "permissionsConfigHash": "0x9baefa04b737b0ada473a054b7e7684e7334cdc9dbb1f2f4ec103b87657aa138"
+  "permissionsConfigHash": "0xa58aa1a8b6a23b6cb4bccc29902c96e9d8dd04202d915c918585af40a8e22180"
 }

--- a/packages/discovery/src/discovery/modelling/generateClingo.ts
+++ b/packages/discovery/src/discovery/modelling/generateClingo.ts
@@ -1,5 +1,8 @@
+import { existsSync, readFileSync } from 'fs'
 import merge from 'lodash/merge'
+import { join } from 'path'
 import type { TemplateService } from '../analysis/TemplateService'
+import type { ConfigReader } from '../config/ConfigReader'
 import type { PermissionsConfig } from '../config/PermissionConfig'
 import type { StructureEntry } from '../output/types'
 import { interpolateModelTemplate } from './interpolate'
@@ -51,4 +54,16 @@ export function generateClingoFromModelLp(
     return interpolated
   }
   return ''
+}
+
+export function getProjectSpecificModelLp(
+  project: string,
+  chain: string,
+  configReader: ConfigReader,
+): string | undefined {
+  const projectPath = configReader.getProjectPath(project)
+  const projectModelLpPath = join(projectPath, 'model.lp')
+  return existsSync(projectModelLpPath)
+    ? readFileSync(projectModelLpPath, 'utf8')
+    : undefined
 }

--- a/packages/discovery/src/discovery/modelling/modelPermissions.ts
+++ b/packages/discovery/src/discovery/modelling/modelPermissions.ts
@@ -14,6 +14,7 @@ import { type ClingoFact, parseClingoFact } from './clingoparser'
 import {
   generateClingoFromModelLp,
   generateClingoFromPermissionsConfig,
+  getProjectSpecificModelLp,
 } from './generateClingo'
 import { KnowledgeBase } from './KnowledgeBase'
 import { ModelIdRegistry } from './ModelIdRegistry'
@@ -234,6 +235,7 @@ export function generateClingoForDiscoveries(
     const config = configReader.readConfig(project, chain)
     const permissionsInClingo = generateClingoForProjectOnChain(
       config.permission,
+      configReader,
       discovery,
       templateService,
     )
@@ -245,6 +247,7 @@ export function generateClingoForDiscoveries(
 
 export function generateClingoForProjectOnChain(
   config: PermissionsConfig,
+  configReader: ConfigReader,
   discovery: DiscoveryOutput,
   templateService: TemplateService,
 ) {
@@ -252,6 +255,15 @@ export function generateClingoForProjectOnChain(
 
   const shortChain = getChainShortName(discovery.chain)
   const addressToNameMap = buildAddressToNameMap(discovery.entries)
+
+  const projectSpecificModelLp = getProjectSpecificModelLp(
+    discovery.name,
+    discovery.chain,
+    configReader,
+  )
+  if (projectSpecificModelLp) {
+    generatedClingo.push(projectSpecificModelLp)
+  }
 
   discovery.entries
     .sort((a, b) => a.address.localeCompare(b.address))


### PR DESCRIPTION
Resolves L2B-11070

Allows creating a model.lp file for a specific project. In the PR it's added as an example to optimism.