### PR TITLE
fix: proposerFailure override key in orbitStackL3 stacked risks

### DIFF
--- a/packages/config/src/templates/orbitStack.ts
+++ b/packages/config/src/templates/orbitStack.ts
@@ -750,7 +750,7 @@ export function orbitStackL3(templateVars: OrbitStackConfigL3): ScalingProject {
           RISK_VIEW.SEQUENCER_SELF_SEQUENCE,
         ),
       proposerFailure:
-        templateVars.stackedRiskView?.sequencerFailure ??
+        templateVars.stackedRiskView?.proposerFailure ??
         sumRisk(
           common.riskView.proposerFailure,
           baseChain.riskView.proposerFailure,


### PR DESCRIPTION
- Correct proposerFailure to read from templateVars.stackedRiskView?.proposerFailure instead of sequencerFailure in 
orbitStackL3().getStackedRisks().
- This bug prevented consumer-provided overrides for proposerFailure from taking effect.
- Aligns behavior with analogous logic in opStack.ts and intended semantics of the stacked risk view.