### PR TITLE
fix: update Manta Pacific project links, add Telegram channel, and fix 404s

### DIFF
--- a/packages/config/src/projects/mantapacific/mantapacific.ts
+++ b/packages/config/src/projects/mantapacific/mantapacific.ts
@@ -21,18 +21,19 @@ export const mantapacific: ScalingProject = opStackL2({
     description:
       'Manta Pacific is an Optimium empowering EVM-native zero-knowledge (ZK) applications and general dapps.',
     links: {
-      websites: ['https://pacific.manta.network/'],
+      websites: ['https://manta.network/'],
       bridges: ['https://pacific-bridge.manta.network/'],
       documentation: ['https://docs.manta.network/'],
       explorers: [
         'https://pacific-explorer.manta.network/',
-        'https://169.routescan.io/',
+        'https://manta.socialscan.io/',
       ],
       repositories: ['https://github.com/Manta-Network'],
       socialMedia: [
         'https://discord.gg/mantanetwork',
         'https://twitter.com/MantaNetwork',
-        'https://medium.com/@mantanetwork',
+        'https://mantanetwork.medium.com/',
+        'https://t.me/mantanetworkofficial',
       ],
     },
   },


### PR DESCRIPTION
- Update website URL to https://manta.network/
- Replace routescan.io explorer with manta.socialscan.io
- Update Medium profile URL format
- Add official Telegram channel link