### PR TITLE
add mayan coverage pie (destination)

### DIFF
--- a/packages/backend/src/modules/interop/engine/dashboard/impls/coveragePies.ts
+++ b/packages/backend/src/modules/interop/engine/dashboard/impls/coveragePies.ts
@@ -63,6 +63,13 @@ const CHART_CONFIGS = [
     type: 'ccip.ExecutionStateChanged',
     chainArg: '$srcChain' as const,
   },
+  {
+    id: 'wormhole-mayan-order-created',
+    title: 'Wormhole (Mayan) destination chains',
+    centerLabel: 'mayan-swift.OrderCreated events',
+    type: 'mayan-swift.OrderCreated',
+    chainArg: '$dstChain' as const,
+  },
 ]
 
 export interface InteropCoveragePieSlice {


### PR DESCRIPTION
outgoing only because mayan incoming has mostly incomplete src chain info

close L2B-13963