### PR TITLE
Make field headers sticky 

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-values/Field.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/Field.tsx
@@ -94,41 +94,43 @@ export function FieldDisplay({ field }: FieldDisplayProps) {
   ] as const
 
   return (
-    <li className="group/field overflow-hidden text-sm">
-      <div className="flex h-fit flex-wrap items-center gap-2 px-4 py-1 font-bold text-xs">
-        <div className="flex flex-wrap items-center gap-1">{field.name}</div>
-        {templateTags
-          .filter((x) => x.isActive)
-          .map((x) => (
-            <FieldTag
-              key={`${field.name}:${x.tag}`}
-              source="template"
-              onRemoveClick={canModify ? x.onClick : undefined}
-            >
-              {x.tag}
-            </FieldTag>
-          ))}
+    <li className="group/field text-sm">
+      <div className="sticky top-0 z-10 border-coffee-600 border-b bg-coffee-800">
+        <div className="flex h-fit flex-wrap items-center gap-2 px-4 py-1 font-bold text-xs">
+          <div className="flex flex-wrap items-center gap-1">{field.name}</div>
+          {templateTags
+            .filter((x) => x.isActive)
+            .map((x) => (
+              <FieldTag
+                key={`${field.name}:${x.tag}`}
+                source="template"
+                onRemoveClick={canModify ? x.onClick : undefined}
+              >
+                {x.tag}
+              </FieldTag>
+            ))}
 
-        {configTags
-          .filter((x) => x.isActive)
-          .map((x) => (
-            <FieldTag
-              key={`${field.name}:${x.tag}`}
-              source="config"
-              onRemoveClick={canModify ? x.onClick : undefined}
-            >
-              {x.tag}
-            </FieldTag>
-          ))}
-        <div className="opacity-0 group-hover/field:opacity-100">
-          {canModify && <FieldConfigDialog field={field} />}
+          {configTags
+            .filter((x) => x.isActive)
+            .map((x) => (
+              <FieldTag
+                key={`${field.name}:${x.tag}`}
+                source="config"
+                onRemoveClick={canModify ? x.onClick : undefined}
+              >
+                {x.tag}
+              </FieldTag>
+            ))}
+          <div className="opacity-0 group-hover/field:opacity-100">
+            {canModify && <FieldConfigDialog field={field} />}
+          </div>
         </div>
+        {description && (
+          <div className="-mt-0.5 whitespace-normal px-5 pb-1 font-serif italic">
+            {description}
+          </div>
+        )}
       </div>
-      {description && (
-        <div className="-mt-0.5 whitespace-normal px-5 pb-1 font-serif italic">
-          {description}
-        </div>
-      )}
       <div className="overflow-x-auto bg-coffee-900 px-10 py-0.5">
         <FieldValueDisplay topLevel value={field.value} />
       </div>

--- a/packages/protocolbeat/src/apps/discovery/panel-values/Field.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/Field.tsx
@@ -106,7 +106,7 @@ export function FieldDisplay({ field }: FieldDisplayProps) {
   ] as const
 
   return (
-    <li className="group/field overflow-hidden border-coffee-800 border-b text-sm last:border-b-0">
+    <li className="group/field border-coffee-800 border-b text-sm last:border-b-0">
       <div className="sticky top-0 z-10 border-coffee-800 border-b bg-coffee-800">
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 px-4 py-1 text-xs">
           <div className="flex flex-wrap items-center gap-1 font-bold">

--- a/packages/protocolbeat/src/apps/discovery/panel-values/Folder.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/Folder.tsx
@@ -10,7 +10,7 @@ export function Folder(props: {
   const [open, setOpen] = useState(!props.collapsed)
 
   return (
-    <div className="overflow-x-auto border-coffee-600 border-t">
+    <div className="border-coffee-600 border-t">
       <button
         onClick={() => setOpen((open) => !open)}
         className="flex min-h-[22px] w-full cursor-pointer select-none items-center gap-1 font-bold text-xs uppercase"

--- a/packages/protocolbeat/src/apps/discovery/panel-values/ValuesPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/ValuesPanel.tsx
@@ -33,7 +33,7 @@ export function ValuesPanel() {
   }
 
   return (
-    <div className="h-full w-full overflow-x-auto">
+    <div className="h-full w-full">
       {!selected && <ActionNeededState message="Select a contract" />}
       {selected && (
         <Display


### PR DESCRIPTION
<img width="589" height="592" alt="image" src="https://github.com/user-attachments/assets/a8fa29bb-0f37-4991-b257-b6ae25cf6018" />


Field headers in values panel are now sticky, so the field name and description stay visible while scrolling long field values. The sticky behavior is implemented in FieldDisplay, with an opaque header layer so value content does not bleed through when the header is pinned.

To make sticky positioning work, redundant overflow-x-auto wrappers also got removed from ValuesPanel and Folder, because those intermediate overflow containers were preventing the header from sticking to the panel’s actual scroll container. Horizontal scrolling is still preserved on the field value body itself.