### PR TITLE
Better logging for discovery

### DIFF
--- a/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
+++ b/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
@@ -149,14 +149,14 @@ export class DiscoveryRunner {
       logger.info(
         `Discovering ${dependencyConfig.name} at timestamp ${dependencyTimestamp}`,
       )
-      const analysis = await this.discoveryEngine.discover(
+      const { analyses } = await this.discoveryEngine.discover(
         this.allProviders,
         dependencyConfig.structure,
         dependencyTimestamp,
       )
 
       const chains = unique(
-        analysis.map((c) => ChainSpecificAddress.longChain(c.address)),
+        analyses.map((c) => ChainSpecificAddress.longChain(c.address)),
       )
 
       const usedBlockNumbers: Record<string, number> = {}
@@ -170,9 +170,9 @@ export class DiscoveryRunner {
         dependencyConfig,
         dependencyTimestamp,
         usedBlockNumbers,
-        analysis,
+        analyses,
       )
-      discoveries.set(dependency, discovery, analysis)
+      discoveries.set(dependency, discovery, analyses)
     }
     return discoveries
   }

--- a/packages/discovery/src/discovery/engine/DiscoveryEngine.test.ts
+++ b/packages/discovery/src/discovery/engine/DiscoveryEngine.test.ts
@@ -72,9 +72,9 @@ describe(DiscoveryEngine.name, () => {
       })
 
     const engine = new DiscoveryEngine(addressAnalyzer, Logger.SILENT)
-    const result = await engine.discover(provider, config.structure, 1234)
+    const { analyses } = await engine.discover(provider, config.structure, 1234)
 
-    expect(result).toEqual([
+    expect(analyses).toEqual([
       {
         ...base,
         type: 'Contract',

--- a/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
+++ b/packages/discovery/src/discovery/engine/DiscoveryEngine.ts
@@ -20,6 +20,11 @@ import { gatherReachableAddresses } from './gatherReachableAddresses'
 import { removeAlreadyAnalyzed } from './removeAlreadyAnalyzed'
 import { shouldSkip } from './shouldSkip'
 
+export interface AddressStats {
+  discovered: number
+  skipped: number
+}
+
 export class DiscoveryEngine {
   constructor(
     private readonly addressAnalyzer: AddressAnalyzer,
@@ -31,11 +36,12 @@ export class DiscoveryEngine {
     config: StructureConfig,
     timestamp: UnixTime,
     counter: DiscoveryCounter = new SimpleDiscoveryCounter(),
-  ): Promise<Analysis[]> {
+  ): Promise<{ analyses: Analysis[]; stats: AddressStats }> {
     const sharedModuleIndex = buildSharedModuleIndex(config)
     const resolved: Record<string, Analysis> = {}
     let toAnalyze: AddressesWithTemplates = {}
     let depth = 0
+    let skipped = 0
 
     config.initialAddresses.forEach((address) => {
       toAnalyze[address.toString()] = new Set()
@@ -121,6 +127,9 @@ export class DiscoveryEngine {
             counter.getCount(),
           )
           if (skipReason !== undefined) {
+            if (skipReason.startsWith('total ')) {
+              skipped++
+            }
             const info = `↓${depth} ${counter.increment()}/${total}`
             const entries = [
               chalk.gray(info),
@@ -165,10 +174,13 @@ export class DiscoveryEngine {
       depth++
     }
 
-    const result = Object.values(resolved)
-    this.checkErrors(result)
+    const analyses = Object.values(resolved)
+    this.checkErrors(analyses)
 
-    return result
+    return {
+      analyses,
+      stats: { discovered: analyses.length, skipped },
+    }
   }
 
   private logObject(

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -133,20 +133,18 @@ function printMaxAddressesWarning(
   maxAddresses: number,
 ) {
   const lines = [
-    `  ⚠  WARNING — DISCOVERY IS INCOMPLETE  ⚠  `,
-    ``,
+    '  ⚠  WARNING — DISCOVERY IS INCOMPLETE  ⚠  ',
+    '',
     `  maxAddresses limit reached: ${skipped} address${skipped === 1 ? '' : 'es'} were SKIPPED.`,
-    `  These addresses were NOT analyzed and are MISSING from discovered.json.`,
-    ``,
+    '  These addresses were NOT analyzed and are MISSING from discovered.json.',
+    '',
     `  FIX: raise "maxAddresses" (currently ${maxAddresses}) in the project config,`,
-    `       then re-run discovery.`,
+    '       then re-run discovery.',
   ]
   const width = lines.reduce((max, l) => Math.max(max, l.length), 0)
   const padded = lines.map((l) => ' ' + l.padEnd(width) + ' ')
   const blank = ' '.repeat(width + 2)
-  const banner = [blank, ...padded, blank].map((l) =>
-    chalk.bgRed.white.bold(l),
-  )
+  const banner = [blank, ...padded, blank].map((l) => chalk.bgRed.white.bold(l))
   logger.info('')
   for (const line of banner) {
     logger.info(line)
@@ -256,11 +254,8 @@ export async function discover(
     logger,
   )
   const timestamp = UnixTime.fromDate(timestampDate ?? new Date())
-  const { analyses: result, stats: addressStats } = await discoveryEngine.discover(
-    allProviders,
-    config.structure,
-    timestamp,
-  )
+  const { analyses: result, stats: addressStats } =
+    await discoveryEngine.discover(allProviders, config.structure, timestamp)
   const chains = unique(
     result.map((c) => ChainSpecificAddress.longChain(c.address)),
   )

--- a/packages/discovery/src/discovery/runDiscovery.ts
+++ b/packages/discovery/src/discovery/runDiscovery.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@l2beat/backend-tools'
 import type { HttpClient } from '@l2beat/shared'
 import { ChainSpecificAddress, UnixTime, unique } from '@l2beat/shared-pure'
+import chalk from 'chalk'
 import path from 'path'
 import type {
   DiscoveryChainConfig,
@@ -12,6 +13,7 @@ import { TEMPLATES_PATH, TemplateService } from './analysis/TemplateService'
 import type { ConfigReader } from './config/ConfigReader'
 import type { ConfigRegistry } from './config/ConfigRegistry'
 import type { DiscoveryPaths } from './config/getDiscoveryPaths'
+import type { AddressStats } from './engine/DiscoveryEngine'
 import { getDiscoveryEngine } from './getDiscoveryEngine'
 import { OverwriteCacheWrapper } from './OverwriteCacheWrapper'
 import { diffDiscovery } from './output/diffDiscovery'
@@ -57,15 +59,16 @@ export async function runDiscovery(
 
   const timestampDate = getTimestamp(configReader, config)
 
-  const { result, timestamp, usedBlockNumbers, providerStats } = await discover(
-    paths,
-    chainConfigs,
-    projectConfig,
-    logger,
-    timestampDate,
-    http,
-    config.overwriteCache,
-  )
+  const { result, timestamp, usedBlockNumbers, providerStats, addressStats } =
+    await discover(
+      paths,
+      chainConfigs,
+      projectConfig,
+      logger,
+      timestampDate,
+      http,
+      config.overwriteCache,
+    )
 
   const templatesFolder = path.join(paths.discovery, TEMPLATES_PATH)
 
@@ -114,6 +117,41 @@ export async function runDiscovery(
     projectConfig.color,
     templateService,
   )
+
+  if (addressStats.skipped > 0) {
+    printMaxAddressesWarning(
+      logger,
+      addressStats.skipped,
+      projectConfig.structure.maxAddresses,
+    )
+  }
+}
+
+function printMaxAddressesWarning(
+  logger: Logger,
+  skipped: number,
+  maxAddresses: number,
+) {
+  const lines = [
+    `  ⚠  WARNING — DISCOVERY IS INCOMPLETE  ⚠  `,
+    ``,
+    `  maxAddresses limit reached: ${skipped} address${skipped === 1 ? '' : 'es'} were SKIPPED.`,
+    `  These addresses were NOT analyzed and are MISSING from discovered.json.`,
+    ``,
+    `  FIX: raise "maxAddresses" (currently ${maxAddresses}) in the project config,`,
+    `       then re-run discovery.`,
+  ]
+  const width = lines.reduce((max, l) => Math.max(max, l.length), 0)
+  const padded = lines.map((l) => ' ' + l.padEnd(width) + ' ')
+  const blank = ' '.repeat(width + 2)
+  const banner = [blank, ...padded, blank].map((l) =>
+    chalk.bgRed.white.bold(l),
+  )
+  logger.info('')
+  for (const line of banner) {
+    logger.info(line)
+  }
+  logger.info('')
 }
 
 export async function dryRunDiscovery(
@@ -202,6 +240,7 @@ export async function discover(
   timestamp: UnixTime
   usedBlockNumbers: Record<string, number>
   providerStats: Record<string, AllProviderStats>
+  addressStats: AddressStats
 }> {
   const sqliteCache = new SQLiteCache(paths.cache)
 
@@ -217,7 +256,7 @@ export async function discover(
     logger,
   )
   const timestamp = UnixTime.fromDate(timestampDate ?? new Date())
-  const result = await discoveryEngine.discover(
+  const { analyses: result, stats: addressStats } = await discoveryEngine.discover(
     allProviders,
     config.structure,
     timestamp,
@@ -237,5 +276,6 @@ export async function discover(
     timestamp,
     usedBlockNumbers,
     providerStats: allProviders.getStats(),
+    addressStats,
   }
 }

--- a/packages/discovery/src/utils/EtherscanClient.ts
+++ b/packages/discovery/src/utils/EtherscanClient.ts
@@ -24,6 +24,12 @@ import { jsonToHumanReadableAbi } from './jsonToHumanReadableAbi'
 
 class EtherscanError extends Error {}
 
+function isRateLimitError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false
+  const message = (error as { message?: unknown }).message
+  return typeof message === 'string' && message.includes('rate limit reached')
+}
+
 const shouldRetry = Retries.exponentialBackOff({
   stepMs: 2000, // 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s, 1024s, 2048s
   maxAttempts: 10,
@@ -249,7 +255,9 @@ export class EtherscanClient implements IEtherscanClient {
         if (result.shouldStop) {
           throw error
         }
-        this.logger.warn('Retrying', { attempts, error })
+        if (!isRateLimitError(error)) {
+          this.logger.warn('Retrying', { attempts, error })
+        }
         await new Promise((resolve) => setTimeout(resolve, result.executeAfter))
       }
     }


### PR DESCRIPTION
Don't print Etherscan rate limit errors
Give a warning if discovery contains skipped addresses

<img width="977" height="389" alt="image" src="https://github.com/user-attachments/assets/4705cf46-1ff9-4876-8ee6-116e3ecdc5dd" />
