### PR TITLE
Archive zkspace.

### DIFF
--- a/packages/config/src/projects/zkspace/zkspace.ts
+++ b/packages/config/src/projects/zkspace/zkspace.ts
@@ -37,6 +37,7 @@ export const zkspace: ScalingProject = {
   id: ProjectId('zkspace'),
   capability: 'appchain',
   addedAt: UnixTime(1629199654), // 2021-08-17T11:27:34Z
+  archivedAt: UnixTime(1761560995),
   badges: [
     BADGES.VM.AppChain,
     BADGES.DA.EthereumCalldata,


### PR DESCRIPTION
The [RPC](https://chainlist.org/chain/1456) is no longer accessible, the explorer shows no data, X is no longer active, and the GitHub hasn’t been updated for a year.