### PR TITLE
Fix Zksync gateway urls 

### DIFF
--- a/packages/config/src/common/explorerUrls.ts
+++ b/packages/config/src/common/explorerUrls.ts
@@ -32,7 +32,7 @@ export const EXPLORER_URLS: Record<string, string> = {
   kinto: 'https://explorer.kinto.xyz',
   taiko: 'https://taikoscan.io',
   facet: 'https://explorer.facet.org',
-  gateway: 'https://gateway.explorer.zksync.io/address',
+  gateway: 'https://gateway.explorer.zksync.io/',
   gnosis: 'https://gnosisscan.io/address',
   zircuit: 'https://explorer.zircuit.com/address',
 }


### PR DESCRIPTION
Permission urls duplicate /address e.g., 
https://l2beat.com/scaling/projects/zksync-era#EOA%201
https://gateway.explorer.zksync.io/address/address/0x30066439887C0a509Cb38E45c9262E6924a29BbD