### PR TITLE
Declarative interop event capturing

### DIFF
--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -374,7 +374,7 @@ describe(InteropEventSyncer.name, () => {
       const plugin = makePlugin({
         dataRequests: [
           {
-            type: 'eventWithTxLogs',
+            type: 'event',
             signature,
             includeTxEvents: [includeSignature],
             addresses: [ethAddress],

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -13,11 +13,12 @@ import {
   UnixTime,
 } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
-import type {
-  DataRequest,
-  InteropEvent,
-  InteropPluginResyncable,
-  LogToCapture,
+import {
+  createEventParser,
+  type DataRequest,
+  type InteropEvent,
+  type InteropPluginResyncable,
+  type LogToCapture,
 } from '../../plugins/types'
 import type { InteropEventStore } from '../capture/InteropEventStore'
 import { toEventSelector } from '../utils'
@@ -264,6 +265,7 @@ describe(InteropEventSyncer.name, () => {
   describe(buildLogQueryForPlugin.name, () => {
     it('includes only addresses on the target chain and their topics', () => {
       const signature = 'event Transfer(address,address,uint256)'
+      const parser = createEventParser(signature)
       const ethAddress = ChainSpecificAddress.fromLong(
         'ethereum',
         EthereumAddress.random(),
@@ -276,8 +278,9 @@ describe(InteropEventSyncer.name, () => {
         dataRequests: [
           {
             type: 'event',
-            signature,
+            signature: parser,
             addresses: [ethAddress, arbAddress],
+            captureFn: (_log) => {},
           },
         ],
       })
@@ -294,6 +297,7 @@ describe(InteropEventSyncer.name, () => {
 
     it('is empty when no addresses match the chain', () => {
       const signature = 'event Transfer(address,address,uint256)'
+      const parser = createEventParser(signature)
       const arbAddress = ChainSpecificAddress.fromLong(
         'arbitrum',
         EthereumAddress.random(),
@@ -302,8 +306,9 @@ describe(InteropEventSyncer.name, () => {
         dataRequests: [
           {
             type: 'event',
-            signature,
+            signature: parser,
             addresses: [arbAddress],
+            captureFn: (_log) => {},
           },
         ],
       })

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
@@ -54,8 +54,12 @@ export function buildLogQueryForPlugin(
     }
     if (addressesOnThisChain > 0) {
       // TODO try also with `toEventSelector` straight from viem
-      const topic0 = toEventSelector(eventRequest.signature)
-      result.topic0s.add(topic0)
+      const topic0 =
+        eventRequest.signature.topic0 ??
+        toEventSelector(eventRequest.signature.signature)
+      if (topic0) {
+        result.topic0s.add(topic0)
+      }
     }
   }
 

--- a/packages/backend/src/modules/interop/plugins/across/across.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/across/across.plugin.ts
@@ -18,7 +18,6 @@ import { AcrossConfig } from './across.config'
 
 const fundsDepositedLog =
   'event FundsDeposited(bytes32 inputToken, bytes32 outputToken, uint256 inputAmount, uint256 outputAmount, uint256 indexed destinationChainId, uint256 indexed depositId, uint32 quoteTimestamp, uint32 fillDeadline, uint32 exclusivityDeadline, bytes32 indexed depositor, bytes32 recipient, bytes32 exclusiveRelayer, bytes message)'
-type ParsedFundsDepositedLog = ParsedEvent<typeof fundsDepositedLog>
 
 export const AcrossFundsDeposited = createInteropEventType<{
   $dstChain: string

--- a/packages/backend/src/modules/interop/plugins/across/across.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/across/across.plugin.ts
@@ -1,6 +1,7 @@
 import { Address32, ChainSpecificAddress } from '@l2beat/shared-pure'
 import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
 import {
+  createEventDataRequest,
   createEventParser,
   createInteropEventType,
   type DataRequest,
@@ -60,21 +61,24 @@ export class AcrossPlugin implements InteropPluginResyncable {
       )
 
     return [
-      {
+      createEventDataRequest({
         type: 'event',
-        signature: fundsDepositedLog,
+        signature: parseFundsDeposited,
         addresses: spokePoolAddresses,
-      },
-      {
+        captureFn: (_log) => {},
+      }),
+      createEventDataRequest({
         type: 'event',
-        signature: filledRelayLog,
+        signature: parseFilledRelay,
         addresses: spokePoolAddresses,
-      },
-      {
+        captureFn: (_log) => {},
+      }),
+      createEventDataRequest({
         type: 'event',
-        signature: filledV3RelayLog,
+        signature: parseFilledV3Relay,
         addresses: spokePoolAddresses,
-      },
+        captureFn: (_log) => {},
+      }),
     ]
   }
 


### PR DESCRIPTION
Remove generic `.capture` method and instead require fine-grained per-request capture functions.