### PR TITLE
Nomad: point docs link to the documentation bucket

### DIFF
--- a/packages/config/src/projects/nomad/nomad.ts
+++ b/packages/config/src/projects/nomad/nomad.ts
@@ -28,7 +28,8 @@ export const nomad: Bridge = {
       'The Nomad token bridge contract has recently been exploited and currently is not operational.',
     category: 'Token Bridge',
     links: {
-      websites: ['https://app.nomad.xyz/', 'https://docs.nomad.xyz/'],
+      websites: ['https://app.nomad.xyz/'],
+      documentation: ['https://docs.nomad.xyz/'],
       repositories: ['https://github.com/nomad-xyz/monorepo'],
       socialMedia: [
         'https://twitter.com/nomadxyz_',


### PR DESCRIPTION
pulled https://docs.nomad.xyz/ out of the websites list and dropped it into documentation so the config stays consistent
left the app URL as the sole website entry; nothing else touched