### PR TITLE
feat(frontend): add unique meta titles and descriptions to pages

### DIFF
--- a/packages/frontend/src/pages/data-availability/archived/getDataAvailabilityArchivedData.ts
+++ b/packages/frontend/src/pages/data-availability/archived/getDataAvailabilityArchivedData.ts
@@ -17,6 +17,9 @@ export async function getDataAvailabilityArchivedData(
     head: {
       manifest,
       metadata: getMetadata(manifest, {
+        title: 'Archived Data Availability Projects - L2BEAT',
+        description:
+          'Browse archived data availability solutions that are no longer actively maintained.',
         openGraph: {
           url,
           image: '/meta-images/data-availability/archived/opengraph-image.png',

--- a/packages/frontend/src/pages/interop/protocol/getInteropProtocolPageData.ts
+++ b/packages/frontend/src/pages/interop/protocol/getInteropProtocolPageData.ts
@@ -57,6 +57,7 @@ export async function getInteropProtocolPageData(
       manifest,
       metadata: getMetadata(manifest, {
         title: `${project.name} - L2BEAT`,
+        description: `Explore ${project.name} interoperability metrics, bridge volumes, and transfer activity on L2BEAT.`,
         openGraph: {
           url: req.originalUrl,
           image: `/meta-images/interop/projects/${project.slug}/opengraph-image.png`,

--- a/packages/frontend/src/pages/multisig-report/getMultisigReportData.ts
+++ b/packages/frontend/src/pages/multisig-report/getMultisigReportData.ts
@@ -17,6 +17,9 @@ export async function getMultisigReportData(
     head: {
       manifest,
       metadata: getMetadata(manifest, {
+        title: 'Multisig Report - L2BEAT',
+        description:
+          'An in-depth analysis of multisig governance across Ethereum scaling projects.',
         openGraph: {
           url,
         },

--- a/packages/frontend/src/pages/scaling/archived/getScalingArchivedData.ts
+++ b/packages/frontend/src/pages/scaling/archived/getScalingArchivedData.ts
@@ -27,6 +27,9 @@ export async function getScalingArchivedData(
     head: {
       manifest,
       metadata: getMetadata(manifest, {
+        title: 'Archived Scaling Projects - L2BEAT',
+        description:
+          'Browse archived Ethereum scaling projects that are no longer actively maintained.',
         openGraph: {
           url: req.originalUrl,
           image: '/meta-images/scaling/archived/opengraph-image.png',

--- a/packages/frontend/src/pages/scaling/summary/getScalingSummaryData.ts
+++ b/packages/frontend/src/pages/scaling/summary/getScalingSummaryData.ts
@@ -33,6 +33,9 @@ export async function getScalingSummaryData(
     head: {
       manifest,
       metadata: getMetadata(manifest, {
+        title: 'Scaling Summary - L2BEAT',
+        description:
+          'Overview of the Ethereum layer 2 scaling ecosystem. Compare rollups, validiums, and optimiums by TVS, activity, and risk.',
         openGraph: {
           url: req.originalUrl,
           image: '/meta-images/scaling/summary/opengraph-image.png',


### PR DESCRIPTION
## Summary
- Add specific `title` and `description` meta to pages that were falling back to the generic default:
  - Scaling Summary
  - Scaling Archived
  - Multisig Report
  - DA Archived
  - Interop Protocol pages

## Test plan
- [ ] Inspect `<meta name="description">` on each updated page and verify it's unique
- [ ] Verify `<title>` is set correctly on each page

Made with [Cursor](https://cursor.com)