### PR TITLE
DeployedToken.address to be lowercase in Interop

### DIFF
--- a/packages/backend/src/modules/interop/engine/financials/DeployedTokenId.ts
+++ b/packages/backend/src/modules/interop/engine/financials/DeployedTokenId.ts
@@ -7,7 +7,8 @@ export function DeployedTokenId(id: string) {
 }
 
 DeployedTokenId.from = function from(chain: string, address: string) {
-  return `${chain}+${address}` as DeployedTokenId
+  // Addresses of DeployedTokens in TokenDB are always lowercase
+  return `${chain}+${address.toLowerCase()}` as DeployedTokenId
 }
 
 DeployedTokenId.chain = function chain(id: DeployedTokenId) {

--- a/packages/backend/src/modules/interop/engine/financials/InteropFinancialsLoop.test.ts
+++ b/packages/backend/src/modules/interop/engine/financials/InteropFinancialsLoop.test.ts
@@ -62,7 +62,7 @@ describe(InteropFinancialsLoop.name, () => {
     it('calculates financials and updates transfers records', async () => {
       const srcToken1 = DeployedTokenId.from(
         'ethereum',
-        EthereumAddress.random(),
+        '0xcebA9300f2b948710d2653dD7B07f33A8B32118C',
       )
       const dstToken1 = DeployedTokenId.from(
         'arbitrum',
@@ -128,7 +128,7 @@ describe(InteropFinancialsLoop.name, () => {
         {
           deployedToken: {
             chain: 'ethereum',
-            address: DeployedTokenId.address(srcToken1),
+            address: DeployedTokenId.address(srcToken1).toLowerCase(), // addresses in TokenDB are lowercase
             symbol: 'ETH',
             decimals: 18,
           },


### PR DESCRIPTION
Resolves L2B-12747

Interop needs to make addresses lowercase when constructing DeployedTokenId