### PR TITLE
FIx Hyperlane Nexus URL to nexus.hyperlane.xyz

### DIFF
--- a/packages/config/src/projects/hyperlane/hyperlane.ts
+++ b/packages/config/src/projects/hyperlane/hyperlane.ts
@@ -33,7 +33,7 @@ export const hyperlane: Bridge = {
     category: 'Token Bridge',
     links: {
       websites: ['https://hyperlane.xyz/'],
-      bridges: ['https://usenexus.org/'],
+      bridges: ['https://nexus.hyperlane.xyz/'],
       repositories: ['https://github.com/hyperlane-xyz'],
       documentation: ['https://docs.hyperlane.xyz/'],
       socialMedia: [


### PR DESCRIPTION
Nexus is moving to nexus.hyperlane.xyz
On Saturday 8/30, Nexus will move to nexus.hyperlane.xyz.