### PR TITLE
Clarify call rate bound message

### DIFF
--- a/packages/l2b/src/commands/types.ts
+++ b/packages/l2b/src/commands/types.ts
@@ -45,7 +45,7 @@ export const PositiveRpcBoundNumber: Type<string, number> = extendType(string, {
     const num = await Promise.resolve(Number.parseInt(str, 10))
     assert(
       !isNaN(num) && num > 0 && num <= 1000000,
-      'Call rate bound per minute must be a positive integer between 1 and 1,000,000',
+      'Call rate bound per minute must be a positive integer in [1, 1,000,000]',
     )
     return num
   },


### PR DESCRIPTION
## Description

Refines the validation error in PositiveRpcBoundNumber to state “Call rate bound per minute must be a positive integer in [1, 1,000,000]”, making the inclusive endpoints and positivity explicit and fully aligned with the enforcement logic.