### PR TITLE
Fix activity count formatting in ScalingProjectStats

### DIFF
--- a/packages/frontend/src/pages/scaling/project/components/ScalingProjectStats.tsx
+++ b/packages/frontend/src/pages/scaling/project/components/ScalingProjectStats.tsx
@@ -21,6 +21,7 @@ import {
 import { RoundedWarningIcon } from '~/icons/RoundedWarning'
 import type { ProjectScalingEntry } from '~/server/features/scaling/project/getScalingProjectEntry'
 import { cn } from '~/utils/cn'
+import { formatActivityCount } from '~/utils/number-format/formatActivityCount'
 import { formatCurrency } from '~/utils/number-format/formatCurrency'
 
 interface Props {
@@ -83,7 +84,7 @@ export function ProjectScalingStats({ project, className }: Props) {
             className="text-nowrap font-medium! text-base! leading-[100%]!"
             changeClassName="text-label-value-14 font-bold"
           >
-            {project.header.activity.lastDayUops.toFixed(2)}
+            {formatActivityCount(project.header.activity.lastDayUops)}
           </ValueWithPercentageChange>
         ) : (
           <NoDataBadge />


### PR DESCRIPTION
Before (value = 0.002345):
<img width="346" height="214" alt="image" src="https://github.com/user-attachments/assets/a783abb6-2df4-48d4-8610-0ec252982fd2" />

After:
<img width="329" height="197" alt="image" src="https://github.com/user-attachments/assets/ecf5649a-9c7e-4b28-a630-fcbde37928d7" />
