### PR TITLE
Add Unichain to OP Stack interop plugins

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -53,6 +53,7 @@
     "tvs:translate-id": "ts-node ./scripts/tvs/translate-id.ts",
     "anomalies": "ts-node ./scripts/anomalies/anomalies.ts",
     "interop:example": "ts-node ./src/modules/interop/examples/script.ts",
+    "interop:find-opstack": "ts-node ./src/modules/interop/examples/findOpstackExamples.ts",
     "restore-table": "cd ../database && ./scripts/db-restore/table-restore.sh"
   },
   "dependencies": {

--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -1935,6 +1935,32 @@
       {
         "chain": "ethereum",
         "tx": "0x74d2a903013d5a37f12038c74246cc186e779e212747292e5c5c0f5e959df421"
+      },
+      // unichain related txs
+      {
+        "chain": "ethereum",
+        "tx": "0x649cfb5a89b65c1dd71e082e2af083df986a56d5c57865731997f7fcd4b02777"
+      },
+      {
+        "chain": "unichain",
+        "tx": "0x8dcf7afd10aad147976524365f7032324580e89d40fc6ad7400b602ba06346ee"
+      },
+      {
+        "chain": "unichain",
+        "tx": "0x634a1c590ee45268f643562f24b161be70697b8a0414e579de788d1855c27fe6"
+      },
+      {
+        "chain": "ethereum",
+        "tx": "0xc0c36f3dc6c442b3c0ad8172eed87189570d20dd571583c5c47ff7525596c2f3"
+      },
+      // ETH sent directly via OptimismPortal (bypassing StandardBridge) - L1->L2
+      {
+        "chain": "ethereum",
+        "tx": "0xfff7bec8cee081db53a953b8bbaff13ba2b791b072db31d09c818398cefc9a0f"
+      },
+      {
+        "chain": "unichain",
+        "tx": "0xc6ae8abbfdb4b01f4cae51e52748c86186ac0dfe6568585b5479d7df5f1ad6b9"
       }
     ],
     "events": [
@@ -2303,6 +2329,70 @@
       { "type": "opstack.L1ToL2Message", "app": "opstack-standardbridge" }
     ],
     "transfers": ["opstack-standardbridge.L1ToL2Transfer"]
+  },
+  "opstack-standardbridge-unichain-eth": {
+    "tags": ["opstack"],
+    "description": "unichain <-> ethereum (eth)",
+    "txs": [
+      // L1 -> L2: 5 ETH deposit (script-found)
+      {
+        "chain": "ethereum",
+        "tx": "0x8833416874efc4c740f2bf8c993ad07670b0642754831d879acea34f0e0b4a54"
+      },
+      {
+        "chain": "unichain",
+        "tx": "0x86c91a53d4cb8ef78cd12de2c784b8cfa664bacf276b0f0577ad5e2d88869dee"
+      },
+      // L2 -> L1: ETH withdrawal
+      {
+        "chain": "unichain",
+        "tx": "0x634a1c590ee45268f643562f24b161be70697b8a0414e579de788d1855c27fe6"
+      },
+      {
+        "chain": "ethereum",
+        "tx": "0xc0c36f3dc6c442b3c0ad8172eed87189570d20dd571583c5c47ff7525596c2f3"
+      }
+    ],
+    "messages": [
+      { "type": "opstack.L1ToL2Message", "app": "opstack-standardbridge" },
+      { "type": "opstack.L2ToL1Message", "app": "opstack-standardbridge" }
+    ],
+    "transfers": [
+      "opstack-standardbridge.L1ToL2Transfer",
+      "opstack-standardbridge.L2ToL1Transfer"
+    ]
+  },
+  "opstack-standardbridge-unichain-erc20": {
+    "tags": ["opstack"],
+    "description": "unichain <-> ethereum (erc20)",
+    "txs": [
+      // L1 -> L2: ERC20 deposit
+      {
+        "chain": "ethereum",
+        "tx": "0x793fc6e58d2ab0ef0d88eb1e902801a99878f0f5d49d3579bf07d93c4c83f9d3"
+      },
+      {
+        "chain": "unichain",
+        "tx": "0xf3ab091247cc65cf9b80c96705b5958043cee8e32e36c6dd3073513004954e22"
+      },
+      // L2 -> L1: ERC20 withdrawal
+      {
+        "chain": "unichain",
+        "tx": "0xeedafd459966b4af16973b25815b1fce3d93d136713165abbb51b6e0ea175983"
+      },
+      {
+        "chain": "ethereum",
+        "tx": "0x29beb21e991da378d2b5e946bde1bb903581692464bbabc8f0d8c73162dbc3fa"
+      }
+    ],
+    "messages": [
+      { "type": "opstack.L1ToL2Message", "app": "opstack-standardbridge" },
+      { "type": "opstack.L2ToL1Message", "app": "opstack-standardbridge" }
+    ],
+    "transfers": [
+      "opstack-standardbridge.L1ToL2Transfer",
+      "opstack-standardbridge.L2ToL1Transfer"
+    ]
   },
   "opstack-standardbridge-ink-eth": {
     "tags": ["opstack"],

--- a/packages/backend/src/modules/interop/examples/findOpstackExamples.ts
+++ b/packages/backend/src/modules/interop/examples/findOpstackExamples.ts
@@ -1,0 +1,493 @@
+import { ChainSpecificAddress } from '@l2beat/shared-pure'
+import { config as dotenv } from 'dotenv'
+import {
+  type AbiEvent,
+  createPublicClient,
+  decodeEventLog,
+  type Hex,
+  http,
+  type PublicClient,
+  parseAbiItem,
+  toEventSelector,
+} from 'viem'
+import { OPSTACK_NETWORKS } from '../plugins/opstack/opstack'
+
+dotenv({ path: '../config/.env' })
+dotenv()
+
+const L1_RPC_BATCH = 50_000
+const L2_RPC_BATCH = 200_000
+const DEFAULT_L1_BLOCK_RANGE = 10_000
+
+const EV = {
+  TransactionDeposited: parseAbiItem(
+    'event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData)',
+  ),
+  WithdrawalFinalized: parseAbiItem(
+    'event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success)',
+  ),
+  ETHDepositInitiated: parseAbiItem(
+    'event ETHDepositInitiated(address indexed from, address indexed to, uint256 amount, bytes extraData)',
+  ),
+  ERC20DepositInitiated: parseAbiItem(
+    'event ERC20DepositInitiated(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)',
+  ),
+  ETHBridgeFinalized: parseAbiItem(
+    'event ETHBridgeFinalized(address indexed from, address indexed to, uint256 amount, bytes extraData)',
+  ),
+  ERC20BridgeFinalized: parseAbiItem(
+    'event ERC20BridgeFinalized(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)',
+  ),
+  MessagePassed: parseAbiItem(
+    'event MessagePassed(uint256 indexed nonce, address indexed sender, address indexed target, uint256 value, uint256 gasLimit, bytes data, bytes32 withdrawalHash)',
+  ),
+  DepositFinalized: parseAbiItem(
+    'event DepositFinalized(address indexed l1Token, address indexed l2Token, address indexed from, address to, uint256 amount, bytes extraData)',
+  ),
+} as const
+
+interface LogRow {
+  address: Hex
+  data: Hex
+  topics: readonly Hex[]
+  transactionHash: Hex
+  blockNumber: bigint
+}
+
+interface FoundExample {
+  description: string
+  l1Tx: Hex
+  l2Tx: Hex
+}
+
+export interface Findings {
+  chain: string
+  ethDeposit?: FoundExample
+  erc20Deposit?: FoundExample
+  ethWithdrawal?: FoundExample
+  erc20Withdrawal?: FoundExample
+  directPortalEthDeposit?: FoundExample
+}
+
+function env(name: string): string {
+  const v = process.env[name]
+  if (!v) throw new Error(`Missing env: ${name}`)
+  return v
+}
+
+function client(url: string): PublicClient {
+  return createPublicClient({ transport: http(url) })
+}
+
+async function getLogs(
+  c: PublicClient,
+  address: Hex,
+  event: AbiEvent,
+  fromBlock: bigint,
+  toBlock: bigint,
+  batch: number,
+): Promise<LogRow[]> {
+  const out: LogRow[] = []
+  for (let from = fromBlock; from <= toBlock; from += BigInt(batch)) {
+    const to =
+      from + BigInt(batch) - 1n > toBlock ? toBlock : from + BigInt(batch) - 1n
+    const chunk = await c.getLogs({
+      address,
+      event,
+      fromBlock: from,
+      toBlock: to,
+    })
+    for (const l of chunk) {
+      if (!l.transactionHash || l.blockNumber === null) continue
+      out.push({
+        address: l.address,
+        data: l.data,
+        topics: l.topics,
+        transactionHash: l.transactionHash,
+        blockNumber: l.blockNumber,
+      })
+    }
+  }
+  return out
+}
+
+function decode<T extends AbiEvent>(
+  ev: T,
+  log: LogRow,
+): { args: Record<string, unknown> } {
+  return decodeEventLog({
+    abi: [ev],
+    data: log.data,
+    topics: log.topics as [Hex, ...Hex[]],
+  }) as never
+}
+
+async function findEthDeposit(
+  l1: PublicClient,
+  l2: PublicClient,
+  l1Bridge: Hex,
+  l2Bridge: Hex,
+  l1From: bigint,
+  l1To: bigint,
+  l2From: bigint,
+  l2To: bigint,
+): Promise<FoundExample | undefined> {
+  const initiated = await getLogs(
+    l1,
+    l1Bridge,
+    EV.ETHDepositInitiated,
+    l1From,
+    l1To,
+    L1_RPC_BATCH,
+  )
+  if (initiated.length === 0) return
+  const finalized = await getLogs(
+    l2,
+    l2Bridge,
+    EV.ETHBridgeFinalized,
+    l2From,
+    l2To,
+    L2_RPC_BATCH,
+  )
+  for (const l1Log of initiated) {
+    const amount = decode(EV.ETHDepositInitiated, l1Log).args.amount as bigint
+    const l2Match = finalized.find(
+      (f) =>
+        (decode(EV.ETHBridgeFinalized, f).args.amount as bigint) === amount,
+    )
+    if (l2Match) {
+      return {
+        description: `${formatEth(amount)} ETH`,
+        l1Tx: l1Log.transactionHash,
+        l2Tx: l2Match.transactionHash,
+      }
+    }
+  }
+}
+
+async function findErc20Deposit(
+  l1: PublicClient,
+  l2: PublicClient,
+  l1Bridge: Hex,
+  l2Bridge: Hex,
+  l1From: bigint,
+  l1To: bigint,
+  l2From: bigint,
+  l2To: bigint,
+): Promise<FoundExample | undefined> {
+  const initiated = await getLogs(
+    l1,
+    l1Bridge,
+    EV.ERC20DepositInitiated,
+    l1From,
+    l1To,
+    L1_RPC_BATCH,
+  )
+  if (initiated.length === 0) return
+  const finalized = await getLogs(
+    l2,
+    l2Bridge,
+    EV.DepositFinalized,
+    l2From,
+    l2To,
+    L2_RPC_BATCH,
+  )
+  for (const l1Log of initiated) {
+    const args = decode(EV.ERC20DepositInitiated, l1Log).args
+    const amount = args.amount as bigint
+    const l1Token = (args.l1Token as string).toLowerCase()
+    const l2Match = finalized.find((f) => {
+      const d = decode(EV.DepositFinalized, f).args
+      return (
+        (d.amount as bigint) === amount &&
+        (d.l1Token as string).toLowerCase() === l1Token
+      )
+    })
+    if (l2Match) {
+      return {
+        description: `ERC20 ${l1Token} amount=${amount.toString()}`,
+        l1Tx: l1Log.transactionHash,
+        l2Tx: l2Match.transactionHash,
+      }
+    }
+  }
+}
+
+async function findWithdrawal(
+  l1: PublicClient,
+  l2: PublicClient,
+  portal: Hex,
+  l1Bridge: Hex,
+  l2Passer: Hex,
+  tokenKind: 'eth' | 'erc20',
+  l1From: bigint,
+  l1To: bigint,
+  l2WithdrawalFrom: bigint,
+  l2To: bigint,
+): Promise<FoundExample | undefined> {
+  const finals = await getLogs(
+    l1,
+    portal,
+    EV.WithdrawalFinalized,
+    l1From,
+    l1To,
+    L1_RPC_BATCH,
+  )
+  const selector =
+    tokenKind === 'eth'
+      ? toEventSelector(EV.ETHBridgeFinalized)
+      : toEventSelector(EV.ERC20BridgeFinalized)
+  const messagePassed = await getLogs(
+    l2,
+    l2Passer,
+    EV.MessagePassed,
+    l2WithdrawalFrom,
+    l2To,
+    L2_RPC_BATCH,
+  )
+
+  for (const wf of finals) {
+    const receipt = await l1.getTransactionReceipt({ hash: wf.transactionHash })
+    const hasBridgeFinalized = receipt.logs.some(
+      (l) =>
+        l.address.toLowerCase() === l1Bridge.toLowerCase() &&
+        l.topics[0] === selector,
+    )
+    if (!hasBridgeFinalized) continue
+    const withdrawalHash = wf.topics[1]
+    const mp = messagePassed.find(
+      (m) =>
+        (
+          decode(EV.MessagePassed, m).args.withdrawalHash as string
+        ).toLowerCase() === withdrawalHash.toLowerCase(),
+    )
+    if (mp) {
+      return {
+        description: `withdrawal (${tokenKind}) wh=${withdrawalHash.slice(0, 12)}…`,
+        l1Tx: wf.transactionHash,
+        l2Tx: mp.transactionHash,
+      }
+    }
+  }
+}
+
+async function findDirectPortalEthDeposit(
+  l1: PublicClient,
+  l2: PublicClient,
+  portal: Hex,
+  l1Bridge: Hex,
+  l1Xdom: Hex,
+  l1From: bigint,
+  l1To: bigint,
+): Promise<FoundExample | undefined> {
+  const deposits = await getLogs(
+    l1,
+    portal,
+    EV.TransactionDeposited,
+    l1From,
+    l1To,
+    L1_RPC_BATCH,
+  )
+  for (const d of deposits) {
+    const receipt = await l1.getTransactionReceipt({ hash: d.transactionHash })
+    const addrs = new Set(receipt.logs.map((l) => l.address.toLowerCase()))
+    if (addrs.has(l1Bridge.toLowerCase()) || addrs.has(l1Xdom.toLowerCase()))
+      continue
+    const tx = await l1.getTransaction({ hash: d.transactionHash })
+    if (tx.value === 0n) continue
+    const recipient = `0x${d.topics[2].slice(-40)}` as Hex
+    const block = await l1.getBlock({ blockNumber: d.blockNumber })
+    const l2Hash = await findL2DepositTxByTimestamp(
+      l2,
+      block.timestamp,
+      recipient.toLowerCase(),
+    )
+    if (l2Hash) {
+      return {
+        description: `direct portal ETH deposit ${formatEth(tx.value)}`,
+        l1Tx: d.transactionHash,
+        l2Tx: l2Hash,
+      }
+    }
+  }
+}
+
+async function findL2DepositTxByTimestamp(
+  l2: PublicClient,
+  l1Timestamp: bigint,
+  recipientLc: string,
+): Promise<Hex | undefined> {
+  const tip = await l2.getBlock({ blockTag: 'latest' })
+  const secondsSince = Number(tip.timestamp - l1Timestamp)
+  const btMs = await estimateBlockTimeMs(l2, tip.number, tip.timestamp)
+  const guess = tip.number - BigInt(Math.round((secondsSince * 1000) / btMs))
+  const window = BigInt(Math.max(240, Math.ceil((240 * 1000) / btMs)))
+  for (let delta = 0n; delta <= window; delta++) {
+    for (const sign of [1n, -1n] as const) {
+      const b = guess + sign * delta
+      if (b < 0n) continue
+      const block = (await l2.getBlock({
+        blockNumber: b,
+        includeTransactions: true,
+      })) as unknown as {
+        transactions: Array<{ typeHex?: string; hash: Hex; to?: string | null }>
+      }
+      const match = block.transactions.find(
+        (t) =>
+          t.typeHex === '0x7e' && (t.to ?? '').toLowerCase() === recipientLc,
+      )
+      if (match) return match.hash
+    }
+  }
+}
+
+function formatEth(value: bigint): string {
+  const s = value.toString().padStart(19, '0')
+  const whole = s.slice(0, -18) || '0'
+  const frac = s.slice(-18).replace(/0+$/, '')
+  return frac ? `${whole}.${frac}` : whole
+}
+
+async function estimateBlockTimeMs(
+  c: PublicClient,
+  tipNumber: bigint,
+  tipTs: bigint,
+  sampleBack = 1000n,
+): Promise<number> {
+  const back = tipNumber > sampleBack ? tipNumber - sampleBack : 0n
+  const sample = await c.getBlock({ blockNumber: back })
+  const blocks = tipNumber - back
+  if (blocks === 0n) return 1000
+  const seconds = Number(tipTs - sample.timestamp)
+  return (seconds * 1000) / Number(blocks)
+}
+
+async function blocksForSeconds(
+  c: PublicClient,
+  tipNumber: bigint,
+  tipTs: bigint,
+  seconds: number,
+): Promise<bigint> {
+  const btMs = await estimateBlockTimeMs(c, tipNumber, tipTs)
+  return BigInt(Math.ceil((seconds * 1000) / btMs))
+}
+
+export async function findOpstackExamples(
+  chain: string,
+  opts: { l1Blocks?: number } = {},
+): Promise<Findings> {
+  const network = OPSTACK_NETWORKS.find((n) => n.chain === chain)
+  if (!network) throw new Error(`Unknown opstack chain: ${chain}`)
+
+  const l1 = client(env('ETHEREUM_RPC_URL'))
+  const l2 = client(env(`${chain.toUpperCase()}_RPC_URL`))
+
+  const l1Tip = await l1.getBlockNumber()
+  const l2Tip = await l2.getBlockNumber()
+  const l1BlockRange = BigInt(opts.l1Blocks ?? DEFAULT_L1_BLOCK_RANGE)
+  const l1From = l1Tip - l1BlockRange
+  const l1To = l1Tip
+
+  const l1FromTs = (await l1.getBlock({ blockNumber: l1From })).timestamp
+  const l2TipTs = (await l2.getBlock({ blockNumber: l2Tip })).timestamp
+  const depositWindowSec = Number(l2TipTs - l1FromTs)
+  const depositL2Blocks = await blocksForSeconds(
+    l2,
+    l2Tip,
+    l2TipTs,
+    depositWindowSec + 200,
+  )
+  const l2From = l2Tip > depositL2Blocks ? l2Tip - depositL2Blocks : 0n
+  const l2To = l2Tip
+  // MessagePassed on L2 happens ~7 days before WithdrawalFinalized on L1. Look back 14 days.
+  const withdrawalL2Blocks = await blocksForSeconds(
+    l2,
+    l2Tip,
+    l2TipTs,
+    14 * 24 * 60 * 60,
+  )
+  const l2WithdrawalFrom =
+    l2Tip > withdrawalL2Blocks ? l2Tip - withdrawalL2Blocks : 0n
+
+  const portal = ChainSpecificAddress.address(network.optimismPortal) as Hex
+  const l1Bridge = ChainSpecificAddress.address(network.l1StandardBridge) as Hex
+  const l1Xdom = ChainSpecificAddress.address(
+    network.l1CrossDomainMessenger,
+  ) as Hex
+  const l2Bridge = ChainSpecificAddress.address(network.l2StandardBridge) as Hex
+  const l2Passer = ChainSpecificAddress.address(
+    network.l2ToL1MessagePasser,
+  ) as Hex
+
+  const [
+    ethDeposit,
+    erc20Deposit,
+    ethWithdrawal,
+    erc20Withdrawal,
+    directPortalEthDeposit,
+  ] = await Promise.all([
+    findEthDeposit(l1, l2, l1Bridge, l2Bridge, l1From, l1To, l2From, l2To),
+    findErc20Deposit(l1, l2, l1Bridge, l2Bridge, l1From, l1To, l2From, l2To),
+    findWithdrawal(
+      l1,
+      l2,
+      portal,
+      l1Bridge,
+      l2Passer,
+      'eth',
+      l1From,
+      l1To,
+      l2WithdrawalFrom,
+      l2To,
+    ),
+    findWithdrawal(
+      l1,
+      l2,
+      portal,
+      l1Bridge,
+      l2Passer,
+      'erc20',
+      l1From,
+      l1To,
+      l2WithdrawalFrom,
+      l2To,
+    ),
+    findDirectPortalEthDeposit(l1, l2, portal, l1Bridge, l1Xdom, l1From, l1To),
+  ])
+
+  return {
+    chain,
+    ethDeposit,
+    erc20Deposit,
+    ethWithdrawal,
+    erc20Withdrawal,
+    directPortalEthDeposit,
+  }
+}
+
+if (require.main === module) {
+  const chain = process.argv[2]
+  const l1Blocks = process.argv[3] ? Number(process.argv[3]) : undefined
+  if (!chain) {
+    console.error('usage: find-opstack-examples <chain> [l1Blocks]')
+    process.exit(1)
+  }
+  findOpstackExamples(chain, { l1Blocks })
+    .then((f) => {
+      for (const [k, v] of Object.entries(f)) {
+        if (k === 'chain') continue
+        if (v === undefined) {
+          console.log(`${k}: not found`)
+        } else {
+          const ex = v as FoundExample
+          console.log(`${k}: ${ex.description}`)
+          console.log(`  ethereum: ${ex.l1Tx}`)
+          console.log(`  ${chain}:  ${ex.l2Tx}`)
+        }
+      }
+    })
+    .catch((e) => {
+      console.error(e)
+      process.exit(1)
+    })
+}

--- a/packages/backend/src/modules/interop/plugins/opstack/ADD_CHAIN_GUIDE.md
+++ b/packages/backend/src/modules/interop/plugins/opstack/ADD_CHAIN_GUIDE.md
@@ -1,0 +1,101 @@
+# Adding a new OP Stack chain to interop
+
+## 1. Collect L1 proxy addresses
+
+From the project's `discovered.json` (e.g. `packages/config/src/projects/<chain>/discovered.json`), grab the **proxy** addresses (not implementations) for:
+
+- `OptimismPortal2`
+- `L1CrossDomainMessenger`
+- `L1StandardBridge`
+
+```bash
+grep -A3 '"name": "OptimismPortal2"\|"name": "L1StandardBridge"\|"name": "L1CrossDomainMessenger"' \
+  packages/config/src/projects/<chain>/discovered.json | grep '"address"'
+```
+
+The implementation address is the second one listed under `implementationNames`. Use the top-level `address` instead.
+
+## 2. Register the chain in `opstack.ts`
+
+Add an entry to `OPSTACK_NETWORKS`. L2 predeploys are the same across OP Stack chains:
+
+```ts
+{
+  chain: '<chain>',
+  l2ToL1MessagePasser: ChainSpecificAddress('<chain>:0x4200000000000000000000000000000000000016'),
+  l2CrossDomainMessenger: ChainSpecificAddress('<chain>:0x4200000000000000000000000000000000000007'),
+  l2StandardBridge: ChainSpecificAddress('<chain>:0x4200000000000000000000000000000000000010'),
+  optimismPortal: ChainSpecificAddress('eth:0x...'),
+  l1CrossDomainMessenger: ChainSpecificAddress('eth:0x...'),
+  l1StandardBridge: ChainSpecificAddress('eth:0x...'),
+  // only for chains with a custom gas token (e.g. Celo)
+  // l1CustomGasToken: Address32.from('0x...'),
+},
+```
+
+Verify the `<chain>:` prefix exists in `packages/shared-pure/src/types/ChainSpecificAddress.ts`. If not, add it there first.
+
+## 3. Find example txs
+
+Requires `ETHEREUM_RPC_URL` and `<CHAIN>_RPC_URL` in `packages/config/.env`.
+
+```bash
+cd packages/backend
+NODE_OPTIONS="--no-experimental-strip-types" pnpm interop:find-opstack <chain>
+```
+
+The script (`findOpstackExamples.ts`) searches the last 10k L1 blocks and prints tx pairs for:
+
+- `ethDeposit` — L1→L2 ETH via StandardBridge
+- `erc20Deposit` — L1→L2 ERC20 via StandardBridge
+- `ethWithdrawal` — L2→L1 ETH via StandardBridge (looks back 14 days on L2)
+- `erc20Withdrawal` — L2→L1 ERC20 via StandardBridge
+- `directPortalEthDeposit` — L1→L2 ETH via direct OptimismPortal call (exercises the generic `OpStackPlugin` with `app: unknown`)
+
+L2 block time is auto-detected by sampling recent blocks, so the withdrawal lookback window works for any OP Stack chain.
+
+If a category comes back `not found`, try a larger range: `pnpm interop:find-opstack <chain> 30000`.
+
+## 4. Add the txs to `examples.jsonc`
+
+Mirror existing patterns. At minimum add two bidirectional standard bridge examples (eth + erc20) and append the direct portal deposit pair into the main `opstack` group:
+
+```jsonc
+"opstack-standardbridge-<chain>-eth": {
+  "tags": ["opstack"],
+  "description": "<chain> <-> ethereum (eth)",
+  "txs": [
+    { "chain": "ethereum", "tx": "<l1EthDeposit>" },
+    { "chain": "<chain>",  "tx": "<l2EthDeposit>" },
+    { "chain": "<chain>",  "tx": "<l2EthWithdrawal>" },
+    { "chain": "ethereum", "tx": "<l1EthWithdrawal>" }
+  ],
+  "messages": [
+    { "type": "opstack.L1ToL2Message", "app": "opstack-standardbridge" },
+    { "type": "opstack.L2ToL1Message", "app": "opstack-standardbridge" }
+  ],
+  "transfers": [
+    "opstack-standardbridge.L1ToL2Transfer",
+    "opstack-standardbridge.L2ToL1Transfer"
+  ]
+},
+```
+
+The main `opstack` group should cover direct portal deposits so the generic plugin path is exercised.
+
+## 5. Run examples to verify
+
+```bash
+cd packages/backend
+NODE_OPTIONS="--no-experimental-strip-types" pnpm interop:example opstack-standardbridge-<chain>-eth --simple
+NODE_OPTIONS="--no-experimental-strip-types" pnpm interop:example opstack-standardbridge-<chain>-erc20 --simple
+NODE_OPTIONS="--no-experimental-strip-types" pnpm interop:example opstack --simple
+```
+
+All messages/transfers for the new chain should report `PASS`.
+
+## Common pitfalls
+
+- **Using implementation addresses instead of proxies.** Implementations are shared across OP Stack chains and emit no events for your specific rollup. Always use the proxy.
+- **Custom gas token chains.** If the chain uses a non-ETH gas token (Celo-style), set `l1CustomGasToken` and expect native transfers to reference that ERC-20 on L1.
+- **No withdrawals in recent range.** The script searches the recent 10k L1 blocks for `WithdrawalFinalized`. Rollups with low activity may need a larger `l1Blocks` argument.

--- a/packages/backend/src/modules/interop/plugins/opstack/opstack.ts
+++ b/packages/backend/src/modules/interop/plugins/opstack/opstack.ts
@@ -159,6 +159,27 @@ export const OPSTACK_NETWORKS = defineNetworks<OpStackNetwork>('opstack', [
     ),
   },
   {
+    chain: 'unichain',
+    l2ToL1MessagePasser: ChainSpecificAddress(
+      'unichain:0x4200000000000000000000000000000000000016',
+    ),
+    l2CrossDomainMessenger: ChainSpecificAddress(
+      'unichain:0x4200000000000000000000000000000000000007',
+    ),
+    l2StandardBridge: ChainSpecificAddress(
+      'unichain:0x4200000000000000000000000000000000000010',
+    ),
+    optimismPortal: ChainSpecificAddress(
+      'eth:0x0bd48f6B86a26D3a217d0Fa6FfE2B491B956A7a2',
+    ),
+    l1CrossDomainMessenger: ChainSpecificAddress(
+      'eth:0x9A3D64E386C18Cb1d6d5179a9596A4B5736e98A6',
+    ),
+    l1StandardBridge: ChainSpecificAddress(
+      'eth:0x81014F44b0a345033bB2b3B21C7a1A308B35fEeA',
+    ),
+  },
+  {
     chain: 'celo',
     l2ToL1MessagePasser: ChainSpecificAddress(
       'celo:0x4200000000000000000000000000000000000016',


### PR DESCRIPTION
## Summary
- Register Unichain in `OPSTACK_NETWORKS` so `OpStackPlugin` and `OpStackStandardBridgePlugin` pick up its L1 portal, bridge, and cross-domain messenger events.
- Add bridge examples (ETH + ERC20, bidirectional) plus a direct OptimismPortal deposit pair to exercise the generic plugin path.
- Add `findOpstackExamples.ts` (run via `pnpm interop:find-opstack <chain>`) to auto-discover candidate example txs (ETH/ERC20 deposits and withdrawals via StandardBridge, plus direct OptimismPortal deposits) for any registered OP Stack chain; L2 block time is estimated by sampling so the withdrawal lookback works on any chain.
- Add a step-by-step guide at `plugins/opstack/ADD_CHAIN_GUIDE.md` for wiring up future OP Stack chains.

## Test plan
- [x] `pnpm interop:example opstack-standardbridge-unichain-eth --simple`
- [x] `pnpm interop:example opstack-standardbridge-unichain-erc20 --simple`
- [x] `pnpm interop:example opstack --simple` (covers direct portal deposit via generic plugin)
- [x] `pnpm interop:find-opstack unichain` recovers all five example categories