### PR TITLE
chore: add INTMAX Discord link

### DIFF
--- a/packages/config/src/projects/intmax/intmax.ts
+++ b/packages/config/src/projects/intmax/intmax.ts
@@ -39,7 +39,10 @@ export const intmax: ScalingProject = {
         'https://medium.com/intmax/the-deep-dive-into-statelessness-intmax2-algorithm-was-published-be7a306048ff',
       ],
       repositories: ['https://github.com/InternetMaximalism'],
-      socialMedia: ['https://twitter.com/intmaxIO'],
+      socialMedia: [
+        'https://twitter.com/intmaxIO',
+        'https://discord.com/invite/TGMctchPR6',
+      ],
       bridges: ['https://app.intmax.io/bridge'],
     },
   },


### PR DESCRIPTION
Expose the official INTMAX Discord invite in the project config so users can quickly find the community channel from the L2BEAT project page.

taken from their website https://intmax.io/