### PR TITLE
chore(celo): remove deprecated explorer URL and add Blockscout API

### DIFF
--- a/packages/config/src/projects/celo/celo.ts
+++ b/packages/config/src/projects/celo/celo.ts
@@ -39,7 +39,6 @@ export const celo: ScalingProject = opStackL2({
       bridges: ['https://superbridge.app/celo'],
       documentation: ['https://docs.celo.org/'],
       explorers: [
-        'https://explorer.celo.org/mainnet/',
         'https://celoscan.io',
         'https://celo.blockscout.com/',
       ],
@@ -80,6 +79,7 @@ export const celo: ScalingProject = opStackL2({
         chainId,
         contractCreationUnsupported: true,
       },
+      { type: 'blockscoutV2', url: 'https://celo.blockscout.com/api/v2' },
     ],
   },
   nonTemplateContractRisks: CONTRACTS.UPGRADE_NO_DELAY_RISK,


### PR DESCRIPTION
- Remove https://explorer.celo.org/mainnet/ from explorers as it redirects to Blockscout and is redundant.
- Add Blockscout V2 API (https://celo.blockscout.com/api/v2) for parity with other OP Stack L2 configs (e.g., Base, Optimism) and to enable API consumers to use Blockscout endpoints directly.

These changes improve link accuracy, avoid duplicate explorer entries, and align the project with established patterns across OP Stack L2 configurations without altering runtime behavior.