### PR TITLE
chore: add discord and instagram links for spheron

### DIFF
--- a/packages/config/src/projects/spheron/spheron.ts
+++ b/packages/config/src/projects/spheron/spheron.ts
@@ -25,7 +25,6 @@ export const spheron: ScalingProject = upcomingL3({
         'https://youtube.com/@spheronfdn',
         'https://www.instagram.com/spheronhq',
         'https://discord.com/invite/spheron-network-745315423783878757',
-        'https://t.me/Spheron',
       ],
     },
   },


### PR DESCRIPTION
[instagram](https://www.instagram.com/spheronhq) and [discord](https://discord.com/invite/spheron-network-745315423783878757?utm_source=LP&utm_medium=landing_page&utm_campaign=landing_page) were added.
<img width="546" height="311" alt="Снимок экрана 2026-01-12 в 20 13 58" src="https://github.com/user-attachments/assets/4d26a407-0639-4956-87ea-78d7cc1164ae" />
