### PR TITLE
fix: update invalid Discord links for Rise and Sorare projects

### DIFF
--- a/packages/config/src/projects/rise/rise.ts
+++ b/packages/config/src/projects/rise/rise.ts
@@ -21,7 +21,7 @@ export const rise: ScalingProject = upcomingL2({
       repositories: ['https://github.com/risechain'],
       explorers: ['https://explorer.testnet.riselabs.xyz'],
       socialMedia: [
-        'https://discord.com/invite/4yWVabz63y',
+        'https://discord.com/invite/risechain',
         'https://medium.com/@rise_chain',
         'https://x.com/rise_chain',
       ],

--- a/packages/config/src/projects/sorare/sorare.ts
+++ b/packages/config/src/projects/sorare/sorare.ts
@@ -72,7 +72,7 @@ export const sorare: ScalingProject = {
       documentation: ['https://docs.starkware.co/starkex/index.html'],
       repositories: ['https://github.com/starkware-libs/starkex-contracts'],
       socialMedia: [
-        'https://discord.gg/TSjtHaM',
+        'https://discord.com/invite/sorare',
         'https://reddit.com/r/Sorare/',
         'https://twitter.com/Sorare',
         'https://instagram.com/sorare_official/',


### PR DESCRIPTION
- Update Rise Discord link from invalid invite to risechain
- Update Sorare Discord link from invalid invite to sorare
- Both links now use the correct discord.com/invite format