### PR TITLE
Add official documentation link for Beamer Bridge V2

### DIFF
--- a/packages/config/src/projects/beamer-bridge-v2/beamer-bridge-v2.ts
+++ b/packages/config/src/projects/beamer-bridge-v2/beamer-bridge-v2.ts
@@ -27,7 +27,7 @@ export const beamerbridgev2: Bridge = {
     links: {
       websites: ['https://beamerbridge.com'],
       bridges: ['https://app.beamerbridge.com'],
-      documentation: ['https://docs.aevo.xyz/#nature-of-the-token-documentation'],
+      documentation: ['https://docs.beamerbridge.com/'],
       repositories: ['https://github.com/beamer-bridge/beamer'],
       socialMedia: [
         'https://twitter.com/BeamerBridge',


### PR DESCRIPTION
Add the Beamer Bridge V2 documentation URL to the project links so the UI surfaces the official docs