### PR TITLE
feat(frontend): add web app manifest

### DIFF
--- a/packages/frontend/src/ssr/head/Head.tsx
+++ b/packages/frontend/src/ssr/head/Head.tsx
@@ -31,6 +31,7 @@ export function Head({ manifest, metadata }: HeadProps) {
         type="image/png"
         sizes="180x180"
       />
+      <link rel="manifest" href="/site.webmanifest" />
 
       <title>{metadata.title}</title>
       <meta name="description" content={metadata.description} />

--- a/packages/frontend/static/site.webmanifest
+++ b/packages/frontend/static/site.webmanifest
@@ -1,0 +1,21 @@
+{
+  "name": "L2BEAT",
+  "short_name": "L2BEAT",
+  "description": "Analytics and research website about Ethereum layer 2 scaling",
+  "start_url": "/scaling/summary",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#e91d8a",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any"
+    },
+    {
+      "src": "/apple-icon.png",
+      "type": "image/png",
+      "sizes": "180x180"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `static/site.webmanifest` with app name, icons, and theme color
- Add `<link rel="manifest">` in `Head.tsx`

Enables mobile "Add to Home Screen" and improves PWA engagement signals.

## Test plan
- [ ] Verify `GET /site.webmanifest` returns valid JSON
- [ ] Verify `<link rel="manifest">` is present in page source

Made with [Cursor](https://cursor.com)