### PR TITLE
fix: remove stray icon from backoffice sidebar sub-items

### DIFF
--- a/packages/backoffice/src/components/AppSidebar.tsx
+++ b/packages/backoffice/src/components/AppSidebar.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowLeftRightIcon,
   ChevronRightIcon,
   ClipboardCheckIcon,
   LayersIcon,
@@ -240,7 +239,6 @@ export function AppSidebar() {
                               <SidebarMenuSubItem key={subItem.title}>
                                 <SidebarMenuSubButton asChild>
                                   <Link to={subItem.url}>
-                                    <ArrowLeftRightIcon />
                                     <span>{subItem.title}</span>
                                   </Link>
                                 </SidebarMenuSubButton>


### PR DESCRIPTION
## Summary
- Sub-items inside collapsible groups in the backoffice `AppSidebar` rendered a hardcoded `ArrowLeftRightIcon` next to every entry, regardless of the parent group's purpose (e.g. "Tracked txs", "DA tracking" under Status).
- Drop the stray icon (and its unused import) so sub-items are text-only, matching the visual pattern of the rest of the sidebar.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Verified in browser at `/website/status/tracked-txs` — sub-items now render without the misleading arrow icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)