### PR TITLE
fix: correct spelling errors in diffHistory files

### DIFF
--- a/packages/config/src/projects/appchain/ethereum/diffHistory.md
+++ b/packages/config/src/projects/appchain/ethereum/diffHistory.md
@@ -1059,7 +1059,7 @@ Generated with discovered.json: 0x472d524045dc782d30bd1e31419a1954850c0c72
 
 ## Description
 
-intial discovery of an orbit stack chain with espresso sequencing and anytrust DA.
+initial discovery of an orbit stack chain with espresso sequencing and anytrust DA.
 
 ## Initial discovery
 

--- a/packages/config/src/projects/zksync2/ethereum/diffHistory.md
+++ b/packages/config/src/projects/zksync2/ethereum/diffHistory.md
@@ -4955,7 +4955,7 @@ Generated with discovered.json: 0xb99d6a83690f166d2551d4c4cf9d8dd3b3ba1a3b
 
 Overall seems like a step towards introducing a security council.
 The Governance contract is improved and written in a way that allows to simply set the security councils address and increase the minimum delay.
-Any reference to AllowList has been deleted in favour of Gorvernance.
+Any reference to AllowList has been deleted in favour of Governance.
 Removed the deposit limit.
 
 ### L1ERC20Bridge


### PR DESCRIPTION
- Fix \"intial\" → \"initial\" in appchain diffHistory  
- Fix \"Gorvernance\" → \"Governance\" in zksync2 diffHistory"