### PR TITLE
fix: correct variable reference in impRecord type check

### DIFF
--- a/packages/validate/src/validate.ts
+++ b/packages/validate/src/validate.ts
@@ -532,7 +532,7 @@ function impRecord<K extends string | number, V>(
   }
 
   return function impRecord(value: unknown): Result<Record<K, V>> {
-    if (typeof value !== 'object' || value === null || Array.isArray(object)) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       return failType('object', value)
     }
     const result = {} as Record<K, V>


### PR DESCRIPTION
Fixed a bug in the impRecord function where Array.isArray() was checking an undefined variable 'object' instead of the actual parameter 'value'. 

This would have caused a ReferenceError at runtime whenever the validation tried to reject array inputs for record types.