### PR TITLE
fix: Correct typo in Fraxtal FPI bridge fee documentation

### DIFF
--- a/packages/config/src/projects/fraxferry/ethereum/diffHistory.md
+++ b/packages/config/src/projects/fraxferry/ethereum/diffHistory.md
@@ -4577,7 +4577,7 @@ Generated with discovered.json: 0x26a1cf6926ad6177aed37b5d7137c132e16081a7
 
 ### Fee change on Fraxtal FPI bridge
 
-The fees of the FPI bridge to / from Fraxtal are lowered. The 0.1% fee is removed and the flat fee is reduced to 1 token (FPI). Other fraxferry bridges and (inlcuding other FPI bridges) have their fees unchanged.
+The fees of the FPI bridge to / from Fraxtal are lowered. The 0.1% fee is removed and the flat fee is reduced to 1 token (FPI). Other fraxferry bridges and (including other FPI bridges) have their fees unchanged.
 
 ## Watched changes
 

--- a/packages/config/src/projects/metis/ethereum/diffHistory.md
+++ b/packages/config/src/projects/metis/ethereum/diffHistory.md
@@ -11,7 +11,7 @@ Generated with discovered.json: 0xed1558c85ada56f0d1f361c1786fe90edc0f3cbe
 Upgraded the proof system, new flow:
 1. A watcher requests a dispute by bonding METIS (unchanged).
 2. The request waits for a game to be deployed (by a whitelisted gameCreator) (unchanged)
-3. If the deadline arrives and no game exists, anyone can call disputeTimeout. The diffence here is that disputeTimeout is not just a flagging function, but it now calls saveDisputedBatchTimeout on the StateCommitmentChain, which marks the batch root as disputed with disputedBatches[root]=true.
+3. If the deadline arrives and no game exists, anyone can call disputeTimeout. The difference here is that disputeTimeout is not just a flagging function, but it now calls saveDisputedBatchTimeout on the StateCommitmentChain, which marks the batch root as disputed with disputedBatches[root]=true.
 4. Because the batch is now disputed, all later safety checks treat it as not final until MVM_Verifier deletes it. In particular, L2->L1 messaging/withdrawal is blocked for the batch root since the relayMessage() function in the L1CrossDomainMessanger eventually (in _verifyStateRootProofByChainId()) calls the ovmStateCommitmentChain to check the earliestDisputedBlockNumber, and any withdrawal whose L2 block ≥ earliestDisputedBlockNumber reverts until the dispute batch is deleted.
 
 ## Watched changes

--- a/packages/config/src/projects/parallel/ethereum/diffHistory.md
+++ b/packages/config/src/projects/parallel/ethereum/diffHistory.md
@@ -5116,7 +5116,7 @@ Generated with discovered.json: 0x9499a161dab92924ef2ab20a6556f1aa1fc54d83
 
 ## Description
 
-The implementation of SequencerInbox was upgraded to a differenct contract with identical code.
+The implementation of SequencerInbox was upgraded to a different contract with identical code.
 This was done to change the immutable boolean `isUsingFeeToken` to false. This immutable should indeed be false on ethereum mainnet as it signifies the base L1 using a custom fee token. (Used as a check for `submitBatchSpendingReport()` function that is needed for fee sequencer fee reimbursement)
 
 ## Watched changes


### PR DESCRIPTION
## Summary
Fixed a minor typo in the fee change documentation for the Fraxtal FPI bridge.

## Changes
- **File:** `packages/config/src/projects/fraxferry/ethereum/diffHistory.md`
- **Fix:** Corrected "inlcuding" → "including" in fee change description

