### PR TITLE
fix: update Blessnet bridge URL

### DIFF
--- a/packages/config/src/projects/blessnet/blessnet.ts
+++ b/packages/config/src/projects/blessnet/blessnet.ts
@@ -26,7 +26,7 @@ export const blessnet: ScalingProject = orbitStackL3({
       websites: ['https://bless.net/'],
       bridges: [
         'https://blessnet.bridge.caldera.xyz/',
-        'https://bridge.bless.net/',
+        'https://bless.net/bridge',
       ],
       documentation: ['https://docs.bless.net/'],
       explorers: ['https://scan.bless.net/'],


### PR DESCRIPTION
- Changed bridge URL from https://bridge.bless.net/ to https://bless.net/bridge
- This aligns with the current Blessnet website structure