### PR TITLE
Fix flaky PrivacyFlowIndexer test

### DIFF
--- a/packages/backend/src/modules/privacy/indexers/PrivacyFlowIndexer.test.ts
+++ b/packages/backend/src/modules/privacy/indexers/PrivacyFlowIndexer.test.ts
@@ -20,7 +20,7 @@ const TOPIC_B =
 describe(PrivacyFlowIndexer.name, () => {
   describe(PrivacyFlowIndexer.prototype.multiUpdate.name, () => {
     it('fetches logs, extracts records, and saves to DB', async () => {
-      const from = UnixTime.toStartOf(UnixTime.now(), 'hour')
+      const from = UnixTime.toStartOf(UnixTime(0), 'day')
       const to = from + 5 * UnixTime.HOUR
       const blockTimestamp = from + UnixTime.HOUR
 


### PR DESCRIPTION
## Summary

Fixes a flaky test in `PrivacyFlowIndexer.test.ts` that could fail depending on the time of day.

## Problem

The test `fetches logs, extracts records, and saves to DB` used `UnixTime.toStartOf(UnixTime.now(), 'hour')` for the `from` timestamp and added `5 * UnixTime.HOUR` to get `to`.

The `PrivacyFlowIndexer.multiUpdate` clamps the update window to the next day boundary:

```ts
const adjustedTo = Math.min(UnixTime.toNext(from, 'day'), to)
```

When `UnixTime.now()` fell near the end of a day (e.g. 23:00), the 5-hour window crossed midnight. In that case `adjustedTo` was clamped to the next day boundary instead of `to`, causing the assertion `expect(safeHeight).toEqual(to)` to fail.

## Fix

Replaced the dynamic `UnixTime.now()` with a deterministic, day-aligned timestamp (`UnixTime(0)`) so the test window never crosses a day boundary.