### PR TITLE
fix: remove duplicated Aurora destination in Synapse config

### DIFF
--- a/packages/config/src/projects/synapse/synapse.ts
+++ b/packages/config/src/projects/synapse/synapse.ts
@@ -68,7 +68,6 @@ export const synapse: Bridge = {
       'DFK Chain',
       'Optimism',
       'Polygon',
-      'Aurora',
       'Boba Network',
       'Fantom',
       'Metis',


### PR DESCRIPTION
The Synapse bridge technology section listed Aurora twice in the destination chains array. This change removes the duplicate entry to keep the configuration accurate and avoid confusion in downstream consumers that rely on the destination list.