### PR TITLE
feat(bobanetwork): add eth.bobascan.com to explorers

### DIFF
--- a/packages/config/src/projects/bobanetwork/bobanetwork.ts
+++ b/packages/config/src/projects/bobanetwork/bobanetwork.ts
@@ -24,10 +24,7 @@ export const bobanetwork: ScalingProject = opStackL2({
       websites: ['https://boba.network'],
       bridges: ['https://hub.boba.network/bridge'],
       documentation: ['https://docs.boba.network/'],
-      explorers: [
-        'https://eth.bobascan.com/',
-        'https://bobascan.com/',
-      ],
+      explorers: ['https://eth.bobascan.com/', 'https://bobascan.com/'],
       repositories: ['https://github.com/bobanetwork/boba'],
       socialMedia: [
         'https://boba.network/',


### PR DESCRIPTION
Add https://eth.bobascan.com/ to display.links.explorers in bobanetwork.ts to align with chainConfig.explorerUrl and provide a direct Etherscan-compatible Bobascan link.