### PR TITLE
fix: typos in documentation files

### DIFF
--- a/packages/config/src/projects/publicgoodsnetwork/ethereum/diffHistory.md
+++ b/packages/config/src/projects/publicgoodsnetwork/ethereum/diffHistory.md
@@ -1856,7 +1856,7 @@ Generated with discovered.json: 0x450ab2617c6d7c7826a6f90f48870b03e998d403
 
 Upgrade to a new version of OptimismPortal which adds an `IEthBalanceWithdrawer` that allows the `BALANCE_CLAIMER` address to withdraw ETH and bypass the usual OP stack proving of withdrawals.
 
-A similar uprade is made to the L1StandardBridge regarding ERC20 tokens, and referencing the same privileged address which is the following SC:
+A similar upgrade is made to the L1StandardBridge regarding ERC20 tokens, and referencing the same privileged address which is the following SC:
 
 ### BalanceClaimer.sol
 

--- a/packages/config/src/projects/swell/ethereum/diffHistory.md
+++ b/packages/config/src/projects/swell/ethereum/diffHistory.md
@@ -4453,7 +4453,7 @@ discovery. Values are for block 20985756 (main branch discovery), not current.
 ```diff
 -   Status: DELETED
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90)
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
 ```
 
 ```diff
@@ -4494,11 +4494,11 @@ discovery. Values are for block 20985756 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       descriptions:
--        ["Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem"]
+-        ["Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem"]
       description:
-+        "Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem"
++        "Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem"
     }
 ```
 
@@ -4518,7 +4518,7 @@ Generated with discovered.json: 0x3548a172928f0df4e9b68a8a9ed5bc2ac911e55e
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       values.$members.6:
 -        "0x5b27b9279251904AaF2127463eeFf91E0037F725"
       values.$members.5:
@@ -4549,7 +4549,7 @@ One new signer added to SwellMultisig.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       values.$members.6:
 +        "0x5b27b9279251904AaF2127463eeFf91E0037F725"
       values.$members.5:
@@ -4596,7 +4596,7 @@ discovery. Values are for block 20016207 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       sourceHashes:
 +        ["0x81a7349eebb98ac33b0bc6842e3cb258034a8f2a4ba004570bb8e2e25947f9ff","0xd42bbf9f7dcd3720a7fc6bdc6edfdfae8800a37d6dd4decfa0ef6ca4a2e88940"]
     }
@@ -4646,7 +4646,7 @@ discovery. Values are for block 20016207 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       values.$multisigThreshold:
 -        "4 of 6 (67%)"
       values.getOwners:
@@ -4682,7 +4682,7 @@ discovery. Values are for block 20016207 (main branch discovery), not current.
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
       fieldMeta:
 +        {"nonce":{"severity":"MEDIUM","description":"Watch out for txs concerning the prelaunch vault and swell L2 launch"}}
     }
@@ -4704,7 +4704,7 @@ A timelock transaction is queued by the SwellMultisig to support the Lyra-associ
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
 +++ description: Watch out for txs concerning the prelaunch vault and swell L2 launch
 +++ severity: MEDIUM
       values.nonce:
@@ -4760,7 +4760,7 @@ A timelock transaction is queued to whitelist (`supportToken(address,(bool,bool)
 
 ```diff
     contract SwellMultisig (0x20fDF47509C5eFC0e1101e3CE443691781C17F90) {
-    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin fucntions in the swell ecosystem
+    +++ description: Can queue transactions in the swell L2 prelaunch vault's timelock among other admin functions in the swell ecosystem
 +++ description: Watch out for txs concerning the prelaunch vault and swell L2 launch
 +++ severity: MEDIUM
       values.nonce:

--- a/packages/config/src/projects/xai/arbitrum/diffHistory.md
+++ b/packages/config/src/projects/xai/arbitrum/diffHistory.md
@@ -7103,7 +7103,7 @@ Generated with discovered.json: 0x897a47e36aae203ad1b76427051d8c24b7bc8dfe
 
 ### Staking Pools upgrade
 
-This implementation uprade adds support for esXAI staking pools and removes the support for adding to normal staking (Withdrawals and rewards from normal staking remain enabled). Since staking V2 is still disabled and some contracts are still managed by the deployer, a new assessment of admin roles is necessary as soon as staking V2 is enabled.
+This implementation upgrade adds support for esXAI staking pools and removes the support for adding to normal staking (Withdrawals and rewards from normal staking remain enabled). Since staking V2 is still disabled and some contracts are still managed by the deployer, a new assessment of admin roles is necessary as soon as staking V2 is enabled.
 edit: Staking pools are active now and the [Xai Deployer EOA](https://arbiscan.io/address/0x7C94E07bbf73518B0E25D1Be200a5b58F46F9dC7) is admin (via owner or ProxyAdmin) of all the staking-related contracts.
 
 #### Referee5


### PR DESCRIPTION
Corrected `uprade` → `upgrade` x2
Corrected `fucntions` → `functions` x10