### PR TITLE
fix: update broken Celo Plumo link in zkCatalogTrustedSetups

### DIFF
--- a/packages/config/src/common/zkCatalogTrustedSetups.ts
+++ b/packages/config/src/common/zkCatalogTrustedSetups.ts
@@ -60,7 +60,7 @@ export const TRUSTED_SETUPS = {
     Plumo and later reused for Linea prover. Ceremony has 55 participants.
 
   - Repo with ceremony instructions: https://github.com/celo-org/snark-setup?tab=readme-ov-file
-  - Link to the ceremony details: https://celo.org/plumo (it is broken. Archived version here: https://web.archive.org/web/20221201203227/https://celo.org/plumo)
+  - Link to the ceremony details: https://celo.org/papers/plumo
   - Links to ceremony transcript: https://console.cloud.google.com/storage/browser/plumoceremonyphase1/chunks
   - Link to ceremony verification code: https://github.com/Consensys/gnark-ignition-verifier/blob/feat/celo_parser/celo/main.go
     `,


### PR DESCRIPTION
Replace broken celo.org/plumo link with working celo.org/papers/plumo link for ceremony details reference.