### PR TITLE
chore: add link to optimism docs

### DIFF
--- a/packages/config/src/projects/optimism/optimism.ts
+++ b/packages/config/src/projects/optimism/optimism.ts
@@ -29,7 +29,10 @@ export const optimism: ScalingProject = opStackL2({
     links: {
       websites: ['https://optimism.io/'],
       bridges: ['https://app.optimism.io'],
-      documentation: ['https://docs.optimism.io/', 'https://community.optimism.io'],
+      documentation: [
+        'https://docs.optimism.io/',
+        'https://community.optimism.io',
+      ],
       explorers: [
         'https://optimistic.etherscan.io',
         'https://optimism.blockscout.com/',


### PR DESCRIPTION
Add https://docs.optimism.io/ alongside the community site to improve accuracy and discoverability.
Aligns Optimism config with analogous OP Stack L2 configs (e.g., base).