### PR TITLE
Fix wiping plugin data on resync

### DIFF
--- a/packages/backend/src/modules/interop/engine/dashboard/InteropRouter.test.ts
+++ b/packages/backend/src/modules/interop/engine/dashboard/InteropRouter.test.ts
@@ -23,29 +23,32 @@ const config: InteropFeatureConfig = {
 describe(createInteropRouter.name, () => {
   describe('POST /interop/resync', () => {
     it('applies wildcard to unspecified existing chains', async () => {
-      const setResyncRequestedFrom = mockFn().resolvesTo(undefined)
+      const setResyncRequest = mockFn().resolvesTo(undefined)
       const interopPluginSyncState = mockObject<
         Database['interopPluginSyncState']
       >({
-        setResyncRequestedFrom,
+        setResyncRequest,
         findByPluginName: mockFn().resolvesTo([
           {
             pluginName: 'plugin',
             chain: 'chain-a',
             lastError: null,
             resyncRequestedFrom: null,
+            resyncRequestedAt: null,
           },
           {
             pluginName: 'plugin',
             chain: 'chain-b',
             lastError: null,
             resyncRequestedFrom: null,
+            resyncRequestedAt: null,
           },
           {
             pluginName: 'plugin',
             chain: 'chain-c',
             lastError: null,
             resyncRequestedFrom: null,
+            resyncRequestedAt: null,
           },
         ]),
       })
@@ -81,21 +84,26 @@ describe(createInteropRouter.name, () => {
         })
         .expect(200)
 
-      expect(setResyncRequestedFrom).toHaveBeenCalledTimes(3)
-      expect(setResyncRequestedFrom).toHaveBeenCalledWith(
+      expect(setResyncRequest).toHaveBeenCalledTimes(3)
+      const requestIds = setResyncRequest.calls.map((call) => call.args[3])
+      expect(new Set(requestIds).size).toEqual(1)
+      expect(setResyncRequest).toHaveBeenCalledWith(
         'plugin',
         'chain-a',
         UnixTime(1000),
+        requestIds[0],
       )
-      expect(setResyncRequestedFrom).toHaveBeenCalledWith(
+      expect(setResyncRequest).toHaveBeenCalledWith(
         'plugin',
         'chain-b',
         UnixTime(2000),
+        requestIds[0],
       )
-      expect(setResyncRequestedFrom).toHaveBeenCalledWith(
+      expect(setResyncRequest).toHaveBeenCalledWith(
         'plugin',
         'chain-c',
         UnixTime(2000),
+        requestIds[0],
       )
     })
   })

--- a/packages/backend/src/modules/interop/engine/sync/FollowingState.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/FollowingState.test.ts
@@ -23,7 +23,10 @@ describe(FollowingState.name, () => {
       })
       const saveProducedInteropEvents = mockFn().resolvesTo(undefined)
       const syncer = createSyncer({
-        isResyncRequestedFrom: mockFn().resolvesTo(UnixTime(1)),
+        getResyncRequest: mockFn().resolvesTo({
+          from: UnixTime(1),
+          requestedAt: UnixTime(10),
+        }),
         getLastSyncedRange,
         getItemsToCapture,
         saveProducedInteropEvents,
@@ -203,7 +206,7 @@ function createSyncer(
       name: 'mock-cluster',
       plugins: [],
     } as InteropEventSyncer['cluster'],
-    isResyncRequestedFrom: mockFn().resolvesTo(undefined),
+    getResyncRequest: mockFn().resolvesTo(undefined),
     getLastSyncedRange: mockFn().resolvesTo(undefined),
     getOldestEventForPluginAndChain: mockFn().resolvesTo(undefined),
     getItemsToCapture: mockFn().returns({

--- a/packages/backend/src/modules/interop/engine/sync/FollowingState.ts
+++ b/packages/backend/src/modules/interop/engine/sync/FollowingState.ts
@@ -21,8 +21,7 @@ export class FollowingState implements BlockProcessorState {
   async processNewestBlock(block: Block, logs: Log[]): Promise<SyncerState> {
     this.status = 'processing'
 
-    const resyncRequested =
-      (await this.syncer.isResyncRequestedFrom()) !== undefined
+    const resyncRequested = (await this.syncer.getResyncRequest()) !== undefined
     const lastSyncedRecord = resyncRequested
       ? undefined
       : await this.syncer.getLastSyncedRange()

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -235,7 +235,7 @@ describe(InteropEventSyncer.name, () => {
     })
   })
 
-  describe(InteropEventSyncer.prototype.isResyncRequestedFrom.name, () => {
+  describe(InteropEventSyncer.prototype.getResyncRequest.name, () => {
     it('returns undefined when no resync requested', async () => {
       const syncer = createSyncer({
         db: mockObject<InteropEventSyncer['db']>({
@@ -247,7 +247,7 @@ describe(InteropEventSyncer.name, () => {
         }),
       })
 
-      const result = await syncer.isResyncRequestedFrom()
+      const result = await syncer.getResyncRequest()
 
       expect(result).toEqual(undefined)
     })
@@ -260,14 +260,18 @@ describe(InteropEventSyncer.name, () => {
           >({
             findByPluginNameAndChain: mockFn().resolvesTo({
               resyncRequestedFrom: UnixTime(123),
+              resyncRequestedAt: UnixTime(456),
             }),
           }),
         }),
       })
 
-      const result = await syncer.isResyncRequestedFrom()
+      const result = await syncer.getResyncRequest()
 
-      expect(result).toEqual(UnixTime(123))
+      expect(result).toEqual({
+        from: UnixTime(123),
+        requestedAt: UnixTime(456),
+      })
     })
   })
 

--- a/packages/backend/src/modules/interop/engine/sync/InteropSyncersManager.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropSyncersManager.ts
@@ -8,6 +8,7 @@ import type { PluginCluster } from '../../plugins'
 import { isPluginResyncable } from '../../plugins/types'
 import type { InteropEventStore } from '../capture/InteropEventStore'
 import { InteropEventSyncer } from './InteropEventSyncer'
+import { ResyncWipeCoordinator } from './ResyncWipeCoordinator'
 
 export type PluginSyncStatus = {
   pluginName: string
@@ -45,6 +46,11 @@ export class InteropSyncersManager {
           `Cluster of plugins '${cluster.name} contains mix of non- and resyncable plugins. They must all be the same kind.`,
         )
       }
+      const resyncCoordinator = new ResyncWipeCoordinator(
+        cluster.name,
+        enabledChains,
+        logger.for(ResyncWipeCoordinator.name),
+      )
       for (const chain of enabledChains) {
         const chainConfig = chainConfigs.find((c) => c.name === chain)
         if (!chainConfig) {
@@ -58,6 +64,7 @@ export class InteropSyncersManager {
           eventStore,
           db,
           logger,
+          resyncCoordinator,
         )
         this.syncers
           .getOrInsertComputed(cluster.name, () => new UpsertMap())

--- a/packages/backend/src/modules/interop/engine/sync/ResyncWipeCoordinator.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/ResyncWipeCoordinator.test.ts
@@ -1,0 +1,100 @@
+import { Logger } from '@l2beat/backend-tools'
+import type { LongChainName } from '@l2beat/shared-pure'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockFn } from 'earl'
+import { ResyncWipeCoordinator } from './ResyncWipeCoordinator'
+
+const CHAINS = ['ethereum', 'arbitrum'] as LongChainName[]
+
+describe(ResyncWipeCoordinator.name, () => {
+  it('waits until all chains are ready before wiping', async () => {
+    const wipe = mockFn().resolvesTo(undefined)
+    const coordinator = new ResyncWipeCoordinator(
+      'cluster',
+      CHAINS,
+      Logger.SILENT,
+    )
+
+    const requestId = UnixTime(100)
+    const first = await coordinator.waitForWipe({
+      requestId,
+      chain: 'ethereum',
+      wipe,
+    })
+    const second = await coordinator.waitForWipe({
+      requestId,
+      chain: 'arbitrum',
+      wipe,
+    })
+    const third = await coordinator.waitForWipe({
+      requestId,
+      chain: 'ethereum',
+      wipe,
+    })
+
+    expect(first).toEqual(false)
+    expect(second).toEqual(true)
+    expect(third).toEqual(true)
+    expect(wipe).toHaveBeenCalledTimes(1)
+  })
+
+  it('requires all chains again for a newer request', async () => {
+    const wipe = mockFn().resolvesTo(undefined)
+    const coordinator = new ResyncWipeCoordinator(
+      'cluster',
+      CHAINS,
+      Logger.SILENT,
+    )
+
+    const firstRequest = UnixTime(100)
+    await coordinator.waitForWipe({
+      requestId: firstRequest,
+      chain: 'ethereum',
+      wipe,
+    })
+    await coordinator.waitForWipe({
+      requestId: firstRequest,
+      chain: 'arbitrum',
+      wipe,
+    })
+
+    const secondRequest = UnixTime(200)
+    const first = await coordinator.waitForWipe({
+      requestId: secondRequest,
+      chain: 'ethereum',
+      wipe,
+    })
+    const second = await coordinator.waitForWipe({
+      requestId: secondRequest,
+      chain: 'arbitrum',
+      wipe,
+    })
+
+    expect(first).toEqual(false)
+    expect(second).toEqual(true)
+    expect(wipe).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores stale requests', async () => {
+    const wipe = mockFn().resolvesTo(undefined)
+    const coordinator = new ResyncWipeCoordinator(
+      'cluster',
+      CHAINS,
+      Logger.SILENT,
+    )
+
+    await coordinator.waitForWipe({
+      requestId: UnixTime(200),
+      chain: 'ethereum',
+      wipe,
+    })
+    const stale = await coordinator.waitForWipe({
+      requestId: UnixTime(100),
+      chain: 'arbitrum',
+      wipe,
+    })
+
+    expect(stale).toEqual(false)
+    expect(wipe).toHaveBeenCalledTimes(0)
+  })
+})

--- a/packages/backend/src/modules/interop/engine/sync/ResyncWipeCoordinator.ts
+++ b/packages/backend/src/modules/interop/engine/sync/ResyncWipeCoordinator.ts
@@ -1,0 +1,71 @@
+import type { Logger } from '@l2beat/backend-tools'
+import type { LongChainName, UnixTime } from '@l2beat/shared-pure'
+
+export class ResyncWipeCoordinator {
+  private currentRequestId?: UnixTime
+  private waitingChains = new Set<LongChainName>()
+  private wipeInProgressFor?: UnixTime
+  private wipeCompletedFor?: UnixTime
+
+  constructor(
+    private readonly clusterName: string,
+    private readonly chains: LongChainName[],
+    private readonly logger: Logger,
+  ) {}
+
+  async waitForWipe(params: {
+    requestId: UnixTime
+    chain: LongChainName
+    wipe: () => Promise<void>
+  }): Promise<boolean> {
+    const { requestId, chain, wipe } = params
+
+    if (
+      this.currentRequestId === undefined ||
+      requestId > this.currentRequestId
+    ) {
+      this.currentRequestId = requestId
+      this.waitingChains.clear()
+    }
+
+    if (
+      this.currentRequestId !== undefined &&
+      requestId < this.currentRequestId
+    ) {
+      return false
+    }
+
+    if (this.wipeCompletedFor === requestId) {
+      return true
+    }
+
+    this.waitingChains.add(chain)
+    if (this.waitingChains.size < this.chains.length) {
+      return false
+    }
+
+    if (this.wipeInProgressFor !== undefined) {
+      return false
+    }
+
+    this.wipeInProgressFor = requestId
+    try {
+      this.logger.info('Resync wipe starting', {
+        pluginName: this.clusterName,
+        requestId,
+      })
+      await wipe()
+      this.wipeCompletedFor = requestId
+      this.logger.info('Resync wipe completed', {
+        pluginName: this.clusterName,
+        requestId,
+      })
+    } finally {
+      if (this.wipeInProgressFor === requestId) {
+        this.wipeInProgressFor = undefined
+      }
+    }
+
+    return true
+  }
+}


### PR DESCRIPTION
Resolves L2B-13016

Interop syncers must all finish current work and notify they wait for DB wipe before the wipe happens.