### PR TITLE
Re-align field indices

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/onMouseDown.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/onMouseDown.ts
@@ -61,7 +61,14 @@ export function onMouseDown(
         if (event.metaKey || event.altKey) {
           selected = []
 
-          const field = node.fields.find((f) => boxContains(f.box, x, y))
+          const hiddenFields =
+            node.hiddenFields.length > 0
+              ? new Set(node.hiddenFields)
+              : undefined
+          const field = node.fields.find(
+            (f) =>
+              !hiddenFields?.has(f.name) && boxContains(f.box, x, y),
+          )
           if (field !== undefined) {
             selected = [field.target]
           }

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/onMouseDown.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/onMouseDown.ts
@@ -66,8 +66,7 @@ export function onMouseDown(
               ? new Set(node.hiddenFields)
               : undefined
           const field = node.fields.find(
-            (f) =>
-              !hiddenFields?.has(f.name) && boxContains(f.box, x, y),
+            (f) => !hiddenFields?.has(f.name) && boxContains(f.box, x, y),
           )
           if (field !== undefined) {
             selected = [field.target]

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/updateNodePositions.test.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/updateNodePositions.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'earl'
 import type { Node, State } from '../State'
 import {
   BOTTOM_PADDING,
+  FIELD_HEIGHT,
   HEADER_HEIGHT,
   HIDDEN_FIELDS_FOOTER_HEIGHT,
 } from './constants'
@@ -171,6 +172,29 @@ describe('updateNodePositions', () => {
       false,
     )
     expect(result.nodes[0]?.fields[0]?.connection.to.x === 0).toEqual(false)
+  })
+
+  it('aligns visible field hit-boxes with their rendered row, ignoring hidden fields above', () => {
+    const state = buildState([
+      makeNode(
+        'a',
+        0,
+        0,
+        [
+          ['signers0', 'b'],
+          ['signers1', 'b'],
+          ['transmitter0', 'c'],
+          ['transmitter1', 'c'],
+        ],
+        ['signers0', 'signers1'],
+      ),
+      makeNode('b', 400, 0, []),
+      makeNode('c', 800, 0, []),
+    ])
+
+    const fields = (state.nodes[0] as Node).fields
+    expect(fields[2]?.box.y).toEqual(HEADER_HEIGHT)
+    expect(fields[3]?.box.y).toEqual(HEADER_HEIGHT + FIELD_HEIGHT)
   })
 
   it('clamps visible field count to zero when hidden fields exceed field count', () => {

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/updateNodePositions.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/updateNodePositions.ts
@@ -105,7 +105,7 @@ export function updateNodePositions(
 
       const nextFieldBox: Box = {
         x: nextBox.x,
-        y: nextBox.y + HEADER_HEIGHT + i * FIELD_HEIGHT,
+        y: nextBox.y + HEADER_HEIGHT + currentVisibleIndex * FIELD_HEIGHT,
         width: nextBox.width,
         height: FIELD_HEIGHT,
       }


### PR DESCRIPTION
Optimized way too heavily ;p 

Bug: In the ProtocolBeat nodes view, clicking a field on a node with hidden fields routed the click to the wrong target. The field's hit-box y was computed from the raw array index, while the field was rendered using the visible index (hidden fields skipped in the DOM). As soon as any field above was hidden, every visible field below it had a hit-box offset by (#hiddenAbove) × FIELD_HEIGHT from where it was actually drawn — so the click landed in a neighboring field's box (often a hidden one, whose target then got selected).

Fix:

Use the visible index when computing the field hit-box y, matching the render order.
Defense-in-depth: filter out hidden fields in the click handler so their stale boxes can never intercept a click.
Tests: Added a regression test asserting that, with hidden fields above, the remaining visible fields' hit-boxes line up with their rendered rows. All existing tests still pass; typecheck clean.

Perf: No change on the hot path (drag loop does the same arithmetic). The click handler allocates one small Set per meta/alt-click on a node that has hidden fields — negligible.

@codex review please