### PR TITLE
Add LensCan explorer to Lens project

### DIFF
--- a/packages/config/src/projects/lens/lens.ts
+++ b/packages/config/src/projects/lens/lens.ts
@@ -34,7 +34,11 @@ export const lens: ScalingProject = zkStackL2({
         'https://onboarding.lens.xyz/explore',
       ],
       documentation: ['https://lens.xyz/docs'],
-      explorers: ['https://momoka.lens.xyz', 'https://explorer.lens.xyz/'],
+      explorers: [
+        'https://momoka.lens.xyz',
+        'https://explorer.lens.xyz/',
+        'https://lenscan.io/',
+      ],
       repositories: ['https://github.com/lens-protocol'],
       socialMedia: [
         'https://hey.xyz/u/lens',


### PR DESCRIPTION
## Summary
This PR adds the new LensCan explorer (`https://lenscan.io/`) to the Lens project configuration.

## Changes
- Added `https://lenscan.io/` to the explorers list in `packages/config/src/projects/lens/lens.ts`

## Context
Based on the official announcement from Lens Protocol on X (Twitter): https://x.com/LC/status/1960001225656574435

The LensCan explorer provides users with an additional way to explore and interact with the Lens Network blockchain.
