### PR TITLE
docs(across): fix misleading link

### DIFF
--- a/packages/config/src/projects/across-v3/across-v3.ts
+++ b/packages/config/src/projects/across-v3/across-v3.ts
@@ -192,7 +192,7 @@ The permissioned proposer of the root bundle can also propose rebalancing liquid
       references: [
         {
           title: 'Across V4 Architecture',
-          url: 'https://docs.across.to/exclusive/what-is-across-v4#across-protocol-v4-architecture',
+          url: 'https://docs.across.to/concepts/what-is-across-v4#across-protocol-v4-architecture',
         },
       ],
       risks: [


### PR DESCRIPTION
Hi, https://docs.across.to/exclusive/what-is-across-v4#across-protocol-v4-architecture - this link works, but it leads to wrong point as i see, here is prove: 
<img width="1681" height="977" alt="image" src="https://github.com/user-attachments/assets/257f7db6-e198-4610-a7b7-d051f4a375a8" />

and https://docs.across.to/concepts/what-is-across-v4#across-protocol-v4-architecture this link leads to correct point