### PR TITLE
fix: correct command name for CompareSingleOpStackProjects

### DIFF
--- a/packages/l2b/src/commands/CompareOpStacks.ts
+++ b/packages/l2b/src/commands/CompareOpStacks.ts
@@ -4,7 +4,7 @@ import { analyzeAllOpStackChains } from '../implementations/compareOpStacks'
 import { discoveryPath } from './args'
 
 const CompareSingleOpStackProjects = command({
-  name: 'compare-op-stacks-all',
+  name: 'compare-op-stacks-single',
   description:
     'Compare semantic versioning in all projects using the op stack.',
   version: '1.0.0',


### PR DESCRIPTION
CompareSingleOpStackProjects had name compare-op-stacks-all instead of compare-op-stacks-single, duplicating the name of CompareAllOpStackProjects.