### PR TITLE
feat: add Unichain flashblocks milestone

### DIFF
--- a/packages/config/src/projects/unichain/unichain.ts
+++ b/packages/config/src/projects/unichain/unichain.ts
@@ -99,6 +99,13 @@ export const unichain: ScalingProject = opStackL2({
   },
   milestones: [
     {
+      title: 'Unichain flashblocks are live',
+      url: 'https://blog.uniswap.org/flashblocks-are-live',
+      description: 'Unichain Hits 200ms Sub-Blocks Inside Trusted Execution Environments.',
+      date: '2025-08-14T00:00:00Z',
+      type: 'general',
+    },
+    {
       title: 'Mainnet Launch',
       url: 'https://x.com/unichain/status/1889313993296064770',
       date: '2025-02-12T00:00:00Z',


### PR DESCRIPTION
Add milestone for Unichain flashblocks going live with 200ms sub-blocks inside trusted execution environments.