### PR TITLE
Remove unused default React import from Breadcrumbs

### DIFF
--- a/packages/frontend/src/components/Breadcrumbs.tsx
+++ b/packages/frontend/src/components/Breadcrumbs.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react'
-import React from 'react'
+import { Fragment, type ReactNode } from 'react'
 import { ChevronIcon } from '~/icons/Chevron'
 import { cn } from '~/utils/cn'
 
@@ -22,14 +21,14 @@ export function Breadcrumbs({ items, className }: Props) {
       )}
     >
       {items.map((item, i) => (
-        <React.Fragment key={i}>
+        <Fragment key={i}>
           <BreadcrumbItem href={item.href} className="last:text-primary">
             {item.content}
           </BreadcrumbItem>
           {i < items.length - 1 && (
             <ChevronIcon className="-rotate-90 size-2.5 fill-current" />
           )}
-        </React.Fragment>
+        </Fragment>
       ))}
     </nav>
   )


### PR DESCRIPTION
replace the default React import with a named Fragment import in packages/frontend/src/components/Breadcrumbs.tsx, keeping JSX fragments intact while eliminating the unused binding

ensure the component still renders items via <Fragment> wrappers