### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/config/src/templates/orbitStack.ts
+++ b/packages/config/src/templates/orbitStack.ts
@@ -275,7 +275,7 @@ function defaultStateValidation(
       references: [
         {
           title: 'How is fraud proven - Arbitrum documentation FAQ',
-          url: 'https://docs.arbitrum.io/welcome/arbitrum-gentle-introduction#q-and-how-exactly-is-fraud-proven-sounds-complicated',
+          url: 'https://docs.arbitrum.io/how-arbitrum-works/validation-and-proving/validation-and-proving',
         },
       ],
     },


### PR DESCRIPTION
https://docs.arbitrum.io/welcome/arbitrum-gentle-introduction#q-and-how-exactly-is-fraud-proven-sounds-complicated - doesn't work
https://docs.arbitrum.io/how-arbitrum-works/validation-and-proving/validation-and-proving - this link is correct

There is an article connected with 'q-and-how-exactly-is-fraud-proven-sounds-complicated' here is link - https://docs.arbitrum.io/get-started/arbitrum-introduction and this link redirects to correct link - https://docs.arbitrum.io/how-arbitrum-works/validation-and-proving/validation-and-proving

<img width="1168" height="215" alt="image" src="https://github.com/user-attachments/assets/d228cef9-49c8-4cbd-b943-ca5502947b78" />
