### PR TITLE
Add Unite Telegram and Discord links

### DIFF
--- a/packages/config/src/projects/unite/unite.ts
+++ b/packages/config/src/projects/unite/unite.ts
@@ -17,7 +17,11 @@ export const unite: ScalingProject = underReviewL3({
     stacks: ['Arbitrum'],
     links: {
       documentation: ['https://unite-1.gitbook.io/unite-docs'],
-      socialMedia: ['https://x.com/uniteio'],
+      socialMedia: [
+        'https://x.com/uniteio',
+        'https://t.me/uniteiotg',
+        'https://discord.com/invite/unite-io',
+      ],
       websites: ['https://unite.io/'],
       explorers: ['https://unite-mainnet.explorer.alchemy.com/'],
       bridges: [


### PR DESCRIPTION
Add Unite Telegram channel to social media links https://t.me/uniteiotg
Add Unite Discord server to social media links https://discord.com/invite/unite-io

both were found on https://unite.io/