### PR TITLE
Fix typos in test descriptions and URL formatting

### DIFF
--- a/packages/backend/scripts/bridges/chains.ts
+++ b/packages/backend/scripts/bridges/chains.ts
@@ -81,8 +81,8 @@ export const CHAINS: Chain[] = [
     name: 'scroll',
     shortName: 'scr',
     rpcCallsPerMinute: 120,
-    getTxUrl: (hash: string) => `hhttps://scrollscan.com/tx/${hash}`,
-    getAddressUrl: (hash: string) => `hhttps://scrollscan.com/address/${hash}`,
+    getTxUrl: (hash: string) => `https://scrollscan.com/tx/${hash}`,
+    getAddressUrl: (hash: string) => `https://scrollscan.com/address/${hash}`,
     envioUrl: 'https://scroll.hypersync.xyz/query', //🥉
     envioCallsPerMinute: 120,
     envioBatchSize: 2000,

--- a/packages/backend/src/modules/tracked-txs/modules/liveness/utils/groupByType.test.ts
+++ b/packages/backend/src/modules/tracked-txs/modules/liveness/utils/groupByType.test.ts
@@ -39,7 +39,7 @@ describe(groupByType.name, () => {
     ])
   })
 
-  it('should throw on uknown type', () => {
+  it('should throw on unknown type', () => {
     const records = [
       {
         timestamp: NOW - 1 * UnixTime.HOUR,

--- a/packages/discovery/src/discovery/utils/prefixAddresses.test.ts
+++ b/packages/discovery/src/discovery/utils/prefixAddresses.test.ts
@@ -73,7 +73,7 @@ describe(prefixAddresses.name, () => {
     ])
   })
 
-  it('prefixes addreses in objects values and keys', () => {
+  it('prefixes addresses in objects values and keys', () => {
     const obj = {
       '0x07D5c2f0eC7f791F1BB0760C7BaC21Eef10a0956':
         '0x33D66941465ac776C38096cb1bc496C673aE7390',
@@ -85,7 +85,7 @@ describe(prefixAddresses.name, () => {
     })
   })
 
-  it('prefixes addreses in objects values and keys', () => {
+  it('prefixes addresses in objects values and keys', () => {
     const obj = {
       k1: 123,
       k2: 'foo',


### PR DESCRIPTION
## Summary
This PR fixes several typos and formatting issues across the codebase.

## Changes
- **Test descriptions**: Fixed typos in test case descriptions
  - `uknown` → `unknown` in `groupByType.test.ts`
  - `addreses` → `addresses` in `prefixAddresses.test.ts`
- **URL formatting**: Fixed malformed URLs in `chains.ts`
  - `hhttps://` → `https://` for Scrollscan URLs

## Files Modified
- `packages/backend/src/modules/tracked-txs/modules/liveness/utils/groupByType.test.ts`
- `packages/discovery/src/discovery/utils/prefixAddresses.test.ts`
- `packages/backend/scripts/bridges/chains.ts`

