### PR TITLE
Fix logging confusion

### DIFF
--- a/packages/token-backend/src/execution.ts
+++ b/packages/token-backend/src/execution.ts
@@ -28,16 +28,9 @@ export function executePlan(
   logger.info('Executing plan', { plan, meta })
   return db.transaction(
     async (): Promise<PlanExecutionResult> => {
-      const planRegeneration = await generatePlan(
-        db,
-        plan.intent,
-        meta
-          ? {
-              ...meta,
-              caller: 'executePlan',
-            }
-          : undefined,
-      )
+      const planRegeneration = await generatePlan(db, plan.intent, {
+        skipLogs: true,
+      })
       if (planRegeneration.outcome === 'error') {
         logger.error('Plan is no longer valid', {
           error: planRegeneration.error,
@@ -64,6 +57,7 @@ export function executePlan(
         await executeCommand(db, command)
         logger.info('Command executed', { command, meta })
       }
+      logger.info('Plan executed', { plan, meta })
       return {
         outcome: 'success',
       }

--- a/packages/token-backend/src/planning.ts
+++ b/packages/token-backend/src/planning.ts
@@ -41,13 +41,17 @@ interface PlanningResultError {
 export async function generatePlan(
   db: TokenDatabase,
   intent: Intent,
-  meta?: {
-    email: string
-    caller?: 'executePlan'
+  opts?: {
+    skipLogs?: boolean
+    meta?: {
+      email: string
+    }
   },
 ): Promise<PlanningResult> {
   const logger = getLogger().for('generatePlan')
-  logger.info('Generating plan', { intent, meta })
+  if (!opts?.skipLogs) {
+    logger.info('Generating plan', { intent, meta: opts?.meta })
+  }
   let commands: Command[]
   try {
     switch (intent.type) {
@@ -83,7 +87,9 @@ export async function generatePlan(
     throw error
   }
 
-  logger.info('Plan generated', { commands, meta })
+  if (!opts?.skipLogs) {
+    logger.info('Plan generated', { commands, meta: opts?.meta })
+  }
   return {
     outcome: 'success',
     plan: {

--- a/packages/token-backend/src/trpc/routers/plan.ts
+++ b/packages/token-backend/src/trpc/routers/plan.ts
@@ -6,7 +6,7 @@ import { protectedProcedure, router } from '../trpc'
 
 export const planRouter = router({
   generate: protectedProcedure.input(Intent).mutation(({ input, ctx }) => {
-    return generatePlan(db, input, { email: ctx.email })
+    return generatePlan(db, input, { meta: { email: ctx.email } })
   }),
   execute: protectedProcedure.input(Plan).mutation(({ input, ctx }) => {
     return executePlan(db, input, { email: ctx.email })


### PR DESCRIPTION
executePlan calls generatePlan to regenerate the plan to check if its valid.
logs were identical, so I added caller so that we know that this plan was generated for check