### PR TITLE
fix(hyperliquid): use ChainSpecificAddress[] for lockers getContractValue

### DIFF
--- a/packages/config/src/projects/hyperliquid/hyperliquid.ts
+++ b/packages/config/src/projects/hyperliquid/hyperliquid.ts
@@ -1,9 +1,4 @@
-import {
-  ChainSpecificAddress,
-  type EthereumAddress,
-  ProjectId,
-  UnixTime,
-} from '@l2beat/shared-pure'
+import { ChainSpecificAddress, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { BRIDGE_RISK_VIEW } from '../../common'
 import { ProjectDiscovery } from '../../discovery/ProjectDiscovery'
 import type { Bridge } from '../../internalTypes'


### PR DESCRIPTION
The discovery output for Hyperliquid stores lockers as chain-prefixed addresses (e.g., arb1:0x...) which are ChainSpecificAddress values rather than raw Ethereum addresses. The previous typing EthereumAddress[] in packages/config/src/projects/hyperliquid/hyperliquid.ts was semantically incorrect and could mislead downstream usage even if only .length was used. The project’s conventions and other usages (e.g., sophon.ts) confirm that arrays of addresses coming from discovery should be represented as ChainSpecificAddress[] or at least string[]. Updating the generic in getContractValue to 
ChainSpecificAddress[] ensures type accuracy with the discovery data model and improves type safety without altering runtime behavior.