### PR TITLE
chore: add Blockscout API endpoint for plume

### DIFF
--- a/packages/config/src/projects/plumenetwork/plumenetwork.ts
+++ b/packages/config/src/projects/plumenetwork/plumenetwork.ts
@@ -75,6 +75,10 @@ export const plumenetwork: ScalingProject = orbitStackL2({
         url: 'https://rpc.plume.org',
         callsPerMinute: 300,
       },
+      {
+        type: 'blockscout',
+        url: 'https://explorer.plume.org/api',
+      },
     ],
     multicallContracts: [
       {


### PR DESCRIPTION
Add blockscout API entry https://explorer.plume.org/api to chainConfig.apis
The endpoint returns a valid Etherscan/Blockscout-style response (e.g., module=block&action=eth_block_number), confirming compatibility and availability.