### PR TITLE
Add documentation link to FraxFerry bridge configuration

### DIFF
--- a/packages/config/src/projects/fraxferry/fraxferry.ts
+++ b/packages/config/src/projects/fraxferry/fraxferry.ts
@@ -27,6 +27,7 @@ export const fraxferry: Bridge = {
     slug: 'fraxferry',
     links: {
       websites: ['https://frax.com/'],
+      documentation: ['https://docs.frax.com/'],
       bridges: ['https://mainnet.frax.com/tools/bridge/'],
       repositories: ['https://github.com/FraxFinance/frax-solidity'],
       socialMedia: ['https://twitter.com/fraxfinance'],


### PR DESCRIPTION
This PR adds the official Frax documentation link to the FraxFerry bridge configuration.
 Added `documentation: ['https://docs.frax.com/']` to the `fraxferry.ts` bridge configuration
