### PR TITLE
Support slug lookup in l2b getconfig

### DIFF
--- a/packages/l2b/src/commands/GetConfig.ts
+++ b/packages/l2b/src/commands/GetConfig.ts
@@ -61,10 +61,7 @@ export const GetConfig = command({
   handler: async (args) => {
     const ps = new ProjectService()
     const [project, allProjects] = await Promise.all([
-      ps.getProject({
-        id: ProjectId(args.project),
-        optional: [...ALL_PROJECT_OPTIONAL_KEYS],
-      }),
+      getProjectByIdOrSlug(ps, args.project),
       ps.getProjects({ select: ['display'] }),
     ])
 
@@ -93,4 +90,19 @@ function getProjectNotFoundMessage(
   }
 
   return `Project "${projectName}" not found. Did you mean: ${suggestions.join(', ')}? ${buildCallout}`
+}
+
+async function getProjectByIdOrSlug(ps: ProjectService, projectName: string) {
+  const project = await ps.getProject({
+    id: ProjectId(projectName),
+    optional: [...ALL_PROJECT_OPTIONAL_KEYS],
+  })
+  if (project) {
+    return project
+  }
+
+  return await ps.getProject({
+    slug: projectName,
+    optional: [...ALL_PROJECT_OPTIONAL_KEYS],
+  })
 }


### PR DESCRIPTION
Allow l2b getconfig to resolve projects by slug when id lookup misses, matching the command's existing not-found suggestions.