### PR TITLE
support dynamic bridge types for onesided transfers of token framework plugins

### DIFF
--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -4262,6 +4262,10 @@
       },
       {
         "chain": "ethereum",
+        "tx": "0x4d76c29a53347e095f751f8af8aa27602e729d7bb1123a08c5b7b7cc8e34dc5b" // ethereum -> solana lockAndMint
+      },
+      {
+        "chain": "ethereum",
         "tx": "0x6938c3677d8855d94f289f5ece9aed150bee9744a221a2124112338a251752b5" // solana -> eth
       }
     ],
@@ -4275,7 +4279,13 @@
         },
         {
           "type": "oftv2.Transfer",
-          "bridgeType": "burnAndMint",
+          "bridgeType": "lockAndMint",
+          "src": { "event": { "ctx": { "chain": "ethereum" } } },
+          "dst": { "chain": "solana" }
+        },
+        {
+          "type": "oftv2.Transfer",
+          "bridgeType": "lockAndMint",
           "src": { "chain": "solana" },
           "dst": { "event": { "ctx": { "chain": "ethereum" } } }
         }

--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -926,7 +926,7 @@
         {
           "type": "ccip.Transfer",
           "plugin": "ccip",
-          "bridgeType": "burnAndMint",
+          "bridgeType": "lockAndMint",
           "src": {
             "tokenAddress": "0x000000000000000000000000243c9be13faba09f945ccc565547293337da0ad7",
             "wasBurned": false,
@@ -938,7 +938,7 @@
         {
           "type": "ccip.Transfer",
           "plugin": "ccip",
-          "bridgeType": "burnAndMint",
+          "bridgeType": "lockAndMint",
           "src": { "chain": "solana" },
           "dst": {
             "tokenAddress": "0x00000000000000000000000080ac24aa929eaf5013f6436cda2a7ba190f5cc0b",
@@ -1724,7 +1724,27 @@
         "chain": "polygonpos",
         "tx": "0x86fd6f0fa2719ab88d35cfae7d124ee4f8214f09a5b993550d49ae097481859a"
       }
-    ]
+    ],
+    "expects": {
+      "transfers": [
+        {
+          "type": "axelar-squid.Transfer",
+          "bridgeType": "nonMinting"
+        },
+        {
+          "type": "axelar.Transfer",
+          "bridgeType": "lockAndMint"
+        },
+        {
+          "type": "axelar.Transfer",
+          "bridgeType": "lockAndMint"
+        },
+        {
+          "type": "axelar.Transfer",
+          "bridgeType": "lockAndMint"
+        }
+      ]
+    }
   },
   "axelar-its": {
     "txs": [
@@ -1764,7 +1784,23 @@
         "chain": "arbitrum",
         "tx": "0x3ea610acd6fc3422099437b3c6c5d47ccc1c97b7e9c75e0adc9577cda3bebe5c"
       }
-    ]
+    ],
+    "expects": {
+      "transfers": [
+        {
+          "type": "axelar-its.Transfer",
+          "bridgeType": "burnAndMint"
+        },
+        {
+          "type": "axelar-its.Transfer",
+          "bridgeType": "lockAndMint"
+        },
+        {
+          "type": "axelar-its.Transfer",
+          "bridgeType": "lockAndMint"
+        }
+      ]
+    }
   },
   "centrifuge": {
     "txs": [
@@ -2058,14 +2094,14 @@
         {
           "type": "wormhole-ntt.Transfer",
           "plugin": "wormhole-ntt",
-          "bridgeType": "burnAndMint",
+          "bridgeType": "lockAndMint",
           "src": { "event": { "ctx": { "chain": "ethereum" } } },
           "dst": { "chain": "solana" }
         },
         {
           "type": "wormhole-ntt.Transfer",
           "plugin": "wormhole-ntt",
-          "bridgeType": "burnAndMint",
+          "bridgeType": "lockAndMint",
           "src": { "chain": "solana" },
           "dst": { "event": { "ctx": { "chain": "polygonpos" } } }
         }
@@ -4134,7 +4170,7 @@
       "transfers": [
         {
           "type": "hyperlaneHwr.Transfer",
-          "bridgeType": "burnAndMint",
+          "bridgeType": "lockAndMint",
           "src": { "event": { "ctx": { "chain": "ethereum" } } },
           "dst": { "chain": "solana" }
         },

--- a/packages/backend/src/modules/interop/plugins/axelar-its.ts
+++ b/packages/backend/src/modules/interop/plugins/axelar-its.ts
@@ -11,8 +11,8 @@ import {
   ContractCallApproved,
   ContractCallExecuted,
 } from './axelar'
-import { getBridgeType } from './layerzero/layerzero-v2-ofts.plugin'
 import { findParsedAround } from './logScan'
+import { getTokenFrameworkBridgeType } from './tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -178,7 +178,7 @@ export class AxelarITSPlugin implements InteropPlugin {
       const dstTokenAddress = interchainTransferReceived.args.tokenAddress
       const srcWasBurned = interchainTransfer.args.srcWasBurned
       const dstWasMinted = interchainTransferReceived.args.dstWasMinted
-      const bridgeType = getBridgeType({
+      const bridgeType = getTokenFrameworkBridgeType({
         srcTokenAddress,
         dstTokenAddress,
         srcWasBurned,

--- a/packages/backend/src/modules/interop/plugins/axelar-its.ts
+++ b/packages/backend/src/modules/interop/plugins/axelar-its.ts
@@ -12,7 +12,10 @@ import {
   ContractCallExecuted,
 } from './axelar'
 import { findParsedAround } from './logScan'
-import { getTokenFrameworkBridgeType } from './tokenFrameworkBridgeTyping'
+import {
+  getBestEffortTokenFrameworkBridgeType,
+  getTokenFrameworkBridgeType,
+} from './tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -56,6 +59,8 @@ export const InterchainTransferReceived = createInteropEventType<{
 
 export class AxelarITSPlugin implements InteropPlugin {
   readonly name = 'axelar-its'
+
+  constructor(private oneSidedChains: string[] = []) {}
 
   capture(input: LogToCapture) {
     const interchainTransfer = parseInterchainTransfer(input.log, null)
@@ -148,66 +153,135 @@ export class AxelarITSPlugin implements InteropPlugin {
     }
   }
 
-  matchTypes = [ContractCallExecuted] // same entry as axelar.ts to prevent it stealing events
+  matchTypes = [ContractCallExecuted, InterchainTransfer] // ContractCallExecuted is same entry as axelar.ts to prevent it stealing events
   match(
-    contractCallExecuted: InteropEvent,
+    event: InteropEvent,
     db: InteropEventDb,
     tokenMap: TokenMap,
   ): MatchResult | undefined {
-    if (ContractCallExecuted.checkType(contractCallExecuted)) {
-      const interchainTransferReceived = db.find(InterchainTransferReceived, {
-        commandId: contractCallExecuted.args.commandId,
-      })
-      if (!interchainTransferReceived) return
-      const contractCallApproved = db.find(ContractCallApproved, {
-        commandId: interchainTransferReceived.args.commandId,
-      })
-      if (!contractCallApproved) return
-      const interchainTransfer = db.find(InterchainTransfer, {
-        // matching by our own ID because commandId, payload(hash) and 'txHash' are associated on axelar
-        matchId: interchainTransferReceived.args.matchId,
-      })
-      if (!interchainTransfer) return
+    if (ContractCallExecuted.checkType(event)) {
+      return this.matchExecuted(event, db, tokenMap)
+    }
 
-      const contractCall = db.find(ContractCall, {
-        sameTxAfter: interchainTransfer,
-      })
-      if (!contractCall) return
+    if (InterchainTransfer.checkType(event)) {
+      return this.matchOneSidedSent(event, db)
+    }
+  }
 
-      const srcTokenAddress = interchainTransfer.args.tokenAddress
-      const dstTokenAddress = interchainTransferReceived.args.tokenAddress
-      const srcWasBurned = interchainTransfer.args.srcWasBurned
-      const dstWasMinted = interchainTransferReceived.args.dstWasMinted
-      const bridgeType = getTokenFrameworkBridgeType({
-        srcTokenAddress,
-        dstTokenAddress,
-        srcWasBurned,
-        dstWasMinted,
-        srcChain: interchainTransfer.ctx.chain,
-        dstChain: interchainTransferReceived.ctx.chain,
-        tokenMap,
-      })
+  private matchExecuted(
+    contractCallExecuted: InteropEvent<{
+      commandId: `0x${string}`
+      tokenAddressUnsafe?: Address32
+      amountUnsafe?: bigint
+      isLayerZeroApp?: boolean
+      dstWasMinted?: boolean
+    }>,
+    db: InteropEventDb,
+    tokenMap: TokenMap,
+  ): MatchResult | undefined {
+    const interchainTransferReceived = db.find(InterchainTransferReceived, {
+      commandId: contractCallExecuted.args.commandId,
+    })
+    if (!interchainTransferReceived) return
+    const contractCallApproved = db.find(ContractCallApproved, {
+      commandId: interchainTransferReceived.args.commandId,
+    })
+    if (!contractCallApproved) return
+    const interchainTransfer = db.find(InterchainTransfer, {
+      // matching by our own ID because commandId, payload(hash) and 'txHash' are associated on axelar
+      matchId: interchainTransferReceived.args.matchId,
+    })
+    if (!interchainTransfer) {
+      const srcChain = interchainTransferReceived.args.$srcChain
+      if (!srcChain || !this.oneSidedChains.includes(srcChain)) return
 
       return [
-        Result.Message('axelar.Message', {
-          app: 'axelar-its',
-          srcEvent: contractCall,
-          dstEvent: contractCallApproved,
-          extraEvents: [contractCallExecuted],
-        }),
         Result.Transfer('axelar-its.Transfer', {
-          srcEvent: interchainTransfer,
-          srcAmount: interchainTransfer.args.amount,
-          srcTokenAddress,
-          srcWasBurned,
+          srcChain,
           dstEvent: interchainTransferReceived,
           dstAmount: interchainTransferReceived.args.amount,
-          dstTokenAddress,
-          dstWasMinted,
-          bridgeType,
+          dstTokenAddress: interchainTransferReceived.args.tokenAddress,
+          dstWasMinted: interchainTransferReceived.args.dstWasMinted,
+          bridgeType: getBestEffortTokenFrameworkBridgeType({
+            srcWasBurned: undefined,
+            dstWasMinted: interchainTransferReceived.args.dstWasMinted,
+          }),
+          extraEvents: [contractCallApproved, contractCallExecuted],
         }),
       ]
     }
+
+    const contractCall = db.find(ContractCall, {
+      sameTxAfter: interchainTransfer,
+    })
+    if (!contractCall) return
+
+    const srcTokenAddress = interchainTransfer.args.tokenAddress
+    const dstTokenAddress = interchainTransferReceived.args.tokenAddress
+    const srcWasBurned = interchainTransfer.args.srcWasBurned
+    const dstWasMinted = interchainTransferReceived.args.dstWasMinted
+    const bridgeType = getTokenFrameworkBridgeType({
+      srcTokenAddress,
+      dstTokenAddress,
+      srcWasBurned,
+      dstWasMinted,
+      srcChain: interchainTransfer.ctx.chain,
+      dstChain: interchainTransferReceived.ctx.chain,
+      tokenMap,
+    })
+
+    return [
+      Result.Message('axelar.Message', {
+        app: 'axelar-its',
+        srcEvent: contractCall,
+        dstEvent: contractCallApproved,
+        extraEvents: [contractCallExecuted],
+      }),
+      Result.Transfer('axelar-its.Transfer', {
+        srcEvent: interchainTransfer,
+        srcAmount: interchainTransfer.args.amount,
+        srcTokenAddress,
+        srcWasBurned,
+        dstEvent: interchainTransferReceived,
+        dstAmount: interchainTransferReceived.args.amount,
+        dstTokenAddress,
+        dstWasMinted,
+        bridgeType,
+      }),
+    ]
+  }
+
+  private matchOneSidedSent(
+    interchainTransfer: InteropEvent<{
+      matchId: string
+      amount: bigint
+      tokenAddress?: Address32
+      srcWasBurned?: boolean
+      $dstChain: string
+    }>,
+    db: InteropEventDb,
+  ): MatchResult | undefined {
+    const dstChain = interchainTransfer.args.$dstChain
+    if (!dstChain || !this.oneSidedChains.includes(dstChain)) return
+
+    const hasCounterpart = db.find(InterchainTransferReceived, {
+      matchId: interchainTransfer.args.matchId,
+    })
+    if (hasCounterpart) return
+
+    return [
+      Result.Transfer('axelar-its.Transfer', {
+        srcEvent: interchainTransfer,
+        dstChain,
+        srcAmount: interchainTransfer.args.amount,
+        srcTokenAddress: interchainTransfer.args.tokenAddress,
+        srcWasBurned: interchainTransfer.args.srcWasBurned,
+        bridgeType: getBestEffortTokenFrameworkBridgeType({
+          srcWasBurned: interchainTransfer.args.srcWasBurned,
+          dstWasMinted: undefined,
+        }),
+      }),
+    ]
   }
 }
 

--- a/packages/backend/src/modules/interop/plugins/axelar.ts
+++ b/packages/backend/src/modules/interop/plugins/axelar.ts
@@ -9,7 +9,10 @@
 import { Address32, EthereumAddress } from '@l2beat/shared-pure'
 import type { TokenMap } from '../engine/match/TokenMap'
 import { findParsedAround } from './logScan'
-import { getTokenFrameworkBridgeType } from './tokenFrameworkBridgeTyping'
+import {
+  getBestEffortTokenFrameworkBridgeType,
+  getTokenFrameworkBridgeType,
+} from './tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -133,6 +136,8 @@ export const ContractCallExecuted = createInteropEventType<{
 
 export class AxelarPlugin implements InteropPlugin {
   readonly name = 'axelar'
+
+  constructor(private oneSidedChains: string[] = []) {}
 
   capture(input: LogToCapture) {
     const expressExecutedWithToken = parseExpressExecutedWithToken(
@@ -326,129 +331,204 @@ export class AxelarPlugin implements InteropPlugin {
 
   */
 
-  matchTypes = [ContractCallExecuted]
+  matchTypes = [ContractCallExecuted, ContractCallWithToken]
   match(
-    contractCallExecuted: InteropEvent,
+    event: InteropEvent,
     db: InteropEventDb,
     tokenMap: TokenMap,
   ): MatchResult | undefined {
-    if (ContractCallExecuted.checkType(contractCallExecuted)) {
-      const contractCallApproved = db.find(ContractCallApproved, {
-        commandId: contractCallExecuted.args.commandId,
-      })
-      if (contractCallApproved) {
-        const contractCall = db.find(ContractCall, {
-          ctx: {
-            txHash: contractCallApproved.args.srcTxHash, // TODO: this does not match if axelar chain is used as an intermediate hop, same with the payloadHash
-          },
-        })
-        if (!contractCall) return
-        return [
-          Result.Message('axelar.Message', {
-            app: contractCallExecuted.args.isLayerZeroApp
-              ? 'layerzero-wrapper'
-              : 'unknown',
-            srcEvent: contractCall,
-            dstEvent: contractCallExecuted,
-            extraEvents: [contractCallApproved],
-          }),
-        ]
-      }
+    if (ContractCallExecuted.checkType(event)) {
+      return this.matchExecuted(event, db, tokenMap)
+    }
 
-      const contractCallApprovedWithMint = db.find(
-        ContractCallApprovedWithMint,
-        {
-          commandId: contractCallExecuted.args.commandId,
-        },
-      )
-      if (!contractCallApprovedWithMint) return
+    if (ContractCallWithToken.checkType(event)) {
+      return this.matchOneSidedSent(event, db)
+    }
+  }
 
-      const contractCallWithToken = db.find(ContractCallWithToken, {
+  private matchExecuted(
+    contractCallExecuted: InteropEvent<{
+      commandId: `0x${string}`
+      tokenAddressUnsafe?: Address32
+      amountUnsafe?: bigint
+      isLayerZeroApp?: boolean
+      dstWasMinted?: boolean
+    }>,
+    db: InteropEventDb,
+    tokenMap: TokenMap,
+  ): MatchResult | undefined {
+    const contractCallApproved = db.find(ContractCallApproved, {
+      commandId: contractCallExecuted.args.commandId,
+    })
+    if (contractCallApproved) {
+      const contractCall = db.find(ContractCall, {
         ctx: {
-          txHash: contractCallApprovedWithMint.args.srcTxHash, // TODO: this does not match if axelar chain is used as an intermediate hop, same with the payloadHash
+          txHash: contractCallApproved.args.srcTxHash, // TODO: this does not match if axelar chain is used as an intermediate hop, same with the payloadHash
         },
       })
-      if (!contractCallWithToken) return
-
-      const matchingUnsafeAmount =
-        contractCallApprovedWithMint.args.amount ===
-        contractCallExecuted.args.amountUnsafe
-
-      const expressExecuted = db.find(SquidExpressExecutedWithToken, {
-        commandId: contractCallExecuted.args.commandId,
-      })
-
-      const srcTokenAddress = contractCallWithToken.args.tokenAddress
-      const dstTokenAddress = matchingUnsafeAmount
-        ? contractCallExecuted.args.tokenAddressUnsafe
-        : undefined
-      const srcWasBurned = contractCallWithToken.args.srcWasBurned
-      const dstWasMinted = contractCallExecuted.args.dstWasMinted
-      // we are using this implicitly with
-      // defaultBridgeType = 'burnAndMint' because axelar has axlUSDC
-      const bridgeType = getTokenFrameworkBridgeType({
-        srcTokenAddress,
-        dstTokenAddress,
-        srcWasBurned,
-        dstWasMinted,
-        srcChain: contractCallWithToken.ctx.chain,
-        dstChain: contractCallExecuted.ctx.chain,
-        tokenMap,
-      })
-
-      const result: MatchResult = []
-      if (expressExecuted) {
-        result.push(
-          // TODO: do we want to count intent fill AND settlement as message/transfer?
-          // INTENT FILL
-          Result.Message('axelar-squid.Message', {
-            app: 'axelar-squid',
-            srcEvent: contractCallWithToken,
-            dstEvent: expressExecuted,
-          }),
-          Result.Transfer('axelar-squid.Transfer', {
-            srcEvent: contractCallWithToken,
-            srcTokenAddress: contractCallWithToken.args.tokenAddress,
-            srcAmount: contractCallWithToken.args.amount,
-            srcWasBurned: contractCallWithToken.args.srcWasBurned,
-            dstEvent: expressExecuted,
-            dstTokenAddress: expressExecuted.args.tokenAddress,
-            dstAmount: expressExecuted.args.amount,
-            dstWasMinted: false,
-            // fast execution special case: the destination is intent-based (never minted)
-            // but the source often is burned since it is part of the token bridge
-            // so this fast execution is non-minting, while the
-            // axelar transfer (settlement) in lock-mint or even burn-mint
-            bridgeType: 'nonMinting',
-          }),
-        )
-      }
-
-      result.push(
+      if (!contractCall) return
+      return [
         Result.Message('axelar.Message', {
-          app: expressExecuted
-            ? 'axelar-tokenbridge-squid-settlement'
-            : 'axelar-tokenbridge',
-          srcEvent: contractCallWithToken,
+          app: contractCallExecuted.args.isLayerZeroApp
+            ? 'layerzero-wrapper'
+            : 'unknown',
+          srcEvent: contractCall,
           dstEvent: contractCallExecuted,
-          extraEvents: [contractCallApprovedWithMint],
+          extraEvents: [contractCallApproved],
         }),
+      ]
+    }
+
+    const contractCallApprovedWithMint = db.find(ContractCallApprovedWithMint, {
+      commandId: contractCallExecuted.args.commandId,
+    })
+    if (!contractCallApprovedWithMint) return
+
+    const contractCallWithToken = db.find(ContractCallWithToken, {
+      ctx: {
+        txHash: contractCallApprovedWithMint.args.srcTxHash, // TODO: this does not match if axelar chain is used as an intermediate hop, same with the payloadHash
+      },
+    })
+
+    const matchingUnsafeAmount =
+      contractCallApprovedWithMint.args.amount ===
+      contractCallExecuted.args.amountUnsafe
+
+    if (!contractCallWithToken) {
+      const srcChain = contractCallApprovedWithMint.args.$srcChain
+      if (!srcChain || !this.oneSidedChains.includes(srcChain)) return
+
+      return [
         Result.Transfer('axelar.Transfer', {
-          srcEvent: contractCallWithToken,
-          srcTokenAddress,
-          srcAmount: contractCallWithToken.args.amount,
-          srcWasBurned,
+          srcChain,
           dstEvent: contractCallExecuted,
-          dstTokenAddress,
+          dstTokenAddress: matchingUnsafeAmount
+            ? contractCallExecuted.args.tokenAddressUnsafe
+            : undefined,
           dstAmount: matchingUnsafeAmount
             ? contractCallApprovedWithMint.args.amount
             : undefined,
-          dstWasMinted,
-          bridgeType,
+          dstWasMinted: contractCallExecuted.args.dstWasMinted,
+          bridgeType: getBestEffortTokenFrameworkBridgeType({
+            srcWasBurned: undefined,
+            dstWasMinted: contractCallExecuted.args.dstWasMinted,
+          }),
+          extraEvents: [contractCallApprovedWithMint],
+        }),
+      ]
+    }
+
+    const expressExecuted = db.find(SquidExpressExecutedWithToken, {
+      commandId: contractCallExecuted.args.commandId,
+    })
+
+    const srcTokenAddress = contractCallWithToken.args.tokenAddress
+    const dstTokenAddress = matchingUnsafeAmount
+      ? contractCallExecuted.args.tokenAddressUnsafe
+      : undefined
+    const srcWasBurned = contractCallWithToken.args.srcWasBurned
+    const dstWasMinted = contractCallExecuted.args.dstWasMinted
+    // Axelar token bridge is not a token framework, but the local supply-action
+    // model is the same. We use the helper out of context, with the implicit
+    // defaultBridgeType = 'burnAndMint' because Axelar has axlUSDC.
+    const bridgeType = getTokenFrameworkBridgeType({
+      srcTokenAddress,
+      dstTokenAddress,
+      srcWasBurned,
+      dstWasMinted,
+      srcChain: contractCallWithToken.ctx.chain,
+      dstChain: contractCallExecuted.ctx.chain,
+      tokenMap,
+    })
+
+    const result: MatchResult = []
+    if (expressExecuted) {
+      result.push(
+        // TODO: do we want to count intent fill AND settlement as message/transfer?
+        // INTENT FILL
+        Result.Message('axelar-squid.Message', {
+          app: 'axelar-squid',
+          srcEvent: contractCallWithToken,
+          dstEvent: expressExecuted,
+        }),
+        Result.Transfer('axelar-squid.Transfer', {
+          srcEvent: contractCallWithToken,
+          srcTokenAddress: contractCallWithToken.args.tokenAddress,
+          srcAmount: contractCallWithToken.args.amount,
+          srcWasBurned: contractCallWithToken.args.srcWasBurned,
+          dstEvent: expressExecuted,
+          dstTokenAddress: expressExecuted.args.tokenAddress,
+          dstAmount: expressExecuted.args.amount,
+          dstWasMinted: false,
+          // fast execution special case: the destination is intent-based (never minted)
+          // but the source often is burned since it is part of the token bridge
+          // so this fast execution is non-minting, while the
+          // axelar transfer (settlement) in lock-mint or even burn-mint
+          bridgeType: 'nonMinting',
         }),
       )
-
-      return result
     }
+
+    result.push(
+      Result.Message('axelar.Message', {
+        app: expressExecuted
+          ? 'axelar-tokenbridge-squid-settlement'
+          : 'axelar-tokenbridge',
+        srcEvent: contractCallWithToken,
+        dstEvent: contractCallExecuted,
+        extraEvents: [contractCallApprovedWithMint],
+      }),
+      Result.Transfer('axelar.Transfer', {
+        srcEvent: contractCallWithToken,
+        srcTokenAddress,
+        srcAmount: contractCallWithToken.args.amount,
+        srcWasBurned,
+        dstEvent: contractCallExecuted,
+        dstTokenAddress,
+        dstAmount: matchingUnsafeAmount
+          ? contractCallApprovedWithMint.args.amount
+          : undefined,
+        dstWasMinted,
+        bridgeType,
+      }),
+    )
+
+    return result
+  }
+
+  private matchOneSidedSent(
+    contractCallWithToken: InteropEvent<{
+      sender: EthereumAddress
+      destinationContractAddress: string
+      payloadHash: `0x${string}`
+      tokenAddress?: Address32
+      symbol: string
+      amount: bigint
+      $dstChain?: string
+      srcWasBurned?: boolean
+    }>,
+    db: InteropEventDb,
+  ): MatchResult | undefined {
+    const dstChain = contractCallWithToken.args.$dstChain
+    if (!dstChain || !this.oneSidedChains.includes(dstChain)) return
+
+    const hasCounterpart = db.find(ContractCallApprovedWithMint, {
+      srcTxHash: contractCallWithToken.ctx.txHash as `0x${string}`,
+    })
+    if (hasCounterpart) return
+
+    return [
+      Result.Transfer('axelar.Transfer', {
+        srcEvent: contractCallWithToken,
+        dstChain,
+        srcTokenAddress: contractCallWithToken.args.tokenAddress,
+        srcAmount: contractCallWithToken.args.amount,
+        srcWasBurned: contractCallWithToken.args.srcWasBurned,
+        bridgeType: getBestEffortTokenFrameworkBridgeType({
+          srcWasBurned: contractCallWithToken.args.srcWasBurned,
+          dstWasMinted: undefined,
+        }),
+      }),
+    ]
   }
 }

--- a/packages/backend/src/modules/interop/plugins/axelar.ts
+++ b/packages/backend/src/modules/interop/plugins/axelar.ts
@@ -8,8 +8,8 @@
  */
 import { Address32, EthereumAddress } from '@l2beat/shared-pure'
 import type { TokenMap } from '../engine/match/TokenMap'
-import { getBridgeType } from './layerzero/layerzero-v2-ofts.plugin'
 import { findParsedAround } from './logScan'
+import { getTokenFrameworkBridgeType } from './tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -73,6 +73,7 @@ export const AXELAR_NETWORKS = defineNetworks('axelar', [
   { axelarChainName: 'Avalanche', chain: 'avalanche' },
   { axelarChainName: 'hyperliquid', chain: 'hyperevm' },
   { axelarChainName: 'monad', chain: 'monad' },
+  { axelarChainName: 'solana', chain: 'solana' },
   // tempo unsupported
 ])
 
@@ -385,7 +386,7 @@ export class AxelarPlugin implements InteropPlugin {
       const dstWasMinted = contractCallExecuted.args.dstWasMinted
       // we are using this implicitly with
       // defaultBridgeType = 'burnAndMint' because axelar has axlUSDC
-      const bridgeType = getBridgeType({
+      const bridgeType = getTokenFrameworkBridgeType({
         srcTokenAddress,
         dstTokenAddress,
         srcWasBurned,

--- a/packages/backend/src/modules/interop/plugins/ccip/ccip.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/ccip/ccip.plugin.ts
@@ -16,6 +16,7 @@ import {
   EthereumAddress,
 } from '@l2beat/shared-pure'
 import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
+import { getBestEffortTokenFrameworkBridgeType } from '../tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -697,7 +698,10 @@ export class CCIPPlugin implements InteropPluginResyncable {
             dstTokenAddress: dstToken.address,
             dstAmount: dstToken.amount,
             dstWasMinted: dstToken.wasMinted,
-            bridgeType: 'burnAndMint',
+            bridgeType: getBestEffortTokenFrameworkBridgeType({
+              srcWasBurned: undefined,
+              dstWasMinted: dstToken.wasMinted,
+            }),
           }),
         )
       }
@@ -764,7 +768,10 @@ export class CCIPPlugin implements InteropPluginResyncable {
         srcTokenAddress: delivery.args.token,
         srcAmount: delivery.args.amount,
         srcWasBurned: delivery.args.wasBurned,
-        bridgeType: 'burnAndMint',
+        bridgeType: getBestEffortTokenFrameworkBridgeType({
+          srcWasBurned: delivery.args.wasBurned,
+          dstWasMinted: undefined,
+        }),
       }),
     ]
   }

--- a/packages/backend/src/modules/interop/plugins/hyperlane-hwr.ts
+++ b/packages/backend/src/modules/interop/plugins/hyperlane-hwr.ts
@@ -23,6 +23,7 @@ import {
 import { findHyperlaneChain, HyperlaneConfig } from './hyperlane.config'
 import { getBridgeType } from './layerzero/layerzero-v2-ofts.plugin'
 import { findParsedAround, type ParsedTransferLog } from './logScan'
+import { getBestEffortTokenFrameworkBridgeType } from './tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -284,7 +285,10 @@ export class HyperlaneHwrPlugin implements InteropPluginResyncable {
             dstTokenAddress: event.args.tokenAddress,
             dstAmount: event.args.amount,
             dstWasMinted: event.args.minted,
-            bridgeType: 'burnAndMint',
+            bridgeType: getBestEffortTokenFrameworkBridgeType({
+              srcWasBurned: undefined,
+              dstWasMinted: event.args.minted,
+            }),
           }),
         ]
       }
@@ -365,7 +369,10 @@ export class HyperlaneHwrPlugin implements InteropPluginResyncable {
         srcAmount: event.args.amount,
         srcWasBurned: event.args.burned,
         dstChain,
-        bridgeType: 'burnAndMint',
+        bridgeType: getBestEffortTokenFrameworkBridgeType({
+          srcWasBurned: event.args.burned,
+          dstWasMinted: undefined,
+        }),
       }),
     ]
   }

--- a/packages/backend/src/modules/interop/plugins/hyperlane-hwr.ts
+++ b/packages/backend/src/modules/interop/plugins/hyperlane-hwr.ts
@@ -21,9 +21,11 @@ import {
   processLog,
 } from './hyperlane'
 import { findHyperlaneChain, HyperlaneConfig } from './hyperlane.config'
-import { getBridgeType } from './layerzero/layerzero-v2-ofts.plugin'
 import { findParsedAround, type ParsedTransferLog } from './logScan'
-import { getBestEffortTokenFrameworkBridgeType } from './tokenFrameworkBridgeTyping'
+import {
+  getBestEffortTokenFrameworkBridgeType,
+  getTokenFrameworkBridgeType,
+} from './tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -322,7 +324,7 @@ export class HyperlaneHwrPlugin implements InteropPluginResyncable {
       const dstTokenAddress = event.args.tokenAddress
       const srcWasBurned = hwrSent.args.burned
       const dstWasMinted = event.args.minted
-      const bridgeType = getBridgeType({
+      const bridgeType = getTokenFrameworkBridgeType({
         srcTokenAddress,
         dstTokenAddress,
         srcWasBurned,

--- a/packages/backend/src/modules/interop/plugins/index.test.ts
+++ b/packages/backend/src/modules/interop/plugins/index.test.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@l2beat/backend-tools'
-import { ProjectService } from '@l2beat/config'
+import { INTEROP_ONE_SIDED_CHAINS, ProjectService } from '@l2beat/config'
 import type { HttpClient, RpcClient } from '@l2beat/shared'
 import { assert } from '@l2beat/shared-pure'
 import type { TokenDbClient } from '@l2beat/token-backend'
@@ -32,6 +32,9 @@ describe('Interop Plugins', async () => {
     const projects = await ps.getProjects({ select: ['chainConfig'] })
     for (const p of projects) {
       chainNames.add(p.chainConfig.name)
+    }
+    for (const chain of INTEROP_ONE_SIDED_CHAINS) {
+      chainNames.add(chain)
     }
   })
 

--- a/packages/backend/src/modules/interop/plugins/index.ts
+++ b/packages/backend/src/modules/interop/plugins/index.ts
@@ -221,8 +221,8 @@ export function createInteropPlugins(
       {
         name: 'axelar',
         plugins: [
-          new AxelarITSPlugin(), // should be run before Axelar
-          new AxelarPlugin(),
+          new AxelarITSPlugin(deps.oneSidedChains), // should be run before Axelar
+          new AxelarPlugin(deps.oneSidedChains),
         ],
       },
       new AcrossPlugin(deps.configs, deps.oneSidedChains),

--- a/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
@@ -83,6 +83,11 @@ type OFTSentTransferData = {
   burned: boolean
 }
 
+const LAYERZERO_OFT_ONE_SIDED_BRIDGE_TYPE_FALLBACK_PRIORITY = [
+  'burnAndMint',
+  'lockAndMint',
+] as const satisfies KnownInteropBridgeType[]
+
 export function getBridgeType({
   srcTokenAddress,
   dstTokenAddress,
@@ -153,6 +158,57 @@ export function getBridgeType({
   return srcAbstractToken.issuer === dstAbstractToken.issuer
     ? 'nonMinting'
     : 'lockAndMint'
+}
+
+export function getBestEffortLayerZeroOFTOneSidedBridgeType({
+  srcWasBurned,
+  dstWasMinted,
+}: {
+  srcWasBurned: boolean | undefined
+  dstWasMinted: boolean | undefined
+}): KnownInteropBridgeType | undefined {
+  const candidates = getBridgeTypeCandidatesFromPartialSupplyActions({
+    srcWasBurned,
+    dstWasMinted,
+  })
+
+  // One-sided OFT events expose only the local supply action. Pick the best
+  // LayerZero display fallback from the bridge types that are still possible.
+  return LAYERZERO_OFT_ONE_SIDED_BRIDGE_TYPE_FALLBACK_PRIORITY.find(
+    (bridgeType) => candidates.has(bridgeType),
+  )
+}
+
+function getBridgeTypeCandidatesFromPartialSupplyActions({
+  srcWasBurned,
+  dstWasMinted,
+}: {
+  srcWasBurned: boolean | undefined
+  dstWasMinted: boolean | undefined
+}): Set<KnownInteropBridgeType> {
+  const candidates = new Set<KnownInteropBridgeType>()
+  const srcCandidates =
+    srcWasBurned === undefined ? [false, true] : [srcWasBurned]
+  const dstCandidates =
+    dstWasMinted === undefined ? [false, true] : [dstWasMinted]
+
+  if (srcWasBurned === undefined && dstWasMinted === undefined) {
+    return candidates
+  }
+
+  for (const srcCandidate of srcCandidates) {
+    for (const dstCandidate of dstCandidates) {
+      if (srcCandidate && dstCandidate) {
+        candidates.add('burnAndMint')
+      } else if (srcCandidate || dstCandidate) {
+        candidates.add('lockAndMint')
+      } else {
+        candidates.add('nonMinting')
+      }
+    }
+  }
+
+  return candidates
 }
 
 function parseMatchingOFTSentTransfer(
@@ -365,7 +421,10 @@ export class LayerZeroV2OFTsPlugin implements InteropPlugin {
           dstAmount: oftReceivedPacketDelivered.args.amountReceivedLD,
           dstTokenAddress: oftReceivedPacketDelivered.args.dstTokenAddress,
           dstWasMinted: oftReceivedPacketDelivered.args.minted,
-          bridgeType: 'burnAndMint',
+          bridgeType: getBestEffortLayerZeroOFTOneSidedBridgeType({
+            srcWasBurned: undefined,
+            dstWasMinted: oftReceivedPacketDelivered.args.minted,
+          }),
           extraEvents: packetDelivered ? [packetDelivered] : undefined,
         }),
       ]
@@ -435,7 +494,10 @@ export class LayerZeroV2OFTsPlugin implements InteropPlugin {
         srcAmount: oftSentPacketSent.args.amountSentLD,
         srcTokenAddress: oftSentPacketSent.args.srcTokenAddress,
         srcWasBurned: oftSentPacketSent.args.burned,
-        bridgeType: 'burnAndMint',
+        bridgeType: getBestEffortLayerZeroOFTOneSidedBridgeType({
+          srcWasBurned: oftSentPacketSent.args.burned,
+          dstWasMinted: undefined,
+        }),
         extraEvents: packetSent ? [packetSent] : undefined,
       }),
     ]

--- a/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
@@ -1,13 +1,11 @@
-import {
-  Address32,
-  assert,
-  ChainSpecificAddress,
-  type KnownInteropBridgeType,
-} from '@l2beat/shared-pure'
+import { Address32, assert } from '@l2beat/shared-pure'
 import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
 import type { TokenMap } from '../../engine/match/TokenMap'
 import { findParsedAround } from '../logScan'
-import { getBestEffortTokenFrameworkBridgeType } from '../tokenFrameworkBridgeTyping'
+import {
+  getBestEffortTokenFrameworkBridgeType,
+  getTokenFrameworkBridgeType,
+} from '../tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -82,78 +80,6 @@ type NormalizedOFTSentAmounts = {
 type OFTSentTransferData = {
   address: Address32
   burned: boolean
-}
-
-export function getBridgeType({
-  srcTokenAddress,
-  dstTokenAddress,
-  srcWasBurned,
-  dstWasMinted,
-  srcChain,
-  dstChain,
-  tokenMap,
-  defaultBridgeType = 'burnAndMint',
-}: {
-  srcTokenAddress: Address32 | undefined
-  dstTokenAddress: Address32 | undefined
-  srcWasBurned: boolean | undefined
-  dstWasMinted: boolean | undefined
-  srcChain: string
-  dstChain: string
-  tokenMap: TokenMap
-  defaultBridgeType?: 'burnAndMint' | 'nonMinting' // defaults to burnAndMint, see above
-}): KnownInteropBridgeType | undefined {
-  if (
-    !srcTokenAddress ||
-    !dstTokenAddress ||
-    srcWasBurned === undefined ||
-    dstWasMinted === undefined
-  ) {
-    return
-  }
-
-  // chainspecificaddress does not support 'native' so we make do without the abstract map
-  if (
-    srcTokenAddress === Address32.NATIVE &&
-    dstTokenAddress === Address32.NATIVE
-  ) {
-    return 'nonMinting'
-  }
-  if (
-    srcTokenAddress === Address32.NATIVE ||
-    dstTokenAddress === Address32.NATIVE
-  ) {
-    return 'lockAndMint'
-  }
-
-  if (srcWasBurned && dstWasMinted) {
-    return 'burnAndMint'
-  }
-  if (srcWasBurned || dstWasMinted) {
-    return 'lockAndMint'
-  }
-
-  const srcAbstractToken = tokenMap.get(
-    ChainSpecificAddress.fromLong(
-      srcChain,
-      Address32.cropToEthereumAddress(srcTokenAddress),
-    ),
-  )
-  const dstAbstractToken = tokenMap.get(
-    ChainSpecificAddress.fromLong(
-      dstChain,
-      Address32.cropToEthereumAddress(dstTokenAddress),
-    ),
-  )
-  if (!srcAbstractToken || !dstAbstractToken) return
-  if (srcAbstractToken.issuer === null || dstAbstractToken.issuer === null) {
-    return defaultBridgeType
-  }
-
-  // lock + release
-  return srcAbstractToken.issuer === dstAbstractToken.issuer
-    ? 'nonMinting'
-    : 'lockAndMint'
 }
 
 function parseMatchingOFTSentTransfer(
@@ -385,7 +311,7 @@ export class LayerZeroV2OFTsPlugin implements InteropPlugin {
     const dstTokenAddress = oftReceivedPacketDelivered.args.dstTokenAddress
     const srcWasBurned = oftSentPacketSent.args.burned
     const dstWasMinted = oftReceivedPacketDelivered.args.minted
-    const bridgeType = getBridgeType({
+    const bridgeType = getTokenFrameworkBridgeType({
       srcTokenAddress,
       dstTokenAddress,
       srcWasBurned,

--- a/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
+++ b/packages/backend/src/modules/interop/plugins/layerzero/layerzero-v2-ofts.plugin.ts
@@ -7,6 +7,7 @@ import {
 import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
 import type { TokenMap } from '../../engine/match/TokenMap'
 import { findParsedAround } from '../logScan'
+import { getBestEffortTokenFrameworkBridgeType } from '../tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -83,11 +84,6 @@ type OFTSentTransferData = {
   burned: boolean
 }
 
-const LAYERZERO_OFT_ONE_SIDED_BRIDGE_TYPE_FALLBACK_PRIORITY = [
-  'burnAndMint',
-  'lockAndMint',
-] as const satisfies KnownInteropBridgeType[]
-
 export function getBridgeType({
   srcTokenAddress,
   dstTokenAddress,
@@ -158,57 +154,6 @@ export function getBridgeType({
   return srcAbstractToken.issuer === dstAbstractToken.issuer
     ? 'nonMinting'
     : 'lockAndMint'
-}
-
-export function getBestEffortLayerZeroOFTOneSidedBridgeType({
-  srcWasBurned,
-  dstWasMinted,
-}: {
-  srcWasBurned: boolean | undefined
-  dstWasMinted: boolean | undefined
-}): KnownInteropBridgeType | undefined {
-  const candidates = getBridgeTypeCandidatesFromPartialSupplyActions({
-    srcWasBurned,
-    dstWasMinted,
-  })
-
-  // One-sided OFT events expose only the local supply action. Pick the best
-  // LayerZero display fallback from the bridge types that are still possible.
-  return LAYERZERO_OFT_ONE_SIDED_BRIDGE_TYPE_FALLBACK_PRIORITY.find(
-    (bridgeType) => candidates.has(bridgeType),
-  )
-}
-
-function getBridgeTypeCandidatesFromPartialSupplyActions({
-  srcWasBurned,
-  dstWasMinted,
-}: {
-  srcWasBurned: boolean | undefined
-  dstWasMinted: boolean | undefined
-}): Set<KnownInteropBridgeType> {
-  const candidates = new Set<KnownInteropBridgeType>()
-  const srcCandidates =
-    srcWasBurned === undefined ? [false, true] : [srcWasBurned]
-  const dstCandidates =
-    dstWasMinted === undefined ? [false, true] : [dstWasMinted]
-
-  if (srcWasBurned === undefined && dstWasMinted === undefined) {
-    return candidates
-  }
-
-  for (const srcCandidate of srcCandidates) {
-    for (const dstCandidate of dstCandidates) {
-      if (srcCandidate && dstCandidate) {
-        candidates.add('burnAndMint')
-      } else if (srcCandidate || dstCandidate) {
-        candidates.add('lockAndMint')
-      } else {
-        candidates.add('nonMinting')
-      }
-    }
-  }
-
-  return candidates
 }
 
 function parseMatchingOFTSentTransfer(
@@ -421,7 +366,7 @@ export class LayerZeroV2OFTsPlugin implements InteropPlugin {
           dstAmount: oftReceivedPacketDelivered.args.amountReceivedLD,
           dstTokenAddress: oftReceivedPacketDelivered.args.dstTokenAddress,
           dstWasMinted: oftReceivedPacketDelivered.args.minted,
-          bridgeType: getBestEffortLayerZeroOFTOneSidedBridgeType({
+          bridgeType: getBestEffortTokenFrameworkBridgeType({
             srcWasBurned: undefined,
             dstWasMinted: oftReceivedPacketDelivered.args.minted,
           }),
@@ -494,7 +439,7 @@ export class LayerZeroV2OFTsPlugin implements InteropPlugin {
         srcAmount: oftSentPacketSent.args.amountSentLD,
         srcTokenAddress: oftSentPacketSent.args.srcTokenAddress,
         srcWasBurned: oftSentPacketSent.args.burned,
-        bridgeType: getBestEffortLayerZeroOFTOneSidedBridgeType({
+        bridgeType: getBestEffortTokenFrameworkBridgeType({
           srcWasBurned: oftSentPacketSent.args.burned,
           dstWasMinted: undefined,
         }),

--- a/packages/backend/src/modules/interop/plugins/tokenFrameworkBridgeTyping.ts
+++ b/packages/backend/src/modules/interop/plugins/tokenFrameworkBridgeTyping.ts
@@ -1,4 +1,9 @@
-import type { KnownInteropBridgeType } from '@l2beat/shared-pure'
+import {
+  Address32,
+  ChainSpecificAddress,
+  type KnownInteropBridgeType,
+} from '@l2beat/shared-pure'
+import type { TokenMap } from '../engine/match/TokenMap'
 
 const TOKEN_FRAMEWORK_BRIDGE_TYPE_FALLBACK_PRIORITY = [
   'burnAndMint',
@@ -22,6 +27,78 @@ export function getBestEffortTokenFrameworkBridgeType({
   return TOKEN_FRAMEWORK_BRIDGE_TYPE_FALLBACK_PRIORITY.find((bridgeType) =>
     candidates.has(bridgeType),
   )
+}
+
+export function getTokenFrameworkBridgeType({
+  srcTokenAddress,
+  dstTokenAddress,
+  srcWasBurned,
+  dstWasMinted,
+  srcChain,
+  dstChain,
+  tokenMap,
+  defaultBridgeType = 'burnAndMint',
+}: {
+  srcTokenAddress: Address32 | undefined
+  dstTokenAddress: Address32 | undefined
+  srcWasBurned: boolean | undefined
+  dstWasMinted: boolean | undefined
+  srcChain: string
+  dstChain: string
+  tokenMap: TokenMap
+  defaultBridgeType?: 'burnAndMint' | 'nonMinting'
+}): KnownInteropBridgeType | undefined {
+  if (
+    !srcTokenAddress ||
+    !dstTokenAddress ||
+    srcWasBurned === undefined ||
+    dstWasMinted === undefined
+  ) {
+    return
+  }
+
+  // chainspecificaddress does not support 'native' so we make do without the abstract map
+  if (
+    srcTokenAddress === Address32.NATIVE &&
+    dstTokenAddress === Address32.NATIVE
+  ) {
+    return 'nonMinting'
+  }
+  if (
+    srcTokenAddress === Address32.NATIVE ||
+    dstTokenAddress === Address32.NATIVE
+  ) {
+    return 'lockAndMint'
+  }
+
+  if (srcWasBurned && dstWasMinted) {
+    return 'burnAndMint'
+  }
+  if (srcWasBurned || dstWasMinted) {
+    return 'lockAndMint'
+  }
+
+  const srcAbstractToken = tokenMap.get(
+    ChainSpecificAddress.fromLong(
+      srcChain,
+      Address32.cropToEthereumAddress(srcTokenAddress),
+    ),
+  )
+  const dstAbstractToken = tokenMap.get(
+    ChainSpecificAddress.fromLong(
+      dstChain,
+      Address32.cropToEthereumAddress(dstTokenAddress),
+    ),
+  )
+  if (!srcAbstractToken || !dstAbstractToken) return
+  if (srcAbstractToken.issuer === null || dstAbstractToken.issuer === null) {
+    return defaultBridgeType
+  }
+
+  // lock + release
+  return srcAbstractToken.issuer === dstAbstractToken.issuer
+    ? 'nonMinting'
+    : 'lockAndMint'
 }
 
 function getBridgeTypeCandidatesFromPartialSupplyActions({

--- a/packages/backend/src/modules/interop/plugins/tokenFrameworkBridgeTyping.ts
+++ b/packages/backend/src/modules/interop/plugins/tokenFrameworkBridgeTyping.ts
@@ -1,0 +1,57 @@
+import type { KnownInteropBridgeType } from '@l2beat/shared-pure'
+
+const TOKEN_FRAMEWORK_BRIDGE_TYPE_FALLBACK_PRIORITY = [
+  'burnAndMint',
+  'lockAndMint',
+] as const satisfies KnownInteropBridgeType[]
+
+export function getBestEffortTokenFrameworkBridgeType({
+  srcWasBurned,
+  dstWasMinted,
+}: {
+  srcWasBurned: boolean | undefined
+  dstWasMinted: boolean | undefined
+}): KnownInteropBridgeType | undefined {
+  const candidates = getBridgeTypeCandidatesFromPartialSupplyActions({
+    srcWasBurned,
+    dstWasMinted,
+  })
+
+  // One-sided token-framework events expose only the local supply action. Pick
+  // the best display fallback from bridge types that are still possible.
+  return TOKEN_FRAMEWORK_BRIDGE_TYPE_FALLBACK_PRIORITY.find((bridgeType) =>
+    candidates.has(bridgeType),
+  )
+}
+
+function getBridgeTypeCandidatesFromPartialSupplyActions({
+  srcWasBurned,
+  dstWasMinted,
+}: {
+  srcWasBurned: boolean | undefined
+  dstWasMinted: boolean | undefined
+}): Set<KnownInteropBridgeType> {
+  const candidates = new Set<KnownInteropBridgeType>()
+  const srcCandidates =
+    srcWasBurned === undefined ? [false, true] : [srcWasBurned]
+  const dstCandidates =
+    dstWasMinted === undefined ? [false, true] : [dstWasMinted]
+
+  if (srcWasBurned === undefined && dstWasMinted === undefined) {
+    return candidates
+  }
+
+  for (const srcCandidate of srcCandidates) {
+    for (const dstCandidate of dstCandidates) {
+      if (srcCandidate && dstCandidate) {
+        candidates.add('burnAndMint')
+      } else if (srcCandidate || dstCandidate) {
+        candidates.add('lockAndMint')
+      } else {
+        candidates.add('nonMinting')
+      }
+    }
+  }
+
+  return candidates
+}

--- a/packages/backend/src/modules/interop/plugins/wormhole-ntt.ts
+++ b/packages/backend/src/modules/interop/plugins/wormhole-ntt.ts
@@ -27,6 +27,7 @@ Note that (TODO: )
 import { Address32, EthereumAddress } from '@l2beat/shared-pure'
 import { BinaryReader } from '../../../tools/BinaryReader'
 import type { InteropConfigStore } from '../engine/config/InteropConfigStore'
+import { getBestEffortTokenFrameworkBridgeType } from './tokenFrameworkBridgeTyping'
 import {
   createEventParser,
   createInteropEventType,
@@ -486,7 +487,10 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
         srcTokenAddress,
         srcAmount,
         srcWasBurned: sentTransceiverMessage.args.srcWasBurned,
-        bridgeType: 'burnAndMint',
+        bridgeType: getBestEffortTokenFrameworkBridgeType({
+          srcWasBurned: sentTransceiverMessage.args.srcWasBurned,
+          dstWasMinted: undefined,
+        }),
         extraEvents: [logMessagePublished],
       }),
     ]
@@ -513,7 +517,10 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
         dstTokenAddress: received.args.transferTokenAddress,
         dstAmount: received.args.transferAmount,
         dstWasMinted: received.args.dstWasMinted,
-        bridgeType: 'burnAndMint',
+        bridgeType: getBestEffortTokenFrameworkBridgeType({
+          srcWasBurned: undefined,
+          dstWasMinted: received.args.dstWasMinted,
+        }),
         extraEvents,
       }),
     ]


### PR DESCRIPTION
close L2B-13982

tldr: burnAndMint if burn or mint, lockAndMint if a lock or release is indexed (for onesided transfers)

this also centralises the old helper for the twosided transfers 