### PR TITLE
chore: correct github link to Miden

### DIFF
--- a/packages/config/src/projects/polygonmiden/polygonmiden.ts
+++ b/packages/config/src/projects/polygonmiden/polygonmiden.ts
@@ -17,7 +17,7 @@ export const polygonmiden: ScalingProject = upcomingL2({
     links: {
       websites: ['https://polygon.technology/polygon-miden'],
       documentation: ['https://docs.polygon.technology/miden/'],
-      repositories: ['https://github.com/0xPolygonMiden'],
+      repositories: ['https://github.com/0xMiden'],
       socialMedia: [
         'https://x.com/0xPolygon',
         'https://x.com/0xPolygonMiden',


### PR DESCRIPTION
https://github.com/0xPolygonMiden - their old github, they moved to https://github.com/0xMiden