### PR TITLE
Fix sinceTimestamp derivation for Amount in tvs-generate

### DIFF
--- a/packages/backend/src/modules/tvs/tools/extractPricesAndAmounts.test.ts
+++ b/packages/backend/src/modules/tvs/tools/extractPricesAndAmounts.test.ts
@@ -335,7 +335,7 @@ describe(extractPricesAndAmounts.name, () => {
           address,
           chain: 'chain',
           decimals: 18,
-          sinceTimestamp: 300,
+          sinceTimestamp: 50,
           untilTimestamp: undefined,
         },
       ],

--- a/packages/backend/src/modules/tvs/tools/extractPricesAndAmounts.ts
+++ b/packages/backend/src/modules/tvs/tools/extractPricesAndAmounts.ts
@@ -165,7 +165,7 @@ function setAmount(
     ...existingAmount,
     sinceTimestamp: Math.min(
       amountToAdd.sinceTimestamp,
-      amountToAdd.sinceTimestamp,
+      existingAmount.sinceTimestamp,
     ),
   }
 


### PR DESCRIPTION
This will prevent critical errors in the backend, but still the issue of duplicate entries persists

Resolves L2B-11254