### PR TITLE
Proper fix for path-related issue in updateDiffHistory

### DIFF
--- a/packages/l2b/src/implementations/discovery/updateDiffHistory.ts
+++ b/packages/l2b/src/implementations/discovery/updateDiffHistory.ts
@@ -26,7 +26,7 @@ import {
 import chalk from 'chalk'
 import { execSync } from 'child_process'
 import { existsSync, readFileSync, statSync, writeFileSync } from 'fs'
-import path, { join, relative } from 'path'
+import path, { relative } from 'path'
 import { rimraf } from 'rimraf'
 import { getPlainLogger } from '../common/getPlainLogger'
 import { updateDiffHistoryHash } from './hashing'
@@ -65,12 +65,14 @@ export async function updateDiffHistoryForChain(
 ) {
   // Get discovered.json from main branch and compare to current
   logger.info(`Updating diffHistory for: ${projectName} on ${chain}`)
-  const paths = getDiscoveryPaths()
   const curDiscovery = configReader.readDiscovery(projectName, chain)
   const discoveryFolder =
     '.' +
     path.sep +
-    relative(process.cwd(), join(paths.discovery, projectName, chain))
+    relative(
+      process.cwd(),
+      configReader.getProjectChainPath(projectName, chain),
+    )
 
   const { content: discoveryJsonFromMainBranch, mainBranchHash } =
     getFileVersionOnMainBranch(`${discoveryFolder}/discovered.json`, logger)


### PR DESCRIPTION
A proper follow-up fix that correctly turns full project paths into relative ones. 