### PR TITLE
docs(orbitstack): fix broken link

### DIFF
--- a/packages/config/src/templates/orbitStack.ts
+++ b/packages/config/src/templates/orbitStack.ts
@@ -620,7 +620,7 @@ function orbitStackCommon(
             },
             {
               title: 'L2 to L1 Messages - Arbitrum documentation',
-              url: 'https://developer.offchainlabs.com/arbos/l2-to-l1-messaging',
+              url: 'https://docs.arbitrum.io/how-arbitrum-works/deep-dives/l2-to-l1-messaging',
             },
             {
               title: 'Mainnet for everyone - Arbitrum Blog',


### PR DESCRIPTION
https://developer.offchainlabs.com/arbos/l2-to-l1-messaging - not found
https://docs.arbitrum.io/how-arbitrum-works/deep-dives/l2-to-l1-messaging - works