### PR TITLE
Add Wormhole V1 documentation link to project config

### DIFF
--- a/packages/config/src/projects/wormholeV1/wormholeV1.ts
+++ b/packages/config/src/projects/wormholeV1/wormholeV1.ts
@@ -15,6 +15,7 @@ export const wormholeV1: Bridge = {
     description: 'First version of the Wormhole bridge.',
     links: {
       websites: ['https://wormhole.com/'],
+      documentation: ['https://wormhole.com/docs/'],
     },
     category: 'Token Bridge',
   },


### PR DESCRIPTION
add documentation entry under display.links for Wormhole V1 so docs show alongside the website link, metadata-only change; no runtime impact