### PR TITLE
feat(config): add Agglayer GitHub org to repositories links

### DIFF
--- a/packages/config/src/projects/agglayer/agglayer.ts
+++ b/packages/config/src/projects/agglayer/agglayer.ts
@@ -19,6 +19,7 @@ export const agglayer: BaseProject = {
         'https://www.agglayer.dev/learn',
       ],
       explorers: ['https://visualizer.agglayer.dev/'],
+      repositories: ['https://github.com/AggLayer'],
       socialMedia: ['https://x.com/agglayer'],
     },
     badges: [BADGES.Stack.CDKErigon, BADGES.Infra.Agglayer],


### PR DESCRIPTION
Added the official Agglayer GitHub organization to display.links.repositories in packages/config/src/projects/agglayer/agglayer.ts.