### PR TITLE
Fix Funki explorer URL to explorer.funkichain.com

### DIFF
--- a/packages/config/src/projects/funki/funki.ts
+++ b/packages/config/src/projects/funki/funki.ts
@@ -87,7 +87,7 @@ export const funki: ScalingProject = opStackL2({
   chainConfig: {
     name: 'funki',
     chainId: 33979,
-    explorerUrl: 'https://funkiscan.io',
+    explorerUrl: 'https://explorer.funkichain.com',
     sinceTimestamp: genesisTimestamp,
     apis: [
       {


### PR DESCRIPTION
- Changed explorer URL from funkiscan.io to explorer.funkichain.com
- This update ensures the correct explorer is used for Funki chain