### PR TITLE
Fix memory-db event consistency in Interop

### DIFF
--- a/packages/backend/src/modules/interop/engine/capture/InteropEventStore.ts
+++ b/packages/backend/src/modules/interop/engine/capture/InteropEventStore.ts
@@ -28,11 +28,12 @@ export class InteropEventStore implements InteropEventDb {
   }
 
   async saveNewEvents(events: InteropEvent[]): Promise<void> {
+    // Add to DB first, so if it fails, events will not be added to memory
+    const records = events.map((e) => toDbRecord(e))
+    await this.db.interopEvent.insertMany(records)
     for (const event of events) {
       this.eventDb.addEvent(event)
     }
-    const records = events.map((e) => toDbRecord(e))
-    await this.db.interopEvent.insertMany(records)
   }
 
   async updateMatchedAndUnsupported({
@@ -42,13 +43,13 @@ export class InteropEventStore implements InteropEventDb {
     matched: InteropEvent[]
     unsupported: InteropEvent[]
   }): Promise<void> {
-    this.eventDb.removeEvents([...matched, ...unsupported])
     await this.db.transaction(async () => {
       await this.db.interopEvent.updateMatched(matched.map((e) => e.eventId))
       await this.db.interopEvent.updateUnsupported(
         unsupported.map((e) => e.eventId),
       )
     })
+    this.eventDb.removeEvents([...matched, ...unsupported])
   }
 
   getEvents(type: string): InteropEvent[] {
@@ -86,8 +87,9 @@ export class InteropEventStore implements InteropEventDb {
   }
 
   async deleteExpired(now: UnixTime) {
+    const count = await this.db.interopEvent.deleteExpired(now)
     this.eventDb.removeExpired(now)
-    return await this.db.interopEvent.deleteExpired(now)
+    return count
   }
 }
 


### PR DESCRIPTION
Saving to DB, which can fail and rollback, *must* happen before udating the memory, which can't fail. Change the order of instructions.