### PR TITLE
fix(astarzkevm): update broken documentation link

### DIFF
--- a/packages/config/src/projects/astarzkevm/astarzkevm.ts
+++ b/packages/config/src/projects/astarzkevm/astarzkevm.ts
@@ -72,7 +72,7 @@ export const astarzkevm: ScalingProject = polygonCDKStack({
       "Astar zkEVM is a Validium that leverages Polygon's CDK and zero-knowledge cryptography to enable off-chain transactions while maintaining EVM equivalence.",
     links: {
       websites: ['https://astar.network/blog/astar-evolution-phase-1-56'],
-      documentation: ['https://docs.astar.network/docs/build/zkEVM/'],
+      documentation: ['https://docs.astar.network/docs/learn/zkEVM/'],
       explorers: ['https://astar-zkevm.explorer.startale.com/'],
       repositories: ['https://github.com/AstarNetwork'],
       socialMedia: [


### PR DESCRIPTION
Replace outdated documentation URL from /docs/build/zkEVM/ to /docs/learn/zkEVM/
The previous link returned 404, updated to working documentation path.