### PR TITLE
Fix incorrect SQL call in Interop Repos

### DIFF
--- a/packages/database/src/repositories/InteropMessageRepository.test.ts
+++ b/packages/database/src/repositories/InteropMessageRepository.test.ts
@@ -130,6 +130,82 @@ describeDatabase(InteropMessageRepository.name, (database) => {
     })
   })
 
+  describe(InteropMessageRepository.prototype.getExistingItems.name, () => {
+    const baseTime = UnixTime(1_000_000)
+
+    it('returns rows that match the requested src/dst pairs', async () => {
+      await repository.insertMany([
+        makeRecord(baseTime, {
+          messageId: 'msg1',
+          srcTxHash: '0xa',
+          dstTxHash: '0xx',
+        }),
+        makeRecord(baseTime, {
+          messageId: 'msg2',
+          srcTxHash: '0xb',
+          dstTxHash: '0xy',
+        }),
+      ])
+
+      const result = await repository.getExistingItems([
+        { srcTxHash: '0xa', dstTxHash: '0xx' },
+        { srcTxHash: '0xb', dstTxHash: '0xy' },
+      ])
+
+      expect(result.map((r) => r.messageId)).toEqualUnsorted(['msg1', 'msg2'])
+    })
+
+    it('does not return rows that only cross-match individual hashes', async () => {
+      await repository.insertMany([
+        makeRecord(baseTime, {
+          messageId: 'msg1',
+          srcTxHash: '0xa',
+          dstTxHash: '0xx',
+        }),
+        makeRecord(baseTime, {
+          messageId: 'msg2',
+          srcTxHash: '0xb',
+          dstTxHash: '0xy',
+        }),
+        // Trap row: src is in the requested src list, dst is in the requested
+        // dst list, but the pair (A, Y) was never asked for.
+        makeRecord(baseTime, {
+          messageId: 'msg3',
+          srcTxHash: '0xa',
+          dstTxHash: '0xy',
+        }),
+      ])
+
+      const result = await repository.getExistingItems([
+        { srcTxHash: '0xa', dstTxHash: '0xx' },
+        { srcTxHash: '0xb', dstTxHash: '0xy' },
+      ])
+
+      expect(result.map((r) => r.messageId)).toEqualUnsorted(['msg1', 'msg2'])
+    })
+
+    it('lowercases input tx hashes when matching', async () => {
+      await repository.insertMany([
+        makeRecord(baseTime, {
+          messageId: 'msg1',
+          srcTxHash: '0xabc',
+          dstTxHash: '0xdef',
+        }),
+      ])
+
+      const result = await repository.getExistingItems([
+        { srcTxHash: '0xABC', dstTxHash: '0xDEF' },
+      ])
+
+      expect(result.map((r) => r.messageId)).toEqual(['msg1'])
+    })
+
+    it('returns empty array for empty input', async () => {
+      const result = await repository.getExistingItems([])
+      expect(result).toEqual([])
+    })
+  })
+
   describe(InteropMessageRepository.prototype.deleteForPlugin.name, () => {
     it('deletes only records for the given plugin', async () => {
       const now = UnixTime.now()

--- a/packages/database/src/repositories/InteropMessageRepository.ts
+++ b/packages/database/src/repositories/InteropMessageRepository.ts
@@ -180,13 +180,19 @@ export class InteropMessageRepository extends BaseRepository {
   ): Promise<InteropMessageRecord[]> {
     if (items.length === 0) return []
 
-    const srcHashes = items.map((x) => x.srcTxHash.toLowerCase())
-    const dstHashes = items.map((x) => x.dstTxHash.toLowerCase())
     const rows = await this.db
       .selectFrom('InteropMessage')
       .selectAll()
-      .where('srcTxHash', 'in', srcHashes)
-      .where('dstTxHash', 'in', dstHashes)
+      .where((eb) =>
+        eb.or(
+          items.map((item) =>
+            eb.and([
+              eb('srcTxHash', '=', item.srcTxHash.toLowerCase()),
+              eb('dstTxHash', '=', item.dstTxHash.toLowerCase()),
+            ]),
+          ),
+        ),
+      )
       .execute()
     return rows.map(toRecord)
   }

--- a/packages/database/src/repositories/InteropTransferRepository.test.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.test.ts
@@ -1417,6 +1417,68 @@ describeDatabase(InteropTransferRepository.name, (db) => {
     },
   )
 
+  describe(InteropTransferRepository.prototype.getExistingItems.name, () => {
+    it('returns rows that match the requested src/dst pairs', async () => {
+      const t1 = transfer('plugin1', 'msg1', 'deposit', UnixTime(100))
+      t1.srcTxHash = '0xa'
+      t1.dstTxHash = '0xx'
+      const t2 = transfer('plugin1', 'msg2', 'deposit', UnixTime(200))
+      t2.srcTxHash = '0xb'
+      t2.dstTxHash = '0xy'
+
+      await repository.insertMany([t1, t2])
+
+      const result = await repository.getExistingItems([
+        { srcTxHash: '0xa', dstTxHash: '0xx' },
+        { srcTxHash: '0xb', dstTxHash: '0xy' },
+      ])
+
+      expect(result.map((r) => r.transferId)).toEqualUnsorted(['msg1', 'msg2'])
+    })
+
+    it('does not return rows that only cross-match individual hashes', async () => {
+      const requested1 = transfer('plugin1', 'msg1', 'deposit', UnixTime(100))
+      requested1.srcTxHash = '0xa'
+      requested1.dstTxHash = '0xx'
+      const requested2 = transfer('plugin1', 'msg2', 'deposit', UnixTime(200))
+      requested2.srcTxHash = '0xb'
+      requested2.dstTxHash = '0xy'
+      // Trap row: src is in the requested src list, dst is in the requested
+      // dst list, but the pair (A, Y) was never asked for.
+      const trap = transfer('plugin1', 'msg3', 'deposit', UnixTime(300))
+      trap.srcTxHash = '0xa'
+      trap.dstTxHash = '0xy'
+
+      await repository.insertMany([requested1, requested2, trap])
+
+      const result = await repository.getExistingItems([
+        { srcTxHash: '0xa', dstTxHash: '0xx' },
+        { srcTxHash: '0xb', dstTxHash: '0xy' },
+      ])
+
+      expect(result.map((r) => r.transferId)).toEqualUnsorted(['msg1', 'msg2'])
+    })
+
+    it('lowercases input tx hashes when matching', async () => {
+      const record = transfer('plugin1', 'msg1', 'deposit', UnixTime(100))
+      record.srcTxHash = '0xabc'
+      record.dstTxHash = '0xdef'
+
+      await repository.insertMany([record])
+
+      const result = await repository.getExistingItems([
+        { srcTxHash: '0xABC', dstTxHash: '0xDEF' },
+      ])
+
+      expect(result.map((r) => r.transferId)).toEqual(['msg1'])
+    })
+
+    it('returns empty array for empty input', async () => {
+      const result = await repository.getExistingItems([])
+      expect(result).toEqual([])
+    })
+  })
+
   afterEach(async () => {
     await repository.deleteAll()
   })

--- a/packages/database/src/repositories/InteropTransferRepository.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.ts
@@ -583,13 +583,19 @@ export class InteropTransferRepository extends BaseRepository {
   ): Promise<InteropTransferRecord[]> {
     if (items.length === 0) return []
 
-    const srcHashes = items.map((x) => x.srcTxHash.toLowerCase())
-    const dstHashes = items.map((x) => x.dstTxHash.toLowerCase())
     const rows = await this.db
       .selectFrom('InteropTransfer')
       .selectAll()
-      .where('srcTxHash', 'in', srcHashes)
-      .where('dstTxHash', 'in', dstHashes)
+      .where((eb) =>
+        eb.or(
+          items.map((item) =>
+            eb.and([
+              eb('srcTxHash', '=', item.srcTxHash.toLowerCase()),
+              eb('dstTxHash', '=', item.dstTxHash.toLowerCase()),
+            ]),
+          ),
+        ),
+      )
       .execute()
     return rows.map(toRecord)
   }


### PR DESCRIPTION
Bug was found by AI during review of unrealted PR.

There should be no meaningful impact of the fix. Query returned more items than requested, but subsequent filter luckyly filtered them out anyway. 