### PR TITLE
docs: update default branch reference from 'master' to 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We believe in knowledge sharing and open access. Our code is and will remain ope
 
 ## Versioning and publishing (tooling)
 
-Some of the sub-packages are published to NPM. We use a tool called [changesets](https://github.com/changesets/changesets) to manage versioning, cross-dependency versioning and publishing new versions to NPM.  When you make a change, before merging to master:
+Some of the sub-packages are published to NPM. We use a tool called [changesets](https://github.com/changesets/changesets) to manage versioning, cross-dependency versioning and publishing new versions to NPM.  When you make a change, before merging to main:
 
 - run `pnpm changeset` and mark the packages you wish to publish, select what kind of a change it is (major,minor,patch) and provide the summary of the changes
 


### PR DESCRIPTION
Update README documentation to use the modern Git branch naming convention. Changes reference from "merging to master" to  "merging to main" in the versioning and publishing section