### PR TITLE
Coolify check-env CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,26 @@ L2BEAT (Layer 2 Beat) is a website dedicated to providing research and statistic
 
 You can visit the site yourself at https://www.l2beat.com/.
 
+## Scripts
+
+### Coolify: check environment variables
+
+[`scripts/coolify/check-env.ts`](scripts/coolify/check-env.ts) lists every application on your [Coolify](https://coolify.io/) instance (via the HTTP API) and checks whether each one defines a given environment variable **by key** (exact match). Output uses `project/environment/application` labels when project and environment metadata are available.
+
+From the repository root:
+
+```bash
+pnpm coolify:check-env SOME_ENV_VAR
+```
+
+**Configuration**
+
+- Loads [dotenv](https://github.com/motdotla/dotenv) from the **repo root** `.env` if present.
+- **`COOLIFY_API_KEY`** (required): Coolify API token (Keys & Tokens → API tokens). Pass with `--api-key` or set in `.env` / the environment.
+- **`COOLIFY_SERVER`** (optional): Coolify base URL. Defaults to `https://coolify.l2beat.com`; override with `--server` / `-s` or `COOLIFY_SERVER`.
+
+Run `pnpm coolify:check-env --help` for full CLI options.
+
 ## Contributing
 
 We welcome and encourage contributions. To learn about the project structure and contributions please read [`CONTRIBUTING.md`](https://github.com/l2beat/l2beat/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ You can visit the site yourself at https://www.l2beat.com/.
 
 [`scripts/coolify/check-env.ts`](scripts/coolify/check-env.ts) lists every application on your [Coolify](https://coolify.io/) instance (via the HTTP API) and checks whether each one defines a given environment variable **by key** (exact match). Output uses `project/environment/application` labels when project and environment metadata are available.
 
+It is especially handy when you are changing, rotating, or cleaning up a variable and you are not sure which application still uses it—before you had to click through Coolify apps by hand; this script checks all of them in one run.
+
 From the repository root:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -55,12 +55,16 @@
     "typecheck": "turbo run typecheck",
     "ci:check": "turbo run ci:check",
     "heroku-postbuild": "pnpm build:backend && pnpm install --production",
-    "checkout": "pnpm clean && pnpm && pnpm build"
+    "checkout": "pnpm clean && pnpm && pnpm build",
+    "coolify:check-env": "node -r esbuild-register scripts/coolify/check-env.ts"
   },
   "devDependencies": {
+    "@l2beat/validate": "workspace:*",
     "@biomejs/biome": "2.3.8",
     "@changesets/cli": "^2.26.2",
     "@sinonjs/fake-timers": "^10.0.2",
+    "cmd-ts": "^0.13.0",
+    "dotenv": "^16.4.5",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.11.16",
     "@types/sinonjs__fake-timers": "^8.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.26.2
         version: 2.27.9
+      '@l2beat/validate':
+        specifier: workspace:*
+        version: link:packages/validate
       '@sinonjs/fake-timers':
         specifier: ^10.0.2
         version: 10.3.0
@@ -30,6 +33,12 @@ importers:
       '@types/sinonjs__fake-timers':
         specifier: ^8.1.2
         version: 8.1.5
+      cmd-ts:
+        specifier: ^0.13.0
+        version: 0.13.0
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       earl:
         specifier: ^1.1.0
         version: 1.3.0

--- a/scripts/coolify/CoolifyClient.ts
+++ b/scripts/coolify/CoolifyClient.ts
@@ -1,0 +1,158 @@
+import { v } from '@l2beat/validate'
+
+export const CoolifyProjectSchema = v.object({
+  uuid: v.string(),
+  name: v.string().optional(),
+})
+
+export const CoolifyEnvironmentSchema = v.object({
+  id: v.number(),
+  name: v.string().optional(),
+})
+
+export const CoolifyApplicationSchema = v.object({
+  uuid: v.string(),
+  name: v.string().optional(),
+  environment_id: v.number().optional(),
+})
+
+export const CoolifyEnvRowSchema = v.object({
+  key: v.string().optional(),
+})
+
+const ProjectsListSchema = v.array(CoolifyProjectSchema)
+const EnvironmentsListSchema = v.array(CoolifyEnvironmentSchema)
+const ApplicationsListSchema = v.array(CoolifyApplicationSchema)
+const EnvsListSchema = v.array(CoolifyEnvRowSchema)
+
+export type CoolifyProject = v.infer<typeof CoolifyProjectSchema>
+export type CoolifyEnvironment = v.infer<typeof CoolifyEnvironmentSchema>
+export type CoolifyApplication = v.infer<typeof CoolifyApplicationSchema>
+export type CoolifyEnvRow = v.infer<typeof CoolifyEnvRowSchema>
+
+type CoolifyFetchReason = 'network' | 'bad_status' | 'bad_json'
+
+type CoolifyResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; reason: CoolifyFetchReason }
+
+export type EnvironmentLabelMap = Map<number, { project: string; env: string }>
+
+export class CoolifyClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string,
+  ) {}
+
+  async listProjects(): Promise<CoolifyResult<CoolifyProject[]>> {
+    const r = await this.fetchJson(this.apiUrl('/projects'))
+    if (!r.ok) {
+      return r
+    }
+    const parsed = ProjectsListSchema.safeParse(r.data)
+    if (!parsed.success) {
+      return { ok: false, reason: 'bad_json' }
+    }
+    return { ok: true, data: parsed.data }
+  }
+
+  async getEnvironments(
+    projectUuid: string,
+  ): Promise<CoolifyResult<CoolifyEnvironment[]>> {
+    const r = await this.fetchJson(
+      this.apiUrl(`/projects/${projectUuid}/environments`),
+    )
+    if (!r.ok) {
+      return r
+    }
+    const parsed = EnvironmentsListSchema.safeParse(r.data)
+    if (!parsed.success) {
+      return { ok: false, reason: 'bad_json' }
+    }
+    return { ok: true, data: parsed.data }
+  }
+
+  async getApplications(): Promise<CoolifyResult<CoolifyApplication[]>> {
+    const r = await this.fetchJson(this.apiUrl('/applications'))
+    if (!r.ok) {
+      return r
+    }
+    const parsed = ApplicationsListSchema.safeParse(r.data)
+    if (!parsed.success) {
+      return { ok: false, reason: 'bad_json' }
+    }
+    return { ok: true, data: parsed.data }
+  }
+
+  async getApplicationEnvs(
+    applicationUuid: string,
+  ): Promise<CoolifyResult<CoolifyEnvRow[]>> {
+    const r = await this.fetchJson(
+      this.apiUrl(`/applications/${applicationUuid}/envs`),
+    )
+    if (!r.ok) {
+      return r
+    }
+    const parsed = EnvsListSchema.safeParse(r.data)
+    if (!parsed.success) {
+      return { ok: false, reason: 'bad_json' }
+    }
+    return { ok: true, data: parsed.data }
+  }
+
+  async getEnvironmentLabelMap(): Promise<CoolifyResult<EnvironmentLabelMap>> {
+    const projectsRes = await this.listProjects()
+    if (!projectsRes.ok) {
+      return projectsRes
+    }
+
+    const byEnvironmentId: EnvironmentLabelMap = new Map()
+
+    await Promise.all(
+      projectsRes.data.map(async (project) => {
+        const projectName = project.name ? project.name : '?'
+        const envRes = await this.getEnvironments(project.uuid)
+        if (!envRes.ok) {
+          return
+        }
+
+        for (const e of envRes.data) {
+          const envName = e.name && e.name.length > 0 ? e.name : '?'
+          byEnvironmentId.set(e.id, { project: projectName, env: envName })
+        }
+      }),
+    )
+
+    return { ok: true, data: byEnvironmentId }
+  }
+
+  private apiUrl(path: string): string {
+    const p = path.startsWith('/') ? path : `/${path}`
+    return `${this.baseUrl}/api/v1${p}`
+  }
+
+  private async fetchJson(url: string): Promise<CoolifyResult<unknown>> {
+    const headers = {
+      Authorization: `Bearer ${this.token}`,
+      Accept: 'application/json',
+    }
+
+    let res: Response
+    try {
+      res = await fetch(url, { headers })
+    } catch {
+      return { ok: false, reason: 'network' }
+    }
+
+    if (!res.ok) {
+      return { ok: false, reason: 'bad_status' }
+    }
+
+    try {
+      const data: unknown = await res.json()
+      return { ok: true, data }
+    } catch {
+      return { ok: false, reason: 'bad_json' }
+    }
+  }
+}

--- a/scripts/coolify/check-env.ts
+++ b/scripts/coolify/check-env.ts
@@ -1,0 +1,134 @@
+import { join } from 'node:path'
+import { command, option, positional, run, string } from 'cmd-ts'
+import { config as loadEnv } from 'dotenv'
+
+import {
+  type CoolifyApplication,
+  CoolifyClient,
+  type CoolifyEnvRow,
+  type EnvironmentLabelMap,
+} from './CoolifyClient'
+
+loadEnv({
+  path: join(__dirname, '../../.env'),
+})
+
+const args = {
+  envVarName: positional({
+    type: string,
+    displayName: 'envVarName',
+    description:
+      'Environment variable key to look for (exact match on Coolify key)',
+  }),
+  server: option({
+    type: string,
+    long: 'server',
+    short: 's',
+    env: 'COOLIFY_SERVER',
+    defaultValue: () => 'https://coolify.l2beat.com',
+    defaultValueIsSerializable: true,
+    description: 'Coolify base URL',
+  }),
+  apiKey: option({
+    type: string,
+    long: 'api-key',
+    defaultValue: () => process.env.COOLIFY_API_KEY?.trim() ?? '',
+    description: 'API token (uses COOLIFY_API_KEY when omitted)',
+  }),
+}
+
+const cmd = command({
+  name: 'check-env',
+  description:
+    'Check which Coolify applications define a given environment variable.',
+  args,
+  handler: async (cliArgs) => {
+    const base = cliArgs.server.trim()
+    const token = cliArgs.apiKey.trim()
+    if (!token) {
+      console.error('error: COOLIFY_API_KEY must be set or pass --api-key')
+      process.exit(1)
+    }
+
+    const client = new CoolifyClient(base, token)
+
+    const labelMapResult = await client.getEnvironmentLabelMap()
+    if (!labelMapResult.ok) {
+      console.error(
+        `FAIL list projects / environments (${labelMapResult.reason})`,
+      )
+      process.exit(1)
+    }
+
+    const listResult = await client.getApplications()
+    if (!listResult.ok) {
+      console.error(`FAIL list applications (${listResult.reason})`)
+      process.exit(1)
+    }
+
+    const { data: applications } = listResult
+    const { data: byEnvironmentId } = labelMapResult
+
+    if (applications.length === 0) {
+      console.log('no applications returned from API')
+      console.log('---')
+      console.log('OK: 0, MISSING: 0, FAILED: 0')
+      process.exit(0)
+    }
+
+    let ok = 0
+    let missing = 0
+    let failed = 0
+
+    for (const app of applications) {
+      const label = formatAppLabel(app, byEnvironmentId)
+      const result = await client.getApplicationEnvs(app.uuid)
+
+      if (!result.ok) {
+        console.error(`FAIL ${label}  (${result.reason})`)
+        failed++
+        continue
+      }
+
+      if (hasEnvKey(result.data, cliArgs.envVarName)) {
+        console.log(`OK   ${label}`)
+        ok++
+      } else {
+        console.log(`MISSING ${label}`)
+        missing++
+      }
+    }
+
+    console.log('---')
+    console.log(`OK: ${ok}, MISSING: ${missing}, FAILED: ${failed}`)
+
+    if (failed > 0 || missing > 0) {
+      process.exit(1)
+    }
+    process.exit(0)
+  },
+})
+
+run(cmd, process.argv.slice(2))
+
+function formatAppLabel(
+  app: CoolifyApplication,
+  byEnvironmentId: EnvironmentLabelMap,
+): string {
+  const appName = app.name ?? '?'
+
+  if (typeof app.environment_id !== 'number') {
+    return `?/?/${appName}`
+  }
+
+  const ctx = byEnvironmentId.get(app.environment_id)
+  if (!ctx) {
+    return `?/?/${appName}`
+  }
+
+  return `${ctx.project}/${ctx.env}/${appName}`
+}
+
+function hasEnvKey(rows: CoolifyEnvRow[], name: string): boolean {
+  return rows.some((row) => row.key === name)
+}

--- a/scripts/coolify/check-env.ts
+++ b/scripts/coolify/check-env.ts
@@ -102,9 +102,6 @@ const cmd = command({
     console.log('---')
     console.log(`OK: ${ok}, MISSING: ${missing}, FAILED: ${failed}`)
 
-    if (failed > 0 || missing > 0) {
-      process.exit(1)
-    }
     process.exit(0)
   },
 })


### PR DESCRIPTION
## Summary

Adds `pnpm coolify:check-env` — a small CLI that uses the Coolify HTTP API to list applications and verify whether each defines a given environment variable **by key** (exact match). Rows are labeled `project/environment/application` when metadata is available.

## Implementation

- `scripts/coolify/CoolifyClient.ts` — API calls and `@l2beat/validate` response schemas
- `scripts/coolify/check-env.ts` — cmd-ts entrypoint, loads repo-root `.env` via dotenv
- Root `package.json` script and devDependencies: `cmd-ts`, `dotenv`, `@l2beat/validate`
- README section with usage and configuration

## Usage

```bash
pnpm coolify:check-env SOME_ENV_VAR
```

Requires `COOLIFY_API_KEY` (or `--api-key`). Optional `COOLIFY_SERVER` / `--server` (default documented in README).

Made with [Cursor](https://cursor.com)