### PR TITLE
fix: docs link for avalanche

### DIFF
--- a/packages/config/src/projects/avalanche/avalanche.ts
+++ b/packages/config/src/projects/avalanche/avalanche.ts
@@ -25,7 +25,7 @@ export const avalanche: Bridge = {
       explorers: ['https://subnets.avax.network/'],
       bridges: ['https://bridge.avax.network/'],
       repositories: ['https://github.com/ava-labs'],
-      documentation: ['https://build.avax.network/docs'],
+      documentation: ['https://build.avax.network/'],
       socialMedia: [
         'https://twitter.com/avax',
         'https://t.me/avalancheavax',


### PR DESCRIPTION
https://build.avax.network/docs return 404
https://build.avax.network/ - works