### PR TITLE
docs: update Starknet on-chain data reference URL

### DIFF
--- a/packages/config/src/common/technologyDataAvailability.ts
+++ b/packages/config/src/common/technologyDataAvailability.ts
@@ -50,7 +50,7 @@ const STARKNET_ON_CHAIN = (usesBlobs = false): ProjectTechnologyChoice => {
     references: [
       {
         title: 'On-Chain Data - Starknet documentation',
-        url: 'https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/on-chain-data/',
+        url: 'https://docs.starknet.io/architecture/data-availability/',
       },
     ],
   }


### PR DESCRIPTION
Updated the Starknet documentation link in packages/config/src/common/technologyDataAvailability.ts  
to point to the new "Data Availability" page instead of the outdated "On-Chain Data" section.
https://docs.starknet.io/documentation/architecture_and_concepts/Network_Architecture/on-chain-data/ to

https://docs.starknet.io/architecture/data-availability/