### PR TITLE
fix(opstack): decouple Celestia detection from usesEthereumBlobs

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -1451,7 +1451,6 @@ function getDAProvider(
   hostChainDA?: DAProvider,
 ): DAProvider {
   const postsToCelestia =
-    templateVars.usesEthereumBlobs ??
     templateVars.discovery.getContractValue<{
       isUsingCelestia: boolean
     }>('SystemConfig', 'opStackDA').isUsingCelestia
@@ -1719,7 +1718,6 @@ function getTrackedTxs(
 
 function postsToEthereum(templateVars: OpStackConfigCommon): boolean {
   const postsToCelestia =
-    templateVars.usesEthereumBlobs ??
     templateVars.discovery.getContractValue<{
       isUsingCelestia: boolean
     }>('SystemConfig', 'opStackDA').isUsingCelestia


### PR DESCRIPTION
Previously, usesEthereumBlobs was nullish-coalesced into the Celestia detection path, causing any blob-using OP Stack chain to be treated as posting to Celestia. This impacted DA provider selection, stage computation, architecture image, and liveness visibility. This change uses only opStackDA.isUsingCelestia for Celestia detection and leaves usesEthereumBlobs strictly for choosing on-chain DA mode (blobs vs calldata).