### PR TITLE
Shorten addresses and tx hashes in interop tables

### DIFF
--- a/packages/backend/src/modules/interop/engine/dashboard/EventsPage.tsx
+++ b/packages/backend/src/modules/interop/engine/dashboard/EventsPage.tsx
@@ -6,18 +6,7 @@ import {
   type ProcessorsStatus,
   ProcessorsStatusTable,
 } from './ProcessorsStatusTable'
-
-function ShortenedHash({ hash }: { hash: string }) {
-  if (hash.length <= 14) return <>{hash}</>
-  return (
-    <>
-      <span style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}>
-        {hash}
-      </span>
-      {`${hash.slice(0, 6)}...${hash.slice(-4)}`}
-    </>
-  )
-}
+import { ShortenedHash } from './ShortenedHash'
 
 function EventsTable(props: {
   events: InteropEventRecord[]

--- a/packages/backend/src/modules/interop/engine/dashboard/MessagesPage.tsx
+++ b/packages/backend/src/modules/interop/engine/dashboard/MessagesPage.tsx
@@ -7,19 +7,7 @@ import {
   type ProcessorsStatus,
   ProcessorsStatusTable,
 } from './ProcessorsStatusTable'
-
-function ShortenedHash({ hash }: { hash: string | undefined }) {
-  if (!hash) return null
-  if (hash.length <= 14) return <>{hash}</>
-  return (
-    <>
-      <span style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}>
-        {hash}
-      </span>
-      {`${hash.slice(0, 6)}...${hash.slice(-4)}`}
-    </>
-  )
-}
+import { ShortenedHash } from './ShortenedHash'
 
 function MessagesTable(props: {
   messages: InteropMessageRecord[]

--- a/packages/backend/src/modules/interop/engine/dashboard/ShortenedHash.tsx
+++ b/packages/backend/src/modules/interop/engine/dashboard/ShortenedHash.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export function ShortenedHash({ hash }: { hash: string | undefined }) {
+  if (!hash) return null
+  if (hash.length <= 14) return <>{hash}</>
+  return (
+    <>
+      <span style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}>
+        {hash}
+      </span>
+      {`${hash.slice(0, 6)}...${hash.slice(-4)}`}
+    </>
+  )
+}

--- a/packages/backend/src/modules/interop/engine/dashboard/TransfersPage.tsx
+++ b/packages/backend/src/modules/interop/engine/dashboard/TransfersPage.tsx
@@ -8,19 +8,7 @@ import {
   type ProcessorsStatus,
   ProcessorsStatusTable,
 } from './ProcessorsStatusTable'
-
-function ShortenedHash({ hash }: { hash: string | undefined }) {
-  if (!hash) return null
-  if (hash.length <= 14) return <>{hash}</>
-  return (
-    <>
-      <span style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}>
-        {hash}
-      </span>
-      {`${hash.slice(0, 6)}...${hash.slice(-4)}`}
-    </>
-  )
-}
+import { ShortenedHash } from './ShortenedHash'
 
 function TransfersTable(props: {
   transfers: InteropTransferRecord[]


### PR DESCRIPTION
so that everything fits in one view without scrolling. search box still works with full address (hidden span)

<img width="3276" height="1712" alt="image" src="https://github.com/user-attachments/assets/04955d8c-965d-417a-b2d6-0c118b7bc833" />
