### PR TITLE
zksyncprover: add website link to project configuration

### DIFF
--- a/packages/config/src/projects/zksyncprover/zksyncprover.ts
+++ b/packages/config/src/projects/zksyncprover/zksyncprover.ts
@@ -20,6 +20,7 @@ export const zksyncprover: BaseProject = {
     description:
       'Plonk proving system designed by Matter Labs to prove custom predefined state transitions of ZKsync Lite.',
     links: {
+      websites: ['https://lite.zksync.io/'],
       documentation: [
         'https://github.com/matter-labs/zksync/tree/master/docs',
         'https://docs.lite.zksync.io/userdocs/',


### PR DESCRIPTION
Add official website link to ZKsync Lite prover project configuration.