### PR TITLE
Add website link for Espresso light client project

### DIFF
--- a/packages/config/src/projects/espressoprover/espressoprover.ts
+++ b/packages/config/src/projects/espressoprover/espressoprover.ts
@@ -13,9 +13,7 @@ export const espressoprover: BaseProject = {
     description:
       'Espresso Light Client prover generates a Plonk proof of the HotShot consenus of Espresso network.',
     links: {
-      websites: [
-        'https://www.espressosys.com/',
-      ],
+      websites: ['https://www.espressosys.com/'],
       documentation: [
         'https://docs.espressosys.com/network/learn/the-espresso-network/internal-functionality/light-client',
       ],


### PR DESCRIPTION
extend the Espresso light client config with its primary website URL ,keeps packages/config/src/projects/espressoprover/espressoprover.ts aligned with other project metadata fields