### PR TITLE
Fix typo in getBlockNumberSwitching.ts comment and update Taiko diffHistory

### DIFF
--- a/packages/config/src/projects/fraxferry/ethereum/diffHistory.md
+++ b/packages/config/src/projects/fraxferry/ethereum/diffHistory.md
@@ -4577,7 +4577,7 @@ Generated with discovered.json: 0x26a1cf6926ad6177aed37b5d7137c132e16081a7
 
 ### Fee change on Fraxtal FPI bridge
 
-The fees of the FPI bridge to / from Fraxtal are lowered. The 0.1% fee is removed and the flat fee is reduced to 1 token (FPI). Other fraxferry bridges and (inlcuding other FPI bridges) have their fees unchanged.
+The fees of the FPI bridge to / from Fraxtal are lowered. The 0.1% fee is removed and the flat fee is reduced to 1 token (FPI). Other fraxferry bridges and (including other FPI bridges) have their fees unchanged.
 
 ## Watched changes
 

--- a/packages/config/src/projects/taiko/ethereum/diffHistory.md
+++ b/packages/config/src/projects/taiko/ethereum/diffHistory.md
@@ -9694,7 +9694,7 @@ Generated with discovered.json: 0x6ea276c960b8bccf9d9d8ae744307cada936d2e3
 
 ## Description
 
-- L1RollupAddressManager.sol: changed harcoded B_TIER_ROUTER address.
+- L1RollupAddressManager.sol: changed hardcoded B_TIER_ROUTER address.
 - Bridge.sol: small change in retryMessage logic.
 - TaikoL1.sol: changes in block verification. assignedProver and hookCalls now DEPRECATED. assignedProver is now msg.sender of proposeBlock tx. New getters (getLastVerifiedBlock, getLastSyncedBlock), and decreased liveness bond to 125 TAIKO. Block proposers can now bribe the Ethereum block builder. Move some functions into libraries.
 - TaikoToken.sol: can now call batchTransfer for multiple recipients and amounts.
@@ -10399,7 +10399,7 @@ Generated with discovered.json: 0xc7cd32149b27868b3a50016ee3970759f8e9aa0d
 
 Two contracts implementation changed, TaikoL1.sol, and Bridge.sol.
 - TaikoL1.sol: introduced B_TIER_ROUTER = bytes32("tier_router") to replace B_TIER_PROVIDER
-- Bridge.sol: Added a max proof size for a message to be processable by a relayer, an insufficent gas check, and added the B_TIER_ROUTER variable support.
+- Bridge.sol: Added a max proof size for a message to be processable by a relayer, an insufficient gas check, and added the B_TIER_ROUTER variable support.
 
 ## Watched changes
 

--- a/packages/discovery/src/discovery/provider/getBlockNumberSwitching.ts
+++ b/packages/discovery/src/discovery/provider/getBlockNumberSwitching.ts
@@ -11,7 +11,7 @@
 //
 // But doing just that is not enough because we're always searching from the
 // start and block times are the start are very irregular so we want to narrow
-// the search range as fast as possible to have the highest resoluton on our
+// the search range as fast as possible to have the highest resolution on our
 // range. Tested empirically first guessing and later doing a single step of
 // binary search gives us the least amount of calls to the node. On average it
 


### PR DESCRIPTION

- **Fixed typo** : corrected "resoluton" → "resolution" 
- **Fixed typo** : corrected "inlcuding" → "including" 
- **Fixed typo** : corrected "harcoded" → "hardcoded"
- **Fixed typo** : corrected "insufficent" → "insufficient" 



