### PR TITLE
chore: add link for arenaz discord

### DIFF
--- a/packages/config/src/projects/arenaz/arenaz.ts
+++ b/packages/config/src/projects/arenaz/arenaz.ts
@@ -27,7 +27,10 @@ export const arenaz = opStackL2({
       bridges: ['https://bridge.arena-z.gg/', 'https://leagueofkingdoms.com/'],
       documentation: ['https://whitepaper.playersarena.foundation/arena-z'],
       explorers: ['https://explorer.arena-z.gg/'],
-      socialMedia: ['https://x.com/OfficialArenaZ'],
+      socialMedia: [
+        'https://x.com/OfficialArenaZ',
+        'https://discord.com/invite/arenaz-a2z',
+      ],
     },
   },
   hasSuperchainScUpgrades: true,


### PR DESCRIPTION
https://discord.com/invite/arenaz-a2z  , link was taken from their off website https://arena-z.gg/

proof : 

<img width="1738" height="982" alt="image" src="https://github.com/user-attachments/assets/93818e1c-9f2a-44ac-ab1a-8460a2eaa564" />
