### PR TITLE
Fix OP Stack display warning override

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -530,7 +530,6 @@ export function opStackL2(templateVars: OpStackConfigL2): ScalingProject {
     display: {
       ...common.display,
       ...templateVars.display,
-      warning: templateVars.display.warning,
       liveness: getLiveness(templateVars),
     },
     config: {


### PR DESCRIPTION
Removed explicit `warning` assignment in `opStackL2` display configuration, this caused the default warning message to be incorrectly overwritten when custom warning was provided.