### PR TITLE
refactor(backend-tools): remove redundant Promise.resolve in RateLimiter

### DIFF
--- a/packages/backend-tools/src/rate-limit/RateLimiter.ts
+++ b/packages/backend-tools/src/rate-limit/RateLimiter.ts
@@ -58,7 +58,7 @@ export class RateLimiter {
       return
     }
 
-    Promise.resolve(item())
+    item()
       .then((res) => item.resolve(res))
       .catch((err) => item.reject(err))
       .finally(() => this.execute())


### PR DESCRIPTION
Removes unnecessary `Promise.resolve()` wrapper in the `RateLimiter.execute()` method.