### PR TITLE
fix: Respect explicit stateValidationImage in opStack template

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -327,14 +327,14 @@ function opStackCommon(
       architectureImage:
         templateVars.architectureImage ?? architectureImage.join('-'),
       stateValidationImage:
-        (templateVars.stateValidationImage ??
-        fraudProofType === 'Permissionless')
+        templateVars.stateValidationImage ??
+        (fraudProofType === 'Permissionless'
           ? 'opfp'
           : fraudProofType === 'Kailua'
             ? 'kailua'
             : fraudProofType === 'OpSuccinct'
               ? 'opsuccinct'
-              : undefined,
+              : undefined),
       stacks: ['OP Stack'],
       warning:
         templateVars.display.warning === undefined


### PR DESCRIPTION
Corrected operator precedence bug that caused display.stateValidationImage to ignore a provided value in opStack.ts.