### PR TITLE
docs: fix broken links

### DIFF
--- a/packages/config/src/projects/termstructure/termstructure.ts
+++ b/packages/config/src/projects/termstructure/termstructure.ts
@@ -260,7 +260,7 @@ export const termstructure: ScalingProject = {
           },
           {
             title: 'Forced Withdrawal - Term Structure documentation',
-            url: 'https://docs.ts.finance/zktrue-up/zk-architecture/forced-withdrawal-and-evacuation-mode#forced-withdrawal',
+            url: 'https://tutorials.ts.finance/how-to-use-term-structure/onboarding-guide/withdraw?utm_source=chatgpt.com#forced-withdraw-and-evacuation-mode',
           },
         ],
       },
@@ -269,7 +269,7 @@ export const termstructure: ScalingProject = {
         references: [
           {
             title: 'Evacuation Mode - Term Structure documentation',
-            url: 'https://docs.ts.finance/zktrue-up/zk-architecture/forced-withdrawal-and-evacuation-mode#evacuation-mode',
+            url: 'https://tutorials.ts.finance/how-to-use-term-structure/onboarding-guide/withdraw?utm_source=chatgpt.com#forced-withdraw-and-evacuation-mode',
           },
         ],
       },


### PR DESCRIPTION
https://docs.ts.finance/zktrue-up/zk-architecture/forced-withdrawal-and-evacuation-mode#forced-withdrawal - is broken
https://tutorials.ts.finance/how-to-use-term-structure/onboarding-guide/withdraw?utm_source=chatgpt.com#forced-withdraw-and-evacuation-mode - this link is alive, not so informative but still alive