### PR TITLE
Add documentation links for Stargate v2

### DIFF
--- a/packages/config/src/projects/stargatev2/stargatev2.ts
+++ b/packages/config/src/projects/stargatev2/stargatev2.ts
@@ -54,6 +54,7 @@ export const stargatev2: Bridge = {
     links: {
       websites: ['https://stargate.finance/', 'https://layerzero.network/'],
       bridges: ['https://layerzeroscan.com/'],
+      documentation: ['https://docs.stargate.finance/introduction/overview', 'https://docs.layerzero.network/v2'],
       repositories: [
         'https://github.com/stargate-protocol/stargate-v2',
         'https://github.com/LayerZero-Labs/LayerZero-v2',


### PR DESCRIPTION
add Stargate v2 docs and LayerZero v2 docs to the bridge’s links, keep the link structure aligned with other Stargate listings