### PR TITLE
Add Arena-Z documentation link to project config

### DIFF
--- a/packages/config/src/projects/arenaz/arenaz.ts
+++ b/packages/config/src/projects/arenaz/arenaz.ts
@@ -25,6 +25,7 @@ export const arenaz = opStackL2({
     links: {
       websites: ['https://arena-z.gg/'],
       bridges: ['https://bridge.arena-z.gg/', 'https://leagueofkingdoms.com/'],
+      documentation: ['https://whitepaper.playersarena.foundation/arena-z'],
       explorers: ['https://explorer.arena-z.gg/'],
       socialMedia: ['https://x.com/OfficialArenaZ'],
     },


### PR DESCRIPTION
Add the Arena-Z whitepaper URL under links.documentation so the site surfaces the official docs.