### PR TITLE
chore(config): remove unused getReferencedAddresses export

### DIFF
--- a/packages/config/src/processing/layer2s.test.ts
+++ b/packages/config/src/processing/layer2s.test.ts
@@ -2,7 +2,6 @@ import {
   assert,
   assertUnreachable,
   ChainSpecificAddress,
-  EthereumAddress,
   notUndefined,
   ProjectId,
   UnixTime,
@@ -528,4 +527,3 @@ describe('layer2s', () => {
     }
   })
 })
-


### PR DESCRIPTION
Removes the unused `getReferencedAddresses` function from `layer2s.test.ts`.