### PR TITLE
Add beefy bridge plugin

### DIFF
--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -864,6 +864,24 @@
     "messages": ["opstack.L1ToL2Message"],
     "transfers": ["sorare-base.L1ToL2Transfer"]
   },
+  "beefy-bridge": {
+    "txs": [
+      {
+        "chain": "ethereum",
+        "tx": "0xee4c7dd66de02432c3c047d838bae58716e2da57611d4ae0f92a12487d3db9c2"
+      },
+      {
+        "chain": "optimism",
+        "tx": "0x2530394801dcf8331d7761734a899946abc21c0b06208907adbd70ec783a262f"
+      }
+    ],
+    "events": [
+      "beefy-bridge.BridgedOutSentMessage",
+      "beefy-bridge.BridgedInRelayedMessage"
+    ],
+    "messages": ["opstack.L1ToL2Message"],
+    "transfers": ["beefy-bridge.L1ToL2Transfer"]
+  },
   "opstack-standardbridge": {
     "txs": [
       // base -> ethereum (erc20)

--- a/packages/backend/src/modules/interop/plugins/beefy-bridge.ts
+++ b/packages/backend/src/modules/interop/plugins/beefy-bridge.ts
@@ -1,0 +1,182 @@
+import { Address32, EthereumAddress } from '@l2beat/shared-pure'
+import {
+  hashCrossDomainMessageV1,
+  parseRelayedMessage,
+  parseSentMessage,
+  parseSentMessageExtension1,
+  RelayedMessage,
+  SentMessage,
+} from './opstack/opstack'
+import {
+  createEventParser,
+  createInteropEventType,
+  type InteropEvent,
+  type InteropEventDb,
+  type InteropPlugin,
+  type LogToCapture,
+  type MatchResult,
+  Result,
+} from './types'
+
+// Contract addresses - same address on both L1 and L2
+const BEEFY_BRIDGE = EthereumAddress(
+  '0xbbb8971aea2627fa2e1342bb5bf952ec521479f2',
+)
+
+// L1CrossDomainMessenger for Optimism
+const L1_CROSS_DOMAIN_MESSENGER = EthereumAddress(
+  '0x25ace71c97b33cc4729cf772ae268934f7ab5fa1',
+)
+// Standard L2CrossDomainMessenger for OP Stack chains
+const L2_CROSS_DOMAIN_MESSENGER = EthereumAddress(
+  '0x4200000000000000000000000000000000000007',
+)
+
+// Token addresses
+const L1_BIFI_TOKEN = Address32.from(
+  '0xbEEF8e0982874e0292E6C5751C5a4092b3e1bEEF',
+)
+const L2_BIFI_TOKEN = Address32.from(
+  '0xc55e93c62874d8100dbd2dfe307edc1036ad5434',
+)
+
+// L1 event: BridgedOut + SentMessage combined
+const BeefyBridgedOutSentMessage = createInteropEventType<{
+  msgHash: string
+  dstChainId: bigint
+  bridgeUser: string
+  tokenReceiver: string
+  amount: bigint
+}>('beefy-bridge.BridgedOutSentMessage')
+
+// L2 event: BridgedIn + RelayedMessage combined
+const BeefyBridgedInRelayedMessage = createInteropEventType<{
+  msgHash: string
+  srcChainId: bigint
+  tokenReceiver: string
+  amount: bigint
+}>('beefy-bridge.BridgedInRelayedMessage')
+
+// Event parsers
+const parseBridgedOut = createEventParser(
+  'event BridgedOut(uint256 indexed dstChainId, address indexed bridgeUser, address indexed tokenReceiver, uint256 amount)',
+)
+
+const parseBridgedIn = createEventParser(
+  'event BridgedIn(uint256 indexed srcChainId, address indexed tokenReceiver, uint256 amount)',
+)
+
+export class BeefyBridgePlugin implements InteropPlugin {
+  name = 'beefy-bridge'
+
+  capture(input: LogToCapture) {
+    if (input.chain === 'ethereum') {
+      // L1: Capture BridgedOut + SentMessage
+      const bridgedOut = parseBridgedOut(input.log, [BEEFY_BRIDGE])
+      if (bridgedOut) {
+        // Find SentMessage in same tx
+        const sentMessageLog = input.txLogs.find((log) => {
+          const parsed = parseSentMessage(log, [L1_CROSS_DOMAIN_MESSENGER])
+          return parsed !== undefined
+        })
+        if (sentMessageLog) {
+          const sentMessage = parseSentMessage(sentMessageLog, [
+            L1_CROSS_DOMAIN_MESSENGER,
+          ])
+          if (sentMessage) {
+            // Find SentMessageExtension1
+            const nextLog = input.txLogs.find(
+              // biome-ignore lint/style/noNonNullAssertion: It's there
+              (x) => x.logIndex === sentMessageLog.logIndex! + 1,
+            )
+            const extension =
+              nextLog &&
+              parseSentMessageExtension1(nextLog, [L1_CROSS_DOMAIN_MESSENGER])
+
+            const msgHash = hashCrossDomainMessageV1(
+              sentMessage.messageNonce,
+              sentMessage.sender,
+              sentMessage.target,
+              extension?.value ?? 0n,
+              sentMessage.gasLimit,
+              sentMessage.message,
+            )
+
+            return [
+              BeefyBridgedOutSentMessage.create(input, {
+                msgHash,
+                dstChainId: bridgedOut.dstChainId,
+                bridgeUser: bridgedOut.bridgeUser,
+                tokenReceiver: bridgedOut.tokenReceiver,
+                amount: bridgedOut.amount,
+              }),
+            ]
+          }
+        }
+      }
+    } else if (input.chain === 'optimism') {
+      // L2: Capture BridgedIn + RelayedMessage
+      const bridgedIn = parseBridgedIn(input.log, [BEEFY_BRIDGE])
+      if (bridgedIn) {
+        // Find RelayedMessage in same tx
+        const relayedMessageLog = input.txLogs.find((log) => {
+          const parsed = parseRelayedMessage(log, [L2_CROSS_DOMAIN_MESSENGER])
+          return parsed !== undefined
+        })
+        if (relayedMessageLog) {
+          const relayedMessage = parseRelayedMessage(relayedMessageLog, [
+            L2_CROSS_DOMAIN_MESSENGER,
+          ])
+          if (relayedMessage) {
+            return [
+              BeefyBridgedInRelayedMessage.create(input, {
+                msgHash: relayedMessage.msgHash,
+                srcChainId: bridgedIn.srcChainId,
+                tokenReceiver: bridgedIn.tokenReceiver,
+                amount: bridgedIn.amount,
+              }),
+            ]
+          }
+        }
+      }
+    }
+  }
+
+  matchTypes = [BeefyBridgedInRelayedMessage]
+
+  match(event: InteropEvent, db: InteropEventDb): MatchResult | undefined {
+    if (BeefyBridgedInRelayedMessage.checkType(event)) {
+      const srcEvent = db.find(BeefyBridgedOutSentMessage, {
+        msgHash: event.args.msgHash,
+      })
+      if (!srcEvent) return
+
+      // Also find underlying OpStack events for the Message
+      const sentMessage = db.find(SentMessage, {
+        msgHash: event.args.msgHash,
+        chain: 'optimism',
+      })
+      const relayedMessage = db.find(RelayedMessage, {
+        msgHash: event.args.msgHash,
+        chain: 'optimism',
+      })
+      if (!sentMessage || !relayedMessage) return
+
+      return [
+        Result.Message('opstack.L1ToL2Message', {
+          app: 'beefy',
+          srcEvent: sentMessage,
+          dstEvent: relayedMessage,
+        }),
+        Result.Transfer('beefy-bridge.L1ToL2Transfer', {
+          srcEvent,
+          srcAmount: srcEvent.args.amount,
+          srcTokenAddress: L1_BIFI_TOKEN,
+          dstEvent: event,
+          dstAmount: event.args.amount,
+          dstTokenAddress: L2_BIFI_TOKEN,
+        }),
+      ]
+    }
+  }
+}

--- a/packages/backend/src/modules/interop/plugins/index.ts
+++ b/packages/backend/src/modules/interop/plugins/index.ts
@@ -13,6 +13,7 @@ import { AcrossPlugin } from './across/across.plugin'
 import { AllbridgePlugIn } from './allbridge'
 import { AxelarPlugin } from './axelar'
 import { AxelarITSPlugin } from './axelar-its'
+import { BeefyBridgePlugin } from './beefy-bridge'
 import { CCIPPlugIn } from './ccip'
 import { CCTPConfigPlugin } from './cctp/cctp.config'
 import { CCTPV1Plugin } from './cctp/cctp-v1.plugin'
@@ -129,6 +130,7 @@ export function createInteropPlugins(
       new OrbitStackCustomGatewayPlugin(), // should be run before OrbitStack
       new OrbitStackPlugin(),
       new SorareBasePlugin(), // should be run before OpStackStandardBridge
+      new BeefyBridgePlugin(), // should be run before OpStackStandardBridge
       new OpStackStandardBridgePlugin(), // should be run before OpStack
       new OpStackPlugin(),
       new HyperlaneMerklyTokenBridgePlugin(), // should be run before HyperlaneHWR


### PR DESCRIPTION
Part of L2B-12383. This is a dedicated bridge just to bridge the BIFI token from L1 to OP Mainnet. L1 and L2 side of the contracts are the same: on L1 it locks token on a lockbox, mints xBIFI tokens, burns them, and sends a message on L2 to mint. On L2, since no lockbox is specified, tokens are minted and sent to the user. To go back, tokens on L2 are burned, and on L1 xBIFI tokens are minted, and since there is a lockbox specified, they get burned to unlock original BIFI tokens. The L2->L1 side is de facto disabled (i even tried [here](https://optimistic.etherscan.io/tx/0x28081442cfc12d888b33ec396e0a4cffce658d4c75af1d32dcb733c20a30d5d2)) as there are limits specified at zero, so for simplicity i didn't add the L2->L1 support. The construction seems unnecessarily convoluted but whatever