### PR TITLE
Remove isScaling from config

### DIFF
--- a/packages/backend/src/modules/update-monitor/UpdateNotifier.ts
+++ b/packages/backend/src/modules/update-monitor/UpdateNotifier.ts
@@ -241,7 +241,7 @@ export async function generateTemplatizedStatus(): Promise<string> {
   const ps = new ProjectService()
   const scaling = await ps.getProjects({
     select: ['scalingInfo', 'discoveryInfo'],
-    where: ['isScaling'],
+    where: ['scalingInfo'],
     whereNot: ['isUpcoming', 'archivedAt'],
   })
 

--- a/packages/config/src/ProjectDatabase.test.ts
+++ b/packages/config/src/ProjectDatabase.test.ts
@@ -8,7 +8,7 @@ import {
 import { expect } from 'earl'
 import { unlinkSync } from 'fs'
 import { ProjectDatabase } from './ProjectDatabase'
-import type { BaseProject } from './types'
+import type { BaseProject, ProjectScalingInfo } from './types'
 
 describe(ProjectDatabase.name, () => {
   let db: ProjectDatabase
@@ -60,7 +60,7 @@ describe(ProjectDatabase.name, () => {
       name: 'b',
       shortName: undefined,
       addedAt: 0,
-      isScaling: true,
+      scalingInfo: {} as ProjectScalingInfo,
     }
     const projectC: BaseProject = {
       id: ProjectId('c'),
@@ -75,8 +75,8 @@ describe(ProjectDatabase.name, () => {
     await db.saveProject(projectC)
 
     const result = await db.getProjects({
-      select: ['isScaling'],
-      whereNotNull: ['isScaling'],
+      select: ['scalingInfo'],
+      whereNotNull: ['scalingInfo'],
       whereNull: [],
     })
 

--- a/packages/config/src/ProjectDatabase.ts
+++ b/packages/config/src/ProjectDatabase.ts
@@ -67,7 +67,6 @@ const schema = {
   contracts: 'TEXT',
   discoveryInfo: 'TEXT',
 
-  isScaling: 'BOOLEAN',
   isDaLayer: 'BOOLEAN',
   isInteropProtocol: 'BOOLEAN',
   isUpcoming: 'BOOLEAN',

--- a/packages/config/src/ProjectService.test.ts
+++ b/packages/config/src/ProjectService.test.ts
@@ -3,7 +3,7 @@ import { expect } from 'earl'
 import { unlinkSync } from 'fs'
 import { ProjectDatabase } from './ProjectDatabase'
 import { ProjectService } from './ProjectService'
-import type { BaseProject } from './types'
+import type { BaseProject, ProjectScalingInfo } from './types'
 
 describe(ProjectService.name, () => {
   const projects: BaseProject[] = [
@@ -13,7 +13,7 @@ describe(ProjectService.name, () => {
       name: 'Foo Chain',
       shortName: undefined,
       addedAt: 0,
-      isScaling: true,
+      scalingInfo: {} as ProjectScalingInfo,
       archivedAt: UnixTime(1112470620),
     },
     {
@@ -22,7 +22,7 @@ describe(ProjectService.name, () => {
       name: 'Bar Network',
       shortName: 'Bar',
       addedAt: 0,
-      isScaling: true,
+      scalingInfo: {} as ProjectScalingInfo,
     },
   ]
 
@@ -69,7 +69,7 @@ describe(ProjectService.name, () => {
     const ps = new ProjectService(TEMP_PATH)
     const result = await ps.getProject({
       id: ProjectId('foo'),
-      select: ['isScaling'],
+      select: ['scalingInfo'],
       optional: ['archivedAt'],
     })
     expect(result).toEqual({
@@ -78,7 +78,7 @@ describe(ProjectService.name, () => {
       name: 'Foo Chain',
       shortName: undefined,
       addedAt: 0,
-      isScaling: true,
+      scalingInfo: {} as ProjectScalingInfo,
       archivedAt: UnixTime(1112470620),
     })
   })
@@ -86,7 +86,7 @@ describe(ProjectService.name, () => {
   it('returns multiple projects', async () => {
     const ps = new ProjectService(TEMP_PATH)
     const result = await ps.getProjects({
-      select: ['isScaling'],
+      select: ['scalingInfo'],
       optional: ['archivedAt'],
     })
     expect(result).toEqual([
@@ -96,7 +96,7 @@ describe(ProjectService.name, () => {
         name: 'Foo Chain',
         shortName: undefined,
         addedAt: 0,
-        isScaling: true,
+        scalingInfo: {} as ProjectScalingInfo,
         archivedAt: UnixTime(1112470620),
       },
       {
@@ -105,7 +105,7 @@ describe(ProjectService.name, () => {
         name: 'Bar Network',
         shortName: 'Bar',
         addedAt: 0,
-        isScaling: true,
+        scalingInfo: {} as ProjectScalingInfo,
         archivedAt: undefined,
       },
     ])

--- a/packages/config/src/processing/getProjects.test.ts
+++ b/packages/config/src/processing/getProjects.test.ts
@@ -274,7 +274,7 @@ describe('getProjects', () => {
     }
 
     for (const project of projects) {
-      if (!project.isScaling || !project.contracts?.zkVerifiers) continue
+      if (!project.scalingInfo || !project.contracts?.zkVerifiers) continue
       for (const verifier of project.contracts.zkVerifiers) {
         it(`${project.id} verifier ${verifier} is in at least one zk catalog project`, () => {
           expect(zkCatalogAddresses.has(verifier)).toEqual(true)
@@ -719,9 +719,7 @@ describe('getProjects', () => {
   describe('all new projects are discovery driven', () => {
     const isNormalProject = (p: BaseProject) => {
       return (
-        p.isScaling === true &&
-        p.archivedAt === undefined &&
-        p.isUpcoming !== true
+        p.scalingInfo && p.archivedAt === undefined && p.isUpcoming !== true
       )
     }
 
@@ -791,7 +789,8 @@ function getUsageMap(projects: BaseProject[]) {
   }
 
   for (const project of projects) {
-    if (!(project.isScaling || project.daBridge) || !project.contracts) continue
+    if (!(project.scalingInfo || project.daBridge) || !project.contracts)
+      continue
 
     for (const [, contracts] of Object.entries(project.contracts.addresses)) {
       for (const contract of contracts) {

--- a/packages/config/src/processing/getProjects.ts
+++ b/packages/config/src/processing/getProjects.ts
@@ -158,7 +158,6 @@ function layer2Or3ToProject(p: ScalingProject): BaseProject {
     ecosystemInfo: p.ecosystemInfo,
     interopConfig: p.interopConfig,
     // tags
-    isScaling: true,
     isInteropProtocol: p.interopConfig ? true : undefined,
     archivedAt: p.archivedAt,
     isUpcoming: p.isUpcoming ? true : undefined,

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -131,7 +131,6 @@ export interface BaseProject {
   discoveryInfo?: ProjectDiscoveryInfo
 
   // tags
-  isScaling?: true
   isInteropProtocol?: true
   isDaLayer?: true
   isUpcoming?: true

--- a/packages/frontend/scripts/opengraph-images/index.test.ts
+++ b/packages/frontend/scripts/opengraph-images/index.test.ts
@@ -8,7 +8,7 @@ import { getOpengraphProjectTypes } from './projects/generateProjectOgImages'
 describe('opengraph images', () => {
   it('should contain project page opengraph images for all projects', async () => {
     const projects = await ps.getProjects({
-      optional: ['isScaling', 'isDaLayer', 'zkCatalogInfo', 'interopConfig'],
+      optional: ['scalingInfo', 'isDaLayer', 'zkCatalogInfo', 'interopConfig'],
     })
 
     const missingProjects = projects

--- a/packages/frontend/scripts/opengraph-images/projects/generateProjectOgImages.tsx
+++ b/packages/frontend/scripts/opengraph-images/projects/generateProjectOgImages.tsx
@@ -14,7 +14,7 @@ export async function generateProjectOgImages(
   },
 ) {
   const projects = await ps.getProjects({
-    optional: ['isScaling', 'isDaLayer', 'zkCatalogInfo', 'interopConfig'],
+    optional: ['scalingInfo', 'isDaLayer', 'zkCatalogInfo', 'interopConfig'],
   })
 
   for (const project of projects) {
@@ -93,12 +93,12 @@ async function generateProjectOgImage(
 export function getOpengraphProjectTypes(
   project: Project<
     never,
-    'isScaling' | 'isDaLayer' | 'zkCatalogInfo' | 'interopConfig'
+    'scalingInfo' | 'isDaLayer' | 'zkCatalogInfo' | 'interopConfig'
   >,
 ) {
   const types: ('scaling' | 'zk-catalog' | 'data-availability' | 'interop')[] =
     []
-  if (project.isScaling) {
+  if (project.scalingInfo) {
     types.push('scaling')
   }
   if (project.zkCatalogInfo) {

--- a/packages/frontend/scripts/test-all-pages/index.ts
+++ b/packages/frontend/scripts/test-all-pages/index.ts
@@ -11,7 +11,7 @@ async function main() {
     zkCatalogProjects,
   ] = await Promise.all([
     ps.getProjects({
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       optional: ['tvsConfig'],
     }),
     ps.getProjects({

--- a/packages/frontend/src/server/features/data-availability/throughput/getDaThroughputChartByProject.ts
+++ b/packages/frontend/src/server/features/data-availability/throughput/getDaThroughputChartByProject.ts
@@ -230,7 +230,7 @@ async function getMockDaThroughputChartByProject({
   const timestamps = generateTimestamps([from, to], 'daily')
   const value = () => Math.random() * 900_000_000 + 90_000_000
 
-  const projects = (await ps.getProjects({ where: ['isScaling'] }))
+  const projects = (await ps.getProjects({ where: ['scalingInfo'] }))
     .map((p) => p.name)
     .slice(0, 50)
 

--- a/packages/frontend/src/server/features/data-availability/utils/getDaProjectsTvs.ts
+++ b/packages/frontend/src/server/features/data-availability/utils/getDaProjectsTvs.ts
@@ -44,7 +44,7 @@ export function pickTvsForProjects(
 }
 
 async function getMockDaProjectsTvsData(): Promise<DaProjectsTvs> {
-  const projects = await ps.getProjects({ where: ['isScaling'] })
+  const projects = await ps.getProjects({ where: ['scalingInfo'] })
   return projects.map((project) => ({
     projectId: project.id,
     tvs: 100000,

--- a/packages/frontend/src/server/features/ecosystems/getEcosystemEntry.ts
+++ b/packages/frontend/src/server/features/ecosystems/getEcosystemEntry.ts
@@ -138,7 +138,7 @@ export async function getEcosystemEntry(
 
   const [allScalingProjects, projects, zkCatalogProjects] = await Promise.all([
     ps.getProjects({
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['isUpcoming', 'archivedAt'],
     }),
     ps.getProjects({
@@ -161,7 +161,7 @@ export async function getEcosystemEntry(
         'hasTestnet',
         'contracts',
       ],
-      where: ['isScaling'],
+      where: ['scalingInfo'],
     }),
     ps.getProjects({
       select: ['zkCatalogInfo'],

--- a/packages/frontend/src/server/features/monthly-reports/getEcosystemEntries.ts
+++ b/packages/frontend/src/server/features/monthly-reports/getEcosystemEntries.ts
@@ -70,7 +70,7 @@ export interface EcosystemMonthlyUpdateEntry
 
 export async function getEcosystemMonthlyUpdateEntries(
   ecosystemUpdateEntries: EcosystemUpdate[],
-  allScalingProjects: Project<'isScaling'>[],
+  allScalingProjects: Project<'scalingInfo'>[],
   tvs: SevenDayTvsBreakdown,
   activity: ActivityLatestUopsData,
   from: UnixTime,
@@ -79,7 +79,7 @@ export async function getEcosystemMonthlyUpdateEntries(
   const [projects, ecosystems, newProjects] = await Promise.all([
     ps.getProjects({
       select: ['ecosystemInfo'],
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['isUpcoming', 'archivedAt'],
     }),
     ps.getProjects({

--- a/packages/frontend/src/server/features/monthly-reports/getMonthlyUpdateEntry.ts
+++ b/packages/frontend/src/server/features/monthly-reports/getMonthlyUpdateEntry.ts
@@ -35,7 +35,7 @@ export async function getMonthlyUpdateEntry(
   const to = UnixTime.fromDate(entry.data.endDate)
 
   const allScalingProjects = await ps.getProjects({
-    select: ['isScaling'],
+    select: ['scalingInfo'],
   })
 
   const [tvs, activity] = await Promise.all([

--- a/packages/frontend/src/server/features/projects/badges/getScalingBadgeDialogData.ts
+++ b/packages/frontend/src/server/features/projects/badges/getScalingBadgeDialogData.ts
@@ -23,7 +23,7 @@ export async function getScalingBadgeDialogData(input: {
 }): Promise<ScalingBadgeDialogData | undefined> {
   const projects = await ps.getProjects({
     select: ['display', 'scalingInfo'],
-    where: ['isScaling'],
+    where: ['scalingInfo'],
     whereNot: ['isUpcoming', 'archivedAt'],
   })
 

--- a/packages/frontend/src/server/features/projects/search-bar/getRecentlyAddedProjects.ts
+++ b/packages/frontend/src/server/features/projects/search-bar/getRecentlyAddedProjects.ts
@@ -9,7 +9,6 @@ export async function getRecentlyAddedProjects(): Promise<SearchBarProject[]> {
       'scalingInfo',
       'daLayer',
       'daBridge',
-      'isScaling',
       'isDaLayer',
       'ecosystemConfig',
       'interopConfig',

--- a/packages/frontend/src/server/features/projects/search-bar/getSearchBarProjects.test.ts
+++ b/packages/frontend/src/server/features/projects/search-bar/getSearchBarProjects.test.ts
@@ -52,7 +52,6 @@ function scalingProject(
     id: ProjectId(slug),
     slug,
     name,
-    isScaling: true,
     scalingInfo: {
       layer,
       type: scalingCategory,

--- a/packages/frontend/src/server/features/projects/search-bar/getSearchBarProjects.ts
+++ b/packages/frontend/src/server/features/projects/search-bar/getSearchBarProjects.ts
@@ -34,7 +34,6 @@ export async function getSearchBarProjects(search: string) {
       'scalingInfo',
       'daLayer',
       'daBridge',
-      'isScaling',
       'isDaLayer',
       'isUpcoming',
       'ecosystemConfig',

--- a/packages/frontend/src/server/features/projects/search-bar/utils/getSearchBarProjectEntries.ts
+++ b/packages/frontend/src/server/features/projects/search-bar/utils/getSearchBarProjectEntries.ts
@@ -36,7 +36,6 @@ export function getSearchBarProjectEntries<
     | 'daLayer'
     | 'daBridge'
     | 'interopConfig'
-    | 'isScaling'
     | 'isDaLayer'
     | 'ecosystemConfig'
     | 'zkCatalogInfo'
@@ -46,7 +45,7 @@ export function getSearchBarProjectEntries<
 >(project: T, allProjects: T[]): SearchBarProjectEntry[] {
   const results: SearchBarProjectEntry[] = []
   if (
-    !project.isScaling &&
+    !project.scalingInfo &&
     !project.daLayer &&
     !project.daBridge &&
     !project.ecosystemConfig &&
@@ -71,7 +70,7 @@ export function getSearchBarProjectEntries<
     tags: commonTags,
   } satisfies Partial<SearchBarProjectEntry>
 
-  if (project.isScaling) {
+  if (project.scalingInfo) {
     results.push({
       ...common,
       href: `/scaling/projects/${project.slug}`,

--- a/packages/frontend/src/server/features/scaling/activity/getScalingActivityEntries.ts
+++ b/packages/frontend/src/server/features/scaling/activity/getScalingActivityEntries.ts
@@ -20,7 +20,7 @@ export async function getScalingActivityEntries() {
   const unfilteredProjects = await ps.getProjects({
     select: ['statuses', 'scalingInfo', 'activityConfig', 'display'],
     optional: ['contracts'],
-    where: ['isScaling'],
+    where: ['scalingInfo'],
     whereNot: ['isUpcoming', 'archivedAt'],
   })
   const projects = unfilteredProjects.filter(

--- a/packages/frontend/src/server/features/scaling/archived/getScalingArchivedEntries.ts
+++ b/packages/frontend/src/server/features/scaling/archived/getScalingArchivedEntries.ts
@@ -24,7 +24,7 @@ export async function getScalingArchivedEntries() {
       ps.getProjects({
         select: ['statuses', 'scalingInfo', 'scalingRisks', 'display'],
         optional: ['contracts'],
-        where: ['isScaling', 'archivedAt'],
+        where: ['scalingInfo', 'archivedAt'],
       }),
       ps.getProjects({
         select: ['zkCatalogInfo'],

--- a/packages/frontend/src/server/features/scaling/costs/getScalingCostsEntries.ts
+++ b/packages/frontend/src/server/features/scaling/costs/getScalingCostsEntries.ts
@@ -21,7 +21,7 @@ export async function getScalingCostsEntries(helpers: SsrHelpers) {
     ps.getProjects({
       select: ['statuses', 'scalingInfo', 'costsInfo', 'display'],
       optional: ['contracts'],
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['isUpcoming', 'archivedAt'],
     }),
     helpers.costs.table.fetch({ range: optionToRange('30d') }),

--- a/packages/frontend/src/server/features/scaling/data-availability/getScalingDaEntries.ts
+++ b/packages/frontend/src/server/features/scaling/data-availability/getScalingDaEntries.ts
@@ -43,7 +43,7 @@ export async function getScalingDaEntries() {
     ps.getProjects({
       select: ['statuses', 'scalingInfo', 'scalingDa', 'display'],
       optional: ['customDa', 'contracts'],
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['isUpcoming', 'archivedAt'],
     }),
     ps.getProjects({

--- a/packages/frontend/src/server/features/scaling/liveness/getScalingLivenessEntries.ts
+++ b/packages/frontend/src/server/features/scaling/liveness/getScalingLivenessEntries.ts
@@ -39,7 +39,7 @@ export async function getScalingLivenessEntries() {
           'trackedTxsConfig',
         ],
         optional: ['scalingDa', 'contracts'],
-        where: ['isScaling'],
+        where: ['scalingInfo'],
         whereNot: ['isUpcoming', 'archivedAt'],
       }),
       ps.getProjects({

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -194,7 +194,7 @@ export async function getScalingProjectEntry(
       select: ['contracts'],
     }),
     ps.getProjects({
-      optional: ['daBridge', 'isScaling', 'isDaLayer'],
+      optional: ['daBridge', 'scalingInfo', 'isDaLayer'],
     }),
   ])
 

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectTvsBreakdown.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectTvsBreakdown.ts
@@ -31,7 +31,7 @@ export async function getScalingProjectTvsBreakdown(
     slug,
     select: ['tvsConfig', 'tvsInfo'],
     optional: ['chainConfig', 'milestones', 'contracts', 'archivedAt'],
-    where: ['isScaling'],
+    where: ['scalingInfo'],
   })
 
   if (!project || env.EXCLUDED_TVS_PROJECTS?.includes(project.id.toString())) {

--- a/packages/frontend/src/server/features/scaling/risks/getScalingRiskEntries.ts
+++ b/packages/frontend/src/server/features/scaling/risks/getScalingRiskEntries.ts
@@ -24,7 +24,7 @@ export async function getScalingRiskEntries() {
         'scalingTechnology',
       ],
       optional: ['customDa', 'scalingDa', 'contracts'],
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['isUpcoming', 'archivedAt'],
     }),
   ])

--- a/packages/frontend/src/server/features/scaling/risks/state-validation/getScalingRiskStateValidationEntries.ts
+++ b/packages/frontend/src/server/features/scaling/risks/state-validation/getScalingRiskStateValidationEntries.ts
@@ -44,14 +44,14 @@ export async function getScalingRiskStateValidationEntries() {
     ps.getProjects({
       select: ['statuses', 'scalingInfo', 'scalingRisks', 'display'],
       optional: ['contracts', 'tvsInfo'],
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['isUpcoming', 'archivedAt'],
     }),
     ps.getProjects({
       select: ['zkCatalogInfo'],
     }),
     ps.getProjects({
-      optional: ['daBridge', 'isScaling', 'isDaLayer'],
+      optional: ['daBridge', 'scalingInfo', 'isDaLayer'],
     }),
     getContractUtils(),
     get7dTvsBreakdown({ type: 'all' }),
@@ -133,7 +133,7 @@ function getScalingRiskStateValidationValidityEntry(
   zkCatalogProjects: Project<'zkCatalogInfo'>[],
   contractUtils: ContractUtils,
   tvs: SevenDayTvsBreakdown,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
 ): ScalingRiskStateValidationValidityEntry {
   const proofSystem = project.scalingInfo?.proofSystem
   assert(proofSystem, 'Proof system is required')

--- a/packages/frontend/src/server/features/scaling/summary/getScalingSummaryEntries.ts
+++ b/packages/frontend/src/server/features/scaling/summary/getScalingSummaryEntries.ts
@@ -37,7 +37,7 @@ export async function getScalingSummaryEntries() {
       'chainConfig',
       'contracts',
     ],
-    where: ['isScaling'],
+    where: ['scalingInfo'],
     whereNot: ['isUpcoming', 'archivedAt'],
   })
 

--- a/packages/frontend/src/server/features/scaling/tvs/getScalingTvsEntries.ts
+++ b/packages/frontend/src/server/features/scaling/tvs/getScalingTvsEntries.ts
@@ -20,7 +20,7 @@ export async function getScalingTvsEntries() {
     ps.getProjects({
       select: ['statuses', 'scalingInfo', 'tvsInfo', 'display'],
       optional: ['contracts'],
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['isUpcoming', 'archivedAt'],
     }),
   ])

--- a/packages/frontend/src/server/features/scaling/upcoming/getScalingUpcomingEntries.ts
+++ b/packages/frontend/src/server/features/scaling/upcoming/getScalingUpcomingEntries.ts
@@ -12,7 +12,7 @@ export async function getScalingUpcomingEntries() {
   const [projects, zkCatalogProjects] = await Promise.all([
     ps.getProjects({
       select: ['statuses', 'scalingInfo', 'display'],
-      where: ['isScaling', 'isUpcoming'],
+      where: ['scalingInfo', 'isUpcoming'],
       optional: ['hasTestnet', 'contracts'],
     }),
     ps.getProjects({

--- a/packages/frontend/src/server/features/zk-catalog/getZkCatalogEntries.ts
+++ b/packages/frontend/src/server/features/zk-catalog/getZkCatalogEntries.ts
@@ -43,7 +43,7 @@ export async function getZkCatalogEntries(): Promise<ZkCatalogEntry[]> {
         select: ['zkCatalogInfo', 'display', 'statuses'],
       }),
       ps.getProjects({
-        optional: ['daBridge', 'isScaling', 'isDaLayer'],
+        optional: ['daBridge', 'scalingInfo', 'isDaLayer'],
       }),
       get7dTvsBreakdown({ type: 'all' }),
       getContractUtils(),
@@ -58,7 +58,7 @@ export async function getZkCatalogEntries(): Promise<ZkCatalogEntry[]> {
 
 function getZkCatalogEntry(
   project: Project<'zkCatalogInfo' | 'display' | 'statuses'>,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
   tvs: SevenDayTvsBreakdown,
   contractUtils: ContractUtils,
 ): ZkCatalogEntry {

--- a/packages/frontend/src/server/features/zk-catalog/project/getZkCatalogProjectEntry.ts
+++ b/packages/frontend/src/server/features/zk-catalog/project/getZkCatalogProjectEntry.ts
@@ -58,7 +58,7 @@ export async function getZkCatalogProjectEntry(
   const [allProjects, allProjectsWithContracts, tvs, contractUtils] =
     await Promise.all([
       ps.getProjects({
-        optional: ['daBridge', 'isScaling', 'isDaLayer'],
+        optional: ['daBridge', 'scalingInfo', 'isDaLayer'],
       }),
       ps.getProjects({
         select: ['contracts'],

--- a/packages/frontend/src/server/features/zk-catalog/utils/getTrustedSetupsWithVerifiersAndAttesters.ts
+++ b/packages/frontend/src/server/features/zk-catalog/utils/getTrustedSetupsWithVerifiersAndAttesters.ts
@@ -69,7 +69,7 @@ export function getTrustedSetupsWithVerifiersAndAttesters(
   project: Project<'zkCatalogInfo'>,
   contractUtils: ContractUtils,
   tvs: SevenDayTvsBreakdown,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
   targetProject?: TargetProject,
 ): TrustedSetupsByProofSystem {
   const grouped = groupBy(
@@ -146,7 +146,7 @@ export function getTrustedSetupsWithVerifiersAndAttesters(
 
 function uniqAndSortProjectsUsedIn(
   usedIn: UsedInProjectWithIcon[] | undefined,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
   tvs: SevenDayTvsBreakdown,
 ) {
   if (!usedIn) return undefined
@@ -160,7 +160,7 @@ function getVerifiersWithProcessedUsedIn(
   project: Project<'zkCatalogInfo'>,
   key: string,
   contractUtils: ContractUtils,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
 ) {
   return project.zkCatalogInfo.verifierHashes
     .filter((v) => key === `${v.proofSystem.type}-${v.proofSystem.id}`)
@@ -288,7 +288,7 @@ function getVerifierStatuses(
 
 export function getProjectsUsedIn(
   projectIds: ProjectId[],
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
 ): UsedInProjectWithIcon[] {
   return projectIds
     .map((projectId) => {

--- a/packages/frontend/src/server/features/zk-catalog/utils/getZkCatalogProjectTvs.ts
+++ b/packages/frontend/src/server/features/zk-catalog/utils/getZkCatalogProjectTvs.ts
@@ -8,7 +8,7 @@ import { getTvsTargetTimestamp } from '../../scaling/tvs/utils/getTvsTargetTimes
 
 export function getZkCatalogProjectTvs(
   project: Project<'zkCatalogInfo'>,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
   tvs: SevenDayTvsBreakdown,
 ) {
   const target = getTvsTargetTimestamp()
@@ -64,7 +64,7 @@ function getLiveProjectsAtTimestamp(
 
 function getProjectsForTvs(
   projectIds: ProjectId[],
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
 ) {
   return uniq(
     projectIds.flatMap((tp) => {

--- a/packages/frontend/src/server/features/zk-catalog/utils/getZkCatalogTvsSection.ts
+++ b/packages/frontend/src/server/features/zk-catalog/utils/getZkCatalogTvsSection.ts
@@ -8,7 +8,7 @@ import { getProjectsUsedIn } from './getTrustedSetupsWithVerifiersAndAttesters'
 
 export function getZkCatalogTvsSection(
   project: Project<'zkCatalogInfo', 'tvsInfo' | 'milestones'>,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
 ): Omit<ZkCatalogTvsSectionProps, keyof ProjectSectionProps> | undefined {
   const allProjectsMap = new Map(
     allProjects.map((project) => [project.id, project]),

--- a/packages/frontend/src/server/routers/InternalApiRouter/getLogoGeneratorProjects.ts
+++ b/packages/frontend/src/server/routers/InternalApiRouter/getLogoGeneratorProjects.ts
@@ -2,17 +2,11 @@ import { ps } from '~/server/projects'
 
 export async function getLogoGeneratorProjects() {
   const projects = await ps.getProjects({
-    optional: [
-      'isUpcoming',
-      'archivedAt',
-      'bridgeInfo',
-      'scalingInfo',
-      'isScaling',
-    ],
+    optional: ['isUpcoming', 'archivedAt', 'bridgeInfo', 'scalingInfo'],
   })
 
   return projects
-    .filter((project) => !!project.isScaling)
+    .filter((project) => project.scalingInfo)
     .map((project) => ({
       name: project.name,
       type: project.scalingInfo?.layer,

--- a/packages/frontend/src/server/routers/PublicApiRouter/getScalingActivityProjectApiData.ts
+++ b/packages/frontend/src/server/routers/PublicApiRouter/getScalingActivityProjectApiData.ts
@@ -14,7 +14,7 @@ export async function getScalingActivityProjectApiData({
   const isEthereum = slug === 'ethereum'
   const project = await ps.getProject({
     slug,
-    where: ['activityConfig', 'isScaling'],
+    where: ['activityConfig', 'scalingInfo'],
   })
 
   if (!project && !isEthereum) {

--- a/packages/frontend/src/server/routers/PublicApiRouter/getScalingTvsProjectApiData.ts
+++ b/packages/frontend/src/server/routers/PublicApiRouter/getScalingTvsProjectApiData.ts
@@ -17,7 +17,7 @@ export async function getScalingTvsProjectApiData({
 }: Params) {
   const project = await ps.getProject({
     slug,
-    where: ['tvsConfig', 'isScaling'],
+    where: ['tvsConfig', 'scalingInfo'],
   })
 
   if (!project) {

--- a/packages/frontend/src/server/routers/SitemapRouter.ts
+++ b/packages/frontend/src/server/routers/SitemapRouter.ts
@@ -79,7 +79,7 @@ async function getDynamicPaths(): Promise<string[]> {
     daBridges,
   ] = await Promise.all([
     ps.getProjects({
-      where: ['isScaling'],
+      where: ['scalingInfo'],
       whereNot: ['archivedAt'],
       optional: ['tvsConfig'],
     }),

--- a/packages/frontend/src/utils/project/contracts-and-permissions/getContractUtils.ts
+++ b/packages/frontend/src/utils/project/contracts-and-permissions/getContractUtils.ts
@@ -68,7 +68,7 @@ async function getContractUsageMap() {
     ps.getProjects({ where: ['daLayer'] }),
     ps.getProjects({
       select: ['contracts'],
-      optional: ['permissions', 'isScaling', 'daBridge'],
+      optional: ['permissions', 'scalingInfo', 'daBridge'],
       whereNot: ['archivedAt'],
     }),
   ])

--- a/packages/frontend/src/utils/project/getVerifiersSection.ts
+++ b/packages/frontend/src/utils/project/getVerifiersSection.ts
@@ -21,7 +21,7 @@ function plainDeploymentAddress(
 export async function getVerifiersSection(
   project: Project<'zkCatalogInfo'>,
   contractUtils: ContractUtils,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
   tvs: SevenDayTvsBreakdown,
 ): Promise<Omit<VerifiersSectionProps, keyof ProjectSectionProps>> {
   const projects = await ps.getProjects({

--- a/packages/frontend/src/utils/project/technology/state-validation/getProverInfo.ts
+++ b/packages/frontend/src/utils/project/technology/state-validation/getProverInfo.ts
@@ -11,7 +11,7 @@ export function getProverInfo(
   zkCatalogProjects: Project<'zkCatalogInfo'>[],
   contractUtils: ContractUtils,
   tvs: SevenDayTvsBreakdown,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
 ): StateValidationSectionProps['proverInfo'] {
   const zkCatalogProject = zkCatalogProjects.find(
     (x) => x.id === project.scalingInfo.proofSystem?.zkCatalogId,

--- a/packages/frontend/src/utils/project/technology/state-validation/getStateValidationSection.ts
+++ b/packages/frontend/src/utils/project/technology/state-validation/getStateValidationSection.ts
@@ -14,7 +14,7 @@ export function getStateValidationSection(
   zkCatalogProjects: Project<'zkCatalogInfo'>[],
   contractUtils: ContractUtils,
   tvs: SevenDayTvsBreakdown,
-  allProjects: Project<never, 'daBridge' | 'isScaling' | 'isDaLayer'>[],
+  allProjects: Project<never, 'daBridge' | 'scalingInfo' | 'isDaLayer'>[],
   allProjectsWithContracts: Project<'contracts'>[],
 ):
   | Omit<StateValidationSectionProps, 'id' | 'title' | 'sectionOrder'>

--- a/packages/l2b/src/commands/GetConfig.ts
+++ b/packages/l2b/src/commands/GetConfig.ts
@@ -44,7 +44,6 @@ const ALL_PROJECT_OPTIONAL_KEYS = [
   'permissions',
   'contracts',
   'discoveryInfo',
-  'isScaling',
   'isInteropProtocol',
   'isDaLayer',
   'isUpcoming',

--- a/packages/public-api/src/routes/activity/routes.ts
+++ b/packages/public-api/src/routes/activity/routes.ts
@@ -93,7 +93,7 @@ export function addActivityRoutes(
 async function getActivityProjects(ps: ProjectService): Promise<ProjectId[]> {
   const projects = await ps.getProjects({
     select: ['activityConfig'],
-    where: ['isScaling'],
+    where: ['scalingInfo'],
     whereNot: ['isUpcoming', 'archivedAt'],
   })
 


### PR DESCRIPTION
Resolve L2B-12897

Cross checked with this script:
```
import { getProjects } from '../../src/processing/getProjects'

main()

function main() {
  const projects = getProjects()
  const scalingProjects = projects.filter(
    (project) => project.isScaling === true,
  )
  const invalidProjects = scalingProjects.filter(
    (project) => project.scalingInfo === undefined,
  )

  if (invalidProjects.length > 0) {
    console.error(
      `Found ${invalidProjects.length} project(s) with isScaling=true and no scalingInfo:`,
    )

    for (const project of invalidProjects) {
      console.error(`- ${project.id} (${project.name})`)
    }

    process.exit(1)
  }

  console.log(
    `Checked ${projects.length} projects. All ${scalingProjects.length} scaling project(s) have scalingInfo.`,
  )
}
```