### PR TITLE
fix: correct error message for address validation in decoder form

### DIFF
--- a/packages/tools/src/decoder-new/form/state.ts
+++ b/packages/tools/src/decoder-new/form/state.ts
@@ -114,7 +114,7 @@ export function reducer(state: State, action: Action): State {
           address:
             !value || ADDRESS_REGEX.test(value)
               ? undefined
-              : 'Invalid transaction hash',
+              : 'Invalid address',
         },
       }
     }


### PR DESCRIPTION
Fix incorrect error message in address validation. The validator was checking for a valid address format but displaying "Invalid transaction hash" error message. Changed to "Invalid address" to match the actual validation logic.