### PR TITLE
Add NEAR documentation link to Rainbow Bridge config

### DIFF
--- a/packages/config/src/projects/near/near.ts
+++ b/packages/config/src/projects/near/near.ts
@@ -34,6 +34,7 @@ export const near: Bridge = {
       websites: ['https://near.org/'],
       explorers: ['https://explorer.near.org/', 'https://aurorascan.dev/'],
       bridges: ['https://rainbowbridge.app/'],
+      documentation: ['https://docs.near.org/'],
       repositories: ['https://github.com/aurora-is-near/rainbow-bridge'],
       socialMedia: ['https://twitter.com/auroraisnear'],
     },


### PR DESCRIPTION
Add the official NEAR documentation URL to the Rainbow Bridge documentation links for the near project config