### PR TITLE
Add documentation link to Aztec project config

### DIFF
--- a/packages/config/src/projects/aztec/aztec.ts
+++ b/packages/config/src/projects/aztec/aztec.ts
@@ -64,6 +64,7 @@ export const aztec: ScalingProject = {
     links: {
       websites: ['https://aztec.network/'],
       bridges: ['https://old.zk.money'],
+      documentation: ['https://docs.aztec.network/'],
       repositories: ['https://github.com/AztecProtocol/aztec-2-bug-bounty'],
       socialMedia: [
         'https://twitter.com/aztecnetwork',


### PR DESCRIPTION
include Aztec docs URL in packages/config/src/projects/aztec/aztec.ts. keeps project metadata complete by covering websites, bridges, repositories, and documentation