### PR TITLE
fix(logger): sync docs with code and add METRIC log color

### DIFF
--- a/packages/backend-tools/src/logger/LogFormatterPretty.ts
+++ b/packages/backend-tools/src/logger/LogFormatterPretty.ts
@@ -72,6 +72,8 @@ export class LogFormatterPretty implements LogFormatter {
           return chalk.yellow(chalk.bold(level.toUpperCase()))
         case 'INFO':
           return chalk.green(chalk.bold(level.toUpperCase()))
+        case 'METRIC':
+          return chalk.cyan(chalk.bold(level.toUpperCase()))
         case 'DEBUG':
           return chalk.magenta(chalk.bold(level.toUpperCase()))
         case 'TRACE':

--- a/packages/backend-tools/src/logger/docs.md
+++ b/packages/backend-tools/src/logger/docs.md
@@ -30,7 +30,7 @@ The logger can be configured using the following options, all of them optional:
 - `cwd` - current working directory, used to shorten error stack traces. Defaults to `process.cwd()`.
 - `getTime` - callback that returns the current time. Defaults to `() => new Date()`.
 - `reportError` - callback called when a message is logged at the `ERROR` or `CRITICAL` level. See more in the [Error reporting](#error-reporting) section.
-- `transports` - a set of pairs ([transport](#transports) + [formatter](#formatters)) which define where and in what form logs are being outputted. Defaults to `console` and `pretty` formatter
+- `transports` - a set of pairs ([transport](#transports) + [formatter](#formatters)) which define where and in what form logs are being outputted. Defaults to `console` and JSON formatter
 
 ### Services
 
@@ -89,8 +89,8 @@ class FamilyGreeter {
 }
 
 const logger = Logger.INFO
-const capuletGreeter = new FamilyGreeter(logger.tag('Capulet'))
-const montagueGreeter = new FamilyGreeter(logger.tag('Montague'))
+const capuletGreeter = new FamilyGreeter(logger.tag({ tag: 'Capulet' }))
+const montagueGreeter = new FamilyGreeter(logger.tag({ tag: 'Montague' }))
 
 capuletGreeter.sayHello()
 
@@ -137,7 +137,7 @@ In this format every message is logged on one or more lines with another newline
 This formatter accepts two params:
 
 - `utc` - when set to true time is logged in UTC, otherwise in local time. Defaults to `false`.
-- `colors` - when set to true colors are used in the `pretty` format, otherwise they are not. Defaults to `false`.
+- `colors` - when set to true colors are used in the `pretty` format, otherwise they are not. Defaults to `true`.
 
 Below is an example log output:
 


### PR DESCRIPTION
These changes were made to align documentation with the actual logger implementation and ensure consistency between code and docs.

- The `logger.tag()` method now requires an object with a `tag` key (code changed earlier, docs outdated).
- The default formatter in code is JSON, not `pretty` (docs were misleading).
- The default `colors` value is `true` in code, while docs stated `false`.
- Added `METRIC` log level color (`cyan`) in `LogFormatterPretty.ts` to maintain visual consistency with other log levels.

Without these updates, the documentation does not match the actual behavior of the logger, which can cause confusion for developers.
