### PR TITLE
Fix Fhenix documentation link (404)

### DIFF
--- a/packages/config/src/projects/fhenix/fhenix.ts
+++ b/packages/config/src/projects/fhenix/fhenix.ts
@@ -16,9 +16,7 @@ export const fhenix: ScalingProject = upcomingL2({
     stacks: ['Arbitrum'],
     links: {
       websites: ['https://fhenix.io/'],
-      documentation: [
-        'https://fhenix.io/fhe-rollups-scaling-confidential-smart-contracts-on-ethereum-and-beyond-whitepaper/',
-      ],
+      documentation: ['https://cofhe-docs.fhenix.zone/'],
       repositories: ['https://github.com/orgs/FhenixProtocol/'],
       socialMedia: [
         'https://x.com/FhenixIO',


### PR DESCRIPTION
The previous documentation link was returning 404. 
Updated to the new docs site: https://cofhe-docs.fhenix.zone/