### PR TITLE
chore: add explorerUrl and etherscan API for Worldchain

### DIFF
--- a/packages/config/src/projects/worldchain/worldchain.ts
+++ b/packages/config/src/projects/worldchain/worldchain.ts
@@ -51,12 +51,14 @@ export const worldchain = opStackL2({
     coingeckoPlatform: 'world-chain',
     sinceTimestamp: genesisTimestamp,
     chainId: 480,
+    explorerUrl: 'https://worldscan.org',
     apis: [
       {
         type: 'rpc',
         url: 'https://worldchain-mainnet.g.alchemy.com/public',
         callsPerMinute: 300,
       },
+      { type: 'etherscan', chainId: 480 },
     ],
   },
   stateDerivation: DERIVATION.OPSTACK('WORLD'),


### PR DESCRIPTION
Add explorerUrl (https://worldscan.org) and an etherscan API entry (chainId: 480) to worldchain chainConfig in package. These changes align the project config with the internal chain mapping in packages/tools-api/src/config/chains.json, enabling consistent explorer links and Etherscan-compatible API integrations across the app.