### PR TITLE
Add Frax Ferry Telegram and Discord links

### DIFF
--- a/packages/config/src/projects/fraxferry/fraxferry.ts
+++ b/packages/config/src/projects/fraxferry/fraxferry.ts
@@ -30,7 +30,11 @@ export const fraxferry: Bridge = {
       documentation: ['https://docs.frax.com/'],
       bridges: ['https://mainnet.frax.com/tools/bridge/'],
       repositories: ['https://github.com/FraxFinance/frax-solidity'],
-      socialMedia: ['https://twitter.com/fraxfinance'],
+      socialMedia: [
+        'https://twitter.com/fraxfinance',
+        'https://t.me/fraxfinance',
+        'https://discord.com/invite/fraxfinance',
+      ],
     },
     description:
       'The Frax Ferry is a permissioned bridge that can be used to transfer tokens between chains.',


### PR DESCRIPTION
Add Frax Ferry community links (Telegram and Discord) to the socialMedia section of the project config to surface official communication channels on the site.
Links were found on their website https://frax.com/