### PR TITLE
Add Karak's discord

### DIFF
--- a/packages/config/src/projects/karak/karak.ts
+++ b/packages/config/src/projects/karak/karak.ts
@@ -27,6 +27,7 @@ export const karak: ScalingProject = opStackL2({
       socialMedia: [
         'https://twitter.com/Karak_Network',
         'https://t.me/Karak_Network',
+        'https://discord.com/invite/opengdp',
       ],
     },
   },


### PR DESCRIPTION
Added a Discord link to Karak(now they are named OpenGDP, proof - https://cryptorank.io/ico/karak-network#funding-rounds) 