### PR TITLE
fix: Respect explicit architectureImage in polygonCDKStack display

### DIFF
--- a/packages/config/src/templates/polygonCDKStack.ts
+++ b/packages/config/src/templates/polygonCDKStack.ts
@@ -190,10 +190,10 @@ export function polygonCDKStack(
         ...(templateVars.additionalPurposes ?? []),
       ],
       architectureImage:
-        (templateVars.architectureImage ??
-        templateVars.daProvider !== undefined)
+        templateVars.architectureImage ??
+        (templateVars.daProvider !== undefined
           ? 'polygon-cdk-validium'
-          : 'polygon-cdk-rollup',
+          : 'polygon-cdk-rollup'),
       stacks: ['Agglayer CDK'],
       tvsWarning: templateVars.display.tvsWarning,
     },


### PR DESCRIPTION
Corrected operator precedence bug that caused display.architectureImage to ignore a provided value in polygonCDKStack.ts.
Now uses templateVars.architectureImage when set; otherwise defaults based on whether an external DA provider is configured (validium vs rollup).
This aligns override behavior with other templates and ensures user-provided images are respected.