### PR TITLE
fix: add link to telegram miden

### DIFF
--- a/packages/config/src/projects/polygonmiden/polygonmiden.ts
+++ b/packages/config/src/projects/polygonmiden/polygonmiden.ts
@@ -23,6 +23,7 @@ export const polygonmiden: ScalingProject = upcomingL2({
         'https://x.com/0xMiden',
         'https://discord.gg/0xPolygon',
         'https://t.me/polygonofficial',
+        'https://t.me/BuildOnMiden',
       ],
       bridges: ['https://faucet.testnet.miden.io'],
       explorers: ['https://testnet.midenscan.com'],


### PR DESCRIPTION
https://t.me/polygonofficial - official link of Polygon, but there is also link of miden - https://t.me/BuildOnMiden 
<img width="1461" height="978" alt="image" src="https://github.com/user-attachments/assets/69797239-174b-46a9-bd52-5f1fd69cea53" />

