### PR TITLE
chore: replaced broken bridge link

### DIFF
--- a/packages/config/src/projects/xterio/xterio.ts
+++ b/packages/config/src/projects/xterio/xterio.ts
@@ -69,7 +69,7 @@ export const xterio: ScalingProject = opStackL2({
       'Xterio Chain is an OP stack Optimium on Ethereum. The chain focuses on gaming, high performance and low fees .',
     links: {
       websites: ['https://xter.io/'],
-      bridges: ['https://xter.io/', 'https://eth-bridge.xter.io/'],
+      bridges: ['https://xter.io/', 'https://bnb-bridge.xter.io/'],
       documentation: ['https://stack.optimism.io/'],
       explorers: ['https://eth.xterscan.io/'],
       repositories: ['https://github.com/XterioTech'],


### PR DESCRIPTION
networks in eth no longer exist, only the BSC network and native ones remain

<img width="633" height="325" alt="Знімок екрана 2025-12-11 о 12 39 44" src="https://github.com/user-attachments/assets/bc4185dc-352c-40fc-b6fd-21db61166040" />
