### PR TITLE
fix: add radix parameter to Number.parseInt in blockCountInput

### DIFF
--- a/packages/uops-dashboard/src/components/blockCountInput.tsx
+++ b/packages/uops-dashboard/src/components/blockCountInput.tsx
@@ -16,7 +16,7 @@ export function BlockCountInput({
   }
 
   const handleSet = (input: string) => {
-    const newCount = Number.parseInt(input.replace(/\D/g, ''))
+    const newCount = Number.parseInt(input.replace(/\D/g, ''), 10)
     handleSetBlockCount('edit', newCount)
   }
 


### PR DESCRIPTION
Add explicit radix parameter (10) to Number.parseInt call to follow best practices and prevent potential parsing issues. This ensures consistent decimal parsing behavior across different JavaScript engines