### PR TITLE
chore: fix typos in comments across multiple packages

### DIFF
--- a/packages/discovery/src/discovery/config/StructureConfig.ts
+++ b/packages/discovery/src/discovery/config/StructureConfig.ts
@@ -88,7 +88,7 @@ export const _StructureConfig = {
   sharedModules: v.array(v.string()).default([]),
   types: v.record(v.string(), DiscoveryCustomType).optional(),
 }
-// NOTE(radomsk): Big hack, shouldn't be like this
+// NOTE(radomski): Big hack, shouldn't be like this
 export const StructureConfig = v.object({
   name: v.string().check((v) => v.length >= 1),
   chain: v.string().check((v) => v.length >= 1),

--- a/packages/l2b/src/implementations/discovery/updateDiffHistory.ts
+++ b/packages/l2b/src/implementations/discovery/updateDiffHistory.ts
@@ -90,14 +90,14 @@ export async function updateDiffHistoryForChain(
   let codeDiff
   let configRelatedDiff
 
-  // TDDO(radomski): Use timestamp after the merge
+  // TODO(radomski): Use timestamp after the merge
   if ((discoveryFromMainBranch?.timestamp ?? 0) > curDiscovery.timestamp) {
     throw new Error(
       `Main branch discovery timestamp (${discoveryFromMainBranch?.timestamp}) is higher than current discovery timestamp (${curDiscovery.timestamp})`,
     )
   }
 
-  // TDDO(radomski): Use timestamp after the merge
+  // TODO(radomski): Use timestamp after the merge
   if ((discoveryFromMainBranch?.timestamp ?? 0) < curDiscovery.timestamp) {
     const rerun = await performDiscoveryOnPreviousBlockButWithCurrentConfigs(
       discoveryFolder,

--- a/packages/uif/src/reducer/indexerReducer.test.ts
+++ b/packages/uif/src/reducer/indexerReducer.test.ts
@@ -452,7 +452,7 @@ describe(indexerReducer.name, () => {
 
     describe('complex scenarios', () => {
       it('if parent is waiting, it keeps waiting until notifyReady', () => {
-        //1. grandparent ticks lower (to: x1) && parent updating (to: x2)-> parent sets (safeHeight: x1), but still updating (to:x2), child sets (safeHeight: x1) -> parennt finishes update (to: x2, waiting: true), child notifies ready
+        //1. grandparent ticks lower (to: x1) && parent updating (to: x2)-> parent sets (safeHeight: x1), but still updating (to:x2), child sets (safeHeight: x1) -> parent finishes update (to: x2, waiting: true), child notifies ready
         const initState = getAfterInit({
           safeHeight: 100,
           childCount: 1,


### PR DESCRIPTION
TDDO → TODO (2 instances)

parennt → parent

radomsk → radomski