### PR TITLE
Interop fixes + onesided bridgetypes

### DIFF
--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -643,6 +643,7 @@
         {
           "type": "ccip.Transfer",
           "plugin": "ccip",
+          "bridgeType": "burnAndMint",
           "src": {
             "tokenAddress": "0x000000000000000000000000243c9be13faba09f945ccc565547293337da0ad7",
             "wasBurned": false,
@@ -654,6 +655,7 @@
         {
           "type": "ccip.Transfer",
           "plugin": "ccip",
+          "bridgeType": "burnAndMint",
           "src": { "chain": "solana" },
           "dst": {
             "tokenAddress": "0x00000000000000000000000080ac24aa929eaf5013f6436cda2a7ba190f5cc0b",
@@ -1768,12 +1770,14 @@
         {
           "type": "wormhole-ntt.Transfer",
           "plugin": "wormhole-ntt",
+          "bridgeType": "burnAndMint",
           "src": { "event": { "ctx": { "chain": "ethereum" } } },
           "dst": { "chain": "solana" }
         },
         {
           "type": "wormhole-ntt.Transfer",
           "plugin": "wormhole-ntt",
+          "bridgeType": "burnAndMint",
           "src": { "chain": "solana" },
           "dst": { "event": { "ctx": { "chain": "polygonpos" } } }
         }
@@ -1895,6 +1899,7 @@
       "transfers": [
         {
           "type": "wormhole-tokenbridge.Transfer",
+          "bridgeType": "lockAndMint",
           "src": { "wasBurned": false },
           "dst": { "chain": "solana" }
         }
@@ -3757,11 +3762,13 @@
       "transfers": [
         {
           "type": "hyperlaneHwr.Transfer",
+          "bridgeType": "burnAndMint",
           "src": { "event": { "ctx": { "chain": "ethereum" } } },
           "dst": { "chain": "solana" }
         },
         {
           "type": "hyperlaneHwr.Transfer",
+          "bridgeType": "burnAndMint",
           "src": { "chain": "solana" },
           "dst": { "event": { "ctx": { "chain": "base" } } }
         }
@@ -3885,7 +3892,23 @@
         "chain": "ethereum",
         "tx": "0x6938c3677d8855d94f289f5ece9aed150bee9744a221a2124112338a251752b5" // solana -> eth
       }
-    ]
+    ],
+    "expects": {
+      "transfers": [
+        {
+          "type": "oftv2.Transfer",
+          "bridgeType": "burnAndMint",
+          "src": { "event": { "ctx": { "chain": "bsc" } } },
+          "dst": { "chain": "solana" }
+        },
+        {
+          "type": "oftv2.Transfer",
+          "bridgeType": "burnAndMint",
+          "src": { "chain": "solana" },
+          "dst": { "event": { "ctx": { "chain": "ethereum" } } }
+        }
+      ]
+    }
   },
   "cctp-debug": {
     "loadConfigs": ["cctp-v1", "cctp-v2"],

--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -1188,6 +1188,48 @@
       ]
     }
   },
+  "mayan-swift-solana-ethereum-onesided": {
+    "loadConfigs": ["wormhole"],
+    "description": "Single Mayan Swift fulfill from Solana to Ethereum",
+    "txs": [
+      {
+        "chain": "ethereum",
+        "tx": "0x4157f42d0f0cf65efaa529dfa826ebad230c16f084e81178fc20c680d9edc927"
+      }
+    ],
+    "expects": {
+      "events": ["mayan-swift.OrderFulfilled", "mayan-swift.SettlementSent"],
+      "messages": [],
+      "transfers": [
+        {
+          "type": "mayan-swift.Transfer",
+          "src": { "chain": "solana" },
+          "dst": { "event": { "ctx": { "chain": "ethereum" } } }
+        }
+      ]
+    }
+  },
+  "mayan-swift-solana-bsc-onesided": {
+    "loadConfigs": ["wormhole"],
+    "description": "Single Mayan Swift fulfill from Solana to BSC",
+    "txs": [
+      {
+        "chain": "bsc",
+        "tx": "0x4be43ab7e60b2502bfc5980d6d1b333649f4b8628a9b4167646f706357011f68"
+      }
+    ],
+    "expects": {
+      "events": ["mayan-swift.OrderFulfilled"],
+      "messages": [],
+      "transfers": [
+        {
+          "type": "mayan-swift.Transfer",
+          "src": { "chain": "solana" },
+          "dst": { "event": { "ctx": { "chain": "bsc" } } }
+        }
+      ]
+    }
+  },
   "mayan-swift-settlement-non-batched": {
     "loadConfigs": ["wormhole"],
     "txs": [

--- a/packages/backend/src/modules/interop/plugins/ccip/ccip.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/ccip/ccip.plugin.ts
@@ -697,6 +697,7 @@ export class CCIPPlugin implements InteropPluginResyncable {
             dstTokenAddress: dstToken.address,
             dstAmount: dstToken.amount,
             dstWasMinted: dstToken.wasMinted,
+            bridgeType: 'burnAndMint',
           }),
         )
       }
@@ -763,6 +764,7 @@ export class CCIPPlugin implements InteropPluginResyncable {
         srcTokenAddress: delivery.args.token,
         srcAmount: delivery.args.amount,
         srcWasBurned: delivery.args.wasBurned,
+        bridgeType: 'burnAndMint',
       }),
     ]
   }

--- a/packages/backend/src/modules/interop/plugins/hyperlane-hwr.ts
+++ b/packages/backend/src/modules/interop/plugins/hyperlane-hwr.ts
@@ -284,6 +284,7 @@ export class HyperlaneHwrPlugin implements InteropPluginResyncable {
             dstTokenAddress: event.args.tokenAddress,
             dstAmount: event.args.amount,
             dstWasMinted: event.args.minted,
+            bridgeType: 'burnAndMint',
           }),
         ]
       }
@@ -364,6 +365,7 @@ export class HyperlaneHwrPlugin implements InteropPluginResyncable {
         srcAmount: event.args.amount,
         srcWasBurned: event.args.burned,
         dstChain,
+        bridgeType: 'burnAndMint',
       }),
     ]
   }

--- a/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
@@ -365,6 +365,7 @@ export class LayerZeroV2OFTsPlugin implements InteropPlugin {
           dstAmount: oftReceivedPacketDelivered.args.amountReceivedLD,
           dstTokenAddress: oftReceivedPacketDelivered.args.dstTokenAddress,
           dstWasMinted: oftReceivedPacketDelivered.args.minted,
+          bridgeType: 'burnAndMint',
           extraEvents: packetDelivered ? [packetDelivered] : undefined,
         }),
       ]
@@ -434,6 +435,7 @@ export class LayerZeroV2OFTsPlugin implements InteropPlugin {
         srcAmount: oftSentPacketSent.args.amountSentLD,
         srcTokenAddress: oftSentPacketSent.args.srcTokenAddress,
         srcWasBurned: oftSentPacketSent.args.burned,
+        bridgeType: 'burnAndMint',
         extraEvents: packetSent ? [packetSent] : undefined,
       }),
     ]

--- a/packages/backend/src/modules/interop/plugins/mayan-swift.ts
+++ b/packages/backend/src/modules/interop/plugins/mayan-swift.ts
@@ -3,10 +3,10 @@ Mayan Swift source data comes either from the surrounding MayanForwarder event
 or directly from MayanSwift calldata. The protocol itself is lock/release, so it never burns or mints.
 */
 
-import { Address32, EthereumAddress } from '@l2beat/shared-pure'
+import { Address32 } from '@l2beat/shared-pure'
 import { getInteropTransactionDataCandidates } from '../dto/interopTransaction'
 import type { InteropConfigStore } from '../engine/config/InteropConfigStore'
-import { findParsedAround } from './logScan'
+import { findParsedAround, findTransferLogBefore } from './logScan'
 import {
   decodeMayanData,
   findNativeAmountInTx,
@@ -24,8 +24,10 @@ import {
   toChainSpecificAddresses,
 } from './mayan-shared'
 import {
+  extractMayanSwiftFulfillDestTokenFromTxData,
   extractMayanSwiftFulfillSourceChainFromTxData,
   extractMayanSwiftSettlementDestChain,
+  extractMayanSwiftSettlementUnlockKey,
   getMayanSwiftSettlementMsgType,
   MAYAN_SWIFT_MSG_TYPE_UNLOCK,
 } from './mayan-swift.utils'
@@ -50,6 +52,8 @@ const orderFulfilledLog =
 const orderRefundedLog = 'event OrderRefunded(bytes32 key, uint256 netAmount)'
 const logMessagePublishedLog =
   'event LogMessagePublished(address indexed sender, uint64 sequence, uint32 nonce, bytes payload, uint8 consistencyLevel)'
+const transferLog =
+  'event Transfer(address indexed from, address indexed to, uint256 value)'
 
 const parseOrderCreated = createEventParser(orderCreatedLog)
 
@@ -58,6 +62,7 @@ const parseOrderFulfilled = createEventParser(orderFulfilledLog)
 const parseOrderRefunded = createEventParser(orderRefundedLog)
 
 const parseLogMessagePublished = createEventParser(logMessagePublishedLog)
+const parseTransfer = createEventParser(transferLog)
 
 export const OrderCreated = createInteropEventType<{
   key: string
@@ -71,6 +76,7 @@ export const OrderFulfilled = createInteropEventType<{
   key: string
   dstAmount: bigint
   $srcChain?: string
+  dstTokenAddress?: Address32
 }>('mayan-swift.OrderFulfilled')
 
 export const OrderRefunded = createInteropEventType<{
@@ -89,6 +95,7 @@ type FulfilledOrderEvent = InteropEvent<{
   key: string
   dstAmount: bigint
   $srcChain?: string
+  dstTokenAddress?: Address32
 }>
 type RefundedOrderEvent = InteropEvent<{
   key: string
@@ -150,6 +157,22 @@ function captureOrderFulfilled(
       extractMayanSwiftFulfillSourceChainFromTxData(txData as `0x${string}`),
     )
     .find((srcChainId): srcChainId is number => srcChainId !== undefined)
+  const dstTokenAddress = getInteropTransactionDataCandidates(input.tx)
+    .map((txData) =>
+      extractMayanSwiftFulfillDestTokenFromTxData(txData as `0x${string}`),
+    )
+    .find(
+      (tokenAddress): tokenAddress is Address32 => tokenAddress !== undefined,
+    )
+  const transferMatch =
+    input.log.logIndex === null
+      ? undefined
+      : findTransferLogBefore(
+          input.txLogs,
+          input.log.logIndex,
+          (log) => parseTransfer(log, null),
+          (transfer) => transfer.value === orderFulfilled.netAmount,
+        )
   const $srcChain =
     settlementSent?.args.$dstChain ??
     (fulfilledSrcChainId === undefined || wormholeNetworks.length === 0
@@ -167,6 +190,7 @@ function captureOrderFulfilled(
       key: orderFulfilled.key,
       dstAmount: orderFulfilled.netAmount,
       $srcChain,
+      dstTokenAddress: dstTokenAddress ?? transferMatch?.transfer?.logAddress,
     }),
   ]
   if (settlementSent) {
@@ -183,20 +207,17 @@ function findSingleSettlementSentInTx(
 ) {
   for (const log of input.txLogs) {
     const logMsg = parseLogMessagePublished(log, null)
-    if (
-      !logMsg ||
-      EthereumAddress(logMsg.sender) !== MAYAN_PROTOCOLS.mayanSwift ||
-      logMsg.sequence !== sequence
-    ) {
+    if (!logMsg || logMsg.sequence !== sequence) {
       continue
     }
 
     // Only single UNLOCK is captured here. BATCH_UNLOCK is handled in mayan-swift-settlement plugin.
     if (
       getMayanSwiftSettlementMsgType(logMsg.payload) !==
-      MAYAN_SWIFT_MSG_TYPE_UNLOCK
+        MAYAN_SWIFT_MSG_TYPE_UNLOCK ||
+      extractMayanSwiftSettlementUnlockKey(logMsg.payload) !== orderKey
     ) {
-      return
+      continue
     }
 
     const srcChainId = extractMayanSwiftSettlementDestChain(logMsg.payload)
@@ -289,7 +310,9 @@ function matchFulfilledOrder(
   const srcTokenAddress =
     mayanForwarded?.args.tokenIn ?? orderCreated.args.srcTokenAddress
   const dstTokenAddress =
-    mayanForwarded?.args.tokenOut ?? orderCreated.args.dstTokenAddress
+    mayanForwarded?.args.tokenOut ??
+    orderCreated.args.dstTokenAddress ??
+    orderFulfilled.args.dstTokenAddress
 
   // Settlement messages (LogMessagePublished → OrderUnlocked) are matched separately
   // by the mayan-swift-settlement plugin.
@@ -417,6 +440,7 @@ export class MayanSwiftPlugin implements InteropPluginResyncable {
         Result.Transfer('mayan-swift.Transfer', {
           srcChain,
           dstEvent: orderEvent,
+          dstTokenAddress: orderEvent.args.dstTokenAddress,
           dstAmount: orderEvent.args.dstAmount,
           bridgeType: 'nonMinting',
         }),

--- a/packages/backend/src/modules/interop/plugins/mayan-swift.utils.ts
+++ b/packages/backend/src/modules/interop/plugins/mayan-swift.utils.ts
@@ -1,3 +1,4 @@
+import { Address32 } from '@l2beat/shared-pure'
 import { decodeFunctionData, parseAbi } from 'viem'
 import { BinaryReader } from '../../../tools/BinaryReader'
 
@@ -24,15 +25,65 @@ const mayanSwiftUnlockAbi = parseAbi([
   'function unlockBatch(bytes encodedVm)',
 ])
 
-const mayanSwiftFulfillAbi = parseAbi([
+const mayanSwiftFulfillLegacyAbi = parseAbi([
   'function fulfillOrder(uint256 fulfillAmount, bytes encodedVm, bytes32 recepient, bool batch)',
   'function fulfillSimple(uint256 fulfillAmount, bytes32 orderHash, uint16 srcChainId, bytes32 tokenIn, uint8 protocolBps, (bytes32, bytes32, uint64, uint64, uint64, uint64, uint64, bytes32, uint16, bytes32, uint8, uint8, bytes32), bytes32 recepient, bool batch)',
+])
+
+const mayanSwiftFulfillCurrentAbi = parseAbi([
+  'function fulfillOrder(uint256 fulfillAmount, bytes encodedVm, (uint8, bytes32, bytes32, uint16, bytes32, bytes32, uint64, uint64, uint64, uint64, uint64, uint8, uint8, bytes32), (uint16, bytes32, uint8, bytes32), (bytes32, bytes32, bool), (uint256, uint256, uint8, bytes32, bytes32))',
+  'function fulfillSimple(uint256 fulfillAmount, bytes32 orderHash, (uint8, bytes32, bytes32, uint16, bytes32, bytes32, uint64, uint64, uint64, uint64, uint64, uint8, uint8, bytes32), (uint16, bytes32, uint8, bytes32), (bytes32, bytes32, bool), (uint256, uint256, uint8, bytes32, bytes32))',
 ])
 
 const mayanSwiftFulfillWrapperAbi = parseAbi([
   'function fulfillWithERC20(address tokenIn, uint256 amountIn, address router, address allowanceTarget, bytes swapCalldata, address mayan, bytes mayanCalldata, (uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s))',
   'function directFulfill(address tokenIn, uint256 amountIn, address mayan, bytes mayanCalldata, (uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s))',
 ])
+
+interface MayanSwiftFulfillDetails {
+  srcChainId?: number
+  dstTokenAddress?: Address32
+}
+
+type MayanSwiftCurrentOrderParams = readonly [
+  number,
+  `0x${string}`,
+  `0x${string}`,
+  number,
+  `0x${string}`,
+  `0x${string}`,
+  bigint,
+  bigint,
+  bigint,
+  bigint,
+  bigint,
+  number,
+  number,
+  `0x${string}`,
+]
+
+type MayanSwiftCurrentExtraParams = readonly [
+  number,
+  `0x${string}`,
+  number,
+  `0x${string}`,
+]
+
+type MayanSwiftLegacyOrderParams = readonly [
+  `0x${string}`,
+  `0x${string}`,
+  bigint,
+  bigint,
+  bigint,
+  bigint,
+  bigint,
+  `0x${string}`,
+  number,
+  `0x${string}`,
+  number,
+  number,
+  `0x${string}`,
+]
 
 // Message format:
 // - UNLOCK: 0x02 + orderKey(32) + dstChainId(2) + tokenAddr(32) + recipient(32)
@@ -94,6 +145,14 @@ export function extractMayanSwiftSettlementDestChain(
   return decoded.dstChainId
 }
 
+export function extractMayanSwiftSettlementUnlockKey(
+  payload: string,
+): string | undefined {
+  const decoded = decodeMayanSwiftSettlementPayload(payload)
+  if (!decoded || decoded.msgType !== MAYAN_SWIFT_MSG_TYPE_UNLOCK) return
+  return decoded.key
+}
+
 export function extractMayanSwiftBatchOrderKeys(
   payload: string,
 ): Array<{ key: string; dstChainId: number }> | undefined {
@@ -133,35 +192,34 @@ export function extractWormholeEmitterChainFromTxData(
 export function extractMayanSwiftFulfillSourceChainFromTxData(
   txData: string | undefined,
 ): number | undefined {
+  return extractMayanSwiftFulfillDetailsFromTxData(txData)?.srcChainId
+}
+
+export function extractMayanSwiftFulfillDestTokenFromTxData(
+  txData: string | undefined,
+): Address32 | undefined {
+  return extractMayanSwiftFulfillDetailsFromTxData(txData)?.dstTokenAddress
+}
+
+function extractMayanSwiftFulfillDetailsFromTxData(
+  txData: string | undefined,
+): MayanSwiftFulfillDetails | undefined {
   try {
     if (!txData) return undefined
-    return extractMayanSwiftFulfillSourceChainFromCallData(
-      txData as `0x${string}`,
-    )
+    return extractMayanSwiftFulfillDetailsFromCallData(txData as `0x${string}`)
   } catch {
     return undefined
   }
 }
 
-function extractMayanSwiftFulfillSourceChainFromCallData(
+function extractMayanSwiftFulfillDetailsFromCallData(
   txData: `0x${string}`,
-): number | undefined {
-  try {
-    const decoded = decodeFunctionData({
-      abi: mayanSwiftFulfillAbi,
-      data: txData,
-    })
+): MayanSwiftFulfillDetails | undefined {
+  const current = extractMayanSwiftCurrentFulfillDetailsFromCallData(txData)
+  if (current) return current
 
-    if (decoded.functionName === 'fulfillOrder') {
-      const encodedVm = decoded.args[1]
-      if (typeof encodedVm !== 'string') return undefined
-      return extractMayanSwiftFulfillSourceChainFromVaa(encodedVm)
-    }
-
-    if (decoded.functionName === 'fulfillSimple') {
-      return decoded.args[2]
-    }
-  } catch {}
+  const legacy = extractMayanSwiftLegacyFulfillDetailsFromCallData(txData)
+  if (legacy) return legacy
 
   try {
     const decoded = decodeFunctionData({
@@ -180,7 +238,62 @@ function extractMayanSwiftFulfillSourceChainFromCallData(
         ? decoded.args[6]
         : decoded.args[3]
     if (typeof mayanCalldata !== 'string') return undefined
-    return extractMayanSwiftFulfillSourceChainFromCallData(mayanCalldata)
+    return extractMayanSwiftFulfillDetailsFromCallData(mayanCalldata)
+  } catch {
+    return undefined
+  }
+}
+
+function extractMayanSwiftCurrentFulfillDetailsFromCallData(
+  txData: `0x${string}`,
+): MayanSwiftFulfillDetails | undefined {
+  try {
+    const decoded = decodeFunctionData({
+      abi: mayanSwiftFulfillCurrentAbi,
+      data: txData,
+    })
+    if (
+      decoded.functionName !== 'fulfillOrder' &&
+      decoded.functionName !== 'fulfillSimple'
+    ) {
+      return undefined
+    }
+
+    const params = decoded.args[2] as unknown as MayanSwiftCurrentOrderParams
+    const extraParams = decoded
+      .args[3] as unknown as MayanSwiftCurrentExtraParams
+
+    return {
+      srcChainId: extraParams[0],
+      dstTokenAddress: toMayanTokenAddress(params[5]),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function extractMayanSwiftLegacyFulfillDetailsFromCallData(
+  txData: `0x${string}`,
+): MayanSwiftFulfillDetails | undefined {
+  try {
+    const decoded = decodeFunctionData({
+      abi: mayanSwiftFulfillLegacyAbi,
+      data: txData,
+    })
+
+    if (decoded.functionName === 'fulfillOrder') {
+      const encodedVm = decoded.args[1]
+      if (typeof encodedVm !== 'string') return undefined
+      return extractMayanSwiftFulfillDetailsFromVaa(encodedVm)
+    }
+
+    if (decoded.functionName === 'fulfillSimple') {
+      const order = decoded.args[5] as unknown as MayanSwiftLegacyOrderParams
+      return {
+        srcChainId: decoded.args[2],
+        dstTokenAddress: toMayanTokenAddress(order[1]),
+      }
+    }
   } catch {
     return undefined
   }
@@ -201,9 +314,9 @@ function extractWormholeEmitterChainFromVaa(
   }
 }
 
-function extractMayanSwiftFulfillSourceChainFromVaa(
+function extractMayanSwiftFulfillDetailsFromVaa(
   encodedVm: `0x${string}`,
-): number | undefined {
+): MayanSwiftFulfillDetails | undefined {
   try {
     const payload = extractWormholePayloadFromVaa(encodedVm)
     if (!payload) return undefined
@@ -213,7 +326,19 @@ function extractMayanSwiftFulfillSourceChainFromVaa(
     const action = reader.readUint8()
     if (action !== 1) return undefined
     reader.skipBytes(32)
-    return reader.readUint16()
+    const srcChainId = reader.readUint16()
+
+    // Payload layout matches fulfillSimple:
+    // action + orderHash + srcChainId + tokenIn + protocolBps + trader + tokenOut + ...
+    if (reader.length < 32 + 1 + 32 + 32) {
+      return { srcChainId }
+    }
+
+    reader.skipBytes(32 + 1 + 32)
+    return {
+      srcChainId,
+      dstTokenAddress: toMayanTokenAddress(reader.readBytes(32)),
+    }
   } catch {
     return undefined
   }
@@ -232,4 +357,9 @@ function extractWormholePayloadFromVaa(
   } catch {
     return undefined
   }
+}
+
+function toMayanTokenAddress(token: string): Address32 {
+  const address = Address32.from(token)
+  return address === Address32.ZERO ? Address32.NATIVE : address
 }

--- a/packages/backend/src/modules/interop/plugins/mayan-wormhole.ts
+++ b/packages/backend/src/modules/interop/plugins/mayan-wormhole.ts
@@ -28,10 +28,6 @@ const MAYAN_CIRCLE_WORMHOLE_EMITTING_METHODS = new Set([
   '0x1c59b7fc', // mayanCircle.createOrder (legacy)
 ])
 
-export function isMayanSwiftSender(sender: EthereumAddress): boolean {
-  return sender === MAYAN_PROTOCOLS.mayanSwift
-}
-
 export function isMayanCircleSender(sender: EthereumAddress): boolean {
   return sender === MAYAN_PROTOCOLS.mayanCircle
 }

--- a/packages/backend/src/modules/interop/plugins/relay/relay.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.plugin.ts
@@ -46,6 +46,7 @@ export class RelayPlugin implements InteropPlugin {
             : undefined,
           dstTokenAddress: tokenReceived.args.token,
           dstWasMinted: false,
+          bridgeType: 'nonMinting',
         }),
       ]
     }
@@ -92,6 +93,7 @@ export class RelayPlugin implements InteropPlugin {
           : undefined,
         srcTokenAddress: tokenSent.args.token,
         srcWasBurned: false,
+        bridgeType: 'nonMinting',
       }),
     ]
   }

--- a/packages/backend/src/modules/interop/plugins/wormhole-ntt.ts
+++ b/packages/backend/src/modules/interop/plugins/wormhole-ntt.ts
@@ -486,6 +486,7 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
         srcTokenAddress,
         srcAmount,
         srcWasBurned: sentTransceiverMessage.args.srcWasBurned,
+        bridgeType: 'burnAndMint',
         extraEvents: [logMessagePublished],
       }),
     ]
@@ -512,6 +513,7 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
         dstTokenAddress: received.args.transferTokenAddress,
         dstAmount: received.args.transferAmount,
         dstWasMinted: received.args.dstWasMinted,
+        bridgeType: 'burnAndMint',
         extraEvents,
       }),
     ]

--- a/packages/backend/src/modules/interop/plugins/wormhole-token-bridge.ts
+++ b/packages/backend/src/modules/interop/plugins/wormhole-token-bridge.ts
@@ -139,6 +139,7 @@ export class WormholeTokenBridgePlugin implements InteropPluginResyncable {
             dstTokenAddress: event.args.dstTokenAddress,
             dstAmount: event.args.dstAmount,
             dstWasMinted: event.args.dstWasMinted,
+            bridgeType: 'lockAndMint',
           }),
         ]
       }
@@ -198,6 +199,7 @@ export class WormholeTokenBridgePlugin implements InteropPluginResyncable {
           srcTokenAddress: event.args.srcTokenAddress,
           srcAmount: event.args.srcAmount,
           srcWasBurned,
+          bridgeType: 'lockAndMint',
         }),
       ]
     }

--- a/packages/backend/src/modules/interop/plugins/wormhole/wormhole.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/wormhole/wormhole.plugin.ts
@@ -7,9 +7,13 @@ import {
 import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
 import { findParsedAfter, findTransferLogBefore } from '../logScan'
 import {
+  getMayanSwiftSettlementMsgType,
+  MAYAN_SWIFT_MSG_TYPE_BATCH_UNLOCK,
+  MAYAN_SWIFT_MSG_TYPE_UNLOCK,
+} from '../mayan-swift.utils'
+import {
   findMayanCircleDestinationChain,
   isMayanCircleSender,
-  isMayanSwiftSender,
   MAYAN_FORWARDER_TX_EVENT_SIGNATURES,
 } from '../mayan-wormhole'
 import {
@@ -104,9 +108,13 @@ export class WormholePlugin implements InteropPluginResyncable {
 
     // Skip Mayan Swift settlement messages - they are handled by mayan-swift.ts and
     // mayan-swift-settlement.ts which create SettlementSent events with extracted order keys
-    // for matching with OrderUnlocked. If we captured them here as LogMessagePublished,
-    // they would remain unmatched since the settlement matching uses SettlementSent.
-    if (isMayanSwiftSender(senderAddress)) {
+    // for matching with OrderUnlocked. Sender-based detection is insufficient because
+    // fulfillment wrappers can emit the Wormhole message via helper contracts.
+    const mayanSwiftMsgType = getMayanSwiftSettlementMsgType(parsed.payload)
+    if (
+      mayanSwiftMsgType === MAYAN_SWIFT_MSG_TYPE_UNLOCK ||
+      mayanSwiftMsgType === MAYAN_SWIFT_MSG_TYPE_BATCH_UNLOCK
+    ) {
       return
     }
 


### PR DESCRIPTION
we need to hardcode bridgetypes for onesided bridges for frontend categories. 
but we can still identify onesided data on FE and mark it as such