### PR TITLE
fix: remove stray destination entry from orbit bridge config

### DIFF
--- a/packages/config/src/projects/orbit/orbit.ts
+++ b/packages/config/src/projects/orbit/orbit.ts
@@ -86,7 +86,6 @@ export const orbit: Bridge = {
       'Avalanche',
       'Celo',
       'Fantom',
-      'destination',
       'HECO',
       'ICON',
       'OKC',


### PR DESCRIPTION
The technology.destination list for Orbit Bridge accidentally contained a literal 'destination' string as if it were a chain name. This entry does not correspond to any real network and could confuse readers of the config and UI consumers, so it has been removed.