### PR TITLE
fix: correct spelling errors in project documentation

### DIFF
--- a/packages/config/src/projects/arbitrum/ethereum/diffHistory.md
+++ b/packages/config/src/projects/arbitrum/ethereum/diffHistory.md
@@ -16136,7 +16136,7 @@ Generated with discovered.json: 0xa1e00fdc80fd5a87605ec534b24fed82c3d81449
 
 This timelock transaction is queued and executed, calling the `SwitchManagerRolesAction` on L2.
 
-Decription from the contract:
+Description from the contract:
 `Grant the non emergency council the MEMBER_ADDER_ROLE, MEMBER_REPLACER_ROLE, MEMBER_ROTATOR_ROLE and MEMBER_REMOVER_ROLE on the SecurityCouncilManager. Revoke those same roles from the emergency council.`
 
 Tx: https://app.blocksec.com/explorer/tx/arbitrum/0xf2929a5ee3c2a073de95293f91f163b4d743fdec38e4dceaa7c4796e090783c3

--- a/packages/config/src/projects/taiko/ethereum/diffHistory.md
+++ b/packages/config/src/projects/taiko/ethereum/diffHistory.md
@@ -77,7 +77,7 @@ Generated with discovered.json: 0xa14d0b5804b0b13aa300d9e4913b17ccbac8a1c6
 
 ## Description
 
-Config: add version to verifier decription.
+Config: add version to verifier description.
 
 ## Config/verification related changes
 

--- a/packages/config/src/projects/zkcandy/ethereum/discovered.json
+++ b/packages/config/src/projects/zkcandy/ethereum/discovered.json
@@ -337,7 +337,7 @@
         "0xbc2380479529743c27e6ab96cdf08210319fadcbca0856cf50c6b1b54bf8437f"
       ],
       "proxyType": "EIP2535 diamond proxy",
-      "description": "The main contract defining the Layer 2. Operator actions like commiting blocks, providing ZK proofs and executing batches ultimately target this contract which then processes transactions. During batch execution it processes L1 --> L2 and L2 --> L1 transactions.",
+      "description": "The main contract defining the Layer 2. Operator actions like committing blocks, providing ZK proofs and executing batches ultimately target this contract which then processes transactions. During batch execution it processes L1 --> L2 and L2 --> L1 transactions.",
       "ignoreInWatchMode": [
         "getTotalPriorityTxs",
         "getTotalBlocksCommitted",


### PR DESCRIPTION
- Fix 'Decription' to 'Description' in arbitrum diffHistory.md
- Fix 'decription' to 'description' in taiko diffHistory.md
- Fix 'commiting' to 'committing' in zkcandy discovered.json