### PR TITLE
Remove redundant completion tracking in SignatureService timeout helper

### DIFF
--- a/packages/tools-api/src/modules/decoder-module/domain/SignatureService.ts
+++ b/packages/tools-api/src/modules/decoder-module/domain/SignatureService.ts
@@ -98,16 +98,13 @@ async function promisesWithTimeout<T>(
   logger: Logger,
 ) {
   const results: (T | undefined)[] = new Array(promises.length).fill(undefined)
-  const completed: boolean[] = new Array(promises.length).fill(false)
-
+  
   const racePromises = promises.map(async (promise, index) => {
     try {
       const result = await promise
       results[index] = result
-      completed[index] = true
-    } catch (error) {
+      } catch (error) {
       logger.error(error)
-      completed[index] = true
     }
   })
 


### PR DESCRIPTION
drop the unused completed bookkeeping in promisesWithTimeout avoid allocating and returning data that the caller never consumes