### PR TITLE
Update explorer URLs in config

### DIFF
--- a/packages/config/src/common/explorerUrls.ts
+++ b/packages/config/src/common/explorerUrls.ts
@@ -32,7 +32,7 @@ export const EXPLORER_URLS: Record<string, string> = {
   kinto: 'https://explorer.kinto.xyz',
   taiko: 'https://taikoscan.io',
   facet: 'https://explorer.facet.org',
-  gateway: 'https://gateway.explorer.zksync.io/address',
-  gnosis: 'https://gnosisscan.io/address',
-  zircuit: 'https://explorer.zircuit.com/address',
+  gateway: 'https://gateway.explorer.zksync.io',
+  gnosis: 'https://gnosisscan.io',
+  zircuit: 'https://explorer.zircuit.com',
 }


### PR DESCRIPTION


**Description:**
This PR updates the `explorerUrls.ts` configuration by removing `/address` suffixes from the `gateway`, `gnosis`, and `zircuit` URLs.


---


