### PR TITLE
l2b(AddShape): remove unnecessary await from TemplateService.addToShape

### DIFF
--- a/packages/l2b/src/commands/AddShape.ts
+++ b/packages/l2b/src/commands/AddShape.ts
@@ -87,7 +87,7 @@ export const AddShape = command({
 
     assert(sources.length > 0, 'No sources found')
 
-    await templateService.addToShape(
+    templateService.addToShape(
       args.template,
       args.chain,
       args.addresses,


### PR DESCRIPTION
TemplateService.addToShape returns void, so awaiting it is redundant. This aligns with its signature and other usages, avoids unnecessary microtask scheduling, and clarifies intent.