### PR TITLE
Add social media links for Billions

### DIFF
--- a/packages/config/src/projects/billions/billions.ts
+++ b/packages/config/src/projects/billions/billions.ts
@@ -16,8 +16,12 @@ export const billions: ScalingProject = upcomingL2({
     links: {
       websites: ['https://billions.network/'],
       bridges: [],
-      socialMedia: ['https://x.com/billions_ntwk'],
       repositories: ['https://github.com/0xPolygonID'],
+      socialMedia: [
+        'https://x.com/billions_ntwk',
+        'https://discord.com/invite/billions-ntwk',
+        'https://www.linkedin.com/company/billions-ntwk',
+      ],
     },
   },
   ecosystemInfo: {


### PR DESCRIPTION
Replace the deprecated socialMedia string with the structured list for x.com, Discord, and LinkedIn.