### PR TITLE
fix: update documentation URL for Puffer project

### DIFF
--- a/packages/config/src/projects/puffer/puffer.ts
+++ b/packages/config/src/projects/puffer/puffer.ts
@@ -16,7 +16,7 @@ export const puffer: ScalingProject = upcomingL2({
     links: {
       websites: ['https://puffer.fi/'],
       bridges: ['https://quest.puffer.fi/unifi'],
-      documentation: ['https://docs.puffer.fi/unifi-based-rollup/'],
+      documentation: ['https://docs-unifi.puffer.fi/'],
       repositories: ['https://github.com/PufferFinance'],
       socialMedia: [
         'https://x.com/puffer_unifi',


### PR DESCRIPTION
## Description
Update the broken documentation URL for the Puffer project configuration.

## Changes
- Replace `https://docs.puffer.fi/unifi-based-rollup/` with `https://docs-unifi.puffer.fi/` in `packages/config/src/projects/puffer/puffer.ts`

## Reason
The old documentation URL returns a 404 error. The new URL is the correct current documentation site for Puffer Unifi.
