### PR TITLE
Use TRUNCATE instead of DELETE in db-restore scripts

### DIFF
--- a/packages/database/scripts/db-restore/db-restore.sh
+++ b/packages/database/scripts/db-restore/db-restore.sh
@@ -34,13 +34,20 @@ DO \$\$
 DECLARE
     tables TEXT[] := ARRAY[$quoted_tables];
     table_name TEXT;
+    existing_tables TEXT[] := ARRAY[]::TEXT[];
+    table_list TEXT;
 BEGIN
     FOREACH table_name IN ARRAY tables
     LOOP
         IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = table_name) THEN
-            EXECUTE format('DELETE FROM %I', table_name);
+            existing_tables := array_append(existing_tables, format('%I', table_name));
         END IF;
     END LOOP;
+
+    IF array_length(existing_tables, 1) IS NOT NULL THEN
+        table_list := array_to_string(existing_tables, ', ');
+        EXECUTE format('TRUNCATE TABLE %s', table_list);
+    END IF;
 END \$\$;
 "
 }

--- a/packages/database/scripts/db-restore/table-restore.sh
+++ b/packages/database/scripts/db-restore/table-restore.sh
@@ -21,13 +21,20 @@ DO \$\$
 DECLARE
     tables TEXT[] := ARRAY[$quoted_tables];
     table_name TEXT;
+    existing_tables TEXT[] := ARRAY[]::TEXT[];
+    table_list TEXT;
 BEGIN
     FOREACH table_name IN ARRAY tables
     LOOP
         IF EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = table_name) THEN
-            EXECUTE format('DELETE FROM %I', table_name);
+            existing_tables := array_append(existing_tables, format('%I', table_name));
         END IF;
     END LOOP;
+
+    IF array_length(existing_tables, 1) IS NOT NULL THEN
+        table_list := array_to_string(existing_tables, ', ');
+        EXECUTE format('TRUNCATE TABLE %s', table_list);
+    END IF;
 END \$\$;
 "
 }


### PR DESCRIPTION
## Summary
- Switch DB restore scripts from row-by-row `DELETE` to `TRUNCATE TABLE` for tables that already exist.
- Collect existing public tables first, then truncate them in a single statement before restore.
- Keep the behavior limited to tables present in `public`, avoiding errors when tables are missing.

