### PR TITLE
fix: correct BlockscoutClient.getContractDeploymentTx comment

### DIFF
--- a/packages/discovery/src/utils/BlockscoutClient.ts
+++ b/packages/discovery/src/utils/BlockscoutClient.ts
@@ -145,7 +145,7 @@ export class BlockscoutClient implements IEtherscanClient {
     }
   }
 
-  // Returns undefined if the method is not supported by API.
+  // Returns undefined if the method is not supported by API, or Hash256.ZERO if parsing fails.
   async getContractDeploymentTx(
     address: EthereumAddress,
   ): Promise<Hash256 | undefined> {


### PR DESCRIPTION
The comment for getContractDeploymentTx() only mentioned returning undefined when the method is unsupported, but the code also returns Hash256.ZERO when response parsing fails. Updated the comment to document both return scenarios so developers know what to expect.