### PR TITLE
Use referenced projects instead of sharedModules in DiscoUI

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/getCode.ts
+++ b/packages/l2b/src/implementations/discovery-ui/getCode.ts
@@ -5,9 +5,8 @@ import {
   flatteningHash,
   get$Implementations,
 } from '@l2beat/discovery'
-import { type ChainSpecificAddress, notUndefined } from '@l2beat/shared-pure'
+import type { ChainSpecificAddress } from '@l2beat/shared-pure'
 import { existsSync, readdirSync, readFileSync } from 'fs'
-import uniq from 'lodash/uniq'
 import { join } from 'path'
 import { isDeepStrictEqual } from 'util'
 import {
@@ -15,6 +14,7 @@ import {
   getProjectDiscoveries,
 } from './getDiscoveries'
 import type { ApiCodeResponse } from './types'
+import { getReferencedProjects } from './utils'
 
 export function addFlattenerNote(code: string): string {
   const note = [
@@ -47,15 +47,9 @@ function isFlatCodeCurrent(
   codePaths: CodePathResult['codePaths'],
 ): boolean {
   const discovery = configReader.readDiscovery(project)
-
   const discoveries = [discovery]
+  const referencedProjects = getReferencedProjects(discovery)
 
-  const referencedProjects = uniq(
-    discovery.entries
-      .map((e) => e.targetProject)
-      .filter(notUndefined)
-      .sort(),
-  )
   for (const refProj of referencedProjects) {
     const refDiscovery = configReader.readDiscovery(refProj)
     discoveries.push(refDiscovery)

--- a/packages/l2b/src/implementations/discovery-ui/getDiscoveries.ts
+++ b/packages/l2b/src/implementations/discovery-ui/getDiscoveries.ts
@@ -1,6 +1,5 @@
 import type { ConfigReader, DiscoveryOutput } from '@l2beat/discovery'
-import { notUndefined } from '@l2beat/shared-pure'
-import uniq from 'lodash/uniq'
+import { getReferencedProjects } from './utils'
 
 export function getProjectDiscoveries(
   configReader: ConfigReader,
@@ -8,12 +7,8 @@ export function getProjectDiscoveries(
 ): DiscoveryOutput[] {
   const baseDiscovery = configReader.readDiscovery(project)
   const discoveries = [baseDiscovery]
-  const referencedProjects = uniq(
-    baseDiscovery.entries
-      .map((e) => e.targetProject)
-      .filter(notUndefined)
-      .sort(),
-  )
+  const referencedProjects = getReferencedProjects(baseDiscovery)
+
   for (const refProject of referencedProjects) {
     discoveries.push(configReader.readDiscovery(refProject))
   }

--- a/packages/l2b/src/implementations/discovery-ui/getProject.ts
+++ b/packages/l2b/src/implementations/discovery-ui/getProject.ts
@@ -11,13 +11,8 @@ import {
   type TemplateService,
 } from '@l2beat/discovery'
 import type { ColorContract } from '@l2beat/discovery/dist/discovery/config/ColorConfig'
-import {
-  ChainSpecificAddress,
-  EthereumAddress,
-  notUndefined,
-} from '@l2beat/shared-pure'
+import { ChainSpecificAddress, EthereumAddress } from '@l2beat/shared-pure'
 import { utils } from 'ethers'
-import uniq from 'lodash/uniq'
 import { getContractName } from './getContractName'
 import { getContractType } from './getContractType'
 import { getMeta } from './getMeta'
@@ -33,6 +28,7 @@ import type {
   Field,
   FieldValue,
 } from './types'
+import { getReferencedProjects } from './utils'
 
 interface ProjectData {
   config: ConfigRegistry
@@ -54,12 +50,7 @@ function readProject(
 
   try {
     const discovery = configReader.readDiscovery(project)
-    const referencedProjects = uniq(
-      discovery.entries
-        .map((e) => e.targetProject)
-        .filter(notUndefined)
-        .sort(),
-    )
+    const referencedProjects = getReferencedProjects(discovery)
 
     return [
       { config: configReader.readConfig(project), discovery },

--- a/packages/l2b/src/implementations/discovery-ui/utils.ts
+++ b/packages/l2b/src/implementations/discovery-ui/utils.ts
@@ -1,0 +1,12 @@
+import type { DiscoveryOutput } from '@l2beat/discovery'
+import { notUndefined } from '@l2beat/shared-pure'
+import uniq from 'lodash/uniq'
+
+export function getReferencedProjects(discovery: DiscoveryOutput): string[] {
+  return uniq(
+    discovery.entries
+      .map((e) => e.targetProject)
+      .filter(notUndefined)
+      .sort(),
+  )
+}


### PR DESCRIPTION
Resolves L2B-11755

Fixes issue on Disco UI where projects referencing other projects via entrypoints.json failed to load.