### PR TITLE
Add OP specs link

### DIFF
--- a/packages/config/src/projects/ham/ham.ts
+++ b/packages/config/src/projects/ham/ham.ts
@@ -32,6 +32,7 @@ export const ham: ScalingProject = opStackL3({
       documentation: [
         'https://docs.ham.fun/',
         'https://stack.optimism.io/',
+        'https://specs.optimism.io/',
         'https://ham.fun/developers',
       ],
       explorers: ['https://explorer.ham.fun/'],


### PR DESCRIPTION
Add https://specs.optimism.io/ to Ham’s documentation links and keep the OP Stack entries aligned by exposing the canonical specification site.