### PR TITLE
fix: remove extra closing brace in error message template

### DIFF
--- a/packages/discovery/src/discovery/handlers/user/ArbitrumSequencerVersionHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/ArbitrumSequencerVersionHandler.ts
@@ -154,7 +154,7 @@ export class ArbitrumSequencerVersionHandler implements Handler {
     if (calldata.startsWith(addSequencerBatchEspressoSigHash)) {
       return abi.decodeFunctionData(addSequencerBatchEspresso, calldata)
     }
-    throw new Error(`Unexpected function signature ${calldata.slice(0, 10)}}`)
+    throw new Error(`Unexpected function signature ${calldata.slice(0, 10)}`)
   }
 
   async getLastEventWithTxInput(


### PR DESCRIPTION
Removed an extra closing brace in the error message template string. The original code had `${calldata.slice(0, 10)}}` which would add a trailing "}" character to the error message. Changed it to `${calldata.slice(0, 10)}` to match the correct template literal syntax used elsewhere in the codebase.