### PR TITLE
ocs: add Guild community link for Codex

### DIFF
--- a/packages/config/src/projects/codex/codex.ts
+++ b/packages/config/src/projects/codex/codex.ts
@@ -21,6 +21,7 @@ export const codex: ScalingProject = underReviewL2({
       socialMedia: [
         'https://x.com/codex_pbc',
         'https://linkedin.com/company/codex-pbc',
+        'https://guild.xyz/codex-community-guild',
       ],
     },
   },


### PR DESCRIPTION
Added `https://guild.xyz/codex-community-guild` to the `socialMedia` array.

