### PR TITLE
Optimize project filter allocation in getCostsProjects

### DIFF
--- a/packages/frontend/src/server/features/scaling/costs/utils/getCostsProjects.ts
+++ b/packages/frontend/src/server/features/scaling/costs/utils/getCostsProjects.ts
@@ -49,8 +49,10 @@ function filterToCondition(
       return (p) =>
         p.scalingInfo.type === 'Other' &&
         !(p.statuses.reviewStatus === 'initialReview')
-    case 'projects':
-      return (p) => new Set(filter.projectIds).has(p.id)
+    case 'projects': {
+      const projectIds = new Set(filter.projectIds)
+      return (p) => projectIds.has(p.id)
+    }
     default:
       assertUnreachable(filter)
   }


### PR DESCRIPTION
Cache the `filter.projectIds` set once inside the `projects` branch of `getCostsProjects` preserve the existing filtering logic while avoiding redundant allocations for every project