### PR TITLE
chore(shared): remove redundant await in http client

### DIFF
--- a/packages/shared/src/clients/http/HttpClient.ts
+++ b/packages/shared/src/clients/http/HttpClient.ts
@@ -20,7 +20,7 @@ export class HttpClient {
   }
 
   async fetchRaw(url: string, init: RequestInit & { timeout?: number }) {
-    return await fetch(url, {
+    return fetch(url, {
       ...init,
       timeout: init.timeout ?? 10_000,
     })


### PR DESCRIPTION
remove the redundant await in HttpClient.fetchRaw, rely on the promise returned by node-fetch directly to avoid extra microtask overhead