### PR TITLE
docs: add discrod link for educhain

### DIFF
--- a/packages/config/src/projects/educhain/educhain.ts
+++ b/packages/config/src/projects/educhain/educhain.ts
@@ -38,6 +38,7 @@ export const educhain: ScalingProject = orbitStackL3({
         'https://youtube.com/@OpenCampusxyz',
         'https://t.me/OpenCampusTG',
         'https://linkedin.com/company/opencampus-xyz',
+        'https://discord.com/invite/opencampus',
       ],
     },
   },


### PR DESCRIPTION
<img width="1895" height="1033" alt="image" src="https://github.com/user-attachments/assets/dbc6f1f1-bb97-40b8-a16a-fe7317049cfe" />

added https://discord.com/invite/opencampus
found it on their off website https://educhain.xyz/