### PR TITLE
refactor: eliminate duplicate timestamp calculations in getTransferQuery

### DIFF
--- a/packages/backend/src/modules/tracked-txs/utils/sql/getTransferQuery.ts
+++ b/packages/backend/src/modules/tracked-txs/utils/sql/getTransferQuery.ts
@@ -7,15 +7,18 @@ export function getTransferQuery(
   from: UnixTime,
   to: UnixTime,
 ): BigQueryClientQuery {
+  const fromTimestamp = UnixTime.toDate(from).toISOString()
+  const toTimestamp = UnixTime.toDate(to).toISOString()
+  
   const params = [
-    UnixTime.toDate(from).toISOString(),
-    UnixTime.toDate(to).toISOString(),
+    fromTimestamp,
+    toTimestamp,
     ...transfersConfig.flatMap((c) => [
       ...(c.from ? [c.from.toLowerCase()] : []),
       c.to.toLowerCase(),
     ]),
-    UnixTime.toDate(from).toISOString(),
-    UnixTime.toDate(to).toISOString(),
+    fromTimestamp,
+    toTimestamp,
   ]
 
   // To calculate the non-zero bytes we are grouping bytes by adding 'x' sign between each byte


### PR DESCRIPTION
Avoid redundant calls to UnixTime.toDate().toISOString() by extracting timestamp values into variables. This improves code readability and slightly enhances performance by reducing function call overhead.

The same timestamp values were being calculated twice for the same parameters in the SQL query parameter array.