### PR TITLE
Use POST in TokenDB Client insted of GET (payload too big for URL)

### DIFF
--- a/packages/token-backend/src/client.ts
+++ b/packages/token-backend/src/client.ts
@@ -24,7 +24,7 @@ export function getTokenDbClient(config: TokenClientConfig) {
     links: [
       httpBatchLink({
         url: config.apiUrl,
-        methodOverride: 'POST',
+        methodOverride: 'POST', // Sometimes request body is too large to fit in GET's URL
         transformer: {
           serialize: JSON.stringify,
           deserialize: JSON.parse,

--- a/packages/token-backend/src/server.ts
+++ b/packages/token-backend/src/server.ts
@@ -27,7 +27,7 @@ function main() {
         coingeckoClient,
         etherscanApiKey: config.etherscanApiKey,
       }),
-      allowMethodOverride: true,
+      allowMethodOverride: true, // Allow POST for GET queries due to large payload
       createContext: ({ req }) =>
         createTRPCContext({
           headers: new Headers(req.headers as Record<string, string>),


### PR DESCRIPTION
Whe requesting many addresses via `deployedTokens.getByChainAndAddress`, standard GET query failed due to URL length limitation in express. The proper solution in tRPC is to ask it to use POST.