### PR TITLE
fix(hyperlane): set destinationToken to WRAPPED

### DIFF
--- a/packages/config/src/projects/hyperlane/hyperlane.ts
+++ b/packages/config/src/projects/hyperlane/hyperlane.ts
@@ -105,7 +105,7 @@ export const hyperlane: Bridge = {
         'The Hyperlane message protocol is used. If the verifier (called ISM, default is a multisig) agrees on a message, it is considered verified and can be executed at the destination.',
       sentiment: 'bad',
     },
-    destinationToken: BRIDGE_RISK_VIEW.CANONICAL,
+    destinationToken: BRIDGE_RISK_VIEW.WRAPPED,
   },
   technology: {
     destination: [


### PR DESCRIPTION
Hyperlane Nexus routes use HypERC20Collateral escrows on Ethereum and mint representations on the destination (e.g., Eclipse). This means destination assets are wrapped, not canonical. Updating the risk view aligns with the actual lock-and-mint model observed in the discovery data and L2BEAT conventions.

closes L2B-12476