### PR TITLE
docs: fix broken link in polygoncdk template

### DIFF
--- a/packages/config/src/templates/polygonCDKStack.ts
+++ b/packages/config/src/templates/polygonCDKStack.ts
@@ -349,7 +349,7 @@ export function polygonCDKStack(
           references: [
             {
               title: 'Pessimistic Proof - Polygon Knowledge Layer',
-              url: 'https://docs.agglayer.dev/agglayer/core-concepts/pessimistic-proof/',
+              url: 'https://docs.polygon.technology/cdk/concepts/pessimistic-proofs',
             },
             {
               title:


### PR DESCRIPTION
https://docs.polygon.technology/learn/agglayer/pessimistic_proof - looks broken
https://docs.agglayer.dev/agglayer/core-concepts/pessimistic-proof/ - looks correct