### PR TITLE
chore: add Satellite documentation link

### DIFF
--- a/packages/config/src/projects/satellite/satellite.ts
+++ b/packages/config/src/projects/satellite/satellite.ts
@@ -27,6 +27,7 @@ export const satellite: Bridge = {
     category: 'Hybrid',
     links: {
       websites: ['https://satellite.money/', 'https://axelar.network/'],
+      documentation: ['https://docs.axelar.dev/'],
       explorers: ['https://axelarscan.io/'],
       repositories: ['https://github.com/axelarnetwork/axelar-examples'],
       socialMedia: [


### PR DESCRIPTION
add the Satellite (Axelar) docs URL to the project configuration, keep the rest of the Satellite link set unchanged