### PR TITLE
fix: set ApeX proofSystem to Validity and add zkCatalogId('stone')

### DIFF
--- a/packages/config/src/projects/apex/apex.ts
+++ b/packages/config/src/projects/apex/apex.ts
@@ -111,7 +111,8 @@ export const apex: ScalingProject = {
     BADGES.Infra.SHARP,
   ],
   proofSystem: {
-    type: 'Optimistic',
+    type: 'Validity',
+    zkCatalogId: ProjectId('stone'),
   },
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.LOW_DAC_THRESHOLD],
   display: {


### PR DESCRIPTION
Updated to use Validity proofs with zkCatalogId: ProjectId('stone'). StarkEx-based systems use ZK validity proofs (not optimistic), and this aligns ApeX with other StarkEx configs (e.g., Immutable X, dYdX v3). The existing config already referenced ZK-based risk/state validation (STATE_ZKP_ST, STARKEX_VALIDITY_PROOFS), so this change resolves the inconsistency.