### PR TITLE
chore: upgrade Biome CLI to 2.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
       - name: Setup Biome CLI
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.0.6
+          version: 2.1.2
 
       - name: Run Biome
         run: biome ci

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -65,5 +65,5 @@ jobs:
         run: |
           curl -sS \
             -H "Content-Type: application/json" \
-            -d "{\"content\": \"DB Migration workflow failure at $GITHUB_REF_NAME! Defails: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
+            -d "{\"content\": \"DB Migration workflow failure at $GITHUB_REF_NAME! Details: https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID\"}" \
             "${DISCORD_WEBHOOK_URL}"


### PR DESCRIPTION
Upgrades Biome CLI version in ci.yml from 2.0.6 to 2.1.2 to match package.json dependency and fixes a typo in db.yml from `Defails ` to `Details `.