### PR TITLE
fix: update Kailua documentation URL to current domain

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -724,7 +724,7 @@ A single remaining child in a tournament can be 'resolved' and will be finalized
 The Kailua state validation system is primarily optimistically resolved, so no validity proofs are required in the happy case. But two different zk proofs on unresolved state roots are possible and permissionless: The proveValidity() function proves a state root proposal's full validity, automatically invalidating all conflicting sibling proposals. proveOutputFault() allows any actor to eliminate a state root proposal for which they can prove that any of the ${proposalOutputCount} intermediate state transitions in the proposal are not correct. Both are zk proofs of validity, although one is used as an efficient fault proof to invalidate a single conflicting state transition.`,
             references: [
               {
-                url: 'https://risc0.github.io/kailua/introduction.html',
+                url: 'https://risczero.com/blog/kailua-how-it-works',
                 title: 'Risc0 Kailua Docs',
               },
               {


### PR DESCRIPTION
Update the RISC Zero Kailua documentation reference from the deprecated 
risc0.github.io domain to the current risczero.com blog post. The old 
GitHub Pages URL is no longer accessible, and the comprehensive Kailua 
documentation is now available at risczero.com/blog/kailua-how-it-works.

This ensures users can access up-to-date information about the Kailua 
hybrid ZK rollup system when viewing project documentation.