### PR TITLE
Print server url when starting frontend locally

### DIFF
--- a/packages/frontend/src/server/server.ts
+++ b/packages/frontend/src/server/server.ts
@@ -54,8 +54,13 @@ export function createServer() {
   }
 
   const server = app.listen(port, () => {
+    const url = isProduction
+      ? `Server running on port ${port}`
+      : `http://localhost:${port}`
+
     logger.info('Started', {
       port,
+      url,
     })
   })
 


### PR DESCRIPTION
Resolves L2B-11138

Url print:
<img width="712" height="174" alt="54022" src="https://github.com/user-attachments/assets/af6df788-ebfc-464f-948a-98439649285f" />

Info when port collision:
<img width="1214" height="138" alt="38874" src="https://github.com/user-attachments/assets/e90395d5-231e-462f-bdbc-aef0e1603c1c" />
