### PR TITLE
Disable activity for unite

### DIFF
--- a/packages/config/src/projects/unite/unite.ts
+++ b/packages/config/src/projects/unite/unite.ts
@@ -36,17 +36,6 @@ export const unite: ScalingProject = underReviewL3({
     name: 'unite',
     gasTokens: ['UNITE'],
     chainId: 88899,
-    apis: [
-      {
-        type: 'rpc',
-        url: 'https://unite-mainnet.g.alchemy.com/public',
-        callsPerMinute: 1500,
-      },
-    ],
-  },
-  activityConfig: {
-    type: 'block',
-    startBlock: 1,
-    adjustCount: { type: 'SubtractOne' },
+    apis: [],
   },
 })


### PR DESCRIPTION
Wa are disabling activity for this project as the public RPC throttles as a LOT so syncing entire history of ~20 mln blocks would take months ...