### PR TITLE
Add search aliases to projects

### DIFF
--- a/packages/config/src/projects/aevo/aevo.ts
+++ b/packages/config/src/projects/aevo/aevo.ts
@@ -25,6 +25,7 @@ export const aevo: ScalingProject = opStackL2({
   ],
   display: {
     name: 'Aevo',
+    aliases: ['Ribbon Finance'],
     slug: 'aevo',
     warning:
       'The fault proof system is deployed but is not functional. The chain ID is not included in the op-program superchain registry, causing the dispute game to panic during execution. Security relies entirely on the permissioned proposer and challengers.',

--- a/packages/config/src/projects/agglayer/agglayer.ts
+++ b/packages/config/src/projects/agglayer/agglayer.ts
@@ -7,6 +7,7 @@ export const agglayer: BaseProject = {
   slug: 'agglayer',
   name: 'Agglayer',
   shortName: undefined,
+  aliases: ['Polygon'],
   addedAt: 1743677000,
   display: {
     description:

--- a/packages/config/src/projects/airbender/airbender.ts
+++ b/packages/config/src/projects/airbender/airbender.ts
@@ -9,6 +9,7 @@ export const airbender: BaseProject = {
   slug: 'airbender',
   name: 'Airbender',
   shortName: undefined,
+  aliases: ['Matter Labs', 'ZKsync'],
   addedAt: UnixTime.fromDate(new Date('2025-09-09')),
   display: {
     description:

--- a/packages/config/src/projects/ancient/ancient.ts
+++ b/packages/config/src/projects/ancient/ancient.ts
@@ -24,6 +24,7 @@ export const ancient: ScalingProject = opStackL2({
   ],
   display: {
     name: 'Ancient8',
+    aliases: ['Ancient 8'],
     slug: 'ancient8',
     warning:
       'The fault proof system is deployed but is not functional. The chain ID is not included in the op-program superchain registry, causing the dispute game to panic during execution. Security relies entirely on the permissioned proposer and challengers.',

--- a/packages/config/src/projects/avalanche/avalanche.ts
+++ b/packages/config/src/projects/avalanche/avalanche.ts
@@ -6,6 +6,7 @@ export const avalanche: BaseProject = {
   slug: 'avalanche',
   name: 'Avalanche',
   shortName: undefined,
+  aliases: ['AVAX'],
   addedAt: UnixTime(1662628329),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/barretenberg/barretenberg.ts
+++ b/packages/config/src/projects/barretenberg/barretenberg.ts
@@ -9,6 +9,7 @@ export const barretenberg: BaseProject = {
   slug: 'barretenberg',
   name: 'Barretenberg',
   shortName: undefined,
+  aliases: ['Aztec'],
   addedAt: UnixTime.fromDate(new Date('2026-03-17')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/base/base.ts
+++ b/packages/config/src/projects/base/base.ts
@@ -20,6 +20,7 @@ export const base: ScalingProject = opStackL2({
   genesisTimestamp,
   display: {
     name: 'Base Chain',
+    aliases: ['Coinbase'],
     slug: 'base',
     stateValidationImage: 'opfp',
     stacks: ['OP Stack'],

--- a/packages/config/src/projects/blobstream/blobstream.ts
+++ b/packages/config/src/projects/blobstream/blobstream.ts
@@ -22,6 +22,7 @@ export const blobstream: BaseProject = {
   slug: 'blobstream',
   name: 'Blobstream',
   shortName: undefined,
+  aliases: ['Celestia'],
   addedAt: UnixTime(1729253328), // 2024-10-18T12:08:48Z
   // data
   statuses: {

--- a/packages/config/src/projects/bob/bob.ts
+++ b/packages/config/src/projects/bob/bob.ts
@@ -19,6 +19,7 @@ export const bob: ScalingProject = opStackL2({
   isPartOfSuperchain: true,
   display: {
     name: 'BOB',
+    aliases: ['Build on Bitcoin'],
     slug: 'bob',
     description:
       "BOB (Build on Bitcoin) is an OP Stack rollup that aims to natively support the Bitcoin stack. The current implementation supports a variety of canonical and external bridging for BTC-related assets and a tBTC-v2 LightRelay smart contract for verifying Bitcoin transaction proofs through their blocks' headers on the L2.",

--- a/packages/config/src/projects/boojum/boojum.ts
+++ b/packages/config/src/projects/boojum/boojum.ts
@@ -9,6 +9,7 @@ export const boojum: BaseProject = {
   slug: 'boojum',
   name: 'Boojum',
   shortName: undefined,
+  aliases: ['Matter Labs', 'ZKsync'],
   addedAt: UnixTime.fromDate(new Date('2025-07-11')),
   display: {
     description:

--- a/packages/config/src/projects/bsc/bsc.ts
+++ b/packages/config/src/projects/bsc/bsc.ts
@@ -8,6 +8,7 @@ export const bsc: BaseProject = {
   slug: 'bsc',
   name: 'Binance Smart Chain',
   shortName: 'BSC',
+  aliases: ['BNB Smart Chain'],
   addedAt: UnixTime.fromDate(new Date('2023-01-01')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/cctpv1/cctpv1.ts
+++ b/packages/config/src/projects/cctpv1/cctpv1.ts
@@ -6,6 +6,7 @@ export const cctpv1: BaseProject = {
   slug: 'cctpv1',
   name: 'CCTP v1',
   shortName: undefined,
+  aliases: ['Circle', 'Cross-Chain Transfer Protocol'],
   addedAt: UnixTime(1769523398),
   interopConfig: {
     description:

--- a/packages/config/src/projects/cctpv2/cctpv2.ts
+++ b/packages/config/src/projects/cctpv2/cctpv2.ts
@@ -6,6 +6,7 @@ export const cctpv2: BaseProject = {
   slug: 'cctpv2',
   name: 'CCTP v2',
   shortName: undefined,
+  aliases: ['Circle', 'Cross-Chain Transfer Protocol'],
   addedAt: UnixTime(1769070497),
   interopConfig: {
     description:

--- a/packages/config/src/projects/cronoszkevm/cronoszkevm.ts
+++ b/packages/config/src/projects/cronoszkevm/cronoszkevm.ts
@@ -24,6 +24,7 @@ export const cronoszkevm: ScalingProject = zkStackL2({
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_DA_ORACLE],
   display: {
     name: 'Cronos zkEVM',
+    aliases: ['Crypto.com'],
     slug: 'cronoszkevm',
     description:
       'Cronos zkEVM is a general-purpose Validium on Ethereum built on the ZK Stack, scaling the existing portfolio of Cronos apps and chains.',

--- a/packages/config/src/projects/dodochain/dodochain.ts
+++ b/packages/config/src/projects/dodochain/dodochain.ts
@@ -11,6 +11,7 @@ export const dodochain: ScalingProject = underReviewL3({
   hostChain: ProjectId('arbitrum'),
   display: {
     name: 'Birdlayer',
+    aliases: ['DODO Chain', 'DODOChain'],
     slug: 'dodochain',
     description:
       'Birdlayer is an Omni-Trading Layer-3 connecting liquidity from all chains including BTC and ETH L2s.',

--- a/packages/config/src/projects/educhain/educhain.ts
+++ b/packages/config/src/projects/educhain/educhain.ts
@@ -20,6 +20,7 @@ export const educhain: ScalingProject = orbitStackL3({
   ],
   display: {
     name: 'EDU Chain',
+    aliases: ['Open Campus'],
     slug: 'edu-chain',
     description:
       'EDU Chain is a Layer 3 on Arbitrum, built on the Orbit stack. It is designed to onboard real-world educational economies to the blockchain and establish an innovative "Learn Own Earn" model for education.',

--- a/packages/config/src/projects/eigenda-v2/eigenda-v2.ts
+++ b/packages/config/src/projects/eigenda-v2/eigenda-v2.ts
@@ -20,6 +20,7 @@ export const eigendaV2: BaseProject = {
   slug: 'eigenda-v2',
   name: 'EigenDA V2',
   shortName: 'EigenDA V2',
+  aliases: ['EigenLayer', 'EigenCloud'],
   addedAt: UnixTime.fromDate(new Date('2025-10-22')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/eigenda/eigenda.ts
+++ b/packages/config/src/projects/eigenda/eigenda.ts
@@ -22,6 +22,7 @@ export const eigenda: BaseProject = {
   slug: 'eigenda',
   name: 'EigenDA',
   shortName: undefined,
+  aliases: ['EigenLayer', 'EigenCloud'],
   addedAt: UnixTime.fromDate(new Date('2024-09-03')),
   // data
   statuses: {

--- a/packages/config/src/projects/ethernity/ethernity.ts
+++ b/packages/config/src/projects/ethernity/ethernity.ts
@@ -21,6 +21,7 @@ export const ethernity: ScalingProject = opStackL2({
   isPartOfSuperchain: true,
   display: {
     name: 'Epic Chain',
+    aliases: ['Ethernity'],
     slug: 'epicchain',
     description:
       'Epic chain, previously Ethernity, is a low-cost Layer 2 solution on the Superchain, designed to bring global entertainment franchises onto the blockchain.',

--- a/packages/config/src/projects/everclear/everclear.ts
+++ b/packages/config/src/projects/everclear/everclear.ts
@@ -18,6 +18,7 @@ export const everclear: ScalingProject = orbitStackL2({
   ],
   display: {
     name: 'Everclear Hub',
+    aliases: ['Connext'],
     slug: 'everclear',
     description:
       'Everclear Hub is an AnyTrust Optimium on Ethereum, built on the Orbit stack. It is used as a liquidity hub (clearing layer) to solve the liquidity fragmentation between modular scaling solutions.',

--- a/packages/config/src/projects/galxegravity/galxegravity.ts
+++ b/packages/config/src/projects/galxegravity/galxegravity.ts
@@ -18,6 +18,7 @@ export const galxegravity: ScalingProject = orbitStackL2({
   ],
   display: {
     name: 'Gravity',
+    aliases: ['Galxe'],
     slug: 'galxegravity',
     description:
       'Gravity is an Optimium built on the Orbit stack. It features onchain questing and has its own gas token - G. Other Galxe products are aiming to integrate with the L2 and a future migration to an L1 of the same name is planned.',

--- a/packages/config/src/projects/gateway/gateway.ts
+++ b/packages/config/src/projects/gateway/gateway.ts
@@ -8,6 +8,7 @@ export const gateway: BaseProject = {
   slug: 'gateway',
   name: 'Gateway',
   shortName: 'Gateway',
+  aliases: ['ZKsync Gateway', 'Elastic Chain'],
   addedAt: UnixTime(1753868762),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/gnosis/gnosis.ts
+++ b/packages/config/src/projects/gnosis/gnosis.ts
@@ -8,6 +8,7 @@ export const gnosis: BaseProject = {
   slug: 'gnosis',
   name: 'Gnosis Chain',
   shortName: undefined,
+  aliases: ['xDai'],
   addedAt: UnixTime.fromDate(new Date('2023-01-01')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/hyperevm/hyperevm.ts
+++ b/packages/config/src/projects/hyperevm/hyperevm.ts
@@ -6,6 +6,7 @@ export const hyperevm: BaseProject = {
   slug: 'hyperevm',
   name: 'HyperEVM',
   shortName: undefined,
+  aliases: ['Hyperliquid'],
   addedAt: UnixTime(1773154357),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/ink/ink.ts
+++ b/packages/config/src/projects/ink/ink.ts
@@ -18,6 +18,7 @@ export const ink: ScalingProject = opStackL2({
   discovery,
   display: {
     name: 'Ink',
+    aliases: ['Kraken'],
     slug: 'ink',
     stateValidationImage: 'opfp',
     description:

--- a/packages/config/src/projects/layer2finance/layer2finance.ts
+++ b/packages/config/src/projects/layer2finance/layer2finance.ts
@@ -21,6 +21,7 @@ export const layer2finance: ScalingProject = {
   capability: 'universal',
   display: {
     name: 'Layer2.Finance',
+    aliases: ['Celer'],
     slug: 'layer2finance',
     warning:
       'Currently the TVS is calculated incorrectly, because it does not take assets locked in DeFi into account.',

--- a/packages/config/src/projects/layer2financezk/layer2financezk.ts
+++ b/packages/config/src/projects/layer2financezk/layer2financezk.ts
@@ -31,6 +31,7 @@ export const layer2financezk: ScalingProject = {
   archivedAt: UnixTime(1677196800), // 2023-02-24T00:00:00.000Z,
   display: {
     name: 'L2.Finance-zk',
+    aliases: ['Celer'],
     slug: 'layer2financezk',
     warning:
       'Layer2.finance-ZK has been shut down, users are encouraged to use optimistic rollup version.',

--- a/packages/config/src/projects/lens/lens.ts
+++ b/packages/config/src/projects/lens/lens.ts
@@ -23,6 +23,7 @@ export const lens: ScalingProject = zkStackL2({
   addedAt: UnixTime(1716536821), // 2024-05-24T07:47:01Z
   display: {
     name: 'Lens',
+    aliases: ['Avara'],
     slug: 'lens',
     description:
       "Lens Network is the main social networking hub for the user base of Lens Protocol, built on a Validium using ZKsync's ZK Stack technology.",

--- a/packages/config/src/projects/linea/linea.ts
+++ b/packages/config/src/projects/linea/linea.ts
@@ -118,6 +118,7 @@ export const linea: ScalingProject = {
   addedAt: UnixTime(1679651674), // 2023-03-24T09:54:34Z
   display: {
     name: 'Linea',
+    aliases: ['ConsenSys'],
     slug: 'linea',
     description:
       'Linea is a ZK Rollup powered by a zkEVM developed at Consensys, designed to scale the Ethereum network.',

--- a/packages/config/src/projects/lineaprover/lineaprover.ts
+++ b/packages/config/src/projects/lineaprover/lineaprover.ts
@@ -8,6 +8,7 @@ export const lineaprover: BaseProject = {
   slug: 'lineaprover',
   name: 'Linea',
   shortName: undefined,
+  aliases: ['ConsenSys'],
   addedAt: UnixTime.fromDate(new Date('2025-07-18')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/mantle/mantle.ts
+++ b/packages/config/src/projects/mantle/mantle.ts
@@ -17,6 +17,7 @@ export const mantle: ScalingProject = opStackL2({
   genesisTimestamp: UnixTime(1688314886),
   display: {
     name: 'Mantle',
+    aliases: ['BitDAO'],
     slug: 'mantle',
     description:
       'Mantle is a modular general-purpose Ethereum rollup. Transaction data is posted to Ethereum blobs and state transitions are validated onchain via OP Succinct ZK validity proofs (SP1). Its design philosophy aims to offer users a less costly and more user-friendly experience, provide developers with a simpler and more flexible development environment, and deliver a comprehensive set of infrastructure for the next wave of mass-adopted dApps.',

--- a/packages/config/src/projects/moonchain/moonchain.ts
+++ b/packages/config/src/projects/moonchain/moonchain.ts
@@ -10,6 +10,7 @@ export const moonchain: ScalingProject = underReviewL3({
   display: {
     name: 'MXCzkEVM Moonchain',
     shortName: 'Moonchain',
+    aliases: ['MXC zkEVM'],
     slug: 'moonchain',
     stacks: ['Taiko'],
     description:

--- a/packages/config/src/projects/namechain/namechain.ts
+++ b/packages/config/src/projects/namechain/namechain.ts
@@ -8,6 +8,7 @@ export const namechain: ScalingProject = upcomingL2({
   addedAt: UnixTime(1750840537), // 2025-06-25T08:35:37+00:00
   display: {
     name: 'Namechain',
+    aliases: ['ENS'],
     slug: 'namechain',
     description:
       'Namechain is an upcoming Ethereum L2 chain built on the Linea tech stack. It’s designed to be the home of Ethereum Name Service (ENS) and accompanying identity applications.',

--- a/packages/config/src/projects/nil/nil.ts
+++ b/packages/config/src/projects/nil/nil.ts
@@ -9,6 +9,7 @@ export const nil: ScalingProject = upcomingL2({
   addedAt: UnixTime(1708529553), // 2024-02-21T15:32:33Z
   display: {
     name: '=nil;',
+    aliases: ['nil Foundation'],
     slug: 'nil',
     description:
       '=nil; is a zkRollup that securely scales Ethereum through zkSharding, empowering web3 developers to build scalable and composable applications.',

--- a/packages/config/src/projects/omgnetwork/omgnetwork.ts
+++ b/packages/config/src/projects/omgnetwork/omgnetwork.ts
@@ -27,6 +27,7 @@ export const omgnetwork: ScalingProject = {
   archivedAt: UnixTime(1677196800), // 2023-02-24T00:00:00.000Z,
   display: {
     name: 'OMG Network',
+    aliases: ['OmiseGO'],
     slug: 'omgnetwork',
     description:
       'OMG Network claims to be the leading value transfer network for ETH and ERC20 tokens. The Network scales by centralizing transaction processing and remains safe by decentralizing security.',

--- a/packages/config/src/projects/openvmprover/openvmprover.ts
+++ b/packages/config/src/projects/openvmprover/openvmprover.ts
@@ -9,6 +9,7 @@ export const openvmprover: BaseProject = {
   slug: 'openvmprover',
   name: 'OpenVM',
   shortName: undefined,
+  aliases: ['Axiom'],
   addedAt: UnixTime.fromDate(new Date('2025-07-21')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/rari/rari.ts
+++ b/packages/config/src/projects/rari/rari.ts
@@ -18,6 +18,7 @@ export const rari: ScalingProject = orbitStackL3({
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
   display: {
     name: 'RARI Chain',
+    aliases: ['Rarible'],
     slug: 'rari',
     description:
       'RARI Chain embeds royalties on the node level to guarantee royalty payments. A secure, low-cost, decentralized Ethereum L3 blockchain powered by Arbitrum.',

--- a/packages/config/src/projects/reddioex/reddioex.ts
+++ b/packages/config/src/projects/reddioex/reddioex.ts
@@ -67,6 +67,7 @@ export const reddioex: ScalingProject = {
   ],
   display: {
     name: 'RedSonic',
+    aliases: ['Reddio'],
     slug: 'redsonic',
     headerWarning:
       'This project was sunset on 2024-09-20 and deposits after that time may not be recoverable.',

--- a/packages/config/src/projects/relay/relay.ts
+++ b/packages/config/src/projects/relay/relay.ts
@@ -6,6 +6,7 @@ export const relay: BaseProject = {
   slug: 'relay',
   name: 'Relay',
   shortName: undefined,
+  aliases: ['Reservoir'],
   addedAt: UnixTime(1769070497),
   interopConfig: {
     description:

--- a/packages/config/src/projects/risc0/risc0.ts
+++ b/packages/config/src/projects/risc0/risc0.ts
@@ -9,6 +9,7 @@ export const risc0: BaseProject = {
   slug: 'risc0',
   name: 'RISC Zero',
   shortName: undefined,
+  aliases: ['Risc0'],
   addedAt: UnixTime.fromDate(new Date('2025-07-21')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/ronin-network/ronin-network.ts
+++ b/packages/config/src/projects/ronin-network/ronin-network.ts
@@ -8,6 +8,7 @@ export const roninNetwork: ScalingProject = upcomingL2({
   addedAt: UnixTime(1754639625),
   display: {
     name: 'Ronin',
+    aliases: ['Sky Mavis', 'Axie Infinity'],
     slug: 'ronin-network',
     description:
       "Ronin is an Ethereum L2 running the OP rollup stack built for gaming. The network's key innovation is offering high throughput and low fees optimized for NFT transactions and in-game economies, powering ecosystems like Axie Infinity.",

--- a/packages/config/src/projects/sandchain/sandchain.ts
+++ b/packages/config/src/projects/sandchain/sandchain.ts
@@ -8,6 +8,7 @@ export const sandchain: ScalingProject = upcomingL2({
   addedAt: UnixTime(1763446757),
   display: {
     name: 'SANDchain',
+    aliases: ['The Sandbox'],
     slug: 'sandchain',
     description:
       'SANDchain is a dedicated Layer 2 network designed to empower creators and their communities by providing a financial backbone for the Creator Nation.',

--- a/packages/config/src/projects/soneium/soneium.ts
+++ b/packages/config/src/projects/soneium/soneium.ts
@@ -22,6 +22,7 @@ export const soneium = opStackL2({
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
   display: {
     name: 'Soneium',
+    aliases: ['Sony'],
     slug: 'soneium',
     stateValidationImage: 'opfp',
     description:

--- a/packages/config/src/projects/sp1hypercube/sp1hypercube.ts
+++ b/packages/config/src/projects/sp1hypercube/sp1hypercube.ts
@@ -9,6 +9,7 @@ export const sp1hypercube: BaseProject = {
   slug: 'sp1hypercube',
   name: 'SP1 Hypercube',
   shortName: undefined,
+  aliases: ['Succinct'],
   addedAt: UnixTime.fromDate(new Date('2026-03-04')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/sp1turbo/sp1turbo.ts
+++ b/packages/config/src/projects/sp1turbo/sp1turbo.ts
@@ -9,6 +9,7 @@ export const sp1turbo: BaseProject = {
   slug: 'sp1turbo',
   name: 'SP1 Turbo',
   shortName: undefined,
+  aliases: ['Succinct'],
   addedAt: UnixTime.fromDate(new Date('2025-07-08')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/starknet/starknet.ts
+++ b/packages/config/src/projects/starknet/starknet.ts
@@ -224,6 +224,7 @@ export const starknet: ScalingProject = {
   ],
   display: {
     name: 'Starknet',
+    aliases: ['StarkWare'],
     slug: 'starknet',
     stacks: ['SN Stack'],
     description:

--- a/packages/config/src/projects/stone/stone.ts
+++ b/packages/config/src/projects/stone/stone.ts
@@ -8,6 +8,7 @@ export const stone: BaseProject = {
   slug: 'stone',
   name: 'Stone',
   shortName: undefined,
+  aliases: ['StarkWare'],
   addedAt: UnixTime.fromDate(new Date('2025-07-14')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/stwo/stwo.ts
+++ b/packages/config/src/projects/stwo/stwo.ts
@@ -8,6 +8,7 @@ export const stwo: BaseProject = {
   slug: 'stwo',
   name: 'Stwo',
   shortName: undefined,
+  aliases: ['StarkWare'],
   addedAt: UnixTime.fromDate(new Date('2025-10-29')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/sxnetwork/sxnetwork.ts
+++ b/packages/config/src/projects/sxnetwork/sxnetwork.ts
@@ -16,6 +16,7 @@ export const sxnetwork: ScalingProject = orbitStackL2({
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
   display: {
     name: 'SX Network',
+    aliases: ['SX Bet'],
     slug: 'sxnetwork',
     description:
       "SX Network is an Orbit stack Optimistic Rollup, built to scale the SX team's existing sports betting platform.",

--- a/packages/config/src/projects/sxt/sxt.ts
+++ b/packages/config/src/projects/sxt/sxt.ts
@@ -20,6 +20,7 @@ export const sxt: ScalingProject = zkStackL2({
   additionalBadges: [BADGES.RaaS.Caldera, BADGES.DA.AvailVector],
   display: {
     name: 'Space and Time',
+    aliases: ['SXT'],
     slug: 'sxt',
     description:
       "Space and Time (SxT) is a decentralized data warehouse that aims to provide a zk 'Proof of SQL' to bring offchain data to smart contracts onchain. Built on ZK Stack, the SxT chain will serve as a settlement layer and payment hub for data queries.",

--- a/packages/config/src/projects/ten/ten.ts
+++ b/packages/config/src/projects/ten/ten.ts
@@ -9,6 +9,7 @@ export const ten: ScalingProject = upcomingL2({
   addedAt: UnixTime(1705390051), // 2024-01-16T07:27:31Z
   display: {
     name: 'Ten',
+    aliases: ['Obscuro'],
     slug: 'ten',
     description:
       'Ten is an Encrypted Rollup that has been designed for use on the Ethereum network and uses 100% of the EVM. At present, Ten is available in testnet running on the Sepolia testnet for further testing and optimization.',

--- a/packages/config/src/projects/the-elastic-network/the-elastic-network.ts
+++ b/packages/config/src/projects/the-elastic-network/the-elastic-network.ts
@@ -7,6 +7,7 @@ export const theElasticNetwork: BaseProject = {
   slug: 'the-elastic-network',
   name: 'The Elastic Network',
   shortName: undefined,
+  aliases: ['ZKsync'],
   addedAt: 1743677000,
   display: {
     description:

--- a/packages/config/src/projects/unichain/unichain.ts
+++ b/packages/config/src/projects/unichain/unichain.ts
@@ -23,6 +23,7 @@ export const unichain: ScalingProject = opStackL2({
   additionalPurposes: ['Exchange'],
   display: {
     name: 'Unichain',
+    aliases: ['Uniswap'],
     slug: 'unichain',
     stateValidationImage: 'opfp',
     description:

--- a/packages/config/src/projects/worldchain/worldchain.ts
+++ b/packages/config/src/projects/worldchain/worldchain.ts
@@ -20,6 +20,7 @@ export const worldchain = opStackL2({
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
   display: {
     name: 'World Chain',
+    aliases: ['Worldcoin'],
     slug: 'world',
     description:
       'World Chain is an OP Stack Rollup built to scale Proof of Personhood, aiming to offer priority blockspace for users with a World ID.',

--- a/packages/config/src/projects/zkprover/zkprover.ts
+++ b/packages/config/src/projects/zkprover/zkprover.ts
@@ -9,6 +9,7 @@ export const zkprover: BaseProject = {
   slug: 'zkprover',
   name: 'zkProver',
   shortName: undefined,
+  aliases: ['Polygon Zero'],
   addedAt: UnixTime.fromDate(new Date('2025-07-18')),
   statuses: {
     yellowWarning: undefined,

--- a/packages/config/src/projects/zkspace/zkspace.ts
+++ b/packages/config/src/projects/zkspace/zkspace.ts
@@ -45,6 +45,7 @@ export const zkspace: ScalingProject = {
   ],
   display: {
     name: 'ZKBase',
+    aliases: ['ZKSpace'],
     slug: 'zkspace',
     description:
       'ZKBase is an infrastructure protocol based on Zero-Knowledge (ZK) proof technology. It aims to support various projects across the Bitcoin and Ethereum networks.',

--- a/packages/config/src/projects/zksyncprover/zksyncprover.ts
+++ b/packages/config/src/projects/zksyncprover/zksyncprover.ts
@@ -8,6 +8,7 @@ export const zksyncprover: BaseProject = {
   slug: 'zksyncprover',
   name: 'ZKsync Lite',
   shortName: undefined,
+  aliases: ['Matter Labs'],
   addedAt: UnixTime.fromDate(new Date('2025-07-23')),
   statuses: {
     yellowWarning: undefined,


### PR DESCRIPTION
## Summary
Adds an `aliases` array to 57 projects so the search box matches alternate names (former names, parent companies, alternate spellings, acronym expansions). For example, searching "Succinct" now surfaces SP1 Turbo / SP1 Hypercube, "Ribbon Finance" surfaces Aevo, "Connext" surfaces Everclear, "Matter Labs" surfaces Boojum and Airbender.

Aliases avoid being substrings of the project's `name` (or of each other), since substring search already covers those.

## Test plan
- [ ] Search the L2BEAT UI for several alias terms (Succinct, Ribbon Finance, Connext, Galxe, Sky Mavis, BitDAO) and confirm the right project surfaces.