### PR TITLE
Update upload cache timeout for CI frontend builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_REMOTE_CACHE_UPLOAD_TIMEOUT: 10
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
There doesn't seem to be a way to use turbo cache with upload disabled. Shorter timeout should result with more warnings in log about timeout, however there should be less time wasted on uploading artifacts, that are not that helpfull in this workflow. Deploy builds will still upload turbo cache.