### PR TITLE
fix: correct FXS escrow token config on Starknet

### DIFF
--- a/packages/config/src/projects/starknet/starknet.ts
+++ b/packages/config/src/projects/starknet/starknet.ts
@@ -148,7 +148,7 @@ const escrowFRAXMaxTotalBalanceString = formatMaxTotalBalanceString(
 )
 
 const escrowFXSMaxTotalBalanceString = formatMaxTotalBalanceString(
-  'FRAX',
+  'FXS',
   discovery.getContractValue<number>('FXSBridge', 'maxTotalBalance'),
   18,
 )
@@ -572,7 +572,7 @@ All bridge escrows allow enabling a withdrawal throttle of 5% of the locked fund
       }),
       discovery.getEscrowDetails({
         address: ChainSpecificAddress(ESCROW_FXS_ADDRESS),
-        tokens: ['FRAX'],
+        tokens: ['FXS'],
         description:
           'StarkGate bridge for FXS.' + ' ' + escrowFXSMaxTotalBalanceString,
       }),


### PR DESCRIPTION
This change fixes the Starknet FXS escrow configuration so that it consistently uses the FXS token instead of FRAX. Previously the bridge cap string and the escrow token list were labeled as FRAX while the description and on-chain bridge contract clearly refer to FXS. This mismatch could lead to incorrect token attribution in analytics and UI. With this update, the escrow now uses the FXS ticker in the cap string and reports FXS in the token list, aligning the config with the actual bridge semantics.