### PR TITLE
Refactor interop protocol transfer fetching

### DIFF
--- a/packages/frontend/src/server/features/scaling/interop/getInteropProtocolTransfers.test.ts
+++ b/packages/frontend/src/server/features/scaling/interop/getInteropProtocolTransfers.test.ts
@@ -1,7 +1,11 @@
 import type { InteropTransferRecord } from '@l2beat/database'
-import { UnixTime } from '@l2beat/shared-pure'
+import { InMemoryCache, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
-import { toInteropProtocolTransferDetailsItem } from './getInteropProtocolTransfers'
+import {
+  getInteropProtocolTransfers,
+  toInteropProtocolTransferDetailsItem,
+} from './getInteropProtocolTransfers'
+import type { InteropProtocolTransfersParams } from './types'
 
 describe(toInteropProtocolTransferDetailsItem.name, () => {
   it('maps transfer details with source and destination token amounts', () => {
@@ -83,6 +87,186 @@ describe(toInteropProtocolTransferDetailsItem.name, () => {
     expect(result.duration).toEqual(undefined)
   })
 })
+
+describe(getInteropProtocolTransfers.name, () => {
+  it('returns an empty response when from/to selection is empty', async () => {
+    let getProjectCalls = 0
+    const deps = createDeps({
+      getProject: async () => {
+        getProjectCalls += 1
+        return PROJECT_WITH_PLUGIN
+      },
+    })
+
+    const emptyFromResult = await getInteropProtocolTransfers(
+      params({ from: [] }),
+      deps,
+    )
+    const emptyToResult = await getInteropProtocolTransfers(
+      params({ to: [] }),
+      deps,
+    )
+
+    expect(emptyFromResult).toEqual({
+      items: [],
+      hasIntegrityMismatch: false,
+      nextCursor: undefined,
+    })
+    expect(emptyToResult).toEqual({
+      items: [],
+      hasIntegrityMismatch: false,
+      nextCursor: undefined,
+    })
+    expect(getProjectCalls).toEqual(0)
+  })
+
+  it('returns mismatch response when transfer stats differ from expected', async () => {
+    const deps = createDeps({
+      getFilteredTransfersWithStats: async () => ({
+        items: [transfer()],
+        transferStats: { transferCount: 1, volume: 100 },
+        tokensDetailsMap: new Map(),
+      }),
+    })
+
+    const result = await getInteropProtocolTransfers(
+      params({
+        expectedTransferCount: 2,
+        expectedVolume: 100,
+      }),
+      deps,
+    )
+
+    expect(result).toEqual({
+      items: [],
+      hasIntegrityMismatch: true,
+      nextCursor: undefined,
+    })
+  })
+
+  it('supports cursor pagination across pages', async () => {
+    const transfers = Array.from({ length: 101 }, (_, i) =>
+      transfer({
+        transferId: `transfer-${i}`,
+        srcTxHash: `0xsrc${i}`,
+        dstTxHash: `0xdst${i}`,
+      }),
+    )
+    const deps = createDeps({
+      getFilteredTransfersWithStats: async () => ({
+        items: transfers,
+        transferStats: { transferCount: transfers.length, volume: 101 },
+        tokensDetailsMap: new Map([
+          [
+            'eth',
+            { symbol: 'ETH', iconUrl: 'https://token/eth.png', issuer: null },
+          ],
+        ]),
+      }),
+    })
+
+    const firstPage = await getInteropProtocolTransfers(
+      params({
+        expectedTransferCount: 101,
+        expectedVolume: 101,
+      }),
+      deps,
+    )
+
+    expect(firstPage.hasIntegrityMismatch).toEqual(false)
+    expect(firstPage.items.length).toEqual(100)
+    expect(firstPage.nextCursor).toEqual(100)
+    expect(firstPage.items[0]?.transferId).toEqual('transfer-0')
+    expect(firstPage.items[99]?.transferId).toEqual('transfer-99')
+
+    const secondPage = await getInteropProtocolTransfers(
+      params({
+        expectedTransferCount: 101,
+        expectedVolume: 101,
+        cursor: 100,
+      }),
+      deps,
+    )
+
+    expect(secondPage.items.length).toEqual(1)
+    expect(secondPage.nextCursor).toEqual(undefined)
+    expect(secondPage.items[0]?.transferId).toEqual('transfer-100')
+  })
+
+  it('reuses cached result for equivalent chain selections in different order', async () => {
+    let fetchCalls = 0
+    const deps = createDeps({
+      getFilteredTransfersWithStats: async () => {
+        fetchCalls += 1
+        return {
+          items: [transfer()],
+          transferStats: { transferCount: 1, volume: 1 },
+          tokensDetailsMap: new Map(),
+        }
+      },
+    })
+
+    await getInteropProtocolTransfers(
+      params({
+        from: ['ethereum', 'arbitrum'],
+        to: ['optimism', 'base'],
+        expectedTransferCount: 1,
+        expectedVolume: 1,
+      }),
+      deps,
+    )
+    await getInteropProtocolTransfers(
+      params({
+        from: ['arbitrum', 'ethereum'],
+        to: ['base', 'optimism'],
+        expectedTransferCount: 1,
+        expectedVolume: 1,
+      }),
+      deps,
+    )
+
+    expect(fetchCalls).toEqual(1)
+  })
+})
+
+const PROJECT_WITH_PLUGIN = {
+  interopConfig: {
+    plugins: [{ plugin: 'plugin', bridgeType: 'nonMinting' as const }],
+  },
+}
+
+type TransfersDeps = NonNullable<
+  Parameters<typeof getInteropProtocolTransfers>[1]
+>
+
+function createDeps(overrides: Partial<TransfersDeps> = {}): TransfersDeps {
+  return {
+    getProject: async () => PROJECT_WITH_PLUGIN,
+    cache: new InMemoryCache({}),
+    getFilteredTransfersWithStats: async () => ({
+      items: [transfer()],
+      transferStats: { transferCount: 1, volume: 2000 },
+      tokensDetailsMap: new Map(),
+    }),
+    ...overrides,
+  }
+}
+
+function params(
+  override: Partial<InteropProtocolTransfersParams> = {},
+): InteropProtocolTransfersParams {
+  return {
+    id: ProjectId('test-project'),
+    from: ['ethereum'],
+    to: ['arbitrum'],
+    type: undefined,
+    expectedTransferCount: 1,
+    expectedVolume: 2000,
+    snapshotTimestamp: UnixTime(123),
+    cursor: undefined,
+    ...override,
+  }
+}
 
 function transfer(
   override: Partial<InteropTransferRecord> = {},

--- a/packages/frontend/src/server/features/scaling/interop/getInteropProtocolTransfers.ts
+++ b/packages/frontend/src/server/features/scaling/interop/getInteropProtocolTransfers.ts
@@ -1,6 +1,9 @@
 import { INTEROP_CHAINS } from '@l2beat/config'
 import type { InteropTransferRecord } from '@l2beat/database'
-import { InteropTransferClassifier } from '@l2beat/shared'
+import {
+  InteropTransferClassifier,
+  type InteropTransferPluginMatcher,
+} from '@l2beat/shared'
 import {
   getInteropTransferValue,
   InMemoryCache,
@@ -25,6 +28,34 @@ interface TransfersWithStats {
   tokensDetailsMap: TokensDetailsMap
 }
 
+type InteropPluginMatcherConfig = InteropTransferPluginMatcher
+
+type InteropProjectWithConfig = {
+  interopConfig?: {
+    plugins: InteropPluginMatcherConfig[]
+  }
+}
+
+type TransfersCache = {
+  get<T>(
+    options: {
+      key: (string | null | undefined)[]
+      ttl: number
+      staleWhileRevalidate?: number
+    },
+    fallback: () => Promise<T>,
+  ): Promise<T>
+}
+
+type GetInteropProtocolTransfersDeps = {
+  getProject: (params: {
+    id: InteropProtocolTransfersParams['id']
+    select: ['interopConfig']
+  }) => Promise<InteropProjectWithConfig | null | undefined>
+  cache: TransfersCache
+  getFilteredTransfersWithStats: typeof getFilteredTransfersWithStats
+}
+
 const VALUE_TOLERANCE_RATIO = 0.01
 const MIN_VALUE_TOLERANCE = 0.01
 const PAGE_SIZE = 100
@@ -33,17 +64,25 @@ const INTEROP_CHAIN_EXPLORER_URLS = new Map(
   INTEROP_CHAINS.map((chain) => [chain.id, chain.explorerUrl]),
 )
 const interopTransfersCache = new InMemoryCache({})
+const DEFAULT_DEPS: GetInteropProtocolTransfersDeps = {
+  getProject: (params) => ps.getProject(params),
+  cache: interopTransfersCache,
+  getFilteredTransfersWithStats,
+}
 
-export async function getInteropProtocolTransfers({
-  id,
-  from,
-  to,
-  type,
-  expectedTransferCount,
-  expectedVolume,
-  snapshotTimestamp,
-  cursor,
-}: InteropProtocolTransfersParams): Promise<InteropProtocolTransfersResponse> {
+export async function getInteropProtocolTransfers(
+  {
+    id,
+    from,
+    to,
+    type,
+    expectedTransferCount,
+    expectedVolume,
+    snapshotTimestamp,
+    cursor,
+  }: InteropProtocolTransfersParams,
+  deps: GetInteropProtocolTransfersDeps = DEFAULT_DEPS,
+): Promise<InteropProtocolTransfersResponse> {
   if (from.length === 0 || to.length === 0) {
     return {
       items: [],
@@ -52,7 +91,7 @@ export async function getInteropProtocolTransfers({
     }
   }
 
-  const interopProject = await ps.getProject({
+  const interopProject = await deps.getProject({
     id,
     select: ['interopConfig'],
   })
@@ -80,7 +119,7 @@ export async function getInteropProtocolTransfers({
   const classifier = new InteropTransferClassifier()
   const matcher = classifier.createMatcher<InteropTransferRecord>(plugins)
   const pluginIds = [...new Set(plugins.map((plugin) => plugin.plugin))]
-  const result = await interopTransfersCache.get(
+  const result = await deps.cache.get(
     {
       key: [
         'interop-transfers',
@@ -95,7 +134,7 @@ export async function getInteropProtocolTransfers({
       staleWhileRevalidate: 60 * 15,
     },
     () =>
-      getFilteredTransfersWithStats({
+      deps.getFilteredTransfersWithStats({
         snapshotTimestamp,
         sourceChains: from,
         destinationChains: to,
@@ -269,13 +308,7 @@ function getTxHashHref(
 }
 
 function toPluginMatcherCacheKey(
-  plugins: {
-    plugin: string
-    bridgeType: string
-    chain?: string
-    abstractTokenId?: string
-    transferType?: string
-  }[],
+  plugins: InteropPluginMatcherConfig[],
 ): string {
   return plugins
     .map((plugin) => Object.values(plugin).join(':'))


### PR DESCRIPTION
Refactor getInteropProtocolTransfers to use injected dependencies and stable cache keys for reordered chain filters, add tests for empty selections integrity mismatches cursor pagination and cache reuse.