### PR TITLE
Remove debug console.log from terminal store error handling

### DIFF
--- a/packages/protocolbeat/src/panel-terminal/store.ts
+++ b/packages/protocolbeat/src/panel-terminal/store.ts
@@ -110,7 +110,6 @@ function executeStreaming(
         resolve()
       }
     } catch (error) {
-      console.log('Catch error', error)
       set((state) => ({ output: state.output + `Error: ${error}` }))
       set((state) => ({
         command: { ...state.command, stream: undefined, inFlight: false },


### PR DESCRIPTION
The error is already properly handled through:
- UI output display to user  
- Promise rejection for caller handling
- State cleanup for stream management

Debug console statements should not be present in production code as they can expose internal details and clutter browser console.