### PR TITLE
Fix DirectoryTabs centering by simplifying spacing classes

### DIFF
--- a/packages/frontend/src/components/core/DirectoryTabs.tsx
+++ b/packages/frontend/src/components/core/DirectoryTabs.tsx
@@ -46,13 +46,15 @@ const DirectoryTabsList = ({
   className,
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.List>) => (
-  <OverflowWrapper className="sticky top-0 z-50 bg-background mt-4 pr-4">
-    <TabsPrimitive.List
-      ref={ref}
-      className={cn('flex space-x-1 max-md:pl-4 md:space-x-2', className)}
-      {...props}
-    />
-  </OverflowWrapper>
+  <div className="sticky top-0 z-50 bg-background pt-2 max-md:mt-2 md:pt-4">
+    <OverflowWrapper className="pr-4">
+      <TabsPrimitive.List
+        ref={ref}
+        className={cn('flex space-x-1 max-md:pl-4 md:space-x-2', className)}
+        {...props}
+      />
+    </OverflowWrapper>
+  </div>
 )
 DirectoryTabsList.displayName = TabsPrimitive.List.displayName
 


### PR DESCRIPTION
## Problem
The `DirectoryTabs` component had complex responsive spacing classes (`pt-2 pr-4 max-md:mt-2 md:pt-4`) that were causing layout issues and preventing proper centering of tab elements.


<img width="1862" height="1122" alt="image" src="https://github.com/user-attachments/assets/1cd6e5a9-5c51-480a-86db-14773fe223de" />
