### PR TITLE
Update Sovrun testnet explorer URL

### DIFF
--- a/packages/config/src/projects/sovrun/sovrun.ts
+++ b/packages/config/src/projects/sovrun/sovrun.ts
@@ -15,7 +15,7 @@ export const sovrun: ScalingProject = upcomingL2({
     stacks: ['Arbitrum'],
     links: {
       websites: ['https://sovrun.org/'],
-      explorers: ['https://testnet-l2-explorer-hyperliquid.sovrun.org/'],
+      explorers: ['https://testnet-explorer.sovrun.org/'],
       documentation: ['https://docs.sovrun.org/'],
       socialMedia: [
         'https://medium.com/@sovrun',


### PR DESCRIPTION
Update explorer URL from testnet-l2-explorer-hyperliquid.sovrun.org to testnet-explorer.sovrun.org