### PR TITLE
Update Term Structure documentation link to active URL  

### DIFF
--- a/packages/config/src/projects/termstructure/termstructure.ts
+++ b/packages/config/src/projects/termstructure/termstructure.ts
@@ -231,7 +231,7 @@ export const termstructure: ScalingProject = {
         {
           title:
             'Force Withdrawal and Evacuation Mode - Term Structure documentation',
-          url: 'https://docs.ts.finance/zktrue-up/zk-architecture/forced-withdrawal-and-evacuation-mode',
+          url: 'https://tutorials.ts.finance/how-to-use-term-structure/onboarding-guide/withdraw#forced-withdraw-and-evacuation-mode',
         },
       ],
     },


### PR DESCRIPTION


Updated broken `docs.ts.finance` link to `https://tutorials.ts.finance/how-to-use-term-structure/onboarding-guide/withdraw#forced-withdraw-and-evacuation-mode`  
