### PR TITLE
Fix filter state parsing

### DIFF
--- a/packages/frontend/src/pages/scaling/summary/components/ScalingSummaryTables.tsx
+++ b/packages/frontend/src/pages/scaling/summary/components/ScalingSummaryTables.tsx
@@ -43,7 +43,7 @@ export function ScalingSummaryTables(props: Props) {
   return (
     <>
       <HorizontalSeparator className="my-4 max-md:hidden" />
-      <div className="mr-4 flex flex-wrap items-end justify-between gap-y-1 md:mr-0">
+      <div className="mr-4 flex flex-wrap items-end justify-between gap-x-4 gap-y-1 md:mr-0">
         <TableFilters
           entries={[
             ...props.rollups,
@@ -52,7 +52,7 @@ export function ScalingSummaryTables(props: Props) {
             ...props.notReviewed,
           ]}
         />
-        <div className="ml-4 flex flex-wrap gap-1">
+        <div className="flex flex-wrap gap-1">
           <IncludeRwaRestrictedTokensCheckbox />
           <ExcludeAssociatedTokensCheckbox />
         </div>


### PR DESCRIPTION
Gets rid of this:
<img width="1111" height="866" alt="image" src="https://github.com/user-attachments/assets/96655458-4a26-4be8-b776-f5488e10bd6a" />
And actually makes the parsing safer cuz it sanitizes the input

Resolves L2B-12285