### PR TITLE
fix: add Zora to Socket bridge destinations

### DIFF
--- a/packages/config/src/projects/socket/socket.ts
+++ b/packages/config/src/projects/socket/socket.ts
@@ -51,7 +51,7 @@ export const socket: Bridge = {
     },
   },
   technology: {
-    destination: ['Ethereum', 'Reya', 'Lyra', 'Kinto', 'Polynomial', 'Blast'],
+    destination: ['Ethereum', 'Reya', 'Lyra', 'Kinto', 'Polynomial', 'Blast', 'Zora'],
     principleOfOperation: {
       name: 'Principle of operation',
       description:


### PR DESCRIPTION
Socket config already defines Zora USDC/USDT vaults in config.escrows but the technology.destination list did not include Zora. This caused an inconsistent view of supported destinations in the UI and docs. The change adds Zora to the destination array to align the high-level metadata with the configured vaults.