### PR TITLE
chore: add telegram and discord link for hibachi

### DIFF
--- a/packages/config/src/projects/hibachi/hibachi.ts
+++ b/packages/config/src/projects/hibachi/hibachi.ts
@@ -23,7 +23,11 @@ export const hibachi = {
       websites: ['https://hibachi.xyz/trade'],
       documentation: ['https://docs.hibachi.xyz/'],
       repositories: ['https://github.com/hibachi-xyz/hibachi_sdk'],
-      socialMedia: ['https://x.com/hibachi_xyz'],
+      socialMedia: [
+        'https://x.com/hibachi_xyz',
+        'https://t.me/HibachiPatrons',
+        'https://discord.com/invite/hibachi-xyz',
+      ],
     },
   },
   stage: getStage({


### PR DESCRIPTION
https://t.me/HibachiPatrons and https://discord.com/invite/hibachi-xyz were added
https://hibachi.xyz/ - you can find links on their official website