### PR TITLE
Add Derive Telegram channel link

### DIFF
--- a/packages/config/src/projects/lyra/lyra.ts
+++ b/packages/config/src/projects/lyra/lyra.ts
@@ -39,6 +39,7 @@ export const lyra: ScalingProject = opStackL2({
         'https://discord.gg/Derive',
         'https://youtube.com/@derivexyz',
         'https://linkedin.com/company/derivelabs',
+        'https://t.me/Derive_Announcements',
       ],
       other: ['https://growthepie.com/chains/derive'],
     },


### PR DESCRIPTION
Include the official Derive Telegram announcements channel in the social media links of the Derive (lyra) project config.
the link is available on https://derive.xyz/