### PR TITLE
chore: improve Docker build reproducibility and update branch references

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -23,7 +23,7 @@ ARG COREPACK_VERSION
 RUN npm i -g corepack@${COREPACK_VERSION} && corepack enable pnpm
 WORKDIR /src/
 COPY --from=pruner /src/out/json/ .
-RUN pnpm install
+RUN pnpm install --frozen-lockfile
 COPY --from=pruner /src/.discovery.json .
 COPY --from=pruner /src/out/full/ ./
 RUN pnpm build:backend

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We believe in knowledge sharing and open access. Our code is and will remain ope
 
 ## Versioning and publishing (tooling)
 
-Some of the sub-packages are published to NPM. We use a tool called [changesets](https://github.com/changesets/changesets) to manage versioning, cross-dependency versioning and publishing new versions to NPM.  When you make a change, before merging to master:
+Some of the sub-packages are published to NPM. We use a tool called [changesets](https://github.com/changesets/changesets) to manage versioning, cross-dependency versioning and publishing new versions to NPM.  When you make a change, before merging to main:
 
 - run `pnpm changeset` and mark the packages you wish to publish, select what kind of a change it is (major,minor,patch) and provide the summary of the changes
 


### PR DESCRIPTION
The `--frozen-lockfile` flag ensures that the exact versions specified in `pnpm-lock.yaml` are installed, preventing potential version drift and improving build reproducibility.
Aligns documentation with the actual default branch name used.