### PR TITLE
Order DA "used in" entries by TVS totals

### DIFF
--- a/packages/frontend/src/server/features/data-availability/project/getDaProjectEntry.ts
+++ b/packages/frontend/src/server/features/data-availability/project/getDaProjectEntry.ts
@@ -259,11 +259,13 @@ export async function getDaProjectEntry(
       grissiniValues: mapBridgeRisksToRosetteValues({ isNoBridge: true }),
       name: 'No DA Bridge',
       tvs: getSumFor(layer.daLayer.usedWithoutBridgeIn.map((x) => x.id)).latest,
-      usedIn: layer.daLayer.usedWithoutBridgeIn.map((x) => ({
-        ...x,
-        icon: manifest.getUrl(`/icons/${x.slug}.png`),
-        url: `/scaling/projects/${x.slug}`,
-      })),
+      usedIn: layer.daLayer.usedWithoutBridgeIn
+        .sort((a, b) => getSumFor([b.id]).latest - getSumFor([a.id]).latest)
+        .map((x) => ({
+          ...x,
+          icon: manifest.getUrl(`/icons/${x.slug}.png`),
+          url: `/scaling/projects/${x.slug}`,
+        })),
     })
     result.projectVariants?.unshift({
       title: 'No DA Bridge',

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -696,6 +696,7 @@ export async function getScalingProjectEntry(
     projectsChangeReport,
     zkCatalogProjects,
     allProjectsWithContracts,
+    tvsStats,
   )
   if (contractsSection) {
     sections.push({

--- a/packages/frontend/src/utils/project/contracts-and-permissions/getContractsSection.ts
+++ b/packages/frontend/src/utils/project/contracts-and-permissions/getContractsSection.ts
@@ -14,6 +14,7 @@ import { getDiagramParams } from '~/utils/project/getDiagramParams'
 import type { TechnologyContract } from '../../../components/projects/sections/ContractEntry'
 import type { ContractsSectionProps } from '../../../components/projects/sections/contracts/ContractsSection'
 import { toTechnologyRisk } from '../risk-summary/toTechnologyRisk'
+import type { SevenDayTvsBreakdown } from '~/server/features/scaling/tvs/get7dTvsBreakdown'
 import type { ContractUtils } from './getContractUtils'
 import { getPastUpgradesData } from './getPastUpgradesData'
 import { getProgramHashes } from './getProgramHashes'
@@ -39,6 +40,7 @@ export function getContractsSection(
   projectsChangeReport: ProjectsChangeReport,
   zkCatalogProjects: Project<'zkCatalogInfo'>[],
   allProjects: Project<'contracts'>[],
+  tvs?: SevenDayTvsBreakdown,
 ): ContractsSection | undefined {
   if (!projectParams.contracts) {
     return undefined
@@ -101,6 +103,7 @@ export function getContractsSection(
       projectParams.contracts.programHashes,
       zkCatalogProjects,
       allProjects,
+      tvs,
     ),
   }
 }

--- a/packages/frontend/src/utils/project/contracts-and-permissions/getProgramHashes.ts
+++ b/packages/frontend/src/utils/project/contracts-and-permissions/getProgramHashes.ts
@@ -3,14 +3,16 @@ import type {
   ProjectScalingContractsProgramHash,
 } from '@l2beat/config'
 import type { StateValidationProgramHashData } from '~/components/projects/sections/program-hashes/ProgramHashesSection'
+import type { SevenDayTvsBreakdown } from '~/server/features/scaling/tvs/get7dTvsBreakdown'
 import { manifest } from '~/utils/Manifest'
 
 export function getProgramHashes(
   programHashes: ProjectScalingContractsProgramHash[] | undefined,
   zkCatalogProjects: Project[],
   allProjects: Project<'contracts'>[],
+  tvs?: SevenDayTvsBreakdown,
 ): StateValidationProgramHashData[] {
-  if (!programHashes) return []
+tomasztorz/l2b-13096-order-the-used-in-by-tvs  if (!programHashes) return []
 
   return programHashes
     .map((hash) => {
@@ -22,6 +24,19 @@ export function getProgramHashes(
         project.contracts.programHashes?.some((ph) => ph.hash === hash.hash),
       )
 
+      const usedInWithIcons = usedIn.map((project) => ({
+        ...project,
+        icon: manifest.getUrl(`/icons/${project.slug}.png`),
+        url: `/scaling/projects/${project.slug}`,
+      }))
+
+      const usedInByTvs = tvs
+        ? [...usedInWithIcons].sort(
+            (a, b) =>
+              (tvs.projects[b.id]?.breakdown.total ?? 0) -
+              (tvs.projects[a.id]?.breakdown.total ?? 0),
+          )
+        : usedInWithIcons
       return {
         ...hash,
         zkCatalogProject: zkCatalogProject
@@ -31,11 +46,7 @@ export function getProgramHashes(
               icon: manifest.getUrl(`/icons/${zkCatalogProject.slug}.png`),
             }
           : undefined,
-        usedIn: usedIn.map((project) => ({
-          ...project,
-          icon: manifest.getUrl(`/icons/${project.slug}.png`),
-          url: `/scaling/projects/${project.slug}`,
-        })),
+        usedIn: usedInByTvs,
       }
     })
     .filter((x) => x !== undefined)

--- a/packages/frontend/src/utils/project/getVerifiersSection.ts
+++ b/packages/frontend/src/utils/project/getVerifiersSection.ts
@@ -53,7 +53,7 @@ export async function getVerifiersSection(
     const projectsUsedIn = uniqBy(
       knownDeployments.flatMap((d) => d.projectsUsedIn),
       (u) => u.id,
-    )
+    ).sort(tvsComparator(allProjects, tvs))
 
     if (!proofSystemVerifiers) {
       byProofSystem[key] = {

--- a/packages/frontend/src/utils/project/technology/state-validation/getStateValidationSection.ts
+++ b/packages/frontend/src/utils/project/technology/state-validation/getStateValidationSection.ts
@@ -45,6 +45,7 @@ export function getStateValidationSection(
       project.contracts?.programHashes,
       zkCatalogProjects,
       allProjectsWithContracts,
+      tvs,
     ),
   }
 }


### PR DESCRIPTION
## Summary
- sort "No DA Bridge" listings by latest TVS before rendering the contracts section
- pass TVS stats through contracts/program hashes helpers so project lists respect TVS order
- ensure verifier and state validation sections receive TVS data for consistent sorting

## Testing
- Not run (not requested)