### PR TITLE
Add Hop documentation link to project config

### DIFF
--- a/packages/config/src/projects/hop/hop.ts
+++ b/packages/config/src/projects/hop/hop.ts
@@ -15,6 +15,7 @@ export const hop: Bridge = {
     category: 'Liquidity Network',
     links: {
       websites: ['https://hop.exchange/'],
+      documentation: ['https://docs.hop.exchange/'],
       repositories: ['https://github.com/hop-protocol'],
       socialMedia: [
         'https://twitter.com/HopProtocol',


### PR DESCRIPTION
Add https://docs.hop.exchange/ to the Hop project links so docs appear alongside existing website, repo, and social media entries