### PR TITLE
fix: use console.error for error logging in blockNumberInput

### DIFF
--- a/packages/uops-dashboard/src/components/blockNumberInput.tsx
+++ b/packages/uops-dashboard/src/components/blockNumberInput.tsx
@@ -31,7 +31,7 @@ export function BlockNumberInput({
         setErrorMessage(error.message)
       }
     } catch (err) {
-      console.log(err)
+      console.error(err)
     }
     setIsLoading(false)
   }


### PR DESCRIPTION
Replace console.log with console.error in catch block for proper error level logging. This follows JavaScript best practices and improves debugging experience by ensuring errors appear with appropriate severity in browser dev tools and log aggregation systems.