### PR TITLE
Fix columns in zk catalogue

### DIFF
--- a/packages/frontend/src/pages/zk-catalog/v2/table/Columns.tsx
+++ b/packages/frontend/src/pages/zk-catalog/v2/table/Columns.tsx
@@ -40,6 +40,7 @@ export const zkCatalogColumns = [
   }),
   columnHelper.accessor((row) => row.tvs.value, {
     id: 'tvs',
+    header: 'TVS',
     meta: {
       tooltip:
         'The values secured by the listed verifiers, calculated as a sum of the total value secured of all projects that use them and are listed on L2BEAT.',
@@ -154,6 +155,7 @@ export const zkCatalogColumns = [
   }),
   columnHelper.display({
     id: 'arrow',
+    enableHiding: false,
     cell: (ctx) => {
       const { finalWrap, zkVM, snark } = ctx.row.original.techStack
 


### PR DESCRIPTION
In ZK and DA summary we use TVS and in all other tables we use Total value secured. Idk if that's intentional or we should be consistent.