### PR TITLE
chore: remove redundant import aliases for validate package

### DIFF
--- a/packages/uops-dashboard/src/server/clients/contract/ScanClient.ts
+++ b/packages/uops-dashboard/src/server/clients/contract/ScanClient.ts
@@ -1,4 +1,4 @@
-import { v as v } from '@l2beat/validate'
+import { v } from '@l2beat/validate'
 import type { ContractClient } from './ContractClient'
 
 const Response = v.object({


### PR DESCRIPTION
Remove unnecessary 'v as v' aliases in import statements from @l2beat/validate in ScanClient and blockIndexer types. These aliases provide no value and can be simplified to just 'v' for better code clarity.