### PR TITLE
fix: interop protocols descriptions

### DIFF
--- a/packages/frontend/src/pages/interop/utils/display.ts
+++ b/packages/frontend/src/pages/interop/utils/display.ts
@@ -2,17 +2,17 @@ export const TRANSFER_TYPE_DISPLAY = {
   lockAndMint: {
     label: 'Lock & Mint',
     description:
-      'Includes protocols with transfers where tokens are permanently destroyed on the source chain and minted on the destination. The bridge risk is present at all times, as it can mint tokens on all chains. Flow limits might be applied.',
+      'Includes protocols with transfers where the original assets are locked in a vault on one chain and a 1:1 representation is created on the other. One-sided risk. If user bridges back, the original tokens are unlocked and the bridge risk is removed.',
   },
   burnAndMint: {
     label: 'Burn & Mint',
     description:
-      'Includes protocols with transfers that rely on existing liquidity on both sides. In-flight risk only. Tokens are therefore first created using a different minting mechanism that needs to be separately assessed.',
+      'Includes protocols with transfers where tokens are permanently destroyed on the source chain and minted on the destination. The bridge risk is present at all times, as it can mint tokens on all chains. Flow limits might be applied.',
   },
   nonMinting: {
     label: 'Non-minting',
     description:
-      'Includes protocols with transfers where the original assets are locked in a vault on one chain and a 1:1 representation is created on the other. One-sided risk. If user bridges back, the original tokens are unlocked and the bridge risk is removed.',
+      'Includes protocols with transfers that rely on existing liquidity on both sides. In-flight risk only. Tokens are therefore first created using a different minting mechanism that needs to be separately assessed.',
   },
 }
 


### PR DESCRIPTION
The descriptions for the three types of interop protocols were mixed up:

  - Lock & Mint was showing the Burn & Mint description ("tokens are permanently destroyed…")
  - Burn & Mint was showing the Non-minting description ("rely on existing liquidity…")
  - Non-minting was showing the Lock & Mint description ("original assets are locked in a
  vault…")
  
 This PR fixes this and ensures the descriptions matches the type of interop protocol