### PR TITLE
fix(typos): correct spelling errors in TokenBreakdown, MobileNavTabs, and StageSection

### DIFF
--- a/packages/frontend/src/components/breakdown/TokenBreakdown.tsx
+++ b/packages/frontend/src/components/breakdown/TokenBreakdown.tsx
@@ -71,7 +71,7 @@ export function TokenBreakdownTooltipContent({
       variant: 'stable' as const,
     },
     {
-      title: 'BTC & deriviatives',
+      title: 'BTC & derivatives',
       value: btc,
       variant: 'btc' as const,
     },

--- a/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
+++ b/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
@@ -1,4 +1,4 @@
-import { usePathname } from '~/hooks/usePathname'
+Чimport { usePathname } from '~/hooks/usePathname'
 import { cn } from '~/utils/cn'
 import { OverflowWrapper } from '../../core/OverflowWrapper'
 import type { NavGroup } from '../types'
@@ -8,7 +8,6 @@ import type { NavGroup } from '../types'
  */
 export function MobileNavTabs({ groups }: { groups: NavGroup[] }) {
   const pathname = usePathname()
-
   const currentGroup = groups
     .filter((g) => g.type === 'multiple')
     .find(
@@ -19,7 +18,7 @@ export function MobileNavTabs({ groups }: { groups: NavGroup[] }) {
   if (!currentGroup) return null
 
   // Do not display the tabs if the current group is not found,
-  // or the current group does not have a link that matche the current path.
+  // or the current group does not have a link that matches the current path.
   const display = currentGroup.links.some(({ href }) => href === pathname)
   if (!display) return null
 

--- a/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
+++ b/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
@@ -8,7 +8,7 @@ import type { NavGroup } from '../types'
  */
 export function MobileNavTabs({ groups }: { groups: NavGroup[] }) {
   const pathname = usePathname()
-  
+
   const currentGroup = groups
     .filter((g) => g.type === 'multiple')
     .find(

--- a/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
+++ b/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
@@ -1,4 +1,4 @@
-Чimport { usePathname } from '~/hooks/usePathname'
+import { usePathname } from '~/hooks/usePathname'
 import { cn } from '~/utils/cn'
 import { OverflowWrapper } from '../../core/OverflowWrapper'
 import type { NavGroup } from '../types'
@@ -8,6 +8,7 @@ import type { NavGroup } from '../types'
  */
 export function MobileNavTabs({ groups }: { groups: NavGroup[] }) {
   const pathname = usePathname()
+  
   const currentGroup = groups
     .filter((g) => g.type === 'multiple')
     .find(

--- a/packages/frontend/src/components/projects/sections/StageSection.tsx
+++ b/packages/frontend/src/components/projects/sections/StageSection.tsx
@@ -162,7 +162,7 @@ export function StageSection({
             stage.principle && featureFlags.stageOneRequirementsChanged()
               ? [stage.principle]
               : stage.requirements
-          const satisifedForLabel = requirementsForLabel.filter(
+          const satisfiedForLabel = requirementsForLabel.filter(
             (r) => r.satisfied === true,
           )
           const missingForLabel = requirementsForLabel.filter(
@@ -192,7 +192,7 @@ export function StageSection({
                       <div className="flex items-center gap-2 font-bold">
                         <SatisfiedIcon className="size-4 shrink-0 fill-positive" />
                         <span>
-                          {reqTextSatisfied(satisifedForLabel.length)}
+                          {reqTextSatisfied(satisfiedForLabel.length)}
                         </span>
                       </div>
                       {underReviewForLabel.length > 0 && (


### PR DESCRIPTION
- deriviatives → derivatives in TokenBreakdown.tsx

- matche → matches in MobileNavTabs.tsx

- satisifed → satisfied in StageSection.tsx