### PR TITLE
chore: add discord and telegram links for hyperliquid

### DIFF
--- a/packages/config/src/projects/hyperliquid/hyperliquid.ts
+++ b/packages/config/src/projects/hyperliquid/hyperliquid.ts
@@ -44,9 +44,13 @@ export const hyperliquid: Bridge = {
       websites: ['https://hyperfoundation.org/'],
       explorers: ['https://app.hyperliquid.xyz/explorer'],
       bridges: ['https://app.hyperliquid.xyz/trade'],
-      socialMedia: ['https://x.com/HyperliquidX'],
       documentation: ['https://hyperliquid.gitbook.io/hyperliquid-docs'],
       repositories: ['https://github.com/hyperliquid-dex'],
+      socialMedia: [
+        'https://x.com/HyperliquidX',
+        'https://discord.com/invite/hyperliquid',
+        'https://t.me/hyperliquid_announcements',
+      ],
     },
   },
   config: {


### PR DESCRIPTION
https://discord.com/invite/hyperliquid and https://t.me/hyperliquid_announcements were added.
Found on their website. 
<img width="1494" height="690" alt="Снимок экрана 2025-12-23 в 11 24 40 PM" src="https://github.com/user-attachments/assets/43f15fcd-1a1e-45d4-ae98-dabab1e8c49b" />
