### PR TITLE
Add RPC fallback for deployment timestamp fetch

### DIFF
--- a/packages/token-backend/src/chains/clients/rpc/RpcClient.ts
+++ b/packages/token-backend/src/chains/clients/rpc/RpcClient.ts
@@ -1,11 +1,12 @@
-import { v } from '@l2beat/validate'
+import { UnixTime } from '@l2beat/shared-pure'
+import { type Validator, v } from '@l2beat/validate'
 import {
   decodeFunctionResult,
   encodeFunctionData,
   type Hex,
   parseAbi,
 } from 'viem'
-import type { RpcClientConfig, RpcResponse } from './types'
+import type { RpcClientConfig } from './types'
 
 const DECIMALS_ABI = parseAbi(['function decimals() view returns (uint8)'])
 const SYMBOL_ABI = parseAbi(['function symbol() view returns (string)'])
@@ -13,10 +14,10 @@ const SYMBOL_BYTES32_ABI = parseAbi([
   'function symbol() view returns (bytes32)',
 ])
 
-const RpcResponseSchema = v.object({
+const RpcEnvelopeSchema = v.object({
   id: v.union([v.string(), v.number()]),
   jsonrpc: v.string(),
-  result: v.string().optional(),
+  result: v.unknown().optional(),
   error: v
     .object({
       code: v.number(),
@@ -25,15 +26,21 @@ const RpcResponseSchema = v.object({
     .optional(),
 })
 
+const HexStringSchema = v
+  .string()
+  .check((s): s is Hex => s.startsWith('0x'), 'expected 0x-prefixed hex string')
+
+const BlockSchema = v.object({
+  timestamp: HexStringSchema,
+})
+
 export class RpcClient {
   constructor(private readonly config: RpcClientConfig) {}
 
   async test(): Promise<{ success: boolean; error?: string }> {
     try {
-      const response = await this.query('eth_blockNumber', [])
-      return {
-        success: response.result !== undefined && !response.error,
-      }
+      await this.query('eth_blockNumber', [], HexStringSchema)
+      return { success: true }
     } catch (error) {
       if (error instanceof Error) {
         return {
@@ -57,9 +64,9 @@ export class RpcClient {
       }),
     }
 
-    const response = await this.call(callData, 'latest')
+    const result = await this.call(callData, 'latest')
 
-    if (!response.result || response.result === '0x') {
+    if (result === '0x') {
       throw new Error(
         `Could not get decimals for token ${address} for URL ${this.config.url}`,
       )
@@ -69,13 +76,13 @@ export class RpcClient {
       decodeFunctionResult({
         abi: DECIMALS_ABI,
         functionName: 'decimals',
-        data: response.result as Hex,
+        data: result,
       }),
     )
 
     if (Number.isNaN(decimals)) {
       throw new Error(
-        `Invalid decimals response for token ${address} for URL ${this.config.url}: ${response.result}`,
+        `Invalid decimals response for token ${address} for URL ${this.config.url}: ${result}`,
       )
     }
 
@@ -91,9 +98,9 @@ export class RpcClient {
       }),
     }
 
-    const response = await this.call(callData, 'latest')
+    const result = await this.call(callData, 'latest')
 
-    if (!response.result || response.result === '0x') {
+    if (result === '0x') {
       throw new Error(
         `Could not get symbol for token ${address} for URL ${this.config.url}`,
       )
@@ -103,12 +110,12 @@ export class RpcClient {
       const symbol = decodeFunctionResult({
         abi: SYMBOL_ABI,
         functionName: 'symbol',
-        data: response.result as Hex,
+        data: result,
       })
 
       if (!symbol) {
         throw new Error(
-          `Invalid symbol response for token ${address} for URL ${this.config.url}: ${response.result}`,
+          `Invalid symbol response for token ${address} for URL ${this.config.url}: ${result}`,
         )
       }
 
@@ -120,7 +127,7 @@ export class RpcClient {
     const bytes32Symbol = decodeFunctionResult({
       abi: SYMBOL_BYTES32_ABI,
       functionName: 'symbol',
-      data: response.result as Hex,
+      data: result,
     })
     const symbol = Buffer.from(bytes32Symbol.slice(2), 'hex')
       .toString('utf8')
@@ -128,24 +135,54 @@ export class RpcClient {
 
     if (!symbol) {
       throw new Error(
-        `Invalid symbol response for token ${address} for URL ${this.config.url}: ${response.result}`,
+        `Invalid symbol response for token ${address} for URL ${this.config.url}: ${result}`,
       )
     }
 
     return symbol
   }
 
+  async getBlockNumber(): Promise<number> {
+    const result = await this.query('eth_blockNumber', [], HexStringSchema)
+    return Number.parseInt(result, 16)
+  }
+
+  async getCode(
+    address: string,
+    blockNumber: 'latest' | number,
+  ): Promise<string> {
+    return await this.query(
+      'eth_getCode',
+      [address, encodeBlock(blockNumber)],
+      HexStringSchema,
+    )
+  }
+
+  async getBlockTimestamp(blockNumber: number): Promise<UnixTime> {
+    const block = await this.query(
+      'eth_getBlockByNumber',
+      [encodeBlock(blockNumber), false],
+      BlockSchema,
+    )
+    return UnixTime(Number.parseInt(block.timestamp, 16))
+  }
+
   private async call(
     callData: { to: string; data: string },
     blockNumber: 'latest' | number,
-  ): Promise<RpcResponse> {
-    const blockParam =
-      blockNumber === 'latest' ? 'latest' : `0x${blockNumber.toString(16)}`
-
-    return await this.query('eth_call', [callData, blockParam])
+  ): Promise<Hex> {
+    return await this.query(
+      'eth_call',
+      [callData, encodeBlock(blockNumber)],
+      HexStringSchema,
+    )
   }
 
-  private async query(method: string, params: unknown[]): Promise<RpcResponse> {
+  private async query<T>(
+    method: string,
+    params: unknown[],
+    resultSchema: Validator<T>,
+  ): Promise<T> {
     const body = {
       jsonrpc: '2.0',
       id: 1,
@@ -168,14 +205,18 @@ export class RpcClient {
     }
 
     const data = await response.json()
-    const parsed = RpcResponseSchema.parse(data)
+    const envelope = RpcEnvelopeSchema.parse(data)
 
-    if (parsed.error) {
+    if (envelope.error) {
       throw new Error(
-        `RPC error: ${parsed.error.code} - ${parsed.error.message}`,
+        `RPC error: ${envelope.error.code} - ${envelope.error.message}`,
       )
     }
 
-    return parsed
+    return resultSchema.parse(envelope.result)
   }
+}
+
+function encodeBlock(blockNumber: 'latest' | number): string {
+  return blockNumber === 'latest' ? 'latest' : `0x${blockNumber.toString(16)}`
 }

--- a/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.test.ts
+++ b/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.test.ts
@@ -1,0 +1,35 @@
+import { expect, mockFn, mockObject } from 'earl'
+import { getDeploymentTimestampFromRpc } from './getDeploymentTimestampFromRpc'
+import type { RpcClient } from './RpcClient'
+
+describe(getDeploymentTimestampFromRpc.name, () => {
+  it('returns undefined when address has no code at head', async () => {
+    const rpc = mockObject<RpcClient>({
+      getBlockNumber: mockFn().resolvesTo(100),
+      getCode: mockFn().resolvesTo('0x'),
+      getBlockTimestamp: mockFn(),
+    })
+
+    const result = await getDeploymentTimestampFromRpc(rpc, '0xabc')
+
+    expect(result).toEqual(undefined)
+    expect(rpc.getBlockTimestamp).toHaveBeenCalledTimes(0)
+  })
+
+  it('bisects to the creation block and returns its timestamp', async () => {
+    const creationBlock = 37
+    const timestamp = 1700000000
+    const rpc = mockObject<RpcClient>({
+      getBlockNumber: mockFn().resolvesTo(100),
+      getCode: mockFn().executes(async (_: string, block: number) =>
+        block >= creationBlock ? '0xdead' : '0x',
+      ),
+      getBlockTimestamp: mockFn().resolvesTo(timestamp),
+    })
+
+    const result = await getDeploymentTimestampFromRpc(rpc, '0xabc')
+
+    expect(result).toEqual(timestamp)
+    expect(rpc.getBlockTimestamp).toHaveBeenCalledWith(creationBlock)
+  })
+})

--- a/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.test.ts
+++ b/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.test.ts
@@ -32,4 +32,24 @@ describe(getDeploymentTimestampFromRpc.name, () => {
     expect(result).toEqual(timestamp)
     expect(rpc.getBlockTimestamp).toHaveBeenCalledWith(creationBlock)
   })
+
+  it('returns undefined when the address has a non-monotonic code history', async () => {
+    // Code present in two disjoint ranges — e.g. a metamorphic contract
+    // that was deployed, SELFDESTRUCTed, then redeployed at the same address.
+    // Bisection converges to 37, but the earlier [5, 10] interval means we
+    // cannot trust that as the true first-deployment block.
+    const rpc = mockObject<RpcClient>({
+      getBlockNumber: mockFn().resolvesTo(100),
+      getCode: mockFn().executes(async (_: string, block: number) => {
+        const hasCode = (block >= 5 && block <= 10) || block >= 37
+        return hasCode ? '0xdead' : '0x'
+      }),
+      getBlockTimestamp: mockFn(),
+    })
+
+    const result = await getDeploymentTimestampFromRpc(rpc, '0xabc')
+
+    expect(result).toEqual(undefined)
+    expect(rpc.getBlockTimestamp).toHaveBeenCalledTimes(0)
+  })
 })

--- a/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.ts
+++ b/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.ts
@@ -1,0 +1,32 @@
+import type { UnixTime } from '@l2beat/shared-pure'
+import type { RpcClient } from './RpcClient'
+
+export async function getDeploymentTimestampFromRpc(
+  rpc: RpcClient,
+  address: string,
+): Promise<UnixTime | undefined> {
+  const latest = await rpc.getBlockNumber()
+  const codeAtLatest = await rpc.getCode(address, latest)
+  if (codeAtLatest === '0x') return undefined
+
+  const creationBlock = await bisectCreationBlock(rpc, address, 0, latest)
+  return rpc.getBlockTimestamp(creationBlock)
+}
+
+async function bisectCreationBlock(
+  rpc: RpcClient,
+  address: string,
+  min: number,
+  max: number,
+): Promise<number> {
+  while (min < max) {
+    const mid = Math.floor((min + max) / 2)
+    const code = await rpc.getCode(address, mid)
+    if (code !== '0x') {
+      max = mid
+    } else {
+      min = mid + 1
+    }
+  }
+  return min
+}

--- a/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.ts
+++ b/packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.ts
@@ -10,6 +10,16 @@ export async function getDeploymentTimestampFromRpc(
   if (codeAtLatest === '0x') return undefined
 
   const creationBlock = await bisectCreationBlock(rpc, address, 0, latest)
+
+  // Bisection assumes eth_getCode is monotonic — empty before deployment,
+  // non-empty forever after. Metamorphic contracts and SELFDESTRUCT+redeploy
+  // break that assumption, which would make the bisection result misleading
+  // rather than unknown. Sample the supposedly-empty prefix; if any sample
+  // has code we bail out instead of returning a confidently-wrong timestamp.
+  if (!(await hasEmptyPrefix(rpc, address, creationBlock))) {
+    return undefined
+  }
+
   return rpc.getBlockTimestamp(creationBlock)
 }
 
@@ -29,4 +39,22 @@ async function bisectCreationBlock(
     }
   }
   return min
+}
+
+async function hasEmptyPrefix(
+  rpc: RpcClient,
+  address: string,
+  creationBlock: number,
+): Promise<boolean> {
+  if (creationBlock <= 1) return true
+
+  const samples = new Set<number>([0])
+  for (let b = Math.floor(creationBlock / 2); b > 0; b = Math.floor(b / 2)) {
+    samples.add(b)
+  }
+
+  const codes = await Promise.all(
+    [...samples].map((b) => rpc.getCode(address, b)),
+  )
+  return codes.every((c) => c === '0x')
 }

--- a/packages/token-backend/src/chains/clients/rpc/types.ts
+++ b/packages/token-backend/src/chains/clients/rpc/types.ts
@@ -1,13 +1,3 @@
 export interface RpcClientConfig {
   url: string
 }
-
-export interface RpcResponse {
-  id: string | number
-  jsonrpc: string
-  result?: string
-  error?: {
-    code: number
-    message: string
-  }
-}

--- a/packages/token-backend/src/trpc/routers/deployedTokens/checkDeployedToken.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/checkDeployedToken.ts
@@ -7,6 +7,7 @@ import type { ChainRecord } from '@l2beat/database/dist/repositories/ChainReposi
 import { Address32, type UnixTime } from '@l2beat/shared-pure'
 import { Chain } from '../../../chains/Chain'
 import type { CoingeckoClient } from '../../../chains/clients/coingecko/CoingeckoClient'
+import { getDeploymentTimestampFromRpc } from '../../../chains/clients/rpc/getDeploymentTimestampFromRpc'
 import {
   buildAliasToChainMap,
   findUnregisteredPlatformTokens,
@@ -62,6 +63,14 @@ async function fetchDeploymentTimestamp(
       const txHash = contractCreation[0].txHash
       const txInfo = await chain.blockscout.getTransactionInfo(txHash)
       return txInfo.timeStamp
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  if (chain.rpc) {
+    try {
+      return await getDeploymentTimestampFromRpc(chain.rpc, address)
     } catch (error) {
       console.error(error)
     }

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
@@ -418,6 +418,126 @@ describe('deployedTokensRouter', () => {
       })
     })
 
+    it('falls back to rpc when no block explorer is configured', async () => {
+      const chainRecord = {
+        id: 1,
+        name: 'ethereum',
+        chainId: 1,
+        aliases: [],
+        apis: [],
+      }
+      const deploymentTimestamp = 1700000000
+      const mockCreateChain = mockFn().returns({
+        rpc: {
+          getDecimals: mockFn().resolvesTo(18),
+          getSymbol: mockFn().resolvesTo('TKN'),
+          getBlockNumber: mockFn().resolvesTo(100),
+          getCode: mockFn().executes(async (_: string, block: number) =>
+            block >= 50 ? '0xdead' : '0x',
+          ),
+          getBlockTimestamp: mockFn().resolvesTo(deploymentTimestamp),
+        },
+      })
+      const mockDb = mockObject<Database>({})
+      const mockTokenDb = mockObject<TokenDatabase>({
+        deployedToken: mockObject<DeployedTokenRepository>({
+          findByChainAndAddress: mockFn().resolvesTo(undefined),
+          getByChainsAndAddresses: mockFn().resolvesTo([]),
+        }),
+        chain: mockObject<ChainRepository>({
+          findByName: mockFn().resolvesTo(chainRecord),
+          getAll: mockFn().resolvesTo([chainRecord]),
+        }),
+        abstractToken: mockObject<AbstractTokenRepository>({
+          findByCoingeckoId: mockFn().resolvesTo(undefined),
+        }),
+      })
+      const mockCoingeckoClient = mockObject<CoingeckoClient>({
+        getCoinList: mockFn().resolvesTo([
+          {
+            id: 'token-id',
+            name: 'Token',
+            symbol: 'TKN',
+            platforms: { ethereum: '0x123' },
+          },
+        ]),
+      })
+
+      const caller = createRouter(mockTokenDb, mockDb, mockCoingeckoClient, {
+        createChain: mockCreateChain,
+      })
+      const result = await caller.checks({
+        chain: 'ethereum',
+        address: '0x123',
+      })
+
+      expect(result.data?.deploymentTimestamp).toEqual(deploymentTimestamp)
+    })
+
+    it('falls back to rpc when etherscan and blockscout throw', async () => {
+      const chainRecord = {
+        id: 1,
+        name: 'ethereum',
+        chainId: 1,
+        aliases: [],
+        apis: [],
+      }
+      const deploymentTimestamp = 1700000001
+      const mockCreateChain = mockFn().returns({
+        rpc: {
+          getDecimals: mockFn().resolvesTo(18),
+          getSymbol: mockFn().resolvesTo('TKN'),
+          getBlockNumber: mockFn().resolvesTo(100),
+          getCode: mockFn().executes(async (_: string, block: number) =>
+            block >= 50 ? '0xdead' : '0x',
+          ),
+          getBlockTimestamp: mockFn().resolvesTo(deploymentTimestamp),
+        },
+        etherscan: {
+          getContractCreation: mockFn().rejectsWith(new Error('etherscan 500')),
+        },
+        blockscout: {
+          getContractCreation: mockFn().rejectsWith(
+            new Error('blockscout 500'),
+          ),
+        },
+      })
+      const mockDb = mockObject<Database>({})
+      const mockTokenDb = mockObject<TokenDatabase>({
+        deployedToken: mockObject<DeployedTokenRepository>({
+          findByChainAndAddress: mockFn().resolvesTo(undefined),
+          getByChainsAndAddresses: mockFn().resolvesTo([]),
+        }),
+        chain: mockObject<ChainRepository>({
+          findByName: mockFn().resolvesTo(chainRecord),
+          getAll: mockFn().resolvesTo([chainRecord]),
+        }),
+        abstractToken: mockObject<AbstractTokenRepository>({
+          findByCoingeckoId: mockFn().resolvesTo(undefined),
+        }),
+      })
+      const mockCoingeckoClient = mockObject<CoingeckoClient>({
+        getCoinList: mockFn().resolvesTo([
+          {
+            id: 'token-id',
+            name: 'Token',
+            symbol: 'TKN',
+            platforms: { ethereum: '0x123' },
+          },
+        ]),
+      })
+
+      const caller = createRouter(mockTokenDb, mockDb, mockCoingeckoClient, {
+        createChain: mockCreateChain,
+      })
+      const result = await caller.checks({
+        chain: 'ethereum',
+        address: '0x123',
+      })
+
+      expect(result.data?.deploymentTimestamp).toEqual(deploymentTimestamp)
+    })
+
     it('includes rpc symbol and decimals in not-found-on-coingecko response', async () => {
       const chainRecord = {
         id: 1,


### PR DESCRIPTION
## Summary
- `fetchDeploymentTimestamp` now falls through to a pure JSON-RPC path (bisect via `eth_getCode`, then `eth_getBlockByNumber`) when Etherscan/Blockscout are unavailable or both throw.
- Refactored `RpcClient.query` to take a result schema so every RPC response is validated in one place, removing ad-hoc `typeof` checks and `String(...)` wrapping.
- New bisection helper lives in `packages/token-backend/src/chains/clients/rpc/getDeploymentTimestampFromRpc.ts`; covered by unit tests plus two new integration tests for the fallback paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolve L2B-13679