### PR TITLE
fix(t3rn): move GitHub repo link from socialMedia to repositories

### DIFF
--- a/packages/config/src/projects/t3rn/t3rn.ts
+++ b/packages/config/src/projects/t3rn/t3rn.ts
@@ -26,8 +26,8 @@ export const t3rn: ScalingProject = underReviewL3({
       bridges: ['https://bridge.t3rn.io/'],
       documentation: ['https://docs.t3rn.io/'],
       explorers: ['https://explorer.t3rn.io/'],
-      repositories: ['https://github.com/t3rn'],
-      socialMedia: ['https://x.com/t3rn_io', 'https://github.com/t3rn/t3rn'],
+      repositories: ['https://github.com/t3rn', 'https://github.com/t3rn/t3rn'],
+      socialMedia: ['https://x.com/t3rn_io'],
     },
   },
   proofSystem: {


### PR DESCRIPTION
Move https://github.com/t3rn/t3rn to display.links.repositories to correctly classify it as a code repository rather than social media.
Aligns with conventions used in similar underReviewL3 configs (e.g., bitlazer) where GitHub links live under repositories and socialMedia contains X/Discord/Telegram.