### PR TITLE
chore: replace broken link in canto.ts

### DIFF
--- a/packages/config/src/projects/canto/canto.ts
+++ b/packages/config/src/projects/canto/canto.ts
@@ -15,7 +15,7 @@ export const canto: ScalingProject = upcomingL2({
     stacks: ['Agglayer CDK'],
     links: {
       websites: ['https://canto.io'],
-      bridges: ['https://app.canto.io/bridge'],
+      bridges: ['https://canto.io/bridge'],
       documentation: ['https://docs.canto.io'],
       explorers: ['https://oklink.com/canto'],
       repositories: ['https://github.com/Canto-Network'],


### PR DESCRIPTION
`https://app.canto.io/bridge` - `https://canto.io/bridge` -- fixed