### PR TITLE
Fix getBlockNumberAtOrBefore

### DIFF
--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.test.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.test.ts
@@ -25,6 +25,17 @@ describe(getBlockNumberAtOrBefore.name, () => {
 
     expect(result).toEqual(2137)
   })
+
+  it('includes end as a possible result', async () => {
+    const result = await getBlockNumberAtOrBefore(
+      UnixTime(110000),
+      0,
+      100000,
+      async (n: number) => ({ timestamp: Math.floor(n / 2) }),
+    )
+
+    expect(result).toEqual(100000)
+  })
 })
 
 const fakeGetBlock = async (number: number) => ({

--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
@@ -6,15 +6,19 @@ export async function getBlockNumberAtOrBefore(
   end: number,
   getBlock: (number: number) => Promise<{ timestamp: number }>,
 ): Promise<number> {
-  while (start + 1 < end) {
-    const mid = start + Math.floor((end - start) / 2)
-    const midBlock = await getBlock(mid)
-    if (midBlock.timestamp <= timestamp) {
-      start = mid
+  let result = start
+
+  while (start <= end) {
+    const mid = Math.floor((start + end) / 2)
+    const block = await getBlock(mid)
+
+    if (block.timestamp <= timestamp) {
+      result = mid
+      start = mid + 1
     } else {
-      end = mid
+      end = mid - 1
     }
   }
 
-  return start
+  return result
 }


### PR DESCRIPTION
It was not including the end as the possible result