### PR TITLE
Add OP specs link

### DIFF
--- a/packages/config/src/projects/xterio/xterio.ts
+++ b/packages/config/src/projects/xterio/xterio.ts
@@ -70,7 +70,10 @@ export const xterio: ScalingProject = opStackL2({
     links: {
       websites: ['https://xter.io/'],
       bridges: ['https://xter.io/', 'https://eth-bridge.xter.io/'],
-      documentation: ['https://stack.optimism.io/'],
+      documentation: [
+        'https://stack.optimism.io/',
+        'https://specs.optimism.io/',
+      ],
       explorers: ['https://eth.xterscan.io/'],
       repositories: ['https://github.com/XterioTech'],
       socialMedia: [


### PR DESCRIPTION
Add https://specs.optimism.io/ to Xterio’s documentation links and keep the OP Stack entries aligned by exposing the canonical specification site.