### PR TITLE
fix: broken documentation link

### DIFF
--- a/packages/config/src/templates/orbitStack.ts
+++ b/packages/config/src/templates/orbitStack.ts
@@ -275,7 +275,7 @@ function defaultStateValidation(
       references: [
         {
           title: 'How is fraud proven - Arbitrum documentation FAQ',
-          url: 'https://docs.arbitrum.io/how-arbitrum-works/bold/gentle-introduction',
+          url: 'https://docs.arbitrum.io/get-started/arbitrum-introduction',
         },
       ],
     },


### PR DESCRIPTION

Removed: `https://docs.arbitrum.io/how-arbitrum-works/validation-and-proving/validation-and-proving`
Added: `https://docs.arbitrum.io/how-arbitrum-works/bold/gentle-introduction`