### PR TITLE
Add discord invite link for Creator project

### DIFF
--- a/packages/config/src/projects/creator/creator.ts
+++ b/packages/config/src/projects/creator/creator.ts
@@ -15,7 +15,10 @@ export const creator: ScalingProject = upcomingL2({
     stacks: ['ZK Stack'],
     links: {
       websites: ['https://oncreator.com/'],
-      socialMedia: ['https://x.com/oncreator_'],
+      socialMedia: [
+        'https://x.com/oncreator_',
+        'https://discord.com/invite/oncreator',
+      ],
     },
   },
   ecosystemInfo: {


### PR DESCRIPTION
Added the Discord invite link to the Creator social media list
https://discord.com/invite/oncreator - was taken from https://oncreator.com/