### PR TITLE
test: check absence of BadRequestResponse schema explicitly

### DIFF
--- a/packages/public-api/src/OpenApi.test.ts
+++ b/packages/public-api/src/OpenApi.test.ts
@@ -495,9 +495,7 @@ describe(OpenApi.name, () => {
 
       const schema = openapi.getOpenApiSchema()
 
-      expect(schema.components.schemas).not.toEqual({
-        BadRequestResponse: expect.a(Object),
-      })
+      expect(schema.components.schemas?.BadRequestResponse).toBeUndefined()
     })
 
     it('includes error schemas in components', () => {


### PR DESCRIPTION
Replace fragile .not.toEqual() assertion with explicit absence check using toBeUndefined()