### PR TITLE
fix: correct spelling errors in bridge plugin comments

### DIFF
--- a/packages/backend/src/modules/bridges/plugins/debridge.ts
+++ b/packages/backend/src/modules/bridges/plugins/debridge.ts
@@ -1,4 +1,4 @@
-/* in deBridge messaing protocol allows for token transfers. The only difference between message and token transfer is that
+/* in deBridge messaging protocol allows for token transfers. The only difference between message and token transfer is that
 the latter requires a token address and amount to be specified. In case of token transfer, the tokens are locked in the deBridgeGate contract on the source chain
 and minted (or released if the native token is bridged) on the destination chain. */
 
@@ -128,7 +128,7 @@ export class DeBridgePlugin implements BridgePlugin {
     }
   }
 
-  /* Matching alogrithm:
+  /* Matching algorithm:
 1. For Each Claimed on DST
 2. Find Sent on SRC with the same submissionId
 3. Create Message

--- a/packages/backend/src/modules/bridges/plugins/hyperlane.ts
+++ b/packages/backend/src/modules/bridges/plugins/hyperlane.ts
@@ -1,5 +1,5 @@
 /* 
-Minimalistic plugin matching Hyperlane messsages w/out detecting anything more specific. To detetc sender/receivers
+Minimalistic plugin matching Hyperlane messages w/out detecting anything more specific. To detetc sender/receivers
 additional event parsers would be needed.
 */
 


### PR DESCRIPTION

```markdown

- Fixed "messaing" → "messaging" and "alogrithm" → "algorithm"
- Fixed "messsages" → "messages"

```

