### PR TITLE
Fix OrbitStack Celestia/DAC switch

### DIFF
--- a/packages/config/src/templates/orbitStack.ts
+++ b/packages/config/src/templates/orbitStack.ts
@@ -700,7 +700,7 @@ function orbitStackCommon(
       })(),
     milestones: templateVars.milestones ?? [],
     badges: mergeBadges(automaticBadges, templateVars.additionalBadges ?? []),
-    customDa: templateVars.customDa,
+    customDa: postsToDAC(templateVars) ? templateVars.customDa : undefined,
     reasonsForBeingOther: templateVars.reasonsForBeingOther,
     dataAvailability: extractDAs(daProviders),
     scopeOfAssessment: templateVars.scopeOfAssessment,


### PR DESCRIPTION
this handles the case where a Celestia-first orbitStack chain starts posting to DAC fallback (0x88) and we want to merge it. With this
- Celestia is removed from DA technology, DAC appears and defines risk analysis. 2 DAs max at all times as it should be