### PR TITLE
refactor(relay): handle empty data state in indexer update

### DIFF
--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
@@ -103,16 +103,14 @@ export class RelayIndexer extends ManagedChildIndexer {
       successes.length > 0 ? successes[successes.length - 1] : undefined
 
     if (!last) {
-      // TODO: allow not progressing
-      throw new Error('No entries')
+      return from
     }
     const syncedTo = Math.min(
       to,
       UnixTime.fromDate(new Date(last.updatedAt)) - 1,
     )
     if (syncedTo < from) {
-      // TODO: allow not progressing
-      throw new Error('No entries')
+      return from
     }
 
     const events: InteropEvent[] = []


### PR DESCRIPTION
Replace error throwing with returning `from` when no data is available to process.