### PR TITLE
Handle empty synced windows in DA throughput charts

### DIFF
--- a/packages/frontend/src/server/features/data-availability/throughput/getDaThroughputChart.ts
+++ b/packages/frontend/src/server/features/data-availability/throughput/getDaThroughputChart.ts
@@ -76,6 +76,9 @@ export async function getDaThroughputChart({
     throughput,
     resolution,
   )
+  if (minTimestamp === undefined || maxTimestamp === undefined) {
+    return { data: [] }
+  }
 
   const lastDataForLayers: Record<
     string,
@@ -186,6 +189,17 @@ export function groupByTimestampAndDaLayerId(
     }
     minTimestamp = Math.min(minTimestamp, timestamp)
     maxTimestamp = Math.max(maxTimestamp, timestamp)
+  }
+
+  if (
+    minTimestamp === Number.POSITIVE_INFINITY ||
+    maxTimestamp === Number.NEGATIVE_INFINITY
+  ) {
+    return {
+      grouped: result,
+      minTimestamp: undefined,
+      maxTimestamp: undefined,
+    }
   }
 
   return {

--- a/packages/frontend/src/server/features/data-availability/throughput/getDaThroughputChartByProject.ts
+++ b/packages/frontend/src/server/features/data-availability/throughput/getDaThroughputChartByProject.ts
@@ -102,6 +102,9 @@ export async function getDaThroughputChartByProjectData({
     sovereignProjects,
     includeScalingOnly,
   )
+  if (minTimestamp === undefined || maxTimestamp === undefined) {
+    return undefined
+  }
 
   const expectedTo = getThroughputExpectedTimestamp({
     to: range[1],
@@ -204,17 +207,30 @@ function groupByTimestampAndProjectId(
     }
   }
 
-  return {
-    grouped: Object.fromEntries(
-      Object.entries(result).map(([timestamp, projects]) => [
-        timestamp,
-        Object.fromEntries(
-          Object.entries(projects).sort(
-            ([, valueA], [, valueB]) => valueB - valueA,
-          ),
+  const grouped = Object.fromEntries(
+    Object.entries(result).map(([timestamp, projects]) => [
+      timestamp,
+      Object.fromEntries(
+        Object.entries(projects).sort(
+          ([, valueA], [, valueB]) => valueB - valueA,
         ),
-      ]),
-    ),
+      ),
+    ]),
+  )
+
+  if (
+    minTimestamp === Number.POSITIVE_INFINITY ||
+    maxTimestamp === Number.NEGATIVE_INFINITY
+  ) {
+    return {
+      grouped,
+      minTimestamp: undefined,
+      maxTimestamp: undefined,
+    }
+  }
+
+  return {
+    grouped,
     minTimestamp: UnixTime(minTimestamp),
     maxTimestamp: UnixTime(maxTimestamp),
   }

--- a/packages/frontend/src/server/features/data-availability/throughput/getProjectDaThroughputChart.ts
+++ b/packages/frontend/src/server/features/data-availability/throughput/getProjectDaThroughputChart.ts
@@ -94,6 +94,9 @@ export async function getProjectDaThroughputChartData({
     throughput,
     resolution,
   )
+  if (minTimestamp === undefined || maxTimestamp === undefined) {
+    return undefined
+  }
 
   const expectedTo = getThroughputExpectedTimestamp({
     to: range[1],
@@ -152,6 +155,17 @@ function groupByTimestampAndProjectId(
     }
     minTimestamp = Math.min(minTimestamp, timestamp)
     maxTimestamp = Math.max(maxTimestamp, timestamp)
+  }
+
+  if (
+    minTimestamp === Number.POSITIVE_INFINITY ||
+    maxTimestamp === Number.NEGATIVE_INFINITY
+  ) {
+    return {
+      grouped: result,
+      minTimestamp: undefined,
+      maxTimestamp: undefined,
+    }
   }
 
   return {

--- a/packages/frontend/src/server/features/data-availability/throughput/getScalingProjectDaThroughtputChart.ts
+++ b/packages/frontend/src/server/features/data-availability/throughput/getScalingProjectDaThroughtputChart.ts
@@ -69,6 +69,9 @@ export async function getScalingProjectDaThroughputChart({
     throughput,
     resolution,
   )
+  if (minTimestamp === undefined || maxTimestamp === undefined) {
+    return undefined
+  }
 
   const lastDataForLayers: Record<
     string,
@@ -192,6 +195,16 @@ function groupByTimestamp(
     result[timestamp][record.daLayer] = currentDaLayerValue + Number(value)
     minTimestamp = Math.min(minTimestamp, timestamp)
     maxTimestamp = Math.max(maxTimestamp, timestamp)
+  }
+  if (
+    minTimestamp === Number.POSITIVE_INFINITY ||
+    maxTimestamp === Number.NEGATIVE_INFINITY
+  ) {
+    return {
+      grouped: result,
+      minTimestamp: undefined,
+      maxTimestamp: undefined,
+    }
   }
   return {
     grouped: result,


### PR DESCRIPTION
This prevents Infinity/-Infinity chart ranges when fully synced throughput buckets are absent, and returns empty results instead of generating invalid timelines.