### PR TITLE
fix(multichain, omnichain): address sorting, Etherscan URL typos, and correct JSON file extension

### DIFF
--- a/packages/config/scripts/multichain/generateIntermediateConfig.ts
+++ b/packages/config/scripts/multichain/generateIntermediateConfig.ts
@@ -122,7 +122,7 @@ export function generateIntermediateConfig(config: MultichainConfig) {
         address: x.address,
         tokens: x.tokens.map((t) => t.address).sort(),
       }))
-      .sort((a, b) => a.address.localeCompare(b.address.toString())),
+      .sort((a, b) => a.address.toString().localeCompare(b.address.toString())),
   }
 }
 

--- a/packages/config/scripts/omnichain/getLZ.ts
+++ b/packages/config/scripts/omnichain/getLZ.ts
@@ -91,7 +91,7 @@ async function fetchInternalTxs(
   const response = await fetch(
     `https://api.etherscan.io/api?module=account&startblock=${i - 1}&endblock=${
       i + batchSize
-    }&action=txlistinternal&address=${'0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675'}&apikey=${etherscanApiKey})}`,
+    }&action=txlistinternal&address=${'0x66A71Dcef29A0fFBDBE3c6a460a3B5BC225Cd675'}&apikey=${etherscanApiKey}`,
   )
 
   const data = (await response.json()) as unknown as {
@@ -124,7 +124,7 @@ async function fetchDeployer(
   etherscanApiKey: string,
 ): Promise<string> {
   const response = await fetch(
-    `https://api.etherscan.io/api?module=contract&action=getcontractcreation&contractaddresses=${address}&apikey=${etherscanApiKey})}`,
+    `https://api.etherscan.io/api?module=contract&action=getcontractcreation&contractaddresses=${address}&apikey=${etherscanApiKey}`,
   )
   const data = (await response.json()) as unknown as {
     result: { contractCreator: string }[]
@@ -140,7 +140,7 @@ async function fetchNameAndABI(
   const result = { name: '', isERC20: '' }
 
   const response = await fetch(
-    `https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${address}&apikey=${etherscanApiKey})}`,
+    `https://api.etherscan.io/api?module=contract&action=getsourcecode&address=${address}&apikey=${etherscanApiKey}`,
   )
   const data = (await response.json()) as unknown as {
     result: { ABI: string; ContractName: string }[]

--- a/packages/config/scripts/omnichain/index.ts
+++ b/packages/config/scripts/omnichain/index.ts
@@ -17,7 +17,7 @@ async function main() {
   const libs = await getInboundLibraries(provider)
 
   writeFileSync(
-    './scripts/omnichain/libraries.csv',
+    './scripts/omnichain/libraries.json',
     JSON.stringify(libs, null, 2),
   )
 


### PR DESCRIPTION
1. multichain/generateIntermediateConfig.ts:
   - Fixed potential runtime error in `.sort()` by converting `EthereumAddress` objects to strings before calling `localeCompare`.


2. omnichain/getLZ.ts: 
   - Removed stray `)}` from Etherscan API URLs in `fetchInternalTxs`, `fetchDeployer`, and `fetchNameAndABI` functions, ensuring valid HTTP requests.


3. omnichain/index.ts:
   - Changed output file extension from `.csv` to `.json` for `libraries` data, since the content is actually JSON and there are no `.csv` consumers in the repository.

