### PR TITLE
docs: add OP specs site to documentation links

### DIFF
--- a/packages/config/src/projects/optimism/optimism.ts
+++ b/packages/config/src/projects/optimism/optimism.ts
@@ -31,6 +31,7 @@ export const optimism: ScalingProject = opStackL2({
       bridges: ['https://app.optimism.io'],
       documentation: [
         'https://docs.optimism.io/',
+        'https://specs.optimism.io/',
         'https://community.optimism.io',
       ],
       explorers: [


### PR DESCRIPTION
Add https://specs.optimism.io/ to display.links.documentation in the Optimism project config.
