### PR TITLE
Do not try to extract entries from null

### DIFF
--- a/packages/discovery/src/discovery/utils/extractors.ts
+++ b/packages/discovery/src/discovery/utils/extractors.ts
@@ -45,7 +45,7 @@ export function toAddressArray(
   if (Array.isArray(value)) {
     return value.flatMap((v) => toAddressArray(v))
   }
-  if (typeof value === 'object') {
+  if (typeof value === 'object' && value !== null) {
     return Object.values(value).flatMap((v) => toAddressArray(v))
   }
   if (typeof value === 'string') {


### PR DESCRIPTION
Resolves issues with worldcoin, but potentially with other projects where null values appear in the array/objects somewhere deep in the values.