### PR TITLE
fix: duplicate broken Tally URL

### DIFF
--- a/packages/frontend/src/content/governance-publications/governance-review-71.md
+++ b/packages/frontend/src/content/governance-publications/governance-review-71.md
@@ -182,7 +182,7 @@ You can find us to discuss everything related to Lisk’s governance, from curre
 
 [[ZIP-12] V29 Interop Messaging Upgrade](https://www.tally.xyz/gov/zksync/proposal/40562439712311128665286075271414168289029475306445402072499591795343687723101?govId=eip155:324:0x76705327e682F2d96943280D99464Ab61219e34f) - ends on October 6 at 17:12 UTC.
 
-[[ZIP-13] Adding a ZKsync OS CTM](https://www.tally.xyz/gov/zksync/proposal/22471812359223094779541460804735287481991027375586193607912523407322605938475?govId=eip155:324:0x76705327e682F2d96943280D99464Ab61219e34fhttps://www.tally.xyz/gov/zksync/proposal/22471812359223094779541460804735287481991027375586193607912523407322605938475?govId=eip155:324:0x76705327e682F2d96943280D99464Ab61219e34f) - ends on October 6 at 17:13 UTC.
+[[ZIP-13] Adding a ZKsync OS CTM](https://www.tally.xyz/gov/zksync/proposal/22471812359223094779541460804735287481991027375586193607912523407322605938475?govId=eip155:324:0x76705327e682F2d96943280D99464Ab61219e34f) - ends on October 6 at 17:13 UTC.
 
 ZkSync’s governance hasn’t seen any new developments over the last week. If you believe we might have missed something, please let us know.
 


### PR DESCRIPTION
deduplicate broken Tally URL in Governance Review #71