### PR TITLE
chore(eclipse): replaced broken link to discord

### DIFF
--- a/packages/config/src/projects/eclipse/eclipse.ts
+++ b/packages/config/src/projects/eclipse/eclipse.ts
@@ -52,7 +52,7 @@ export const eclipse: ScalingProject = {
       repositories: ['https://github.com/Eclipse-Laboratories-Inc'],
       socialMedia: [
         'https://twitter.com/eclipsefnd',
-        'https://discord.gg/eclipse-labs',
+        'https://discord.com/invite/eclipse-fnd',
         'https://mirror.xyz/eclipsemainnet.eth',
       ],
     },


### PR DESCRIPTION
new link taken from the official resource

<img width="898" height="551" alt="Знімок екрана 2025-12-09 о 16 39 36" src="https://github.com/user-attachments/assets/1e3ea77b-7ceb-4b12-811a-6646e81ad96a" />

