### PR TITLE
fix(starknet): correct STRK bridge cap ticker in escrow string

### DIFF
--- a/packages/config/src/projects/starknet/starknet.ts
+++ b/packages/config/src/projects/starknet/starknet.ts
@@ -171,7 +171,7 @@ const escrowDAIMaxTotalBalanceString = formatMaxTotalBalanceString(
   18,
 )
 const escrowSTRKMaxTotalBalanceString = formatMaxTotalBalanceString(
-  'DAI',
+  'STRK',
   discovery.getContractValue<number>('STRKBridge', 'maxTotalBalance'),
   18,
 )


### PR DESCRIPTION
Replace incorrect 'DAI' ticker with 'STRK' in 'escrowSTRKMaxTotalBalanceString' within 'packages/config/src/projects/starknet/starknet.ts'. The STRK bridge ('STRKBridge') refers to the STRK token (18 decimals); using 'DAI' was a copy-paste mistake. While current onchain cap is max uint256 (rendering 'no cap'), this ensures accurate user-facing text if a finite cap is set.