### PR TITLE
Fix tests suddenly failing on CI

### DIFF
--- a/packages/backend/src/tools/uif/ManagedChildIndexer.test.ts
+++ b/packages/backend/src/tools/uif/ManagedChildIndexer.test.ts
@@ -116,8 +116,11 @@ describe(ManagedChildIndexer.name, () => {
 })
 
 class TestIndexer extends ManagedChildIndexer {
-  constructor(override readonly options: ManagedChildIndexerOptions) {
+  override readonly options: ManagedChildIndexerOptions
+
+  constructor(options: ManagedChildIndexerOptions) {
     super(options)
+    this.options = options
   }
 
   override update(_from: number, to: number): Promise<number> {

--- a/packages/backend/src/tools/uif/multi/ManagedMultiIndexer.test.ts
+++ b/packages/backend/src/tools/uif/multi/ManagedMultiIndexer.test.ts
@@ -590,8 +590,11 @@ describe(ManagedMultiIndexer.name, () => {
 })
 
 class TestIndexer extends ManagedMultiIndexer<string> {
-  constructor(override readonly options: ManagedMultiIndexerOptions<string>) {
+  override readonly options: ManagedMultiIndexerOptions<string>
+
+  constructor(options: ManagedMultiIndexerOptions<string>) {
     super(options)
+    this.options = options
   }
   multiUpdate = mockFn<ManagedMultiIndexer<string>['multiUpdate']>(
     async (_, targetHeight) => () => Promise.resolve(targetHeight),

--- a/packages/uif/src/Indexer.test.ts
+++ b/packages/uif/src/Indexer.test.ts
@@ -270,12 +270,11 @@ export async function waitUntil(predicate: () => boolean): Promise<void> {
 }
 
 export class InitTestIndexer extends RootIndexer {
-  constructor(
-    private readonly initState:
-      | { safeHeight: number; configHash?: string }
-      | undefined,
-  ) {
+  private readonly initState?: { safeHeight: number; configHash?: string }
+
+  constructor(initState?: { safeHeight: number; configHash?: string }) {
     super(Logger.SILENT)
+    this.initState = initState
   }
 
   override async tick(): Promise<number> {


### PR DESCRIPTION
Somehow suddenly GitHub CI is unhappy with this construct:

`constructor(override readonly options: ManagedChildIndexerOptions)`

because it needs a transform (`readonly` changes into local field and assingment) and is not simply a type drop. It involves only .test files.

Since we're doing this only in 3 places, I'm fixing this in code. We're not able to figure out why this suddenly started happening. Will investigate further.