### PR TITLE
config(polynomial): add Blockscout V2 explorer API

### DIFF
--- a/packages/config/src/projects/polynomial/polynomial.ts
+++ b/packages/config/src/projects/polynomial/polynomial.ts
@@ -44,6 +44,7 @@ export const polynomial: ScalingProject = opStackL2({
         url: 'https://rpc.polynomial.fi',
         callsPerMinute: 300,
       },
+      { type: 'blockscoutV2', url: 'https://polynomialscan.io/api/v2' },
     ],
   },
   isNodeAvailable: true,


### PR DESCRIPTION
- Polynomial explorer is Blockscout-backed (testnet confirms Blockscout UI; Conduit-hosted endpoints follow Blockscout patterns).
- Aligns with other OP Stack L2 configs (e.g., Base, Optimism) that include blockscoutV2 for their explorers.
