### PR TITLE
Add memory usage info to Interop Dashboard

### DIFF
--- a/packages/backend/src/modules/interop/engine/dashboard/InteropRouter.ts
+++ b/packages/backend/src/modules/interop/engine/dashboard/InteropRouter.ts
@@ -53,6 +53,18 @@ export function createInteropRouter(
     ctx.body = configs
   })
 
+  router.get('/interop/memory', (ctx) => {
+    const memoryUsage = process.memoryUsage()
+
+    ctx.body = {
+      rss: `${(memoryUsage.rss / 1024 / 1024).toFixed(2)} MB`, // Resident Set Size - total memory allocated
+      heapTotal: `${(memoryUsage.heapTotal / 1024 / 1024).toFixed(2)} MB`, // Total heap size
+      heapUsed: `${(memoryUsage.heapUsed / 1024 / 1024).toFixed(2)} MB`, // Actual memory used
+      external: `${(memoryUsage.external / 1024 / 1024).toFixed(2)} MB`, // Memory used by C++ objects
+      arrayBuffers: `${(memoryUsage.arrayBuffers / 1024 / 1024).toFixed(2)} MB`, // Memory for ArrayBuffers
+    }
+  })
+
   router.get('/interop.json', async (ctx) => {
     const events = await db.interopEvent.getStats()
     const messages = await db.interopMessage.getStats()


### PR DESCRIPTION
Resolves L2B-12798

Display node's memory usage on `/interop/memory` URL