### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/config/src/projects/near/near-da.ts
+++ b/packages/config/src/projects/near/near-da.ts
@@ -123,7 +123,7 @@ Regarding data retrieval, full nodes prune Receipts after 3 epochs (approximatel
         },
         {
           title: 'Near documentation',
-          url: 'https://dev.near.org/documentation/',
+          url: 'https://docs.near.org/',
         },
         {
           title: 'Near Core - Architecture',


### PR DESCRIPTION
https://dev.near.org/documentation/ - broken
https://docs.near.org/ - correct
<img width="1233" height="727" alt="image" src="https://github.com/user-attachments/assets/ef6424bd-2360-40e2-92ac-e4c26286816e" />

Near also thinks it's their new link