### PR TITLE
Fix L2 token addresses on op stack deposits

### DIFF
--- a/packages/backend/src/modules/interop/plugins/opstack/opstack-standardbridge.ts
+++ b/packages/backend/src/modules/interop/plugins/opstack/opstack-standardbridge.ts
@@ -28,54 +28,54 @@ import {
 const ERC20BridgeInitiatedMessagePassed = createInteropEventType<{
   chain: string
   withdrawalHash: string
-  localToken: Address32
-  remoteToken: Address32
+  l1Token: Address32
+  l2Token: Address32
   amount: bigint
 }>('opstack.MessagePassedERC20BridgeInitiated', {
   ttl: 14 * UnixTime.DAY,
 })
 
 const parseERC20BridgeInitiated = createEventParser(
-  'event ERC20BridgeInitiated(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData)',
+  'event ERC20BridgeInitiated(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)',
 )
 
 // L1 finalization of L2->L1 withdrawal
 const ERC20BridgeFinalizedWithdrawalFinalized = createInteropEventType<{
   chain: string
   withdrawalHash: string
-  localToken: Address32
-  remoteToken: Address32
+  l1Token: Address32
+  l2Token: Address32
   amount: bigint
 }>('opstack.WithdrawalFinalizedERC20BridgeFinalized')
 
 const parseERC20BridgeFinalized = createEventParser(
-  'event ERC20BridgeFinalized(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData)',
+  'event ERC20BridgeFinalized(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)',
 )
 
 // L1 -> L2 deposit initiated
 const ERC20DepositInitiatedSentMessage = createInteropEventType<{
   chain: string
   msgHash: string
-  localToken: Address32
-  remoteToken: Address32
+  l1Token: Address32
+  l2Token: Address32
   amount: bigint
 }>('opstack.SentMessageERC20DepositInitiated')
 
 const parseERC20DepositInitiated = createEventParser(
-  'event ERC20DepositInitiated(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData)',
+  'event ERC20DepositInitiated(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)',
 )
 
 // L2 relay of L1->L2 deposit
 const DepositFinalizedRelayedMessage = createInteropEventType<{
   chain: string
   msgHash: string
-  localToken: Address32
-  remoteToken: Address32
+  l1Token: Address32
+  l2Token: Address32
   amount: bigint
 }>('opstack.RelayedMessageDepositFinalized')
 
 const parseDepositFinalized = createEventParser(
-  'event DepositFinalized(address indexed localToken, address indexed remoteToken, address indexed from, address to, uint256 amount, bytes extraData)',
+  'event DepositFinalized(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)',
 )
 
 // ETH Bridge events
@@ -142,8 +142,8 @@ export class OpStackStandardBridgePlugin implements InteropPlugin {
               ERC20BridgeInitiatedMessagePassed.create(input.ctx, {
                 chain: network.chain,
                 withdrawalHash: messagePassed.withdrawalHash,
-                localToken: Address32.from(erc20BridgeInitiated.localToken),
-                remoteToken: Address32.from(erc20BridgeInitiated.remoteToken),
+                l1Token: Address32.from(erc20BridgeInitiated.l1Token),
+                l2Token: Address32.from(erc20BridgeInitiated.l2Token),
                 amount: erc20BridgeInitiated.amount,
               }),
             ]
@@ -200,8 +200,8 @@ export class OpStackStandardBridgePlugin implements InteropPlugin {
               DepositFinalizedRelayedMessage.create(input.ctx, {
                 chain: network.chain,
                 msgHash: relayedMessage.msgHash,
-                localToken: Address32.from(depositFinalized.localToken),
-                remoteToken: Address32.from(depositFinalized.remoteToken),
+                l1Token: Address32.from(depositFinalized.l1Token),
+                l2Token: Address32.from(depositFinalized.l2Token),
                 amount: depositFinalized.amount,
               }),
             ]
@@ -266,8 +266,8 @@ export class OpStackStandardBridgePlugin implements InteropPlugin {
               ERC20BridgeFinalizedWithdrawalFinalized.create(input.ctx, {
                 chain: network.chain,
                 withdrawalHash: withdrawalFinalized.withdrawalHash,
-                localToken: Address32.from(erc20BridgeFinalized.localToken),
-                remoteToken: Address32.from(erc20BridgeFinalized.remoteToken),
+                l1Token: Address32.from(erc20BridgeFinalized.l1Token),
+                l2Token: Address32.from(erc20BridgeFinalized.l2Token),
                 amount: erc20BridgeFinalized.amount,
               }),
             ]
@@ -343,8 +343,8 @@ export class OpStackStandardBridgePlugin implements InteropPlugin {
               ERC20DepositInitiatedSentMessage.create(input.ctx, {
                 chain: network.chain,
                 msgHash,
-                localToken: Address32.from(erc20DepositInitiated.localToken),
-                remoteToken: Address32.from(erc20DepositInitiated.remoteToken),
+                l1Token: Address32.from(erc20DepositInitiated.l1Token),
+                l2Token: Address32.from(erc20DepositInitiated.l2Token),
                 amount: erc20DepositInitiated.amount,
               }),
             ]
@@ -438,10 +438,10 @@ export class OpStackStandardBridgePlugin implements InteropPlugin {
         Result.Transfer('opstack-standardbridge.L2ToL1Transfer', {
           srcEvent: erc20BridgeInitiated,
           srcAmount: erc20BridgeInitiated.args.amount,
-          srcTokenAddress: erc20BridgeInitiated.args.localToken,
+          srcTokenAddress: erc20BridgeInitiated.args.l2Token,
           dstEvent: event,
           dstAmount: event.args.amount,
-          dstTokenAddress: event.args.localToken,
+          dstTokenAddress: event.args.l1Token,
         }),
       ]
     }
@@ -512,10 +512,10 @@ export class OpStackStandardBridgePlugin implements InteropPlugin {
         Result.Transfer('opstack-standardbridge.L1ToL2Transfer', {
           srcEvent: erc20DepositInitiated,
           srcAmount: erc20DepositInitiated.args.amount,
-          srcTokenAddress: erc20DepositInitiated.args.localToken,
+          srcTokenAddress: erc20DepositInitiated.args.l1Token,
           dstEvent: event,
           dstAmount: event.args.amount,
-          dstTokenAddress: event.args.localToken,
+          dstTokenAddress: event.args.l2Token,
         }),
       ]
     }


### PR DESCRIPTION
Resolves L2B-12364. The same address was used for l1 and l2 token by mistake because of confusion in terminology. made it more clear now