### PR TITLE
Mark INTMAX as appchain and add Privacy badge

### DIFF
--- a/packages/config/src/projects/intmax/intmax.ts
+++ b/packages/config/src/projects/intmax/intmax.ts
@@ -21,9 +21,13 @@ export const intmax: ScalingProject = {
   type: 'layer3',
   hostChain: ProjectId('scroll'),
   id: ProjectId('intmax'),
-  capability: 'universal',
+  capability: 'appchain',
   addedAt: UnixTime(1722256071), // 2024-07-29T12:27:51Z
-  badges: [BADGES.L3ParentChain.Scroll],
+  badges: [
+    BADGES.L3ParentChain.Scroll,
+    BADGES.VM.AppChain,
+    BADGES.Other.Privacy,
+  ],
   display: {
     name: 'INTMAX',
     slug: 'intmax',


### PR DESCRIPTION
## Summary
- Changes INTMAX's `capability` from `universal` to `appchain` so it gets the appchain designation in the Stages framework.
- Adds `BADGES.VM.AppChain` and `BADGES.Other.Privacy` to reflect INTMAX being an application-specific chain with native private transactions.