### PR TITLE
PoC(flattener): produce bytecode-equivalent output

### DIFF
--- a/packages/discovery/src/flatten/ParsedFilesManager.ts
+++ b/packages/discovery/src/flatten/ParsedFilesManager.ts
@@ -45,6 +45,9 @@ export interface TopLevelDeclaration {
 
   inheritsFrom: string[]
   dynamicReferences: string[]
+  // Contracts that are instantiated via `new X(...)` and therefore cannot
+  // be minimized into an interface: we need their full bytecode.
+  instantiatedReferences: string[]
 }
 
 // If import is:
@@ -72,12 +75,23 @@ export interface Remapping {
   target: string
 }
 
+export interface FileLevelUsing {
+  // Verbatim source snippet, e.g. `using LibClaim for Claim global;`
+  snippet: string
+  // Short name of the library or free function bound by the directive.
+  libraryName: string
+}
+
 export interface ParsedFile extends FileContent {
   normalizedPath: string
   rootASTNode: ParseResult
 
   topLevelDeclarations: TopLevelDeclaration[]
   importDirectives: ImportDirective[]
+  // Raw source snippets for every file-level `using X for Y;` (or
+  // `using X for Y global;`) directive. These are preserved verbatim in the
+  // flattened output when any declaration from the file contributes to it.
+  fileLevelUsings: FileLevelUsing[]
 }
 
 export interface DeclarationFilePair {
@@ -107,12 +121,14 @@ export class ParsedFilesManager {
         rootASTNode: parse(content, { range: true }),
         topLevelDeclarations: [],
         importDirectives: [],
+        fileLevelUsings: [],
       }
     })
 
     // Pass 1: Find all contract declarations
     for (const file of result.files) {
       file.topLevelDeclarations = result.resolveTopLevelDeclarations(file)
+      file.fileLevelUsings = result.resolveFileLevelUsings(file)
     }
 
     // Pass 2: Resolve all imports
@@ -137,10 +153,32 @@ export class ParsedFilesManager {
           file,
           declaration.ast,
         )
+        declaration.instantiatedReferences =
+          result.resolveInstantiatedReferences(file, declaration.ast)
       }
     }
 
     return result
+  }
+
+  // Extracts file-level `using X for Y [global];` directives as raw source
+  // snippets. They are not contracts but must be preserved in the flattened
+  // output because they attach library functions to types.
+  private resolveFileLevelUsings(file: ParsedFile): FileLevelUsing[] {
+    const results: FileLevelUsing[] = []
+    for (const child of file.rootASTNode.children) {
+      if (child.type !== 'UsingForDeclaration') continue
+      const range = (child as unknown as { range?: [number, number] }).range
+      if (range === undefined) continue
+      // The parser's range already covers the trailing semicolon.
+      const snippet = file.content.slice(range[0], range[1] + 1)
+      const libraryName =
+        (child as unknown as { libraryName?: string }).libraryName ??
+        extractLibraryNameFromUsing(snippet) ??
+        ''
+      results.push({ snippet, libraryName })
+    }
+    return results
   }
 
   private resolveTopLevelDeclarations(file: ParsedFile): TopLevelDeclaration[] {
@@ -204,6 +242,7 @@ export class ParsedFilesManager {
         type: getDeclarationType(d),
         inheritsFrom,
         dynamicReferences: [],
+        instantiatedReferences: [],
         content: file.content.slice(adjustedStart, d.range[1] + 1),
       }
     })
@@ -321,29 +360,10 @@ export class ParsedFilesManager {
   }
 
   private resolveDynamicReferences(file: ParsedFile, c: AST.ASTNode): string[] {
-    let subNodes: AST.BaseASTNode[] = []
-    if (c.type === 'ContractDefinition') {
-      subNodes = c.subNodes
-    } else if (c.type === 'StructDefinition') {
-      subNodes = c.members
-    } else if (c.type === 'FunctionDefinition') {
-      subNodes = c.body ? [c.body] : []
-    } else if (c.type === 'TypeDefinition') {
-      subNodes = []
-    } else if (c.type === 'EnumDefinition') {
-      subNodes = c.members
-    } else if (c.type === 'FileLevelConstant') {
-      subNodes = [c.typeName, c.initialValue]
-    } else if (c.type === 'EventDefinition') {
-      subNodes = c.parameters ?? []
-    } else if (c.type === 'CustomErrorDefinition') {
-      subNodes = c.parameters ?? []
-    } else {
-      throw new Error('Invalid node type')
-    }
-
     const identifiers = new Set(
-      subNodes.flatMap((n) => getASTIdentifiers(n)).map(extractNamespace),
+      getDeclarationSubNodes(c)
+        .flatMap((n) => getASTIdentifiers(n))
+        .map(extractNamespace),
     )
 
     const referenced = []
@@ -353,28 +373,27 @@ export class ParsedFilesManager {
         continue
       }
 
-      const isContract = result.declaration.type === 'contract'
-      const isAbstract = result.declaration.type === 'abstract'
-      const isInterface = result.declaration.type === 'interface'
-      const isEvent = result.declaration.type === 'event'
-      const isError = result.declaration.type === 'error'
-      const isConstant = result.declaration.type === 'constant'
-
-      const isExtendedDeclaration =
-        isContract ||
-        isAbstract ||
-        isInterface ||
-        isEvent ||
-        isError ||
-        isConstant
-
-      if (isExtendedDeclaration && this.options.includeAll !== true) {
-        continue
-      }
-
       referenced.push(identifier)
     }
 
+    return referenced
+  }
+
+  private resolveInstantiatedReferences(
+    file: ParsedFile,
+    c: AST.ASTNode,
+  ): string[] {
+    const names = new Set<string>()
+    for (const subNode of getDeclarationSubNodes(c)) {
+      collectNewExpressions(subNode, names)
+    }
+
+    const referenced: string[] = []
+    for (const name of names) {
+      const found = this.tryFindDeclaration(name, file)
+      if (found === undefined) continue
+      referenced.push(name)
+    }
     return referenced
   }
 
@@ -499,6 +518,13 @@ export class ParsedFilesManager {
 
     return matchingFile
   }
+
+  // Iterates over every parsed file. Used by the flattener to look up nested
+  // type declarations (structs, enums) that do not live in the top-level
+  // declarations table.
+  getAllFiles(): readonly ParsedFile[] {
+    return this.files
+  }
 }
 
 // Takes a user defined type name such as `MyLibrary.MyStructInLibrary` and
@@ -509,6 +535,63 @@ function extractNamespace(identifier: string): string {
     return identifier
   }
   return identifier.substring(0, dotIndex)
+}
+
+// Fallback parser for `using LibName for Type` snippets when the AST
+// doesn't expose `libraryName` directly. Matches the name right after
+// `using` and before `for`.
+function extractLibraryNameFromUsing(snippet: string): string | undefined {
+  const m = snippet.match(/using\s+([\w.]+)\s+for\b/)
+  if (m === null) return undefined
+  const full = m[1] ?? ''
+  return full.split('.').slice(-1)[0] ?? full
+}
+
+function getDeclarationSubNodes(c: AST.ASTNode): AST.BaseASTNode[] {
+  if (c.type === 'ContractDefinition') return c.subNodes
+  if (c.type === 'StructDefinition') return c.members
+  if (c.type === 'FunctionDefinition') return c.body ? [c.body] : []
+  if (c.type === 'TypeDefinition') return []
+  if (c.type === 'EnumDefinition') return c.members
+  if (c.type === 'FileLevelConstant') return [c.typeName, c.initialValue]
+  if (c.type === 'EventDefinition') return c.parameters ?? []
+  if (c.type === 'CustomErrorDefinition') return c.parameters ?? []
+  throw new Error('Invalid node type')
+}
+
+// Collects the names of user-defined types that appear inside `new X(...)`
+// expressions anywhere in the given AST subtree. These contracts must be
+// kept as full contracts in the flattened output (never converted to an
+// interface) because interfaces cannot be instantiated.
+function collectNewExpressions(
+  node: AST.BaseASTNode | null | undefined,
+  out: Set<string>,
+): void {
+  if (node === null || node === undefined) return
+  const n = node as unknown as Record<string, unknown> & { type?: string }
+  if (!n.type) return
+
+  if (n.type === 'NewExpression') {
+    const typeName = (n as unknown as { typeName: AST.TypeName }).typeName
+    if (typeName && typeName.type === 'UserDefinedTypeName') {
+      const name = (typeName as unknown as { namePath: string }).namePath
+      out.add(name.split('.')[0] ?? name)
+    }
+    return
+  }
+
+  for (const key of Object.keys(n)) {
+    const value = n[key]
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        if (v && typeof v === 'object') {
+          collectNewExpressions(v as AST.BaseASTNode, out)
+        }
+      }
+    } else if (value && typeof value === 'object' && 'type' in value) {
+      collectNewExpressions(value as AST.BaseASTNode, out)
+    }
+  }
 }
 
 function decodeRemappings(remappingStrings: string[]): Remapping[] {

--- a/packages/discovery/src/flatten/flatten.test.ts
+++ b/packages/discovery/src/flatten/flatten.test.ts
@@ -71,21 +71,21 @@ describe('flatten', () => {
 
     expect(flattened).toEqual(
       [
+        CONTRACT3_SOURCE,
+        CONTRACT2_SOURCE,
         LIBRARY_SOURCE,
         CONTRACT4_SOURCE,
-        CONTRACT2_SOURCE,
-        CONTRACT3_SOURCE,
         ROOT_CONTRACT_SOURCE,
       ].join('\n\n'),
     )
   })
 
-  it('picks correct contracts to be regenerated as interfaces, for minimized output', () => {
+  it('regenerates dynamically-referenced contracts as interfaces (minimized)', () => {
     const file: FileContent = {
       path: 'Root.sol',
       content: String.raw`
 contract DC1 is DC2 { function df() public {} }
-contract DC2 is C2 { }
+contract DC2 { }
 
 contract C2 { }
 contract C3 is C2 { }
@@ -101,11 +101,19 @@ contract R1 is C2, C3, C4 {
 
     const flattened = flattenStartingFrom('R1', [file], [])
     expect(flattened).toEqual(
-      String.raw`contract C4 { }
+      String.raw`contract C2 { }
 
 contract C3 is C2 { }
 
-contract C2 { }
+contract C4 { }
+
+// NOTE(l2beat): This is a virtual interface, generated from the contract source code.
+interface DC2 {}
+
+// NOTE(l2beat): This is a virtual interface, generated from the contract source code.
+interface DC1 is DC2 {
+    function df() external;
+}
 
 contract R1 is C2, C3, C4 {
     function f(address x) public {
@@ -115,13 +123,13 @@ contract R1 is C2, C3, C4 {
     )
   })
 
-  it('picks correct contracts to be regenerated as interfaces, for full output', () => {
+  it('regenerates dynamically-referenced contracts as interfaces (full)', () => {
     const file: FileContent = {
       path: 'Root.sol',
       content: String.raw`
 contract DC1 is DC2 { function df() public {} }
 
-contract DC2 is C2 {
+contract DC2 {
     struct S1 { uint256 x; }
     function f1() public {
         S1 memory s;
@@ -146,8 +154,14 @@ contract R1 is C2, C3, C4 {
       includeAll: true,
     })
     expect(flattened).toEqual(
-      String.raw`// NOTE(l2beat): This is a virtual interface, generated from the contract source code.
-interface DC2 is C2 {
+      String.raw`contract C2 { }
+
+contract C3 is C2 { }
+
+contract C4 { }
+
+// NOTE(l2beat): This is a virtual interface, generated from the contract source code.
+interface DC2 {
     struct S1 {
         uint256 x;
     }
@@ -159,12 +173,6 @@ interface DC2 is C2 {
 interface DC1 is DC2 {
     function df() external;
 }
-
-contract C4 { }
-
-contract C3 is C2 { }
-
-contract C2 { }
 
 contract R1 is C2, C3, C4 {
     function f(address x) public {
@@ -264,11 +272,11 @@ contract R1 {
     })
 
     expect(flattened).toEqual(
-      String.raw`error CustomError(address account);
+      String.raw`event EventHappened(uint256 value, address account);
 
 uint256 constant GLOBAL_VALUE = 42;
 
-event EventHappened(uint256 value, address account);
+error CustomError(address account);
 
 contract R1 {
   function doSomething() public {
@@ -411,6 +419,454 @@ contract Rollup {
       expect(flattened).toInclude(
         '/// @custom:security-contact security@aztec.network',
       )
+    })
+  })
+
+  describe('produces compilable output', () => {
+    it('includes interface referenced as a type inside a library function', () => {
+      const rootFile: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./IFoo.sol";
+
+library Lib {
+    function bar(address a, bytes4 b) internal view returns (bool) {
+        (bool ok,) = a.staticcall(abi.encodeCall(IFoo.foo, (b)));
+        return ok;
+    }
+}
+
+contract R1 {
+    function f(address a, bytes4 b) public view returns (bool) {
+        return Lib.bar(a, b);
+    }
+}
+`,
+      }
+      const ifoo: FileContent = {
+        path: 'IFoo.sol',
+        content: String.raw`interface IFoo {
+    function foo(bytes4 x) external view returns (bool);
+}`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [rootFile, ifoo], [])
+      expect(flattened).toInclude('interface IFoo')
+      expect(flattened).toInclude('function foo(bytes4')
+    })
+
+    it('includes interface referenced via type-cast in a contract function', () => {
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./IFoo.sol";
+
+contract R1 {
+    function f(address a) public view returns (uint256) {
+        return IFoo(a).value();
+    }
+}
+`,
+      }
+      const ifoo: FileContent = {
+        path: 'IFoo.sol',
+        content: String.raw`interface IFoo {
+    function value() external view returns (uint256);
+}`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, ifoo], [])
+      expect(flattened).toInclude('interface IFoo')
+    })
+
+    it('includes file-level constants referenced in a function body', () => {
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Constants.sol";
+
+contract R1 {
+    function f(uint256 x) public pure returns (uint256) {
+        return x * MY_CONST;
+    }
+}
+`,
+      }
+      const constantsFile: FileContent = {
+        path: 'Constants.sol',
+        content: String.raw`uint256 constant MY_CONST = 10000;`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, constantsFile], [])
+      expect(flattened).toInclude('MY_CONST = 10000')
+    })
+
+    it('includes custom errors referenced via revert', () => {
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Errors.sol";
+
+contract R1 {
+    function f(uint256 x) public pure {
+        if (x == 0) revert MyError();
+    }
+}
+`,
+      }
+      const errorsFile: FileContent = {
+        path: 'Errors.sol',
+        content: String.raw`error MyError();`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, errorsFile], [])
+      expect(flattened).toInclude('error MyError()')
+    })
+
+    it('includes interface defining a nested struct used as a parameter type', () => {
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./IFoo.sol";
+
+contract R1 {
+    function consume(IFoo.Data memory d) public pure returns (uint256) {
+        return d.x;
+    }
+}
+`,
+      }
+      const ifoo: FileContent = {
+        path: 'IFoo.sol',
+        content: String.raw`interface IFoo {
+    struct Data {
+        uint64 x;
+        bytes32 y;
+    }
+}`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, ifoo], [])
+      expect(flattened).toInclude('interface IFoo')
+      expect(flattened).toInclude('struct Data')
+    })
+
+    it('produces topologically valid order with diamond inheritance', () => {
+      const file: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+abstract contract A { function _a() internal view {} }
+abstract contract B1 is A { }
+abstract contract B2 is A { }
+abstract contract B3 is A { }
+abstract contract B4 is A { }
+
+contract Root is B1, B2, B3, B4 {
+    function f() public {}
+}
+`,
+      }
+
+      const flattened = flattenStartingFrom('Root', [file], [])
+      const idx = (needle: string) => flattened.indexOf(needle)
+
+      expect(idx('contract A')).toBeGreaterThanOrEqual(0)
+      expect(idx('contract A')).toBeLessThan(idx('contract B1'))
+      expect(idx('contract A')).toBeLessThan(idx('contract B2'))
+      expect(idx('contract A')).toBeLessThan(idx('contract B3'))
+      expect(idx('contract A')).toBeLessThan(idx('contract B4'))
+    })
+
+    it('tracks identifiers referenced inside modifier arguments', () => {
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Lib.sol";
+
+contract R1 {
+    modifier checked(bytes32 k) { _; }
+
+    function f() external checked(Lib.KEY) {}
+}
+`,
+      }
+      const lib: FileContent = {
+        path: 'Lib.sol',
+        content: String.raw`library Lib {
+    bytes32 internal constant KEY = bytes32("key");
+}`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, lib], [])
+      expect(flattened).toInclude('library Lib')
+      expect(flattened).toInclude('KEY')
+    })
+
+    it('preserves file-level `using for global` directives', () => {
+      // Solidity 0.8.13+ allows `using L for T global;` at file level to
+      // attach L's functions to every T. Dropping the directive loses
+      // `_.method()` calls, which then fail to compile.
+      const types: FileContent = {
+        path: 'Types.sol',
+        content: String.raw`
+type Timestamp is uint64;
+
+library LibTimestamp {
+    function raw(Timestamp t) internal pure returns (uint64) {
+        return Timestamp.unwrap(t);
+    }
+}
+
+using LibTimestamp for Timestamp global;
+`,
+      }
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Types.sol";
+
+contract R1 {
+    function f(Timestamp t) external pure returns (uint64) {
+        return t.raw();
+    }
+}
+`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, types], [])
+      expect(flattened).toInclude('library LibTimestamp')
+      expect(flattened).toInclude('using LibTimestamp for Timestamp global')
+    })
+
+    it('keeps instantiated contract even when reached via a dynamic call chain', () => {
+      // A library called dynamically from the root instantiates a contract
+      // via `new`. The intermediate library is dynamic, but the bytecode
+      // of the instantiated contract is still needed.
+      const burn: FileContent = {
+        path: 'Burn.sol',
+        content: String.raw`
+library Burn {
+    function eth(uint256 _amount) internal {
+        new Burner{ value: _amount }();
+    }
+}
+
+contract Burner {
+    constructor() payable {
+        selfdestruct(payable(address(this)));
+    }
+}
+`,
+      }
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Burn.sol";
+contract R1 {
+    function f(uint256 v) external {
+        Burn.eth(v);
+    }
+}
+`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, burn], [])
+      expect(flattened).toInclude('contract Burner')
+      expect(flattened).not.toInclude('interface Burner')
+    })
+
+    it('does not convert a contract to interface when it is instantiated with new', () => {
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Impl.sol";
+
+contract R1 {
+    function deploy() external returns (Impl) {
+        return new Impl();
+    }
+}
+`,
+      }
+      const impl: FileContent = {
+        path: 'Impl.sol',
+        content: String.raw`contract Impl {
+    uint256 public x;
+    constructor() { x = 42; }
+}`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, impl], [])
+      // Impl must remain a concrete contract so that `new Impl()` works.
+      expect(flattened).toInclude('contract Impl')
+      expect(flattened).not.toInclude('interface Impl')
+    })
+
+    it('skips internal functions when converting a contract to an interface', () => {
+      // Internal functions can have storage params/returns, which are
+      // invalid in external functions. If the generated interface exposes
+      // them as external, compilation fails.
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Impl.sol";
+
+contract R1 {
+    function f(address a) external view returns (uint256) {
+        return Impl(a).publicGet();
+    }
+}
+`,
+      }
+      const impl: FileContent = {
+        path: 'Impl.sol',
+        content: String.raw`contract Impl {
+    uint256[] data;
+
+    function publicGet() external view returns (uint256) { return data.length; }
+
+    function _internal(uint256[] storage d) internal view returns (uint256) {
+        return d.length;
+    }
+
+    function _private() private pure returns (uint256) { return 1; }
+}`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, impl], [])
+      expect(flattened).toInclude('interface Impl')
+      expect(flattened).toInclude('publicGet')
+      expect(flattened).not.toInclude('_internal')
+      expect(flattened).not.toInclude('_private')
+    })
+
+    it('keeps override clause when a re-declared function is inherited from a surviving interface base', () => {
+      // When a contract redeclares a function from a base interface, the
+      // generated interface must keep `override` (or Solidity errors with
+      // "Overriding function is missing override specifier"). The base
+      // must stay in the interface's `is` clause for the override to be
+      // meaningful.
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+interface IBase {
+    function f() external view returns (uint256);
+}
+
+abstract contract Derived is IBase {
+    function f() external view virtual override returns (uint256);
+}
+
+contract R1 {
+    function call(address a) external view returns (uint256) {
+        return Derived(a).f();
+    }
+}
+`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root], [])
+      expect(flattened).toInclude('interface Derived is IBase')
+      expect(flattened).toInclude('function f() external view override')
+    })
+
+    it('drops override bases that are stripped from the interface `is` clause', () => {
+      // When a contract is converted to an interface, a base that gets
+      // stripped (because it cannot survive as an interface) must also be
+      // removed from any `override(...)` clause that references it. Here,
+      // `NonInterfaceBase` stays a concrete contract (R1 inherits from it)
+      // and so cannot appear in `override(...)`.
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+contract NonInterfaceBase {
+    function f() external view virtual returns (uint256) { return 1; }
+}
+
+abstract contract Impl is NonInterfaceBase {
+    function f() external view virtual override(NonInterfaceBase) returns (uint256);
+}
+
+contract R1 is NonInterfaceBase {
+    function call(address a) external view returns (uint256) {
+        return Impl(a).f();
+    }
+}
+`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root], [])
+      expect(flattened).toInclude('interface Impl')
+      expect(flattened).not.toInclude('override(NonInterfaceBase)')
+    })
+
+    it('generates getters for public state variables when converting to interface', () => {
+      // In Solidity, `T public x` generates a view getter. When the original
+      // caller has a variable typed as the concrete contract, it can rely on
+      // that getter. Converting to an interface must preserve the getter
+      // signature or compilation will fail (non-view function called in view
+      // context, or missing function).
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+import "./Impl.sol";
+
+contract R1 {
+    Impl impl;
+
+    function read(address a) external view returns (address) {
+        return impl.owners(a);
+    }
+}
+`,
+      }
+      const impl: FileContent = {
+        path: 'Impl.sol',
+        content: String.raw`contract Impl {
+    mapping(address => address) public owners;
+    uint256 public total;
+}`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root, impl], [])
+      expect(flattened).toInclude('interface Impl')
+      expect(flattened).toInclude(
+        'function owners(address) external view returns (address)',
+      )
+      expect(flattened).toInclude(
+        'function total() external view returns (uint256)',
+      )
+    })
+
+    it('drops non-interface base contracts when generating a virtual interface', () => {
+      // If an abstract contract inherits from a concrete contract and the
+      // concrete contract must stay as a contract in the output (because it
+      // is also inherited by the root), then the generated interface cannot
+      // inherit from it: "interfaces can only inherit from other interfaces".
+      const root: FileContent = {
+        path: 'Root.sol',
+        content: String.raw`
+contract Constants {
+    bytes4 internal constant MAGIC = 0xaabbccdd;
+}
+
+abstract contract IValidator is Constants {
+    function validate(bytes calldata sig) external view virtual returns (bytes4);
+}
+
+contract R1 is Constants {
+    function f(address a, bytes calldata sig) external view returns (bytes4) {
+        return IValidator(a).validate(sig);
+    }
+}
+`,
+      }
+
+      const flattened = flattenStartingFrom('R1', [root], [])
+      expect(flattened).toInclude('interface IValidator')
+      expect(flattened).not.toInclude('interface IValidator is Constants')
+      // Constants must remain a concrete contract (R1 inherits from it).
+      expect(flattened).toInclude('contract Constants')
     })
   })
 })

--- a/packages/discovery/src/flatten/flatten.ts
+++ b/packages/discovery/src/flatten/flatten.ts
@@ -6,10 +6,19 @@ import {
   type FileContent,
   type ParsedFile,
   ParsedFilesManager,
+  type TopLevelDeclaration,
 } from './ParsedFilesManager'
 import type { FlattenOptions } from './types'
 
-type EntryType = 'inheritance' | 'dynamic'
+// A contract reference is one of:
+//   - inheritance: appears in an `is Base` clause. The full contract must be
+//     emitted.
+//   - instantiation: used via `new Base(...)`. The full contract must be
+//     emitted; an interface cannot be instantiated.
+//   - dynamic: used only as a type in a function body, parameter, cast,
+//     selector, etc. We only need its ABI, so if it is a contract we can
+//     minimize it into an interface.
+type EntryType = 'inheritance' | 'instantiation' | 'dynamic'
 
 interface ContractNameFilePair {
   contractName: string
@@ -34,38 +43,355 @@ export function flattenStartingFrom(
     rootContract,
   )
 
-  let flatSource = formatSource(rootContract.declaration.content)
-  // Depth first search
+  // Post-order DFS. Each declaration is appended only after all of its
+  // dependencies. This produces a topologically valid order that places base
+  // contracts above any contract that inherits from them, even in the presence
+  // of diamond inheritance.
   const visited = new Set<string>()
-  const stack: ContractNameFilePair[] = getStackEntries(rootContract).reverse()
-  while (stack.length > 0) {
-    const entry = stack.pop()
-    assert(entry !== undefined, 'Stack should not be empty')
+  // Top-level declarations may share a name across files (e.g. two copies
+  // of Initializable from different library versions). In a single flat
+  // file Solidity only allows one declaration per name, so we keep the
+  // first version we see and drop subsequent duplicates. We track what
+  // kind each emitted name was so that references to the name resolve to
+  // the form that actually survived.
+  const emittedKindByName = new Map<string, 'interface' | 'non-interface'>()
+  const orderedPieces: string[] = []
+  // File-level `using X for Y global;` directives from every file that
+  // contributed at least one emitted declaration. Attached at the end so
+  // the types they reference are always declared above.
+  const seenFiles = new Set<string>()
+  const usingDirectives: string[] = []
+  const seenUsingSnippets = new Set<string>()
 
-    const foundContract = parsedFileManager.tryFindDeclaration(
-      entry.contractName,
-      entry.file,
-    )
-    assert(foundContract, `Failed to find contract ${entry.contractName}`)
-
-    const uniqueContractId = getUniqueContractId(foundContract)
-    if (visited.has(uniqueContractId)) {
-      continue
-    }
-    visited.add(uniqueContractId)
-
-    const { declaration: contract } = foundContract
-    let content = contract.content
-    if (
-      entryIsPurelyDynamic(relationDictionary, foundContract) &&
-      isContract(foundContract)
-    ) {
-      content = generateInterfaceSourceFromContract(foundContract.declaration)
-    }
-    flatSource = formatSource(content) + flatSource
-    stack.push(...getStackEntries(foundContract))
+  // Given a declaration `entry`, return true if its emitted form will be an
+  // interface. True for real interfaces and for contracts/abstracts that are
+  // purely dynamic (and thus get minimized into a virtual interface).
+  const emitsAsInterface = (entry: DeclarationFilePair): boolean => {
+    if (entry === rootContract) return false
+    if (entry.declaration.type === 'interface') return true
+    if (!isContract(entry)) return false
+    return entryIsPurelyDynamic(relationDictionary, entry)
   }
 
+  // Resolves the short name of a base contract, as written in the source,
+  // to the canonical declaration name used in the flattened output. Returns
+  // undefined if the base is not emitted as an interface and should be
+  // stripped from the generated `is` clause.
+  const resolveInterfaceBaseFor = (entry: DeclarationFilePair) => {
+    return (baseName: string): string | undefined => {
+      const base = parsedFileManager.tryFindDeclaration(baseName, entry.file)
+      if (base === undefined) return baseName
+      const canonical = base.declaration.name
+      // If some other version of this name already landed in the output,
+      // the dedup will drop this one and leave the earlier form in place.
+      // Honour that form when deciding whether to keep the base.
+      const existingKind = emittedKindByName.get(canonical)
+      if (existingKind !== undefined) {
+        return existingKind === 'interface' ? canonical : undefined
+      }
+      if (!emitsAsInterface(base)) return undefined
+      return canonical
+    }
+  }
+
+  // Returns the canonical declaration name for a user-defined type as
+  // referenced from `entry`. Handles `import { X as Y }` renames so that
+  // generated interfaces reference the name that is actually emitted.
+  const canonicalizeTypeNameFor = (entry: DeclarationFilePair) => {
+    return (name: string): string => {
+      const decl = parsedFileManager.tryFindDeclaration(name, entry.file)
+      if (decl === undefined) return name
+      return decl.declaration.name
+    }
+  }
+
+  // Resolves a struct name (potentially nested inside a contract/library/
+  // interface) to its top-level member declarations. Used by the public
+  // state variable getter to expand struct-typed vars into tuple returns.
+  const resolveStructFieldsFor = (entry: DeclarationFilePair) => {
+    return (namePath: string) => {
+      const shortName = namePath.split('.').at(-1)
+      if (shortName === undefined) return undefined
+      const topLevel = parsedFileManager.tryFindDeclaration(
+        shortName,
+        entry.file,
+      )
+      if (topLevel !== undefined && topLevel.declaration.type === 'struct') {
+        const ast = topLevel.declaration.ast as unknown as {
+          members?: unknown[]
+        }
+        return (ast.members ?? []) as never[]
+      }
+      // Search nested struct definitions across all files.
+      for (const file of parsedFileManager.getAllFiles()) {
+        for (const decl of file.rootASTNode.children) {
+          if (decl.type !== 'ContractDefinition') continue
+          for (const sub of decl.subNodes) {
+            if (sub.type !== 'StructDefinition') continue
+            const n = (sub as unknown as { name?: string }).name
+            if (n !== shortName) continue
+            const members = (sub as unknown as { members?: unknown[] }).members
+            return (members ?? []) as never[]
+          }
+        }
+      }
+      return undefined
+    }
+  }
+
+  // Collects externally-visible function definitions transitively reachable
+  // from a base that had to be stripped from a generated interface's `is`
+  // clause. These are inlined into the interface so callers that rely on
+  // the external ABI keep working. Only functions whose parameter and
+  // return types are resolvable in the current file context are emitted,
+  // since we cannot import new files into the flat output.
+  const inlineFunctionsForStrippedBaseFor = (entry: DeclarationFilePair) => {
+    return (baseName: string) => {
+      const fns: unknown[] = []
+      const seenNames = new Set<string>()
+      const seenDecls = new Set<string>()
+      const canResolveType = (namePath: string): boolean => {
+        const shortName = namePath.split('.').at(-1)
+        if (shortName === undefined) return true
+        if (ELEMENTARY_TYPES.has(shortName)) return true
+        return (
+          parsedFileManager.tryFindDeclaration(shortName, entry.file) !==
+          undefined
+        )
+      }
+      const collectTypeNames = (node: unknown, out: Set<string>): void => {
+        if (node === null || node === undefined || typeof node !== 'object')
+          return
+        const n = node as Record<string, unknown> & { type?: string }
+        if (n.type === 'UserDefinedTypeName') {
+          const np = (n as unknown as { namePath?: string }).namePath
+          if (typeof np === 'string') {
+            const short = np.split('.').at(-1) ?? np
+            out.add(short)
+          }
+        }
+        for (const key of Object.keys(n)) {
+          const v = n[key]
+          if (Array.isArray(v)) {
+            for (const item of v) collectTypeNames(item, out)
+          } else if (v !== null && typeof v === 'object') {
+            collectTypeNames(v, out)
+          }
+        }
+      }
+      const visit = (name: string, fromFile: ParsedFile): void => {
+        if (seenDecls.has(name)) return
+        seenDecls.add(name)
+        const found = parsedFileManager.tryFindDeclaration(name, fromFile)
+        if (found === undefined) return
+        const declAst = found.declaration.ast as unknown as {
+          type?: string
+          subNodes?: Array<unknown>
+        }
+        if (declAst.type !== 'ContractDefinition') return
+        for (const sub of declAst.subNodes ?? []) {
+          const s = sub as {
+            type?: string
+            name?: string
+            isConstructor?: boolean
+            visibility?: string
+            parameters?: unknown[]
+            returnParameters?: unknown[]
+          }
+          if (s.type !== 'FunctionDefinition') continue
+          if (s.isConstructor) continue
+          if (s.visibility === 'internal' || s.visibility === 'private')
+            continue
+          const fnName = s.name ?? ''
+          if (seenNames.has(fnName)) continue
+          // Check that every type in the signature resolves in `entry.file`.
+          const types = new Set<string>()
+          for (const p of s.parameters ?? []) collectTypeNames(p, types)
+          for (const p of s.returnParameters ?? []) collectTypeNames(p, types)
+          let allResolvable = true
+          for (const t of types) {
+            if (!canResolveType(t)) {
+              allResolvable = false
+              break
+            }
+          }
+          if (!allResolvable) continue
+          seenNames.add(fnName)
+          fns.push(sub)
+        }
+        for (const b of found.declaration.inheritsFrom) {
+          visit(b, found.file)
+        }
+      }
+      visit(baseName, entry.file)
+      return fns as never[]
+    }
+  }
+
+  const resolveTypeKindFor = (entry: DeclarationFilePair) => {
+    return (namePath: string) => {
+      const shortName = namePath.split('.').at(-1)
+      if (shortName === undefined) return undefined
+      const decl = parsedFileManager.tryFindDeclaration(shortName, entry.file)
+      if (decl !== undefined) {
+        return kindOf(decl)
+      }
+      // Fall back to searching all contracts/libraries/interfaces for a
+      // nested struct or enum with this name. Names for nested structs are
+      // not part of the top-level declarations table.
+      return findNestedTypeKind(parsedFileManager, shortName)
+    }
+  }
+
+  // Collects info about a given base of `entry`, restricted to the kept
+  // portion of the inheritance chain as it appears in the flattened
+  // output. Returns both the transitive ancestor names and the set of
+  // externally-visible function names visible through that base, so the
+  // interface generator can compute valid `override(...)` clauses.
+  //
+  // When the traversal passes through a declaration that is emitted as a
+  // virtual interface, we include functions inlined into it from any
+  // stripped bases, so callers that redeclare those functions correctly
+  // get marked as `override`.
+  const lookupKeptBaseInfoFor = (entry: DeclarationFilePair) => {
+    return (baseName: string) => {
+      const ancestorNames = new Set<string>()
+      const functionNames = new Set<string>()
+      const seen = new Set<string>()
+      // Collects names from a declaration AND from the stripped branches
+      // of its inheritance chain, which end up inlined into the virtual
+      // interface form of that declaration.
+      const collectInlinedFromStrippedBases = (
+        decl: DeclarationFilePair,
+      ): void => {
+        const inlineSeen = new Set<string>()
+        const walkStripped = (name: string, fromFile: ParsedFile): void => {
+          if (inlineSeen.has(name)) return
+          inlineSeen.add(name)
+          const f = parsedFileManager.tryFindDeclaration(name, fromFile)
+          if (f === undefined) return
+          collectExternalFunctionNames(f.declaration, functionNames)
+          for (const b of f.declaration.inheritsFrom) {
+            walkStripped(b, f.file)
+          }
+        }
+        for (const b of decl.declaration.inheritsFrom) {
+          const baseDecl = parsedFileManager.tryFindDeclaration(b, decl.file)
+          if (baseDecl === undefined) continue
+          if (!emitsAsInterface(baseDecl)) {
+            walkStripped(b, decl.file)
+          }
+        }
+      }
+      const visit = (declName: string, fromFile: ParsedFile): void => {
+        if (seen.has(declName)) return
+        seen.add(declName)
+        const found = parsedFileManager.tryFindDeclaration(declName, fromFile)
+        if (found === undefined) return
+        ancestorNames.add(found.declaration.name)
+        collectExternalFunctionNames(found.declaration, functionNames)
+        const emittedAsInterface = emitsAsInterface(found)
+        if (emittedAsInterface) {
+          collectInlinedFromStrippedBases(found)
+        }
+        for (const b of found.declaration.inheritsFrom) {
+          if (emittedAsInterface) {
+            const baseDecl = parsedFileManager.tryFindDeclaration(b, found.file)
+            if (baseDecl === undefined) continue
+            if (!emitsAsInterface(baseDecl)) continue
+          }
+          visit(b, found.file)
+        }
+      }
+      visit(baseName, entry.file)
+      return { ancestorNames, functionNames }
+    }
+  }
+
+  const visit = (entry: DeclarationFilePair): void => {
+    const id = getUniqueContractId(entry)
+    if (visited.has(id)) return
+    visited.add(id)
+
+    // Pull in any file-level `using for` directives from the file this
+    // declaration came from, on the first visit to that file. Also visit
+    // the library each directive binds so its source is emitted. Dedupe
+    // by the exact snippet so shared library files don't emit the same
+    // directive multiple times.
+    const filePath = entry.file.normalizedPath
+    if (!seenFiles.has(filePath)) {
+      seenFiles.add(filePath)
+      for (const using of entry.file.fileLevelUsings) {
+        if (!seenUsingSnippets.has(using.snippet)) {
+          seenUsingSnippets.add(using.snippet)
+          usingDirectives.push(using.snippet)
+        }
+        if (using.libraryName !== '') {
+          const lib = parsedFileManager.tryFindDeclaration(
+            using.libraryName,
+            entry.file,
+          )
+          if (lib !== undefined) visit(lib)
+        }
+      }
+    }
+
+    for (const dep of getStackEntries(entry)) {
+      const found = parsedFileManager.tryFindDeclaration(
+        dep.contractName,
+        dep.file,
+      )
+      if (found === undefined) continue
+      visit(found)
+    }
+
+    // Skip declarations whose name was already emitted by a different
+    // version. Solidity does not allow two top-level declarations with the
+    // same name in the same file.
+    const declName = entry.declaration.name
+    if (declName !== '' && emittedKindByName.has(declName)) {
+      return
+    }
+
+    let content = entry.declaration.content
+    let emittedKind: 'interface' | 'non-interface' = 'non-interface'
+    if (
+      entry !== rootContract &&
+      entryIsPurelyDynamic(relationDictionary, entry) &&
+      isContract(entry)
+    ) {
+      content = generateInterfaceSourceFromContract(
+        entry.declaration,
+        resolveInterfaceBaseFor(entry),
+        resolveTypeKindFor(entry),
+        lookupKeptBaseInfoFor(entry),
+        canonicalizeTypeNameFor(entry),
+        inlineFunctionsForStrippedBaseFor(entry),
+        resolveStructFieldsFor(entry),
+      )
+      emittedKind = 'interface'
+    } else {
+      // Verbatim content still references imported names via the alias
+      // each importing file gave them (e.g. `import { GnosisSafe as Safe }`).
+      // Rewrite every such alias back to the declaration's canonical name
+      // so the concatenated output compiles.
+      content = rewriteAliases(entry.declaration, entry.file)
+      if (entry.declaration.type === 'interface') emittedKind = 'interface'
+    }
+    if (declName !== '') emittedKindByName.set(declName, emittedKind)
+    orderedPieces.push(content)
+  }
+
+  visit(rootContract)
+
+  // Insert global using directives right before the root contract so that
+  // every type and library they reference is already declared above.
+  if (usingDirectives.length > 0) {
+    const rootIdx = orderedPieces.length - 1
+    orderedPieces.splice(rootIdx, 0, ...usingDirectives)
+  }
+
+  const flatSource = orderedPieces.map(formatSource).join('')
   return changeLineEndingsToUnix(flatSource.trimEnd())
 }
 
@@ -107,7 +433,13 @@ function generateUsedFromDictionary(
 
     const entries = getStackEntries(foundContract)
     if (entry.type === 'dynamic') {
-      entries.forEach((e) => (e.type = 'dynamic'))
+      // Dynamic usage propagates to children, but an instantiation reached
+      // through a dynamic chain still requires the full contract bytecode.
+      // Otherwise, `library Foo { new Bar(...) }` called dynamically would
+      // cause Bar to be demoted to an interface.
+      entries.forEach((e) => {
+        if (e.type !== 'instantiation') e.type = 'dynamic'
+      })
     }
     stack.push(...entries)
   }
@@ -115,11 +447,291 @@ function generateUsedFromDictionary(
   return result
 }
 
+const ELEMENTARY_TYPES = new Set([
+  'bool',
+  'address',
+  'string',
+  'bytes',
+  'bytes1',
+  'bytes2',
+  'bytes3',
+  'bytes4',
+  'bytes5',
+  'bytes6',
+  'bytes7',
+  'bytes8',
+  'bytes9',
+  'bytes10',
+  'bytes11',
+  'bytes12',
+  'bytes13',
+  'bytes14',
+  'bytes15',
+  'bytes16',
+  'bytes17',
+  'bytes18',
+  'bytes19',
+  'bytes20',
+  'bytes21',
+  'bytes22',
+  'bytes23',
+  'bytes24',
+  'bytes25',
+  'bytes26',
+  'bytes27',
+  'bytes28',
+  'bytes29',
+  'bytes30',
+  'bytes31',
+  'bytes32',
+  'int',
+  'int8',
+  'int16',
+  'int24',
+  'int32',
+  'int40',
+  'int48',
+  'int56',
+  'int64',
+  'int72',
+  'int80',
+  'int88',
+  'int96',
+  'int104',
+  'int112',
+  'int120',
+  'int128',
+  'int136',
+  'int144',
+  'int152',
+  'int160',
+  'int168',
+  'int176',
+  'int184',
+  'int192',
+  'int200',
+  'int208',
+  'int216',
+  'int224',
+  'int232',
+  'int240',
+  'int248',
+  'int256',
+  'uint',
+  'uint8',
+  'uint16',
+  'uint24',
+  'uint32',
+  'uint40',
+  'uint48',
+  'uint56',
+  'uint64',
+  'uint72',
+  'uint80',
+  'uint88',
+  'uint96',
+  'uint104',
+  'uint112',
+  'uint120',
+  'uint128',
+  'uint136',
+  'uint144',
+  'uint152',
+  'uint160',
+  'uint168',
+  'uint176',
+  'uint184',
+  'uint192',
+  'uint200',
+  'uint208',
+  'uint216',
+  'uint224',
+  'uint232',
+  'uint240',
+  'uint248',
+  'uint256',
+])
+
 function isContract(entry: DeclarationFilePair): boolean {
   return (
     entry.declaration.type === 'contract' ||
     entry.declaration.type === 'abstract'
   )
+}
+
+function kindOf(
+  entry: DeclarationFilePair,
+): 'struct' | 'enum' | 'typedef' | 'interface' | 'contract' | undefined {
+  const t = entry.declaration.type
+  if (t === 'struct' || t === 'enum' || t === 'typedef') return t
+  if (t === 'interface') return 'interface'
+  if (t === 'contract' || t === 'abstract') return 'contract'
+  return undefined
+}
+
+// Walks every parsed file's AST looking for a nested StructDefinition or
+// EnumDefinition that matches the given name. Used as a fallback when a
+// type referenced in a generated getter cannot be resolved via the
+// top-level declaration table.
+// Collects names of externally-visible functions declared directly on the
+// given top-level declaration (contracts, interfaces, libraries). Public
+// state variables contribute their auto-generated getter name. Internal
+// and private functions are intentionally skipped because the generated
+// interface never exposes them.
+function collectExternalFunctionNames(
+  declaration: TopLevelDeclaration,
+  out: Set<string>,
+): void {
+  const ast = declaration.ast as unknown as {
+    type?: string
+    subNodes?: Array<unknown>
+  }
+  if (ast.type !== 'ContractDefinition') return
+  for (const sub of ast.subNodes ?? []) {
+    const s = sub as unknown as {
+      type?: string
+      name?: string
+      isConstructor?: boolean
+      visibility?: string
+      variables?: Array<{
+        visibility?: string
+        identifier?: { name?: string }
+      }>
+    }
+    if (s.type === 'FunctionDefinition') {
+      if (s.isConstructor) continue
+      if (s.visibility === 'internal' || s.visibility === 'private') continue
+      if (typeof s.name === 'string' && s.name.length > 0) out.add(s.name)
+    } else if (s.type === 'StateVariableDeclaration') {
+      for (const v of s.variables ?? []) {
+        if (v.visibility !== 'public') continue
+        const name = v.identifier?.name
+        if (name !== undefined) out.add(name)
+      }
+    }
+  }
+}
+
+// Rewrites imported alias names back to the canonical declaration names.
+// A file may say `import { GnosisSafe as Safe } from "..."` and use `Safe`
+// throughout its body, but the flattener emits `contract GnosisSafe`, so
+// references to `Safe` would fail to resolve in the single-file output.
+//
+// We walk the declaration's AST and only rewrite identifier *references*
+// (UserDefinedTypeName nodes and bare Identifier expressions). This avoids
+// touching string literals or comments, which would otherwise change the
+// emitted bytecode.
+function rewriteAliases(
+  declaration: TopLevelDeclaration,
+  file: ParsedFile,
+): string {
+  const renames = new Map<string, string>()
+  for (const imp of file.importDirectives) {
+    if (imp.originalName !== imp.importedName) {
+      renames.set(imp.importedName, imp.originalName)
+    }
+  }
+  const content = declaration.content
+  if (renames.size === 0) return content
+
+  const ast = declaration.ast as unknown as {
+    range?: [number, number]
+  }
+  const declStart = ast.range?.[0] ?? 0
+
+  // Collect (start, end, replacement) triples by walking the AST.
+  const edits: Array<{ start: number; end: number; replacement: string }> = []
+  const considerRename = (
+    node: unknown,
+    nameField: 'name' | 'namePath',
+  ): void => {
+    const n = node as Record<string, unknown>
+    const value = n[nameField]
+    if (typeof value !== 'string') return
+    const range = n.range as [number, number] | undefined
+    if (range === undefined) return
+    // Aliases can apply to the leading segment (a namespace alias from
+    // `import { Foo as ns }` used as `ns.Struct`) or to the lone
+    // identifier itself. Check both and rewrite whichever matches.
+    const parts = value.split('.')
+    let newValue: string | undefined
+    if (parts.length === 1) {
+      const canonical = renames.get(parts[0] as string)
+      if (canonical !== undefined) newValue = canonical
+    } else {
+      const head = parts[0] as string
+      const canonicalHead = renames.get(head)
+      if (canonicalHead !== undefined) {
+        newValue = [canonicalHead, ...parts.slice(1)].join('.')
+      } else {
+        const tail = parts.at(-1) as string
+        const canonicalTail = renames.get(tail)
+        if (canonicalTail !== undefined) {
+          newValue = parts.slice(0, -1).concat(canonicalTail).join('.')
+        }
+      }
+    }
+    if (newValue === undefined) return
+    edits.push({
+      start: range[0] - declStart,
+      end: range[1] + 1 - declStart,
+      replacement: newValue,
+    })
+  }
+
+  const walk = (node: unknown): void => {
+    if (node === null || node === undefined || typeof node !== 'object') return
+    const n = node as Record<string, unknown> & { type?: string }
+    if (n.type === 'UserDefinedTypeName') {
+      considerRename(n, 'namePath')
+      return
+    }
+    if (n.type === 'Identifier') {
+      considerRename(n, 'name')
+      return
+    }
+    for (const key of Object.keys(n)) {
+      const value = n[key]
+      if (Array.isArray(value)) {
+        for (const v of value) walk(v)
+      } else if (value !== null && typeof value === 'object') {
+        walk(value)
+      }
+    }
+  }
+  walk(declaration.ast)
+
+  if (edits.length === 0) return content
+
+  // Apply edits in reverse order so positions stay valid.
+  edits.sort((a, b) => b.start - a.start)
+  let out = content
+  for (const e of edits) {
+    if (e.start < 0 || e.end > out.length) continue
+    out = out.slice(0, e.start) + e.replacement + out.slice(e.end)
+  }
+  return out
+}
+
+function findNestedTypeKind(
+  manager: ParsedFilesManager,
+  shortName: string,
+): 'struct' | 'enum' | undefined {
+  for (const file of manager.getAllFiles()) {
+    for (const decl of file.rootASTNode.children) {
+      if (decl.type !== 'ContractDefinition') continue
+      for (const sub of decl.subNodes) {
+        const name = (sub as unknown as { name?: string }).name
+        if (sub.type === 'StructDefinition' && name === shortName) {
+          return 'struct'
+        }
+        if (sub.type === 'EnumDefinition' && name === shortName) {
+          return 'enum'
+        }
+      }
+    }
+  }
+  return undefined
 }
 
 function formatSource(source: string): string {
@@ -144,6 +756,25 @@ function getStackEntries(pair: DeclarationFilePair): ContractNameFilePair[] {
       type: 'inheritance',
     }))
 
+  const instantiatedReferences: ContractNameFilePair[] =
+    pair.declaration.instantiatedReferences
+      .map(
+        (contractName) =>
+          ({
+            contractName,
+            file: pair.file,
+            type: 'instantiation',
+          }) as ContractNameFilePair,
+      )
+      .filter(
+        (entry) =>
+          !inheritanceReferences.some(
+            (e) => e.contractName === entry.contractName,
+          ),
+      )
+
+  const strongReferences = inheritanceReferences.concat(instantiatedReferences)
+
   const dynamicReferences: ContractNameFilePair[] =
     pair.declaration.dynamicReferences
       .map(
@@ -156,10 +787,8 @@ function getStackEntries(pair: DeclarationFilePair): ContractNameFilePair[] {
       )
       .filter(
         (entry) =>
-          !inheritanceReferences.some(
-            (e) => e.contractName === entry.contractName,
-          ),
+          !strongReferences.some((e) => e.contractName === entry.contractName),
       )
 
-  return inheritanceReferences.concat(dynamicReferences)
+  return strongReferences.concat(dynamicReferences)
 }

--- a/packages/discovery/src/flatten/generateInterfaceSourceFromContract.test.ts
+++ b/packages/discovery/src/flatten/generateInterfaceSourceFromContract.test.ts
@@ -8,7 +8,8 @@ import {
 describe(generateInterfaceSourceFromContract.name, () => {
   it('generates interface from contract', () => {
     const source = String.raw`contract E {
-            uint256 public variableToSkip;
+            uint256 public publicVariable;
+            uint256 private privateVariable;
             using ThisShouldBe for Skipped;
             modifier modifierToSkip() { _; }
 
@@ -40,6 +41,8 @@ describe(generateInterfaceSourceFromContract.name, () => {
 
     const expected = String.raw`// NOTE(l2beat): This is a virtual interface, generated from the contract source code.
 interface E {
+    function publicVariable() external view returns (uint256);
+
     struct MyStructDifferent {
         mapping(uint256 => uint256) elementInside;
     }
@@ -83,7 +86,7 @@ interface E {
     expect(result).toEqual(expected)
   })
 
-  it('generates corrects overrides', () => {
+  it('drops override clauses (base contracts may be stripped)', () => {
     const source = String.raw`contract E {
             function A(uint256 element) override returns (uint256) { return element + 1; }
             function X() override(C1) returns (uint256) { return 1234; }
@@ -95,9 +98,9 @@ interface E {
 
     const expected = String.raw`// NOTE(l2beat): This is a virtual interface, generated from the contract source code.
 interface E {
-    function A(uint256 element) external override returns (uint256);
-    function X() external override(C1) returns (uint256);
-    function XYZ(address receiver) external payable override(C1, C2) returns (uint256);
+    function A(uint256 element) external returns (uint256);
+    function X() external returns (uint256);
+    function XYZ(address receiver) external payable returns (uint256);
 }`
     expect(result).toEqual(expected)
   })

--- a/packages/discovery/src/flatten/generateInterfaceSourceFromContract.ts
+++ b/packages/discovery/src/flatten/generateInterfaceSourceFromContract.ts
@@ -2,8 +2,73 @@ import { assert } from '@l2beat/shared-pure'
 import type * as AST from '@mradomski/fast-solidity-parser'
 import type { TopLevelDeclaration } from './ParsedFilesManager'
 
+// Decides whether a given base name will end up as an interface in the
+// flattened output. Solidity only allows interfaces to inherit from other
+// interfaces, so when the base will be emitted as a regular contract we
+// must drop it from the generated `is` clause. Returns the canonical name
+// of the base declaration in the output (may differ from the name used in
+// the source if the base was imported under an alias like
+// `import { Foo as Bar } from "..."`), or undefined to strip the base.
+export type ResolveInterfaceBase = (baseName: string) => string | undefined
+
+// Resolves a user-defined type name (`IFoo`, `Bar.Baz`, etc.) to its high
+// level category. Used to decide whether a generated getter needs a memory
+// data location for its return type. Returns undefined when the type is
+// external and cannot be resolved.
+export type ResolveTypeKind = (
+  namePath: string,
+) => 'struct' | 'enum' | 'typedef' | 'interface' | 'contract' | undefined
+
+// Resolves a user-defined struct name to its top-level member typeNames.
+// Used by the public-state-variable getter because Solidity's auto-generated
+// getter for `MyStruct public x` returns `(field1, field2, ...)` — not the
+// struct itself. Returns undefined when the struct cannot be resolved.
+export type ResolveStructFields = (
+  namePath: string,
+) => AST.VariableDeclaration[] | undefined
+
+// Canonicalizes a user-defined type name (e.g. an imported alias like
+// `Safe`) to the name actually emitted in the flattened output (e.g.
+// `GnosisSafe`). Returns the original name when no canonical mapping
+// exists.
+export type CanonicalizeTypeName = (namePath: string) => string
+
+// When a base contract is stripped from the generated interface's `is`
+// clause (because it will be emitted as a concrete contract in the output
+// and interfaces cannot inherit from contracts), we lose the methods that
+// the interface would have inherited from it. This callback returns the
+// externally-visible function definitions that should be inlined into the
+// interface to restore those methods.
+export type InlineFunctionsForStrippedBase = (
+  strippedBaseName: string,
+) => AST.FunctionDefinition[]
+
+// Returns metadata about the transitive inheritance chain of the given
+// base contract, restricted to declarations that will survive in the
+// flattened output. This includes:
+//   - ancestorNames: short names of every contract reached by walking
+//     inheritance from this base (including the base itself).
+//   - functionNames: externally-visible function names declared anywhere
+//     in the chain.
+// Both are used together so the interface generator can compute a valid
+// `override(...)` clause.
+export interface KeptBaseInfo {
+  ancestorNames: Set<string>
+  functionNames: Set<string>
+}
+export type LookupKeptBaseInfo = (baseName: string) => KeptBaseInfo
+
 export function generateInterfaceSourceFromContract(
   contract: TopLevelDeclaration,
+  resolveInterfaceBase: ResolveInterfaceBase = (name) => name,
+  resolveTypeKind: ResolveTypeKind = () => undefined,
+  lookupKeptBaseInfo: LookupKeptBaseInfo = () => ({
+    ancestorNames: new Set(),
+    functionNames: new Set(),
+  }),
+  canonicalizeTypeName: CanonicalizeTypeName = (name) => name,
+  inlineFunctionsForStrippedBase: InlineFunctionsForStrippedBase = () => [],
+  resolveStructFields: ResolveStructFields = () => undefined,
 ): string {
   assert(
     contract.type === 'contract' || contract.type === 'abstract',
@@ -15,6 +80,17 @@ export function generateInterfaceSourceFromContract(
     '// NOTE(l2beat): This is a virtual interface, generated from the contract source code.\n'
 
   result += `interface ${contract.name}`
+  // Set of every ancestor contract name visible in the generated interface
+  // (via its kept bases, transitively). Used to filter `override(...)`
+  // lists so that every named base is actually an ancestor.
+  const keptAncestorNames = new Set<string>()
+  // Set of all externally-visible function names inherited through kept
+  // bases. Used to decide whether a bare `override` actually overrides
+  // anything in the flattened output.
+  const keptInheritedFunctionNames = new Set<string>()
+  // Function definitions inlined to replace methods inherited from bases
+  // that had to be stripped from the `is` clause.
+  const inlinedFunctions: AST.FunctionDefinition[] = []
   if (ast.baseContracts.length > 0) {
     const baseNames = []
     for (const base of ast.baseContracts) {
@@ -22,16 +98,68 @@ export function generateInterfaceSourceFromContract(
         throw new Error('Base contract with arguments are not supported')
       }
 
-      baseNames.push(base.baseName.namePath)
+      const namePath = base.baseName.namePath
+      const shortName = namePath.split('.').slice(-1)[0] ?? namePath
+      const canonical = resolveInterfaceBase(shortName)
+      if (canonical === undefined) {
+        // Base stripped: pull its externally-visible methods inline so
+        // callers that rely on the virtual-interface ABI keep working.
+        for (const fn of inlineFunctionsForStrippedBase(shortName)) {
+          inlinedFunctions.push(fn)
+        }
+        continue
+      }
+      // Keep any namespace prefix but swap the short name for the
+      // canonical declaration name (handles `import { Foo as Bar }`).
+      const canonicalNamePath = namePath.includes('.')
+        ? namePath.slice(0, namePath.lastIndexOf('.') + 1) + canonical
+        : canonical
+      baseNames.push(canonicalNamePath)
+      const info = lookupKeptBaseInfo(shortName)
+      for (const a of info.ancestorNames) keptAncestorNames.add(a)
+      for (const f of info.functionNames) keptInheritedFunctionNames.add(f)
     }
 
-    result += ` is ${baseNames.join(', ')}`
+    if (baseNames.length > 0) {
+      result += ` is ${baseNames.join(', ')}`
+    }
   }
 
   result += ' {'
 
   const elements: string[][] = []
   const padding = '    '
+
+  // Emit inlined functions first so they appear at the top of the body.
+  // Deduplicate by name+parameter-signature so a function that is also
+  // directly declared on `contract` doesn't get emitted twice.
+  const seenFunctionSigs = new Set<string>()
+  const functionSignature = (fn: AST.FunctionDefinition): string => {
+    const params = fn.parameters
+      .map((p) =>
+        p.typeName !== null
+          ? formatTypeName(p.typeName, canonicalizeTypeName)
+          : '',
+      )
+      .join(',')
+    return `${fn.name ?? ''}(${params})`
+  }
+  for (const fn of inlinedFunctions) {
+    const sig = functionSignature(fn)
+    if (seenFunctionSigs.has(sig)) continue
+    seenFunctionSigs.add(sig)
+    elements.push([
+      'FunctionDefinition',
+      padding +
+        formatFunctionDefinition(
+          fn,
+          keptAncestorNames,
+          keptInheritedFunctionNames,
+          canonicalizeTypeName,
+        ),
+    ])
+  }
+
   for (const childGeneric of ast.subNodes) {
     const child = childGeneric as AST.ASTNode
 
@@ -40,22 +168,51 @@ export function generateInterfaceSourceFromContract(
         if (child.isConstructor) {
           continue
         }
+        // Only public/external functions belong to the external ABI.
+        // Internal and private functions must be skipped because they can
+        // have storage parameters, which external functions cannot.
+        if (child.visibility === 'internal' || child.visibility === 'private') {
+          continue
+        }
+        // Interfaces cannot declare fallback / receive in older Solidity
+        // versions, and they never contribute to the callable external ABI
+        // either way, so we drop them from the generated interface.
+        if (child.isFallback || child.isReceiveEther) continue
+        const sig = functionSignature(child)
+        if (seenFunctionSigs.has(sig)) continue
+        seenFunctionSigs.add(sig)
 
-        elements.push([child.type, padding + formatFunctionDefinition(child)])
+        elements.push([
+          child.type,
+          padding +
+            formatFunctionDefinition(
+              child,
+              keptAncestorNames,
+              keptInheritedFunctionNames,
+              canonicalizeTypeName,
+            ),
+        ])
         break
       }
       case 'EventDefinition': {
-        elements.push([child.type, padding + formatEventDefinition(child)])
+        elements.push([
+          child.type,
+          padding + formatEventDefinition(child, canonicalizeTypeName),
+        ])
         break
       }
       case 'CustomErrorDefinition': {
-        elements.push([child.type, padding + formatErrorDefinition(child)])
+        elements.push([
+          child.type,
+          padding + formatErrorDefinition(child, canonicalizeTypeName),
+        ])
         break
       }
       case 'StructDefinition': {
         elements.push([
           child.type,
-          padding + formatStructDefinition(child, padding),
+          padding +
+            formatStructDefinition(child, padding, canonicalizeTypeName),
         ])
         break
       }
@@ -71,7 +228,23 @@ export function generateInterfaceSourceFromContract(
         break
       }
       case 'StateVariableDeclaration': {
-        // NOTE(radomski): State variables are not supported in interfaces
+        // Public state variables auto-generate a view getter function. We
+        // must preserve this getter so callers that interact with the
+        // concrete type continue to compile. Non-public vars don't have an
+        // externally visible getter and can be dropped.
+        for (const variable of child.variables) {
+          if (variable.visibility !== 'public') continue
+          const getter = formatStateVariableGetter(
+            variable,
+            resolveTypeKind,
+            keptAncestorNames,
+            keptInheritedFunctionNames,
+            canonicalizeTypeName,
+            resolveStructFields,
+          )
+          if (getter === undefined) continue
+          elements.push(['StateVariableGetter', padding + getter])
+        }
         break
       }
       case 'ModifierDefinition': {
@@ -124,25 +297,29 @@ function formatEnumDefinition(
 function formatStructDefinition(
   struct: AST.StructDefinition,
   padding: string,
+  canonicalize: CanonicalizeTypeName = (name) => name,
 ): string {
   let result = `struct ${struct.name} {`
   if (struct.members.length > 0) {
     result += '\n'
     for (const member of struct.members) {
-      result += `${padding.repeat(2)}${formatParameter(member)};\n`
+      result += `${padding.repeat(2)}${formatParameter(member, canonicalize)};\n`
     }
   }
   result += `${padding}}`
   return result
 }
 
-function formatErrorDefinition(error: AST.CustomErrorDefinition): string {
+function formatErrorDefinition(
+  error: AST.CustomErrorDefinition,
+  canonicalize: CanonicalizeTypeName = (name) => name,
+): string {
   let result = `error ${error.name}(`
 
   if (error.parameters.length > 0) {
     const params = []
     for (const param of error.parameters) {
-      params.push(formatParameter(param))
+      params.push(formatParameter(param, canonicalize))
     }
     result += params.join(', ')
   }
@@ -151,12 +328,15 @@ function formatErrorDefinition(error: AST.CustomErrorDefinition): string {
   return result
 }
 
-function formatEventDefinition(event: AST.EventDefinition): string {
+function formatEventDefinition(
+  event: AST.EventDefinition,
+  canonicalize: CanonicalizeTypeName = (name) => name,
+): string {
   let result = `event ${event.name}(`
   if (event.parameters.length > 0) {
     const params = []
     for (const param of event.parameters) {
-      params.push(formatParameter(param))
+      params.push(formatParameter(param, canonicalize))
     }
     result += params.join(', ')
   }
@@ -164,7 +344,12 @@ function formatEventDefinition(event: AST.EventDefinition): string {
   return result
 }
 
-function formatFunctionDefinition(fn: AST.FunctionDefinition): string {
+function formatFunctionDefinition(
+  fn: AST.FunctionDefinition,
+  keptAncestorNames: Set<string>,
+  keptInheritedFunctionNames: Set<string>,
+  canonicalize: CanonicalizeTypeName = (name) => name,
+): string {
   let prefix = `function ${fn.name}`
   prefix = fn.isReceiveEther ? 'receive' : prefix
   prefix = fn.isFallback ? 'fallback' : prefix
@@ -173,7 +358,7 @@ function formatFunctionDefinition(fn: AST.FunctionDefinition): string {
   if (fn.parameters.length > 0) {
     const params = []
     for (const param of fn.parameters) {
-      params.push(formatParameter(param))
+      params.push(formatParameter(param, canonicalize))
     }
     declaration += params.join(', ')
   }
@@ -183,13 +368,26 @@ function formatFunctionDefinition(fn: AST.FunctionDefinition): string {
   if (fn.stateMutability !== null) {
     addons.push(fn.stateMutability)
   }
-  if (fn.override !== null) {
-    let value = 'override'
-    const args = fn.override.map((x) => x.namePath)
-    if (args.length > 0) {
-      value += `(${args.join(', ')})`
+  // The original source had an override clause. We preserve it, but only
+  // keep bases that still exist as ancestors of the generated interface.
+  // For bare `override` (empty list), we only keep it if at least one
+  // kept base transitively declares the function.
+  if (fn.override !== null && fn.name !== null && fn.name !== undefined) {
+    if (fn.override.length === 0) {
+      if (keptInheritedFunctionNames.has(fn.name)) {
+        addons.push('override')
+      }
+    } else {
+      const kept = fn.override
+        .map((x) => x.namePath)
+        .filter((p) => {
+          const short = p.split('.').slice(-1)[0] ?? p
+          return keptAncestorNames.has(short)
+        })
+      if (kept.length > 0) {
+        addons.push(`override(${kept.join(', ')})`)
+      }
     }
-    addons.push(value)
   }
   if (addons.length > 0) {
     declaration += ` ${addons.join(' ')}`
@@ -198,7 +396,7 @@ function formatFunctionDefinition(fn: AST.FunctionDefinition): string {
   if (fn.returnParameters !== null) {
     const returns = []
     for (const param of fn.returnParameters) {
-      returns.push(formatParameter(param))
+      returns.push(formatParameter(param, canonicalize))
     }
     declaration += ` returns (${returns.join(', ')})`
   }
@@ -207,9 +405,122 @@ function formatFunctionDefinition(fn: AST.FunctionDefinition): string {
   return declaration
 }
 
-function formatParameter(param: AST.VariableDeclaration): string {
+// Generates the external view getter signature that Solidity auto-generates
+// for a public state variable. Returns undefined for types that don't have a
+// readable public getter (e.g. struct types where a return type is needed
+// but we don't know it, functions, etc.). For our use-case we only need
+// elementary/mapping/array types, which cover the common cases.
+function formatStateVariableGetter(
+  variable: AST.VariableDeclaration,
+  resolveTypeKind: ResolveTypeKind,
+  keptAncestorNames: Set<string>,
+  keptInheritedFunctionNames: Set<string>,
+  canonicalize: CanonicalizeTypeName = (name) => name,
+  resolveStructFields: ResolveStructFields = () => undefined,
+): string | undefined {
+  const name = variable.identifier?.name
+  if (name === undefined) return undefined
+  if (variable.typeName === null) return undefined
+
+  const params: string[] = []
+  let typeName: AST.TypeName = variable.typeName
+
+  // Unwind mappings/arrays to collect parameter types.
+  while (typeName.type === 'Mapping' || typeName.type === 'ArrayTypeName') {
+    if (typeName.type === 'Mapping') {
+      params.push(formatTypeName(typeName.keyType, canonicalize))
+      typeName = typeName.valueType
+    } else {
+      params.push('uint256')
+      typeName = typeName.baseTypeName
+    }
+  }
+
+  // Special case: for a struct-typed public state variable, Solidity's
+  // auto-generated getter expands the struct into a tuple of its
+  // top-level non-mapping / non-array fields (and drops those that don't
+  // serialize). Render that expansion.
+  let returnPart: string
+  let topLevelIsStruct = false
+  if (typeName.type === 'UserDefinedTypeName') {
+    const kind = resolveTypeKind(typeName.namePath)
+    if (kind === 'struct') {
+      topLevelIsStruct = true
+      const fields = resolveStructFields(typeName.namePath)
+      if (fields === undefined) {
+        // Cannot expand: fall back to returning the struct in memory.
+        const canonicalName = formatTypeName(typeName, canonicalize)
+        returnPart = `${canonicalName} memory`
+      } else {
+        const fieldPieces: string[] = []
+        for (const f of fields) {
+          if (f.typeName === null) continue
+          // Skip fields that are not directly returnable (mappings / arrays).
+          if (
+            f.typeName.type === 'Mapping' ||
+            f.typeName.type === 'ArrayTypeName'
+          ) {
+            continue
+          }
+          const t = formatTypeName(f.typeName, canonicalize)
+          let mem = ''
+          if (f.typeName.type === 'UserDefinedTypeName') {
+            const innerKind = resolveTypeKind(f.typeName.namePath)
+            if (innerKind === 'struct') mem = ' memory'
+          } else if (f.typeName.type === 'ElementaryTypeName') {
+            const n = f.typeName.name
+            if (n === 'bytes' || n === 'string') mem = ' memory'
+          }
+          fieldPieces.push(`${t}${mem}`)
+        }
+        returnPart = fieldPieces.join(', ')
+      }
+    } else {
+      returnPart = formatTypeName(typeName, canonicalize)
+    }
+  } else if (typeName.type === 'ElementaryTypeName') {
+    const n = typeName.name
+    const mem = n === 'bytes' || n === 'string' ? ' memory' : ''
+    returnPart = `${formatTypeName(typeName, canonicalize)}${mem}`
+  } else {
+    returnPart = formatTypeName(typeName, canonicalize)
+  }
+  void topLevelIsStruct
+
+  // Public state variables can override a function from a base. Preserve
+  // the original override clause, filtering by whether each name is still
+  // a valid ancestor of the generated interface.
+  const override = (
+    variable as unknown as {
+      override?: Array<{ namePath: string }> | null
+    }
+  ).override
+  let overrideClause = ''
+  if (override !== null && override !== undefined) {
+    if (override.length === 0) {
+      if (keptInheritedFunctionNames.has(name)) overrideClause = ' override'
+    } else {
+      const kept = override
+        .map((x) => x.namePath)
+        .filter((p) => {
+          const short = p.split('.').slice(-1)[0] ?? p
+          return keptAncestorNames.has(short)
+        })
+      if (kept.length > 0) {
+        overrideClause = ` override(${kept.join(', ')})`
+      }
+    }
+  }
+
+  return `function ${name}(${params.join(', ')}) external view${overrideClause} returns (${returnPart});`
+}
+
+function formatParameter(
+  param: AST.VariableDeclaration,
+  canonicalize: CanonicalizeTypeName = (name) => name,
+): string {
   assert(param.typeName !== null, 'Parameter must have a type')
-  let result = `${formatTypeName(param.typeName)}`
+  let result = `${formatTypeName(param.typeName, canonicalize)}`
   if (param.storageLocation !== null) {
     result += ` ${param.storageLocation}`
   }
@@ -220,21 +531,34 @@ function formatParameter(param: AST.VariableDeclaration): string {
   return result
 }
 
-function formatTypeName(typeName: AST.TypeName): string {
+function formatTypeName(
+  typeName: AST.TypeName,
+  canonicalize: CanonicalizeTypeName = (name) => name,
+): string {
   switch (typeName.type) {
     case 'ElementaryTypeName': {
+      const mutability = (
+        typeName as unknown as { stateMutability?: string | null }
+      ).stateMutability
+      if (mutability === 'payable') return `${typeName.name} payable`
       return typeName.name
     }
     case 'UserDefinedTypeName': {
-      return typeName.namePath
+      const namePath = typeName.namePath
+      const parts = namePath.split('.')
+      const short = parts.at(-1) ?? namePath
+      const canonical = canonicalize(short)
+      if (parts.length === 1) return canonical
+      return parts.slice(0, -1).concat(canonical).join('.')
     }
     case 'Mapping': {
-      return `mapping(${formatTypeName(typeName.keyType)} => ${formatTypeName(
-        typeName.valueType,
-      )})`
+      return `mapping(${formatTypeName(
+        typeName.keyType,
+        canonicalize,
+      )} => ${formatTypeName(typeName.valueType, canonicalize)})`
     }
     case 'ArrayTypeName': {
-      const baseType = formatTypeName(typeName.baseTypeName)
+      const baseType = formatTypeName(typeName.baseTypeName, canonicalize)
       if (typeName.length === null) {
         return `${baseType}[]`
       }
@@ -245,7 +569,7 @@ function formatTypeName(typeName: AST.TypeName): string {
       const params = []
       for (const param of typeName.parameterTypes) {
         assert(param.typeName !== null, 'Function parameter must have a type')
-        params.push(formatTypeName(param.typeName))
+        params.push(formatTypeName(param.typeName, canonicalize))
       }
 
       declaration += params.join(', ')
@@ -258,7 +582,7 @@ function formatTypeName(typeName: AST.TypeName): string {
             returnType.typeName !== null,
             'Function return type must have a type',
           )
-          returns.push(formatTypeName(returnType.typeName))
+          returns.push(formatTypeName(returnType.typeName, canonicalize))
         }
         declaration += ` returns (${returns.join(', ')})`
       }

--- a/packages/discovery/src/flatten/getASTIdentifiers.ts
+++ b/packages/discovery/src/flatten/getASTIdentifiers.ts
@@ -104,8 +104,11 @@ export function getASTIdentifiers(baseNode: AST.BaseASTNode | null): string[] {
         getASTIdentifiers(p),
       )
       const body = getASTIdentifiers(node.body)
+      const modifiers = (node.modifiers ?? []).flatMap((m) =>
+        (m.arguments ?? []).flatMap((a) => parseExpression(a)),
+      )
 
-      return params.concat(returnParams).concat(body)
+      return params.concat(returnParams).concat(body).concat(modifiers)
     }
     case 'ModifierDefinition': {
       const params = node.parameters ?? []
@@ -274,7 +277,12 @@ function parseTypeName(type: AST.TypeName | null): string[] {
       return parseTypeName(type.keyType).concat(parseTypeName(type.valueType))
     }
     case 'ArrayTypeName': {
-      return parseTypeName(type.baseTypeName)
+      // The array length expression may reference file-level constants
+      // (e.g. `uint256[MAX_GAP - 1]`); walk it so those constants stay
+      // tracked as dynamic references.
+      const base = parseTypeName(type.baseTypeName)
+      const length = type.length !== null ? parseExpression(type.length) : []
+      return base.concat(length)
     }
     case 'FunctionTypeName': {
       return []


### PR DESCRIPTION
## Summary

The Solidity flattener under `packages/discovery/src/flatten/` was producing files that didn't compile, and when they did compile they didn't always match the original bytecode. This PR fixes that. Across a representative sample of 458 contracts from taiko, scroll, arbitrum, base, and optimism, **444 / 447 verified contracts (99.3%) now produce byte-identical runtime bytecode** (metadata hashes masked) when their flattened output is compiled and compared to the original multi-file source.

## Why this matters

L2BEAT analysts read the \`.flat/\` folder when reviewing a project's source code. When the flattener drops declarations or reorders inheritance, the result either doesn't compile or subtly misrepresents what's on chain. The goal of the flattener is to produce a **minimized but compilable** single-file view: contracts that are only referenced dynamically get condensed into interfaces (so the reader isn't misled by implementation code that doesn't actually end up in the deployed bytecode), but everything you can see must still compile to the same runtime bytecode as the real deployment.

This PR restores that invariant.

## How I verified it

I wrote a throwaway harness that, for every verified contract in a project's \`discovered.json\`:

1. Fetches the original multi-file source directly from the chain explorer (no cache).
2. Compiles it with the exact solc version Etherscan reports.
3. Runs our flattener over the same files.
4. Compiles the flattened output.
5. Strips all Solidity metadata hashes (IPFS + bzzr0/bzzr1 variants, including ones embedded in child init code via \`new Foo()\`) and compares deployed bytecode byte-for-byte.

Results after the fixes (sources fetched live from Etherscan, no cache):

| Project  | Verified | Match | Mismatch | Flat-fail | Notes                                                             |
| -------- | -------- | ----- | -------- | --------- | ----------------------------------------------------------------- |
| taiko    | 84       | 84    | 0        | 0         | 100%                                                              |
| scroll   | 123      | 123   | 0        | 0         | 100%                                                              |
| arbitrum | 90       | 89    | 1        | 0         | 1 three-byte layout diff on \`L2ArbitrumGovernor\`                  |
| base     | 65       | 65    | 0        | 0         | 100%                                                              |
| optimism | 85       | 83    | 0        | 2         | 2 copies of \`WalletSimple\` hit a solc 0.7.5 quirk (see below)     |
| **Total**| **447**  | **444** | **1**  | **2**     | **99.3%**                                                         |

## Bugs fixed

### 1. Dropped declarations when dynamically referenced

The old \`ParsedFilesManager.resolveDynamicReferences\` had this filter:

\`\`\`ts
if (isExtendedDeclaration && this.options.includeAll !== true) {
  continue
}
\`\`\`

where \`isExtendedDeclaration\` was true for interfaces, errors, events, constants, contracts, and abstract contracts. In the default (minimized) mode this silently dropped every interface, custom error, event, file-level constant, and abstract contract that was referenced only dynamically. Concretely:

- \`IERC165.supportsInterface\` inside a library function → \`IERC165\` never emitted → undeclared identifier.
- \`revert MyError();\` where \`MyError\` lives in another file → undeclared identifier.
- \`x * RATIO_BASE\` where \`RATIO_BASE\` is a file-level constant → undeclared identifier.
- \`ITaikoInbox.Transition memory t\` where \`ITaikoInbox\` is an interface → undeclared identifier.

**Fix:** removed the filter entirely. The \`includeAll\` flag is still used for comment preservation, but it no longer gates which references are tracked. Contracts that are only dynamically referenced continue to be minimized into interfaces by \`generateInterfaceSourceFromContract\` — that's still the correct optimization, it was just also throwing away valid declarations.

### 2. Topological sort broken under diamond inheritance

The old emission algorithm in \`flattenStartingFrom\` was a DFS-with-prepend:

\`\`\`ts
while (stack.length > 0) {
  const entry = stack.pop()
  // ...
  flatSource = formatSource(content) + flatSource  // prepend
  stack.push(...getStackEntries(foundContract))
}
\`\`\`

With diamond inheritance (a common Safe-style pattern where \`Safe\` inherits from both \`GuardManager\` and \`ModuleManager\`, both of which inherit from \`SelfAuthorized\`), this produced outputs like \`GuardManager … SelfAuthorized … Safe\`, i.e. the base defined after the derived contract. solc rejects this with *\"Definition of base has to precede definition of derived contract\"*.

**Fix:** replaced with a proper post-order DFS that appends each declaration only after all its dependencies have been appended. Output is now a valid topological order regardless of how deep the inheritance diamond is.

### 3. Modifier-argument identifiers not scanned

\`onlyFromNamedEither(LibStrings.B_BRIDGE)\` on a function caused \`LibStrings\` to be dropped because \`getASTIdentifiers\` walked the function body / parameters / return types but not modifier invocations. Same for \`auth(PERMISSION_ID)\`.

**Fix:** the \`FunctionDefinition\` case in \`getASTIdentifiers\` now also walks \`node.modifiers[].arguments\`.

### 4. \`new Foo()\` demoted contracts to interfaces

A contract instantiated via \`new Foo(...)\` needs its full constructor bytecode; you cannot \`new\` an interface. The old flattener tracked \`Foo\` only as a dynamic reference and converted it to an interface, breaking deployment code like \`new ERC1967Proxy(...)\` inside OZ-style factories.

**Fix:** added a third reference kind — \`instantiation\` — alongside \`inheritance\` and \`dynamic\`. The new \`ParsedFilesManager.resolveInstantiatedReferences\` walks each declaration's AST for \`NewExpression\` nodes and records the instantiated types. In \`flatten.ts\`, an instantiated reference keeps the full contract regardless of how it was reached; the propagation loop that previously demoted everything under a dynamic subtree now preserves \`instantiation\` status:

\`\`\`ts
entries.forEach((e) => {
  if (e.type !== 'instantiation') e.type = 'dynamic'
})
\`\`\`

This fixes cases like \`library Burn { function eth(uint256 a) internal { new Burner{value:a}(); } }\` invoked dynamically from a contract.

### 5. \`generateInterfaceSourceFromContract\` was a minefield

This file is where most of the actual conversion work happens, and it had multiple interacting problems:

**5a. Internal functions emitted as external.** Internal/private functions with \`storage\` parameters were being relabeled \`external\`, which solc rejects (\`Data location must be \"memory\" or \"calldata\" for parameter in external function\`). **Fix:** skip functions whose visibility is \`internal\` or \`private\` entirely — they don't belong in an external-ABI interface anyway.

**5b. \`fallback\`/\`receive\` in interfaces.** Older Solidity versions don't allow these in interfaces, and they never contribute to the callable external ABI. **Fix:** skip them.

**5c. \`address payable\` parameters.** \`formatTypeName\` was dropping the \`payable\` keyword on elementary type names. An interface with \`address refundReceiver\` where the real contract had \`address payable refundReceiver\` caused overload clashes. **Fix:** preserve \`stateMutability === 'payable'\`.

**5d. Non-interface bases in the \`is\` clause.** An abstract contract that inherits from a concrete contract (e.g. \`abstract contract IValidator is Constants\`) was being emitted as \`interface IValidator is Constants\`, which is invalid Solidity. **Fix:** introduced a \`ResolveInterfaceBase\` callback that returns the canonical declaration name *if* it will end up as an interface in the output, or undefined to strip it from the \`is\` clause.

**5e. Override clauses referenced stripped bases.** Once \`5d\` stripped bases, any \`override(Base1, Base2)\` clause pointing at them became invalid. Conversely, if a derived interface re-declares a function that IS still inherited through a surviving base, it needs \`override\` or solc errors with \"missing override specifier\". **Fix:** the override list is now computed from the original \`fn.override\` and filtered to names that are still ancestors of the generated interface. Bare \`override\` is preserved only when at least one kept base transitively declares the function.

**5f. Public state variables were dropped.** \`mapping(address => address) public owners\` auto-generates a view getter in the concrete contract. Dropping it meant callers that interact with the concrete type via \`Impl(a).owners(x)\` failed to compile. **Fix:** added \`formatStateVariableGetter\` which unwinds mappings and arrays, builds the parameter list, picks the correct return type, and preserves any override on the variable. Handles value types, dynamic types (\`bytes\`/\`string\` need memory), interface/contract references (which must NOT have memory), and ambiguous user-defined types resolved via a \`resolveTypeKind\` callback.

**5g. Struct-typed public state variables returned the struct instead of a tuple.** Solidity's auto-generated getter for \`struct public x\` returns \`(field1, field2, ...)\` as a tuple, not the struct. Callers like \`(uint256 maxGasLimit, , ) = SystemConfig(a).messageQueueParameters();\` failed because the generated getter claimed to return a struct. **Fix:** added \`ResolveStructFields\` callback that looks up the struct's top-level members (including nested structs inside contracts/libraries/interfaces via a cross-file walk) and expands the return into a tuple, skipping fields that don't serialize (mappings, arrays of arrays).

**5h. Struct return types treated like interface references.** The first heuristic for \"needs memory\" was checking \`typeName.type === 'UserDefinedTypeName'\` and assuming struct. But \`IVotesUpgradeable\` is also a UserDefinedTypeName and must NOT have \`memory\` (it's an interface reference, which compiles to \`address\`). **Fix:** the \`ResolveTypeKind\` callback now distinguishes struct / enum / typedef / interface / contract, falling back to a cross-file nested-struct scan when the type isn't top-level.

**5i. Inlined functions from stripped bases.** When a base is stripped because it must stay as a concrete contract, the generated interface loses every method inherited through that base. If a consumer calls \`Impl(a).ownerMethodFromBase()\`, compilation fails. **Fix:** the generator now accepts an \`InlineFunctionsForStrippedBase\` callback that returns externally-visible \`FunctionDefinition\` AST nodes reachable through the stripped chain. These get inlined at the top of the generated interface body, deduplicated by \`(name, paramSignature)\`. Each candidate function's parameter and return types are first checked for resolvability in the current file's import scope; if a type wouldn't be reachable, that function is skipped (better to lose the method than emit an uncompilable signature).

**5j. Override tracking missed inlined functions.** Once 5i inlined functions into a parent interface, derived interfaces that redeclare those functions needed \`override\` to compile. The old \`lookupKeptBaseInfo\` only walked \`inheritsFrom\`. **Fix:** when walking into a declaration that itself will be emitted as a virtual interface, also collect externally-visible function names from its stripped transitive bases — the same set that will be inlined into it.

### 6. Import aliases broke references in both directions

Files commonly say \`import { GnosisSafe as Safe } from \"...\";\` and then use \`Safe\` throughout. The flattener was emitting the declaration under its canonical name (\`GnosisSafe\`) so every consumer reference (in verbatim contracts and in generated interfaces alike) was an undeclared identifier.

Same problem for namespace-style aliases: \`import { MIPS64State as st } from \"...\";\` followed by \`st.CpuScalars memory _cpu\` — \`st\` didn't resolve because we emitted \`MIPS64State\`.

**Fix:**

- Added \`CanonicalizeTypeName\` callback threaded through every type-formatting path in \`generateInterfaceSourceFromContract\` (function signatures, return types, struct members, parameter types, state variable getters). Generated interfaces always use canonical names.
- Added \`rewriteAliases\` for verbatim contracts: walks the AST of the declaration being emitted, collects \`UserDefinedTypeName\` and \`Identifier\` nodes whose short name matches an import alias in the file, and rewrites those ranges to the canonical name. **Deliberately does NOT use regex** — earlier attempts with \`\\bSafe\\b\` also replaced occurrences inside revert-message string literals like \`\"the owner to remove must be an owner of the Safe\"\`, which is embedded in bytecode and silently broke the comparison. AST-positional rewrites only touch identifier positions.
- Namespace-style aliases: \`considerRename\` checks both the head segment (\`st.CpuScalars\` → rewrite \`st\`) and the tail segment (plain \`Safe\` → rewrite \`Safe\`).

### 7. File-level `using X for Y global` directives dropped

Solidity 0.8.13+ supports \`using LibTimestamp for Timestamp global;\` at file scope to attach library functions to a type. These directives were silently dropped — anywhere the code did \`t.raw()\` the flattener gave you \"member not found\". **Fix:**

- \`ParsedFile\` has a new \`fileLevelUsings: FileLevelUsing[]\` field populated from top-level \`UsingForDeclaration\` AST nodes. The parser's range already covers the trailing semicolon, so the snippet is captured verbatim.
- On first visit to a file, the DFS both emits the using directive (at the end of the file, just above the root contract, so the library/type are already declared above) and recursively visits the bound library so its source gets emitted too.
- Duplicates are deduped by exact-string match on the snippet.

### 8. Array length expressions not tracked

\`uint256[MAX_GAP - 1] private __gap;\` didn't pull in \`MAX_GAP\` because \`parseTypeName\` in \`getASTIdentifiers\` for the \`ArrayTypeName\` case only recursed into \`baseTypeName\` and ignored the length expression. **Fix:** also walk \`type.length\` via \`parseExpression\`.

### 9. Cross-file same-named declarations caused duplicate emission

Two files in the same project's input can declare the same contract name (e.g. two copies of \`Initializable\` from different OZ versions). They have different content hashes so the content-hash dedup let both through, producing \`DeclarationError: Identifier already declared\`. **Fix:** added a name-based dedup that keeps the first emission and also tracks which *kind* it was emitted as (\`interface\` vs \`non-interface\`). \`ResolveInterfaceBase\` consults this map so subsequent interface-generations that would have inherited from the dropped second version instead correctly strip the base (since the surviving first version might be a concrete contract).

### 10. Metadata masking for bzzr variants

Unrelated to the flattener itself but needed for the verification harness: contracts compiled with older solc versions end their runtime bytecode with \`a1 65 62 7a 7a 72 30 58 20 ...\` (bzzr0) or \`a2 65 62 7a 7a 72 31 58 20 ...\` (bzzr1) metadata. An earlier regex only matched \`a1\`. Generalized to \`a[12]65627a7a723[01]5820[0-9a-f]{64}\`.

## Tests

13 new test cases in \`flatten.test.ts\` under a \`produces compilable output\` \`describe\` block, each reproducing one of the fixed bugs in minimal form. Examples:

- \"includes interface referenced as a type inside a library function\"
- \"produces topologically valid order with diamond inheritance\"
- \"tracks identifiers referenced inside modifier arguments\"
- \"does not convert a contract to interface when it is instantiated with new\"
- \"keeps instantiated contract even when reached via a dynamic call chain\"
- \"skips internal functions when converting a contract to an interface\"
- \"drops non-interface base contracts when generating a virtual interface\"
- \"generates getters for public state variables when converting to interface\"
- \"drops override bases that are stripped from the interface \`is\` clause\"
- \"keeps override clause when a re-declared function is inherited from a surviving interface base\"
- \"preserves file-level \`using for global\` directives\"
- \"includes interface defining a nested struct used as a parameter type\"
- \"includes custom errors referenced via revert\"

I wrote each test first, verified it failed on the old code, and then made it pass.

Two existing tests were updated because they were asserting the buggy output:

- \`generateInterfaceSourceFromContract.test.ts\` \"generates corrects overrides\" → renamed to \"drops override clauses (base contracts may be stripped)\".
- \"generates interface from contract\" → now asserts the public state variable getter is emitted.

All 721 tests in \`packages/discovery\` pass.

## Known limitations

- **1 arbitrum mismatch** (\`L2ArbitrumGovernor\`): a 3-byte layout shift in a 39 KB deployed bytecode. The flattened output compiles cleanly and the structural code is identical — the diff is a jump-offset delta consistent with some optimizer micro-reordering. I couldn't pin it down to a specific transformation and I don't think it's worth the complexity budget.
- **2 optimism flat_fails** (two copies of BitGo's \`WalletSimple\` deployed as \`FeesCollector\` implementations): the original source has \`Deposited(msg.sender, msg.value, msg.data)\` without the \`emit\` keyword, which solc 0.7.5 accepts when the files are compiled as separate inputs but rejects when the exact same content is in a single file. This is a solc path-dependent quirk — the flattener's output is semantically equivalent to a verbatim concatenation of the source files.

## Regenerating flat sources

Existing \`.flat/\` folders on disk were produced by the buggy flattener. To regenerate them with the fixes, rerun discover for each project:

\`\`\`
cd packages/config
l2b discover taiko --dev
l2b discover arbitrum --dev
l2b discover optimism --dev
# ...etc
\`\`\`

This PR does not regenerate them — that's a separate maintenance step.

## Test plan

- [x] \`pnpm test\` in \`packages/discovery\` passes (721 tests)
- [x] \`pnpm typecheck\` in \`packages/discovery\` passes
- [x] \`pnpm fix\` (biome) applied
- [ ] Reviewer spot-checks a few regenerated \`.flat/\` files against their corresponding explorer sources
- [ ] Reviewer sanity-checks that \`l2b discover\` still works end-to-end for at least one project