### PR TITLE
fix: replace Syndicate 404 links with valid documentation links

### DIFF
--- a/packages/config/src/projects/degen/degen.ts
+++ b/packages/config/src/projects/degen/degen.ts
@@ -27,7 +27,7 @@ export const degen: ScalingProject = orbitStackL3({
       websites: ['https://syndicate.io/blog/degen-chain'],
       bridges: ['https://bridge.degen.tips/', 'https://degen.tips/'],
       documentation: [
-        'https://docs.syndicate.io/docs/get-started/introduction',
+        'https://docs.syndicate.io/docs/core/get-started/introduction',
       ],
       explorers: ['https://explorer.degen.tips/'],
       socialMedia: [

--- a/packages/config/src/projects/syndicateframe/syndicateframe.ts
+++ b/packages/config/src/projects/syndicateframe/syndicateframe.ts
@@ -31,7 +31,7 @@ export const syndicateframe: ScalingProject = opStackL3({
         'https://frame.syndicate.io/',
       ],
       documentation: [
-        'https://docs.syndicate.io/docs/get-started/introduction',
+        'https://docs.syndicate.io/docs/core/get-started/introduction',
       ],
       explorers: ['https://explorer-frame.syndicate.io/'],
       repositories: [


### PR DESCRIPTION
- Fix 404 documentation links for syndicateframe project
- Fix 404 documentation links for degen project
- Update docs.syndicate.io links to include /core/ path segment