### PR TITLE
fix: align celo contract risks with superchain template

### DIFF
--- a/packages/config/src/projects/celo/celo.ts
+++ b/packages/config/src/projects/celo/celo.ts
@@ -84,7 +84,6 @@ export const celo: ScalingProject = opStackL2({
       },
     ],
   },
-  nonTemplateContractRisks: CONTRACTS.UPGRADE_NO_DELAY_RISK,
   isNodeAvailable: 'UnderReview',
   discovery,
   genesisTimestamp: UnixTime(1742960663), // ts of first batch posted, block 0 from the rpc: 1587571200


### PR DESCRIPTION
Removed the explicit nonTemplateContractRisks override from the Celo config so that hasSuperchainScUpgrades controls the default contract risk description. This makes Celo consistent with other Superchain projects and avoids masking the shared superchain-specific wording from the opStack template.