### PR TITLE
Update EigenDA throughput ids

### DIFF
--- a/packages/config/src/projects/eigenda/eigenda.ts
+++ b/packages/config/src/projects/eigenda/eigenda.ts
@@ -412,13 +412,13 @@ export const eigenda: BaseProject = {
         ],
       },
       {
-        projectId: ProjectId('megaeth'),
-        name: 'MegaETH',
+        projectId: ProjectId('rise'),
+        name: 'Rise',
         daTrackingConfig: [
           {
             type: 'eigen-da',
-            sinceTimestamp: 1722405600,
-            customerId: '0xcd1161b78f01da838ce0d42ec750891ec8708f1d',
+            sinceTimestamp: 1767607200, // 2026-01-05T10:00:00Z
+            customerId: '0x78d5974216f751eb328018f003067f77e8be2fc4',
           },
         ],
       },

--- a/packages/config/src/projects/megaeth/megaeth.ts
+++ b/packages/config/src/projects/megaeth/megaeth.ts
@@ -104,6 +104,14 @@ export const megaeth: ScalingProject = opStackL2({
     startBlock: 1,
     adjustCount: { type: 'SubtractOneSinceBlock', blockNumber: 1 },
   },
+  nonTemplateDaTracking: [
+    {
+      type: 'eigen-da',
+      daLayer: ProjectId('eigenda'),
+      sinceTimestamp: UnixTime(1762995600), // 2025-11-13T01:00:00Z
+      customerId: '0x42b5ea5238752cc6f70d93fa4249feae480a0b39',
+    },
+  ],
   nonTemplateEscrows: [
     discovery.getEscrowDetails({
       address: ChainSpecificAddress(


### PR DESCRIPTION
resolves L2B-12944

MegaETH new id (prev was testnet)
Rise new id (hasn't launched yet)