### PR TITLE
fix(l2b): remove finish listener to avoid duplicate final progress logs

### DIFF
--- a/packages/l2b/src/implementations/fetchFlatSources.ts
+++ b/packages/l2b/src/implementations/fetchFlatSources.ts
@@ -21,10 +21,6 @@ export async function fetchFlatSources(
 
   const progress = new ResponseProgress(response)
   progress.on('progress', (p) => printProgress(logger, p))
-  progress.on('finish', (p) => {
-    printProgress(logger, p)
-    finishProgress(logger, p)
-  })
 
   return FlatSourcesApiResponse.parse(await response.json())
 }
@@ -45,10 +41,6 @@ function printProgress(logger: Logger, progress: ProgressEvent) {
     'lineDownloaded',
     `Downloaded ${prog} % (${done} of ${total}) [${rate} in ~${eta}]`,
   )
-}
-
-function finishProgress(logger: Logger, progress: ProgressEvent) {
-  printProgress(logger, progress)
 }
 
 export function saveIntoDirectory(


### PR DESCRIPTION
This change removes the redundant final logging of download progress by deleting the 'finish' event listener and the unused finishProgress helper. ResponseProgress already emits a final 'progress' event right before 'finish', and we log on every 'progress', so invoking printProgress again in the 'finish' handler caused duplicate (sometimes triple) final lines in the output. By relying solely on the final 'progress' emission from the stream end, we preserve the last accurate progress snapshot while eliminating noisy, repeated logs. No behavior, timing, or output format changes beyond removing the extra lines; the user still sees a single, correct final progress line when the download completes.