### PR TITLE
Fix dangling EOAs in Nodes view

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/parseFieldValue.ts
+++ b/packages/l2b/src/implementations/discovery-ui/parseFieldValue.ts
@@ -14,7 +14,7 @@ export function parseFieldValue(
       )
       return { type: 'hex', value }
     }
-    if (/^\w*:0x[a-f\d]*$/i.test(value)) {
+    if (/^[\w-]*:0x[a-f\d]*$/i.test(value)) {
       const [prefix, rawAddress] = value.split(':')
 
       if (isChainShortName(prefix) && rawAddress.length === 42) {


### PR DESCRIPTION
metis-andromeda would've skipped regex test and fallback to type: string 