### PR TITLE
docs(scroll): add governance docs hub link to other links

### DIFF
--- a/packages/config/src/projects/scroll/scroll.ts
+++ b/packages/config/src/projects/scroll/scroll.ts
@@ -99,6 +99,7 @@ export const scroll: ScalingProject = {
         'https://rollup.codes/scroll',
         'https://forum.scroll.io',
         'https://growthepie.com/chains/scroll',
+        'https://scroll.io/gov-docs/',
       ],
     },
     liveness: {


### PR DESCRIPTION
Add https://scroll.io/gov-docs/ to display.links.other for Scroll.