### PR TITLE
fix(aptos): set destinationToken risk to WRAPPED

### DIFF
--- a/packages/config/src/projects/aptos/aptos.ts
+++ b/packages/config/src/projects/aptos/aptos.ts
@@ -65,7 +65,7 @@ export const aptos: Bridge = {
           'Although the globalPause function is restricted to a Multisig, parts of the message bridge are upgradeable by an EOA which can be used to freeze the bridge.',
       },
     },
-    destinationToken: BRIDGE_RISK_VIEW.CANONICAL,
+    destinationToken: BRIDGE_RISK_VIEW.WRAPPED,
   },
   technology: {
     destination: ['Aptos'],


### PR DESCRIPTION
Per packages/config/src/common/bridgeRiskView.ts, “Canonical” means the bridged asset is considered the canonical token on the destination chain, while “Wrapped” means it is not canonical.
The Aptos (LayerZero) bridge is explicitly described as lock-and-mint: “locks tokens in Ethereum escrow and mints tokens on Aptos,” which produces non-canonical wrapped assets on the destination chain.