### PR TITLE
chore: fix Kailua documentation URLs in opStack.ts

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -969,8 +969,8 @@ Proving any of the ${proposalOutputCount} intermediate state commitments in a pr
 A single remaining child in a tournament can be 'resolved' and will be finalized and usable for withdrawals after an execution delay of ${formatSeconds(disputeGameFinalityDelaySeconds)} (time for the Guardian to manually blacklist malicious state roots).`,
             references: [
               {
-                url: 'https://boundless-xyz.github.io/kailua/quickstart.html',
-                title: 'Disputes - Kailua Docs',
+                url: 'https://boundless-xyz.github.io/kailua/dispute.html',
+                title: 'Disputes - Kailua Book',
               },
             ],
           },


### PR DESCRIPTION
previous one is dead