### PR TITLE
fix(backend): add missing await for updateSyncedUntil in TrackedTxsIndexer

### DIFF
--- a/packages/backend/src/modules/tracked-txs/TrackedTxsIndexer.ts
+++ b/packages/backend/src/modules/tracked-txs/TrackedTxsIndexer.ts
@@ -61,7 +61,7 @@ export class TrackedTxsIndexer extends ManagedMultiIndexer<TrackedTxConfigEntry>
     return async () => {
       for (const updater of this.$.updaters) {
         const filteredTxs = txs.filter((tx) => tx.type === updater.type)
-        this.$.db.syncMetadata.updateSyncedUntil(
+        await this.$.db.syncMetadata.updateSyncedUntil(
           updater.type,
           uniq(
             activeConfigurations


### PR DESCRIPTION
Found that updateSyncedUntil was called without await in TrackedTxsIndexer.multiUpdate.This async call was the only one in the entire codebase missing the await keyword -all other 7 usages properly await it.

Without await, the sync metadata update could complete after the function returns, potentially causing race conditions or data inconsistency in liveness/l2costs tracking.