### PR TITLE
Fix bottom gradient on scrollable elements

### DIFF
--- a/packages/frontend/src/components/ScrollWithGradient.tsx
+++ b/packages/frontend/src/components/ScrollWithGradient.tsx
@@ -9,7 +9,8 @@ export function ScrollWithGradient({
     const { scrollTop, scrollHeight, clientHeight } = node
 
     const isScrolledToTop = scrollTop === 0
-    const isScrolledToBottom = scrollTop + clientHeight === scrollHeight
+    const isScrolledToBottom =
+      Math.round(scrollTop + clientHeight) >= scrollHeight
     if (isScrolledToTop && isScrolledToBottom) return
 
     if (!isScrolledToTop && !isScrolledToBottom) {


### PR DESCRIPTION
Resolves L2B-12049

The issue was with rounding floating points. Here `scrollTop + clientHeight < scrollHeight` but should be equal
<img width="326" height="166" alt="8257" src="https://github.com/user-attachments/assets/5defc4b3-67b9-4485-aa07-40d09853fc9f" />
