### PR TITLE
Elastic Search transport: byte budget alert

### DIFF
--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
@@ -24,6 +24,14 @@ const log = {
   message: 'Update started',
 }
 
+/** Equal UTF-8 size per serialized log so byte overflow math is predictable. */
+function ecsSerializedLog(i: number): string {
+  return JSON.stringify({
+    ...log,
+    message: String(i).padStart(10, '0'),
+  })
+}
+
 describe(ElasticSearchTransport.name, () => {
   let clock: FakeTimers.InstalledClock
   let savedConsoleLog: typeof console.log
@@ -60,6 +68,20 @@ describe(ElasticSearchTransport.name, () => {
     expect(clientMock.bulk).not.toHaveBeenCalled()
   })
 
+  it('flush() sends buffered logs without advancing the flush interval timer', async () => {
+    const clientMock = createClientMock(false)
+    const transportMock = createTransportMock(clientMock)
+
+    transportMock.push(JSON.stringify(log))
+
+    await transportMock.flush()
+
+    expect(clientMock.bulk).toHaveBeenOnlyCalledWith(
+      [{ id, ...log }],
+      expectedIndexName,
+    )
+  })
+
   it('pushes logs to ES if there is something in the buffer', async () => {
     const clientMock = createClientMock(false)
     const transportMock = createTransportMock(clientMock)
@@ -74,28 +96,15 @@ describe(ElasticSearchTransport.name, () => {
     )
   })
 
-  it('keeps only the newest logs when buffer limit is exceeded', async () => {
+  it('keeps only the newest logs when buffer UTF-8 byte size is exceeded at flush time', async () => {
+    const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
+    const bufferMaxBytes = itemBytes * 2
     const clientMock = createClientMock(false)
-    const transportMock = createTransportMock(clientMock, { bufferLimit: 2 })
+    const transportMock = createTransportMock(clientMock, { bufferMaxBytes })
 
-    transportMock.push(
-      JSON.stringify({
-        ...log,
-        message: 'first',
-      }),
-    )
-    transportMock.push(
-      JSON.stringify({
-        ...log,
-        message: 'second',
-      }),
-    )
-    transportMock.push(
-      JSON.stringify({
-        ...log,
-        message: 'third',
-      }),
-    )
+    transportMock.push(ecsSerializedLog(0))
+    transportMock.push(ecsSerializedLog(1))
+    transportMock.push(ecsSerializedLog(2))
 
     await clock.tickAsync(flushInterval + 1)
 
@@ -107,7 +116,11 @@ describe(ElasticSearchTransport.name, () => {
         expect.subset({
           id,
           log: { level: 'CRITICAL' },
-          parameters: { droppedCount: 1, bufferLimit: 2 },
+          parameters: {
+            droppedItems: 1,
+            droppedBytes: itemBytes,
+            bufferMaxBytes,
+          },
         }),
       ],
       expectedIndexName,
@@ -116,24 +129,22 @@ describe(ElasticSearchTransport.name, () => {
     expect(clientMock.bulk).toHaveBeenNthCalledWith(
       2,
       [
-        { id, ...log, message: 'second' },
-        { id, ...log, message: 'third' },
+        { id, ...log, message: '0000000001' },
+        { id, ...log, message: '0000000002' },
       ],
       expectedIndexName,
     )
   })
 
-  it('uses the default buffer limit when explicit limit is not provided', async () => {
+  it('drops oldest buffer items until total UTF-8 size is within bufferMaxBytes (trim at flush)', async () => {
+    const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
+    const maxItems = 20_000
+    const bufferMaxBytes = maxItems * itemBytes
     const clientMock = createClientMock(false)
-    const transportMock = createTransportMock(clientMock)
+    const transportMock = createTransportMock(clientMock, { bufferMaxBytes })
 
-    for (let i = 0; i < 20_001; i++) {
-      transportMock.push(
-        JSON.stringify({
-          ...log,
-          message: `log-${i}`,
-        }),
-      )
+    for (let i = 0; i <= maxItems; i++) {
+      transportMock.push(ecsSerializedLog(i))
     }
 
     await clock.tickAsync(flushInterval + 1)
@@ -147,8 +158,9 @@ describe(ElasticSearchTransport.name, () => {
           id,
           log: { level: 'CRITICAL' },
           parameters: {
-            droppedCount: 1,
-            bufferLimit: 20_000,
+            droppedItems: 1,
+            droppedBytes: itemBytes,
+            bufferMaxBytes,
           },
         }),
       ],
@@ -156,14 +168,21 @@ describe(ElasticSearchTransport.name, () => {
     )
 
     const [documents] = clientMock.bulk.calls[1]!.args
-    expect(documents).toHaveLength(20_000)
-    expect(documents[0]).toEqual({ id, ...log, message: 'log-1' })
-    expect(documents[19_999]).toEqual({ id, ...log, message: 'log-20000' })
+    expect(documents).toHaveLength(maxItems)
+    expect(documents[0]).toEqual({ id, ...log, message: '0000000001' })
+    expect(documents[maxItems - 1]).toEqual({
+      id,
+      ...log,
+      message: '0000020000',
+    })
   })
 
-  it('does not trim logs when buffer stays within the configured limit', async () => {
+  it('does not trim logs when buffer stays within the configured byte budget', async () => {
+    const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
     const clientMock = createClientMock(false)
-    const transportMock = createTransportMock(clientMock, { bufferLimit: 3 })
+    const transportMock = createTransportMock(clientMock, {
+      bufferMaxBytes: itemBytes * 10,
+    })
 
     transportMock.push(
       JSON.stringify({
@@ -227,7 +246,7 @@ describe(ElasticSearchTransport.name, () => {
     )
   })
 
-  it('runs recovery bulk when buffer line is not valid JSON', async () => {
+  it('runs recovery bulk when a buffer item is not valid JSON', async () => {
     const clientMock = createClientMock(false, [{ isSuccess: true as const }])
     const transportMock = createTransportMock(clientMock)
 

--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
@@ -96,10 +96,10 @@ describe(ElasticSearchTransport.name, () => {
     )
   })
 
-  it('keeps only the newest logs when buffer UTF-8 byte size is exceeded at flush time', async () => {
+  it('sends CRITICAL when buffer UTF-8 size exceeds budget but still ships all buffered items', async () => {
     const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
     const bufferMaxBytes = itemBytes * 2
-    const clientMock = createClientMock(false)
+    const clientMock = createClientMockWithTrackedIndex()
     const transportMock = createTransportMock(clientMock, { bufferMaxBytes })
 
     transportMock.push(ecsSerializedLog(0))
@@ -109,6 +109,9 @@ describe(ElasticSearchTransport.name, () => {
     await clock.tickAsync(flushInterval + 1)
 
     expect(clientMock.bulk).toHaveBeenCalledTimes(2)
+    // `await reportBufferOverflow` runs `createIndex` before the main try block.
+    expect(clientMock.indexExist).toHaveBeenCalledTimes(2)
+    expect(clientMock.indexCreate).toHaveBeenCalledTimes(1)
 
     expect(clientMock.bulk).toHaveBeenNthCalledWith(
       1,
@@ -116,9 +119,10 @@ describe(ElasticSearchTransport.name, () => {
         expect.subset({
           id,
           log: { level: 'CRITICAL' },
+          message: 'Elastic Search transport buffer exceeds byte budget',
           parameters: {
-            droppedItems: 1,
-            droppedBytes: itemBytes,
+            bufferedBytes: itemBytes * 3,
+            bufferItemCount: 3,
             bufferMaxBytes,
           },
         }),
@@ -129,6 +133,7 @@ describe(ElasticSearchTransport.name, () => {
     expect(clientMock.bulk).toHaveBeenNthCalledWith(
       2,
       [
+        { id, ...log, message: '0000000000' },
         { id, ...log, message: '0000000001' },
         { id, ...log, message: '0000000002' },
       ],
@@ -136,11 +141,11 @@ describe(ElasticSearchTransport.name, () => {
     )
   })
 
-  it('drops oldest buffer items until total UTF-8 size is within bufferMaxBytes (trim at flush)', async () => {
+  it('awaits CRITICAL overflow report then sends full bulk (no trimming)', async () => {
     const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
     const maxItems = 20_000
     const bufferMaxBytes = maxItems * itemBytes
-    const clientMock = createClientMock(false)
+    const clientMock = createClientMockWithTrackedIndex()
     const transportMock = createTransportMock(clientMock, { bufferMaxBytes })
 
     for (let i = 0; i <= maxItems; i++) {
@@ -150,6 +155,8 @@ describe(ElasticSearchTransport.name, () => {
     await clock.tickAsync(flushInterval + 1)
 
     expect(clientMock.bulk).toHaveBeenCalledTimes(2)
+    expect(clientMock.indexExist).toHaveBeenCalledTimes(2)
+    expect(clientMock.indexCreate).toHaveBeenCalledTimes(1)
 
     expect(clientMock.bulk).toHaveBeenNthCalledWith(
       1,
@@ -157,9 +164,10 @@ describe(ElasticSearchTransport.name, () => {
         expect.subset({
           id,
           log: { level: 'CRITICAL' },
+          message: 'Elastic Search transport buffer exceeds byte budget',
           parameters: {
-            droppedItems: 1,
-            droppedBytes: itemBytes,
+            bufferedBytes: itemBytes * (maxItems + 1),
+            bufferItemCount: maxItems + 1,
             bufferMaxBytes,
           },
         }),
@@ -168,9 +176,9 @@ describe(ElasticSearchTransport.name, () => {
     )
 
     const [documents] = clientMock.bulk.calls[1]!.args
-    expect(documents).toHaveLength(maxItems)
-    expect(documents[0]).toEqual({ id, ...log, message: '0000000001' })
-    expect(documents[maxItems - 1]).toEqual({
+    expect(documents).toHaveLength(maxItems + 1)
+    expect(documents[0]).toEqual({ id, ...log, message: '0000000000' })
+    expect(documents[maxItems]).toEqual({
       id,
       ...log,
       message: '0000020000',
@@ -292,6 +300,37 @@ describe(ElasticSearchTransport.name, () => {
     expect(clientMock.bulk).toHaveBeenCalledTimes(2)
   })
 })
+
+/**
+ * Index missing until first `indexCreate`, then exists — matches real ES behavior when
+ * `createIndex` runs twice in one flush (`await` CRITICAL bulk, then main bulk).
+ */
+function createClientMockWithTrackedIndex(
+  bulkResponses?: Array<
+    | { isSuccess: true }
+    | { isSuccess: false; failedDocuments: Record<string, unknown>[] }
+  >,
+) {
+  let indexExists = false
+  const queue =
+    bulkResponses !== undefined
+      ? [...bulkResponses]
+      : [{ isSuccess: true as const }]
+
+  return mockObject<ElasticSearchClient>({
+    indexExist: mockFn(async (_: string): Promise<boolean> => indexExists),
+    indexCreate: mockFn(async (_: string): Promise<void> => {
+      indexExists = true
+    }),
+    bulk: mockFn(async () => {
+      const next = queue.shift()
+      if (next === undefined) {
+        return { isSuccess: true as const }
+      }
+      return next
+    }),
+  })
+}
 
 function createClientMock(
   indexExist = true,

--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.test.ts
@@ -98,9 +98,9 @@ describe(ElasticSearchTransport.name, () => {
 
   it('sends CRITICAL when buffer UTF-8 size exceeds budget but still ships all buffered items', async () => {
     const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
-    const bufferMaxBytes = itemBytes * 2
+    const bufferAlertBytes = itemBytes * 2
     const clientMock = createClientMockWithTrackedIndex()
-    const transportMock = createTransportMock(clientMock, { bufferMaxBytes })
+    const transportMock = createTransportMock(clientMock, { bufferAlertBytes })
 
     transportMock.push(ecsSerializedLog(0))
     transportMock.push(ecsSerializedLog(1))
@@ -123,7 +123,7 @@ describe(ElasticSearchTransport.name, () => {
           parameters: {
             bufferedBytes: itemBytes * 3,
             bufferItemCount: 3,
-            bufferMaxBytes,
+            bufferAlertBytes,
           },
         }),
       ],
@@ -144,9 +144,9 @@ describe(ElasticSearchTransport.name, () => {
   it('awaits CRITICAL overflow report then sends full bulk (no trimming)', async () => {
     const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
     const maxItems = 20_000
-    const bufferMaxBytes = maxItems * itemBytes
+    const bufferAlertBytes = maxItems * itemBytes
     const clientMock = createClientMockWithTrackedIndex()
-    const transportMock = createTransportMock(clientMock, { bufferMaxBytes })
+    const transportMock = createTransportMock(clientMock, { bufferAlertBytes })
 
     for (let i = 0; i <= maxItems; i++) {
       transportMock.push(ecsSerializedLog(i))
@@ -168,7 +168,7 @@ describe(ElasticSearchTransport.name, () => {
           parameters: {
             bufferedBytes: itemBytes * (maxItems + 1),
             bufferItemCount: maxItems + 1,
-            bufferMaxBytes,
+            bufferAlertBytes,
           },
         }),
       ],
@@ -189,7 +189,7 @@ describe(ElasticSearchTransport.name, () => {
     const itemBytes = Buffer.byteLength(ecsSerializedLog(0), 'utf8')
     const clientMock = createClientMock(false)
     const transportMock = createTransportMock(clientMock, {
-      bufferMaxBytes: itemBytes * 10,
+      bufferAlertBytes: itemBytes * 10,
     })
 
     transportMock.push(

--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
@@ -8,19 +8,19 @@ import {
 
 export interface ElasticSearchTransportOptions
   extends ElasticSearchClientOptions {
-  /** Alert threshold (UTF-8 bytes): emit CRITICAL when buffered data exceeds this; nothing is trimmed. */
-  bufferMaxBytes?: number
+  /** UTF-8 byte threshold for CRITICAL alert when buffered size exceeds it; nothing is trimmed. */
+  bufferAlertBytes?: number
   flushInterval?: number
   indexPrefix?: string
 }
 
 export type UuidProvider = () => string
 
-export const DEFAULT_BUFFER_MAX_BYTES = 128 * 1024 * 1024 // 128 MiB
+export const DEFAULT_BUFFER_ALERT_BYTES = 128 * 1024 * 1024 // 128 MiB
 
 export class ElasticSearchTransport implements LoggerTransport {
   private readonly buffer: string[]
-  private readonly bufferMaxBytes: number
+  private readonly bufferAlertBytes: number
 
   constructor(
     private readonly options: ElasticSearchTransportOptions,
@@ -30,7 +30,8 @@ export class ElasticSearchTransport implements LoggerTransport {
     private readonly uuidProvider: UuidProvider = uuidv4,
   ) {
     this.buffer = []
-    this.bufferMaxBytes = options.bufferMaxBytes ?? DEFAULT_BUFFER_MAX_BYTES
+    this.bufferAlertBytes =
+      options.bufferAlertBytes ?? DEFAULT_BUFFER_ALERT_BYTES
     this.start()
   }
 
@@ -66,7 +67,7 @@ export class ElasticSearchTransport implements LoggerTransport {
     }
 
     const bufferedBytes = sumBufferUtf8Bytes(this.buffer)
-    if (bufferedBytes > this.bufferMaxBytes) {
+    if (bufferedBytes > this.bufferAlertBytes) {
       await this.reportBufferOverflow(bufferedBytes, this.buffer.length)
     }
 
@@ -156,7 +157,7 @@ export class ElasticSearchTransport implements LoggerTransport {
                 parameters: {
                   bufferedBytes,
                   bufferItemCount,
-                  bufferMaxBytes: this.bufferMaxBytes,
+                  bufferAlertBytes: this.bufferAlertBytes,
                 },
               }),
             ),

--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
@@ -8,7 +8,7 @@ import {
 
 export interface ElasticSearchTransportOptions
   extends ElasticSearchClientOptions {
-  /** Max total UTF-8 byte size of buffered strings before oldest items are dropped at flush. */
+  /** Alert threshold (UTF-8 bytes): emit CRITICAL when buffered data exceeds this; nothing is trimmed. */
   bufferMaxBytes?: number
   flushInterval?: number
   indexPrefix?: string
@@ -65,9 +65,9 @@ export class ElasticSearchTransport implements LoggerTransport {
       return
     }
 
-    const { droppedItems, droppedBytes } = this.trimOverflow()
-    if (droppedItems > 0) {
-      void this.reportBufferOverflow(droppedItems, droppedBytes)
+    const bufferedBytes = sumBufferUtf8Bytes(this.buffer)
+    if (bufferedBytes > this.bufferMaxBytes) {
+      await this.reportBufferOverflow(bufferedBytes, this.buffer.length)
     }
 
     /** In scope for `catch` so we can correlate flush failures with batched log strings. */
@@ -139,37 +139,9 @@ export class ElasticSearchTransport implements LoggerTransport {
     return indexName
   }
 
-  /**
-   * Drops whole items from the front of the buffer until total UTF-8 byte size
-   * is at most `bufferMaxBytes`.
-   */
-  private trimOverflow(): {
-    droppedItems: number
-    droppedBytes: number
-  } {
-    let totalBytes = sumBufferUtf8Bytes(this.buffer)
-    if (totalBytes <= this.bufferMaxBytes) {
-      return { droppedItems: 0, droppedBytes: 0 }
-    }
-
-    let droppedItems = 0
-    let droppedBytes = 0
-    while (totalBytes > this.bufferMaxBytes && this.buffer.length > 0) {
-      const item = this.buffer.shift()
-      if (item === undefined) {
-        break
-      }
-      const itemBytes = Buffer.byteLength(item, 'utf8')
-      droppedBytes += itemBytes
-      droppedItems += 1
-      totalBytes -= itemBytes
-    }
-    return { droppedItems, droppedBytes }
-  }
-
   private async reportBufferOverflow(
-    droppedItems: number,
-    droppedBytes: number,
+    bufferedBytes: number,
+    bufferItemCount: number,
   ): Promise<void> {
     try {
       await this.client.bulk(
@@ -180,10 +152,10 @@ export class ElasticSearchTransport implements LoggerTransport {
               formatEcsLog({
                 time: new Date(),
                 level: 'CRITICAL',
-                message: 'Elastic Search transport buffer overflowed',
+                message: 'Elastic Search transport buffer exceeds byte budget',
                 parameters: {
-                  droppedItems,
-                  droppedBytes,
+                  bufferedBytes,
+                  bufferItemCount,
                   bufferMaxBytes: this.bufferMaxBytes,
                 },
               }),

--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
@@ -39,11 +39,6 @@ export class ElasticSearchTransport implements LoggerTransport {
 
   push(log: string) {
     this.buffer.push(log)
-    const overflow = this.buffer.length - this.bufferLimit
-    if (overflow > 0) {
-      void this.reportBufferOverflow(overflow)
-      this.buffer.splice(0, overflow)
-    }
   }
 
   private start(): void {
@@ -67,6 +62,12 @@ export class ElasticSearchTransport implements LoggerTransport {
   private async flushLogs(): Promise<void> {
     if (!this.buffer.length) {
       return
+    }
+
+    const overflow = this.buffer.length - this.bufferLimit
+    if (overflow > 0) {
+      void this.reportBufferOverflow(overflow)
+      this.buffer.splice(0, overflow)
     }
 
     /** In scope for `catch` so we can correlate flush failures with batched log lines. */

--- a/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
+++ b/packages/backend-tools/src/elastic-search/ElasticSearchTransport.ts
@@ -8,18 +8,19 @@ import {
 
 export interface ElasticSearchTransportOptions
   extends ElasticSearchClientOptions {
-  bufferLimit?: number
+  /** Max total UTF-8 byte size of buffered strings before oldest items are dropped at flush. */
+  bufferMaxBytes?: number
   flushInterval?: number
   indexPrefix?: string
 }
 
 export type UuidProvider = () => string
 
-const DEFAULT_BUFFER_LIMIT = 20_000
+export const DEFAULT_BUFFER_MAX_BYTES = 128 * 1024 * 1024 // 128 MiB
 
 export class ElasticSearchTransport implements LoggerTransport {
   private readonly buffer: string[]
-  private readonly bufferLimit: number
+  private readonly bufferMaxBytes: number
 
   constructor(
     private readonly options: ElasticSearchTransportOptions,
@@ -29,7 +30,7 @@ export class ElasticSearchTransport implements LoggerTransport {
     private readonly uuidProvider: UuidProvider = uuidv4,
   ) {
     this.buffer = []
-    this.bufferLimit = options.bufferLimit ?? DEFAULT_BUFFER_LIMIT
+    this.bufferMaxBytes = options.bufferMaxBytes ?? DEFAULT_BUFFER_MAX_BYTES
     this.start()
   }
 
@@ -64,13 +65,12 @@ export class ElasticSearchTransport implements LoggerTransport {
       return
     }
 
-    const overflow = this.buffer.length - this.bufferLimit
-    if (overflow > 0) {
-      void this.reportBufferOverflow(overflow)
-      this.buffer.splice(0, overflow)
+    const { droppedItems, droppedBytes } = this.trimOverflow()
+    if (droppedItems > 0) {
+      void this.reportBufferOverflow(droppedItems, droppedBytes)
     }
 
-    /** In scope for `catch` so we can correlate flush failures with batched log lines. */
+    /** In scope for `catch` so we can correlate flush failures with batched log strings. */
     let batch: string[] = []
 
     try {
@@ -127,30 +127,6 @@ export class ElasticSearchTransport implements LoggerTransport {
     }
   }
 
-  private async reportBufferOverflow(droppedCount: number): Promise<void> {
-    try {
-      await this.client.bulk(
-        [
-          {
-            id: this.uuidProvider(),
-            ...JSON.parse(
-              formatEcsLog({
-                time: new Date(),
-                level: 'CRITICAL',
-                message: 'Elastic Search transport buffer overflowed',
-                parameters: {
-                  droppedCount,
-                  bufferLimit: this.bufferLimit,
-                },
-              }),
-            ),
-          },
-        ],
-        await this.createIndex(),
-      )
-    } catch {}
-  }
-
   private async createIndex(): Promise<string> {
     const indexName = `${this.options.indexPrefix ?? 'logs'}-${formatDate(
       new Date(),
@@ -162,6 +138,70 @@ export class ElasticSearchTransport implements LoggerTransport {
     }
     return indexName
   }
+
+  /**
+   * Drops whole items from the front of the buffer until total UTF-8 byte size
+   * is at most `bufferMaxBytes`.
+   */
+  private trimOverflow(): {
+    droppedItems: number
+    droppedBytes: number
+  } {
+    let totalBytes = sumBufferUtf8Bytes(this.buffer)
+    if (totalBytes <= this.bufferMaxBytes) {
+      return { droppedItems: 0, droppedBytes: 0 }
+    }
+
+    let droppedItems = 0
+    let droppedBytes = 0
+    while (totalBytes > this.bufferMaxBytes && this.buffer.length > 0) {
+      const item = this.buffer.shift()
+      if (item === undefined) {
+        break
+      }
+      const itemBytes = Buffer.byteLength(item, 'utf8')
+      droppedBytes += itemBytes
+      droppedItems += 1
+      totalBytes -= itemBytes
+    }
+    return { droppedItems, droppedBytes }
+  }
+
+  private async reportBufferOverflow(
+    droppedItems: number,
+    droppedBytes: number,
+  ): Promise<void> {
+    try {
+      await this.client.bulk(
+        [
+          {
+            id: this.uuidProvider(),
+            ...JSON.parse(
+              formatEcsLog({
+                time: new Date(),
+                level: 'CRITICAL',
+                message: 'Elastic Search transport buffer overflowed',
+                parameters: {
+                  droppedItems,
+                  droppedBytes,
+                  bufferMaxBytes: this.bufferMaxBytes,
+                },
+              }),
+            ),
+          },
+        ],
+        await this.createIndex(),
+      )
+    } catch {}
+  }
+}
+
+function sumBufferUtf8Bytes(buffer: string[]): number {
+  let sum = 0
+  for (const item of buffer) {
+    sum += Buffer.byteLength(item, 'utf8')
+  }
+  return sum
 }
 
 export function formatDate(date: Date): string {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -63,7 +63,7 @@ function createLogger(env: Env): Logger {
       node: env.string('ES_NODE'),
       apiKey: env.string('ES_API_KEY'),
       indexPrefix: env.string('ES_INDEX_PREFIX'),
-      bufferMaxBytes: env.optionalInteger('ES_BUFFER_MAX_BYTES'),
+      bufferAlertBytes: env.optionalInteger('ES_BUFFER_ALERT_BYTES'),
       flushInterval: env.optionalInteger('ES_FLUSH_INTERVAL'),
     }
 

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -63,7 +63,7 @@ function createLogger(env: Env): Logger {
       node: env.string('ES_NODE'),
       apiKey: env.string('ES_API_KEY'),
       indexPrefix: env.string('ES_INDEX_PREFIX'),
-      bufferLimit: env.optionalInteger('ES_BUFFER_LIMIT'),
+      bufferMaxBytes: env.optionalInteger('ES_BUFFER_MAX_BYTES'),
       flushInterval: env.optionalInteger('ES_FLUSH_INTERVAL'),
     }
 

--- a/packages/frontend/src/env.ts
+++ b/packages/frontend/src/env.ts
@@ -59,7 +59,7 @@ const SERVER_CONFIG = {
     .optional(),
   ES_API_KEY: z.string().optional(),
   ES_INDEX_PREFIX: z.string().optional(),
-  ES_BUFFER_LIMIT: z
+  ES_BUFFER_MAX_BYTES: z
     .unknown()
     .transform((v) => Number(v))
     .optional(),
@@ -130,7 +130,7 @@ function getRawEnv(): Record<
     ES_NODE: process.env.ES_NODE,
     ES_API_KEY: process.env.ES_API_KEY,
     ES_INDEX_PREFIX: process.env.ES_INDEX_PREFIX,
-    ES_BUFFER_LIMIT: process.env.ES_BUFFER_LIMIT,
+    ES_BUFFER_MAX_BYTES: process.env.ES_BUFFER_MAX_BYTES,
     ES_FLUSH_INTERVAL: process.env.ES_FLUSH_INTERVAL,
     LOG_LEVEL: process.env.LOG_LEVEL,
     INTEROP_DISABLED_CHAINS: process.env.INTEROP_DISABLED_CHAINS,

--- a/packages/frontend/src/env.ts
+++ b/packages/frontend/src/env.ts
@@ -59,7 +59,7 @@ const SERVER_CONFIG = {
     .optional(),
   ES_API_KEY: z.string().optional(),
   ES_INDEX_PREFIX: z.string().optional(),
-  ES_BUFFER_MAX_BYTES: z
+  ES_BUFFER_ALERT_BYTES: z
     .unknown()
     .transform((v) => Number(v))
     .optional(),
@@ -130,7 +130,7 @@ function getRawEnv(): Record<
     ES_NODE: process.env.ES_NODE,
     ES_API_KEY: process.env.ES_API_KEY,
     ES_INDEX_PREFIX: process.env.ES_INDEX_PREFIX,
-    ES_BUFFER_MAX_BYTES: process.env.ES_BUFFER_MAX_BYTES,
+    ES_BUFFER_ALERT_BYTES: process.env.ES_BUFFER_ALERT_BYTES,
     ES_FLUSH_INTERVAL: process.env.ES_FLUSH_INTERVAL,
     LOG_LEVEL: process.env.LOG_LEVEL,
     INTEROP_DISABLED_CHAINS: process.env.INTEROP_DISABLED_CHAINS,

--- a/packages/frontend/src/server/utils/logger.ts
+++ b/packages/frontend/src/server/utils/logger.ts
@@ -38,7 +38,7 @@ export function getLogger(): Logger {
       node: env.ES_NODE,
       apiKey: env.ES_API_KEY,
       indexPrefix: env.ES_INDEX_PREFIX,
-      bufferMaxBytes: env.ES_BUFFER_MAX_BYTES,
+      bufferAlertBytes: env.ES_BUFFER_ALERT_BYTES,
       flushInterval: env.ES_FLUSH_INTERVAL,
     }
 

--- a/packages/frontend/src/server/utils/logger.ts
+++ b/packages/frontend/src/server/utils/logger.ts
@@ -38,7 +38,7 @@ export function getLogger(): Logger {
       node: env.ES_NODE,
       apiKey: env.ES_API_KEY,
       indexPrefix: env.ES_INDEX_PREFIX,
-      bufferLimit: env.ES_BUFFER_LIMIT,
+      bufferMaxBytes: env.ES_BUFFER_MAX_BYTES,
       flushInterval: env.ES_FLUSH_INTERVAL,
     }
 

--- a/packages/public-api/src/utils/logger/createLogger.ts
+++ b/packages/public-api/src/utils/logger/createLogger.ts
@@ -27,7 +27,7 @@ export function createLogger(env: Env): Logger {
       node: env.string('ES_NODE'),
       apiKey: env.string('ES_API_KEY'),
       indexPrefix: env.string('ES_INDEX_PREFIX'),
-      bufferMaxBytes: env.optionalInteger('ES_BUFFER_MAX_BYTES'),
+      bufferAlertBytes: env.optionalInteger('ES_BUFFER_ALERT_BYTES'),
       flushInterval: env.optionalInteger('ES_FLUSH_INTERVAL'),
     }
 

--- a/packages/public-api/src/utils/logger/createLogger.ts
+++ b/packages/public-api/src/utils/logger/createLogger.ts
@@ -27,7 +27,7 @@ export function createLogger(env: Env): Logger {
       node: env.string('ES_NODE'),
       apiKey: env.string('ES_API_KEY'),
       indexPrefix: env.string('ES_INDEX_PREFIX'),
-      bufferLimit: env.optionalInteger('ES_BUFFER_LIMIT'),
+      bufferMaxBytes: env.optionalInteger('ES_BUFFER_MAX_BYTES'),
       flushInterval: env.optionalInteger('ES_FLUSH_INTERVAL'),
     }
 

--- a/packages/token-backend/src/logger/index.ts
+++ b/packages/token-backend/src/logger/index.ts
@@ -33,7 +33,7 @@ export function getLogger(): Logger {
       node: env.string('ES_NODE'),
       apiKey: env.string('ES_API_KEY'),
       indexPrefix: env.string('ES_INDEX_PREFIX'),
-      bufferLimit: env.optionalInteger('ES_BUFFER_LIMIT'),
+      bufferMaxBytes: env.optionalInteger('ES_BUFFER_MAX_BYTES'),
       flushInterval: env.optionalInteger('ES_FLUSH_INTERVAL'),
     }
 

--- a/packages/token-backend/src/logger/index.ts
+++ b/packages/token-backend/src/logger/index.ts
@@ -33,7 +33,7 @@ export function getLogger(): Logger {
       node: env.string('ES_NODE'),
       apiKey: env.string('ES_API_KEY'),
       indexPrefix: env.string('ES_INDEX_PREFIX'),
-      bufferMaxBytes: env.optionalInteger('ES_BUFFER_MAX_BYTES'),
+      bufferAlertBytes: env.optionalInteger('ES_BUFFER_ALERT_BYTES'),
       flushInterval: env.optionalInteger('ES_FLUSH_INTERVAL'),
     }
 


### PR DESCRIPTION
## Summary

- **`bufferAlertBytes`** (default **128 MiB**, env **`ES_BUFFER_ALERT_BYTES`**) is the UTF-8 size threshold for a **CRITICAL** ECS event when buffered data exceeds it; the **full** buffer is still shipped (no trimming).
- Replaces legacy **`ES_BUFFER_LIMIT`** (line count) with **`ES_BUFFER_ALERT_BYTES`** to reflect alert-only semantics.
- Overflow handling lives in **`flushLogs`** (not on `push`).