### PR TITLE
Remove unused pruningIntervalId field from EventTracker

### DIFF
--- a/packages/shared/src/tools/EventTracker.ts
+++ b/packages/shared/src/tools/EventTracker.ts
@@ -7,7 +7,6 @@ interface Event<T extends string> {
 
 export class EventTracker<T extends string> {
   private events: Event<T>[] = []
-  pruningIntervalId?: NodeJS.Timer
 
   constructor(private readonly historySize = ONE_HOUR) {
     this.enablePruning()


### PR DESCRIPTION
Clean up dead code in EventTracker class. Remove the unused pruningIntervalId field that was declared but never assigned or referenced. The interval timer created in enablePruning() already uses unref() to avoid blocking the event loop, making explicit storage of the interval ID unnecessary.