### PR TITLE
add missing social link in hop.ts

### DIFF
--- a/packages/config/src/projects/hop/hop.ts
+++ b/packages/config/src/projects/hop/hop.ts
@@ -19,6 +19,7 @@ export const hop: Bridge = {
       socialMedia: [
         'https://twitter.com/HopProtocol',
         'https://medium.com/hop-protocol',
+        'https://discord.com/invite/PwCF88emV4',
       ],
     },
     description:


### PR DESCRIPTION
add discord invite in `packages/config/src/projects/hop/hop.ts`

`https://discord.com/invite/PwCF88emV4`