### PR TITLE
Add ZKsync docs link to The Elastic Network metadata

### DIFF
--- a/packages/config/src/projects/the-elastic-network/the-elastic-network.ts
+++ b/packages/config/src/projects/the-elastic-network/the-elastic-network.ts
@@ -13,6 +13,7 @@ export const theElasticNetwork: BaseProject = {
       'An ever-expanding, verifiable network of blockchains, powered by ZKsync.',
     links: {
       websites: ['https://www.zksync.io/'],
+      documentation: ['https://docs.zksync.io/'],
     },
     badges: [BADGES.Stack.ZKStack, BADGES.Infra.ElasticChain],
   },


### PR DESCRIPTION
Surface the Elastic Network builder documentation by exposing https://docs.zksync.io/ in the project’s display.links so builders can reach the official guides directly from the project card.