### PR TITLE
chore: add accurate website for arbitrum-orbit

### DIFF
--- a/packages/config/src/projects/arbitrum-orbit/arbitrum-orbit.ts
+++ b/packages/config/src/projects/arbitrum-orbit/arbitrum-orbit.ts
@@ -11,7 +11,11 @@ export const arbitrumOrbit: BaseProject = {
   display: {
     description: 'The Arbitrum Orbit is a network of Arbitrum chains.',
     links: {
-      websites: ['https://arbitrum.io', 'https://portal.arbitrum.io/'],
+      websites: [
+        'https://arbitrum.io',
+        'https://portal.arbitrum.io/',
+        'https://arbitrum.foundation/orbit',
+      ],
       bridges: ['https://bridge.arbitrum.io/'],
     },
     badges: [BADGES.Stack.Orbit],


### PR DESCRIPTION
https://arbitrum.foundation/orbit - added ths link, this link looks more accurate, while https://arbitrum.io and https://portal.arbitrum.io/ are more like general