### PR TITLE
chore: remove redundant isPartOfSuperchain override

### DIFF
--- a/packages/config/src/projects/celo/celo.ts
+++ b/packages/config/src/projects/celo/celo.ts
@@ -27,7 +27,6 @@ export const celo: ScalingProject = opStackL2({
     REASON_FOR_BEING_OTHER.CLOSED_PROOFS,
     REASON_FOR_BEING_OTHER.NO_DA_ORACLE,
   ],
-  isPartOfSuperchain: false,
   display: {
     name: 'Celo',
     slug: 'celo',


### PR DESCRIPTION
The top-level isPartOfSuperchain: false in packages/config/src/projects/celo/celo.ts was redundant. Superchain ecosystem display relies on ecosystemInfo.isPartOfSuperchain, while the top-level flag is an override for badge logic when on-chain detection is inaccurate. Removing it prevents confusion and keeps the source of truth clear.