### PR TITLE
Add documentation link to Arbitrum Orbit project

### DIFF
--- a/packages/config/src/projects/arbitrum-orbit/arbitrum-orbit.ts
+++ b/packages/config/src/projects/arbitrum-orbit/arbitrum-orbit.ts
@@ -13,6 +13,7 @@ export const arbitrumOrbit: BaseProject = {
     links: {
       websites: ['https://arbitrum.io', 'https://portal.arbitrum.io/'],
       bridges: ['https://bridge.arbitrum.io/'],
+      documentation: ['https://docs.arbitrum.io/get-started/overview'],
     },
     badges: [BADGES.Stack.Orbit],
   },


### PR DESCRIPTION
Add documentation field to Arbitrum Orbit project configuration. Include official Arbitrum Orbit getting started guide in project links