### PR TITLE
Remove redundant await in getLiveness

### DIFF
--- a/packages/frontend/src/server/features/scaling/liveness/getLiveness.ts
+++ b/packages/frontend/src/server/features/scaling/liveness/getLiveness.ts
@@ -28,7 +28,7 @@ export async function getLiveness(projectId?: ProjectId) {
     return getMockLivenessData()
   }
 
-  return await getLivenessData(projectId)
+  return getLivenessData(projectId)
 }
 
 async function getLivenessData(projectId?: ProjectId) {


### PR DESCRIPTION
remove the unnecessary await before returning getLivenessData so the wrapper no longer adds an extra microtask keep behavior and error propagation identical while shaving a tiny bit of overhead