### PR TITLE
Remove redundant stacks: ['ZK Stack'] configuration

### DIFF
--- a/packages/config/src/projects/lens/lens.ts
+++ b/packages/config/src/projects/lens/lens.ts
@@ -25,7 +25,6 @@ export const lens: ScalingProject = zkStackL2({
     slug: 'lens',
     description:
       "Lens Network is the main social networking hub for the user base of Lens Protocol, built on a Validium using ZKsync's ZK Stack technology.",
-    stacks: ['ZK Stack'],
     architectureImage: 'zkstack-validium-vector',
     links: {
       websites: ['https://lens.xyz'],

--- a/packages/config/src/projects/zkcandy/zkcandy.ts
+++ b/packages/config/src/projects/zkcandy/zkcandy.ts
@@ -27,7 +27,6 @@ export const zkcandy: ScalingProject = zkStackL2({
     slug: 'zkcandy',
     description:
       "zkCandy is a Gaming Validium built on ZKsync's ZK stack for the next generation of GameFi - Supercharged by iCandy, the largest game developer in ANZ and SEA.",
-    stacks: ['ZK Stack'],
     links: {
       websites: ['https://zkcandy.io', 'https://icandy.io/'],
       socialMedia: [


### PR DESCRIPTION
Remove stacks: ['ZK Stack'] from lens.ts
Remove stacks: ['ZK Stack'] from zkcandy.ts

The ZK Stack is inherited from the zkStackL2 template, so it doesn't need to be specified in individual project files.