### PR TITLE
fix(agglayer): wrap addedAt with UnixTime

### DIFF
--- a/packages/config/src/projects/agglayer/agglayer.ts
+++ b/packages/config/src/projects/agglayer/agglayer.ts
@@ -1,4 +1,4 @@
-import { CoingeckoId, ProjectId } from '@l2beat/shared-pure'
+import { CoingeckoId, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { BADGES } from '../../common/badges'
 import type { BaseProject } from '../../types'
 
@@ -7,7 +7,7 @@ export const agglayer: BaseProject = {
   slug: 'agglayer',
   name: 'Agglayer',
   shortName: undefined,
-  addedAt: 1743677000,
+  addedAt: UnixTime(1743677000),
   display: {
     description:
       'Agglayer is a cross-chain settlement layer that connects the liquidity and users of any blockchain for fast, low cost interoperability and growth.',


### PR DESCRIPTION
The BaseProject interface requires addedAt to be a UnixTime branded type. agglayer.ts previously used a plain number, which violates the type and breaks consistency with other project configs (e.g., superchain, arbitrum-orbit).

Changes:
- Import UnixTime from @l2beat/shared-pure
- Wrap addedAt: UnixTime(1743677000)

This aligns with the repository's typing and prevents branded type mismatches.