### PR TITLE
Use `.` instead of `source` in package.json

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -18,7 +18,7 @@
     "db:migrate": "cd ../database && pnpm db:migrate",
     "run-kroma-propose-script": "ts-node ./discovery/kroma/ethereum/script-ts/propose.ts",
     "start": "node -r source-map-support/register build/src/index.js",
-    "start:dev": "pnpm build:dependencies && source .env && PRISMA_DB_URL=$LOCAL_DB_URL pnpm db:migrate && ts-node-dev --respawn --transpile-only src/index.ts",
+    "start:dev": "pnpm build:dependencies && . ./.env && PRISMA_DB_URL=$LOCAL_DB_URL pnpm db:migrate && ts-node-dev --respawn --transpile-only src/index.ts",
     "start:dev-pure": "ts-node-dev --respawn --transpile-only src/index.ts",
     "start:profile": "node --inspect -r esbuild-register src/index.ts",
     "test": "./scripts/run_tests.sh",


### PR DESCRIPTION
Instead of:

 `source ./.env`

use

`. ./.env`

Because it's more compatible and works on Linux too (where pnpm defaults to `sh` which doesn't support `source`)

Both claude and codex suggest to use `.` instead of `source` for better compatibility.