### PR TITLE
fix: preserve default display.warning from opStackCommon

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -530,7 +530,6 @@ export function opStackL2(templateVars: OpStackConfigL2): ScalingProject {
     display: {
       ...common.display,
       ...templateVars.display,
-      warning: templateVars.display.warning,
       liveness: getLiveness(templateVars),
     },
     config: {


### PR DESCRIPTION
The OP Stack L2 template unintentionally overwrote the default warning set in opStackCommon by explicitly assigning warning: templateVars.display.warning in the opStackL2 display merge. When a project did not provide display.warning, this cleared the default and removed the intended message. This change removes the explicit override so the default warning persists unless a project supplies its own. The behavior now matches opStackL3 and the orbit templates, restoring consistency and the intended defaulting semantics.