### PR TITLE
fix: add missing shebang to frontend build script

### DIFF
--- a/packages/frontend/scripts/build.sh
+++ b/packages/frontend/scripts/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Exit on error
 set -e
 


### PR DESCRIPTION
Adds #!/bin/bash shebang to ensure the script runs in bash interpreter.
The script uses bash-specific features like background processes (&) and wait command, so the shebang is necessary for reliable execution across different environments and CI systems.