### PR TITLE
Add Proof of Play Apex documentation link

### DIFF
--- a/packages/config/src/projects/popapex/popapex.ts
+++ b/packages/config/src/projects/popapex/popapex.ts
@@ -34,6 +34,7 @@ export const popapex: ScalingProject = orbitStackL3({
         'https://bridge.arbitrum.io/?destinationChain=pop-apex&sourceChain=arbitrum-one',
         'https://piratenation.game/',
       ],
+      documentation: ['https://docs.proofofplay.com/introduction']
       explorers: ['https://explorer.apex.proofofplay.com'],
       repositories: ['https://github.com/proofofplay'],
       socialMedia: [


### PR DESCRIPTION
add the official Proof of Play Apex documentation URL to the popapex links keep the link ordering aligned with other project configs