### PR TITLE
refactor(dal): remove redundant hash truncation in cache key builder

### DIFF
--- a/packages/dal/src/utils/packageHash.ts
+++ b/packages/dal/src/utils/packageHash.ts
@@ -37,7 +37,6 @@ function buildCacheKey(dbUrl: string, envs?: Record<string, unknown>) {
     'utf8',
   )
 
-  // envHash already returns a 12-char hash, avoid slicing twice
   const env = envs ? envHash(envs) : undefined
   const dbHash = sha256Hex(dbUrl).slice(0, 12)
 


### PR DESCRIPTION
Removes redundant .slice(0, 12) operation on envHash() return value in the cache key builder.