### PR TITLE
chore: fix link to miden docs

### DIFF
--- a/packages/config/src/projects/polygonmiden/polygonmiden.ts
+++ b/packages/config/src/projects/polygonmiden/polygonmiden.ts
@@ -16,7 +16,7 @@ export const polygonmiden: ScalingProject = upcomingL2({
     stacks: ['Agglayer CDK'],
     links: {
       websites: ['https://polygon.technology/polygon-miden'],
-      documentation: ['https://docs.polygon.technology/miden/'],
+      documentation: ['https://docs.miden.xyz/intro/'],
       repositories: ['https://github.com/0xMiden'],
       socialMedia: [
         'https://x.com/0xPolygon',


### PR DESCRIPTION
https://docs.polygon.technology/miden/ - this link is empty, it has redirection to https://0xpolygonmiden.github.io/miden-docs/ but this link is broken
https://docs.miden.xyz/intro/ - this link is official link to miden docs, stable and actual