### PR TITLE
DiscoUI viewstate fixes + collapse ignored methods

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/hooks/useConfigModel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/hooks/useConfigModel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { updateConfigFile } from '../../../api/api'
 import { useDebouncedCallback } from '../../../utils/debounce'
@@ -17,19 +17,20 @@ type Props = {
 
 export function useConfigModel({ project, config, selectedAddress }: Props) {
   const queryClient = useQueryClient()
-  const [configModel, setConfigModel] = useState(
+  const [prevConfig, setPrevConfig] = useState(config)
+  const [configModel, setConfigModel] = useState(() =>
     ConfigModel.fromRawJsonc(config ?? '{}'),
   )
+  if (config !== prevConfig) {
+    setPrevConfig(config)
+    setConfigModel(ConfigModel.fromRawJsonc(config ?? '{}'))
+  }
 
   const debouncedInvalidateSyncStatus = useDebouncedCallback(() =>
     queryClient.invalidateQueries({
       queryKey: ['config-sync-status', project],
     }),
   )
-
-  useEffect(() => {
-    setConfigModel(ConfigModel.fromRawJsonc(config ?? '{}'))
-  }, [config])
 
   const toggleIgnoreMethods = (fieldName: string) => {
     const current = configModel.getIgnoredMethods(selectedAddress) ?? []

--- a/packages/protocolbeat/src/apps/discovery/hooks/useConfigModels.tsx
+++ b/packages/protocolbeat/src/apps/discovery/hooks/useConfigModels.tsx
@@ -87,5 +87,11 @@ function _useConfigModels() {
     templateModel,
     isError,
     isPending,
+    isConfigPending,
+    isConfigError,
+    isTemplatePending,
+    isTemplateError,
+    isProjectPending,
+    isProjectError,
   }
 }

--- a/packages/protocolbeat/src/apps/discovery/hooks/useTemplateModel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/hooks/useTemplateModel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { writeTemplateFile } from '../../../api/api'
 import { useDebouncedCallback } from '../../../utils/debounce'
@@ -20,19 +20,20 @@ type Props = {
 
 export function useTemplateModel({ templateId, files }: Props) {
   const queryClient = useQueryClient()
-  const [templateModel, setTemplateModel] = useState(
+  const [prevTemplate, setPrevTemplate] = useState(files.template)
+  const [templateModel, setTemplateModel] = useState(() =>
     ContractConfigModel.fromRawJsonc(files.template),
   )
+  if (files.template !== prevTemplate) {
+    setPrevTemplate(files.template)
+    setTemplateModel(ContractConfigModel.fromRawJsonc(files.template))
+  }
 
   const debouncedInvalidateSyncStatus = useDebouncedCallback(() =>
     queryClient.invalidateQueries({
       queryKey: ['config-sync-status'],
     }),
   )
-
-  useEffect(() => {
-    setTemplateModel(ContractConfigModel.fromRawJsonc(files.template))
-  }, [files.template])
 
   const toggleIgnoreMethods = (fieldName: string) => {
     const current = templateModel.ignoreMethods ?? []
@@ -192,7 +193,8 @@ export function useTemplateModel({ templateId, files }: Props) {
 
     save: saveRaw,
 
-    hasTemplate: templateId,
+    hasTemplate: !!templateId,
+    templateId,
 
     files: {
       template: templateString,

--- a/packages/protocolbeat/src/apps/discovery/panel-config/ConfigPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-config/ConfigPanel.tsx
@@ -24,11 +24,11 @@ export function ConfigPanel() {
     [project, configModels],
   )
 
-  if (configModels.isError) {
+  if (configModels.isProjectError || configModels.isConfigError) {
     return <ErrorState />
   }
 
-  if (configModels.isPending) {
+  if (configModels.isProjectPending || configModels.isConfigPending) {
     return <LoadingState />
   }
 

--- a/packages/protocolbeat/src/apps/discovery/panel-template/TemplatePanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-template/TemplatePanel.tsx
@@ -6,12 +6,16 @@ import type { EditorFile } from '../../../components/editor/store'
 import { EditorView } from '../../../components/editor/views/EditorView'
 import { LoadingState } from '../../../components/LoadingState'
 import { IS_READONLY } from '../../../config/readonly'
-import { type ConfigModels, useConfigModels } from '../hooks/useConfigModels'
+import { useConfigModels } from '../hooks/useConfigModels'
 import { useProjectData } from '../hooks/useProjectData'
 
 export function TemplatePanel() {
   const { selectedAddress } = useProjectData()
   const configModels = useConfigModels()
+  const templateId = configModels.templateModel.templateId
+  const templateContent = configModels.templateModel.files.template
+  const shapesContent = configModels.templateModel.files.shapes
+  const criteriaContent = configModels.templateModel.files.criteria
 
   const onSaveCallback: EditorSaveCallback = (content: string) => {
     configModels.templateModel.save(content)
@@ -19,16 +23,22 @@ export function TemplatePanel() {
     return true
   }
 
-  const files = useMemo(
-    () => getTemplateFiles(configModels, selectedAddress),
-    [configModels, selectedAddress],
+  const files = useMemo<EditorFile[]>(
+    () =>
+      getTemplateFiles({
+        templateId,
+        templateContent,
+        shapesContent,
+        criteriaContent,
+      }),
+    [templateId, templateContent, shapesContent, criteriaContent],
   )
 
-  if (configModels.isError) {
+  if (configModels.isProjectError || configModels.isTemplateError) {
     return <ErrorState />
   }
 
-  if (configModels.isPending) {
+  if (configModels.isProjectPending || configModels.isTemplatePending) {
     return <LoadingState />
   }
 
@@ -36,7 +46,7 @@ export function TemplatePanel() {
     return <ActionNeededState message="Select a contract" />
   }
 
-  if (!configModels.templateModel.hasTemplate) {
+  if (!templateId) {
     return <ActionNeededState message="No template files" />
   }
 
@@ -49,39 +59,46 @@ export function TemplatePanel() {
   )
 }
 
-function getTemplateFiles(
-  { templateModel }: ConfigModels,
-  selectedAddress: string | undefined,
-): EditorFile[] {
-  if (!selectedAddress) {
+function getTemplateFiles({
+  templateId,
+  templateContent,
+  shapesContent,
+  criteriaContent,
+}: {
+  templateId: string | undefined
+  templateContent: string
+  shapesContent: string | undefined
+  criteriaContent: string | undefined
+}): EditorFile[] {
+  if (!templateId) {
     return []
   }
 
   const sources: EditorFile[] = []
 
   sources.push({
-    id: 'template',
+    id: `template-${templateId}`,
     name: 'template.jsonc',
-    content: templateModel.files.template,
+    content: templateContent,
     language: 'json',
     readOnly: IS_READONLY,
   })
 
-  if (templateModel.files.shapes) {
+  if (shapesContent) {
     sources.push({
-      id: 'shapes',
+      id: `shapes-${templateId}`,
       name: 'shapes.json',
-      content: templateModel.files.shapes,
+      content: shapesContent,
       language: 'json',
       readOnly: true,
     })
   }
 
-  if (templateModel.files.criteria) {
+  if (criteriaContent) {
     sources.push({
-      id: 'criteria',
+      id: `criteria-${templateId}`,
       name: 'criteria.json',
-      content: templateModel.files.criteria,
+      content: criteriaContent,
       language: 'json',
       readOnly: true,
     })

--- a/packages/protocolbeat/src/apps/discovery/panel-values/ValuesPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/ValuesPanel.tsx
@@ -56,6 +56,7 @@ function Display({
   blockNumber: number
 }) {
   const { configModel, templateModel, canModify } = useConfigModels()
+  const canModifyTemplate = canModify && templateModel.hasTemplate
   const templateIgnoredMethods = templateModel.ignoreMethods ?? []
   const configIgnoredMethods = configModel.ignoreMethods ?? []
   const ignoredMethods = [
@@ -86,16 +87,23 @@ function Display({
   const contractConfigDialog = canModify && <ContractConfigDialog />
 
   const fieldsFromSelected = 'fields' in selected ? selected.fields : []
-  const filteredIgnoredMethods = ignoredMethods
-    .filter(
+  const ignoredMethodsSet = new Set(ignoredMethods)
+  const fields = fieldsFromSelected.filter(
+    (field) => !ignoredMethodsSet.has(field.name),
+  )
+  const ignoredFieldNames = [
+    ...fieldsFromSelected
+      .filter((field) => ignoredMethodsSet.has(field.name))
+      .map((field) => field.name),
+    ...ignoredMethods.filter(
       (method) => !fieldsFromSelected.find((field) => field.name === method),
-    )
-    .map((method) => ({
-      name: method,
-      value: { type: 'empty' as const },
-    }))
-
-  const fields = [...fieldsFromSelected, ...filteredIgnoredMethods]
+    ),
+  ]
+  const ignoredFields = ignoredFieldNames.map((name) => ({
+    name,
+    inTemplate: templateIgnoredMethods.includes(name),
+    inConfig: configIgnoredMethods.includes(name),
+  }))
 
   return (
     <>
@@ -220,6 +228,40 @@ function Display({
               <FieldDisplay key={field.name} field={field} />
             ))}
           </ol>
+        </Folder>
+      )}
+      {ignoredFields.length > 0 && (
+        <Folder title={`Ignored methods (${ignoredFields.length})`} collapsed>
+          <div className="flex flex-wrap items-center gap-1 bg-coffee-900 px-4 py-2 text-2xs">
+            {ignoredFields.flatMap((field) => [
+              field.inTemplate && (
+                <FieldTag
+                  key={`${field.name}:template`}
+                  source="template"
+                  onRemoveClick={
+                    canModifyTemplate
+                      ? () => templateModel.toggleIgnoreMethods(field.name)
+                      : undefined
+                  }
+                >
+                  {field.name}
+                </FieldTag>
+              ),
+              field.inConfig && (
+                <FieldTag
+                  key={`${field.name}:config`}
+                  source="config"
+                  onRemoveClick={
+                    canModify
+                      ? () => configModel.toggleIgnoreMethods(field.name)
+                      : undefined
+                  }
+                >
+                  {field.name}
+                </FieldTag>
+              ),
+            ])}
+          </div>
         </Folder>
       )}
       {'abis' in selected && selected.abis.length > 0 && (

--- a/packages/protocolbeat/src/components/editor/code/editor.ts
+++ b/packages/protocolbeat/src/components/editor/code/editor.ts
@@ -16,9 +16,12 @@ export type EditorCallbacks = {
   onLoad?: EditorContentCallback
 }
 
+// Session-scoped view state cache: persists folds/cursor/scroll per file URI
+// across Editor instance lifecycles - stable and mainly to help with React's StrictMode double-renders
+const viewStateCache: Map<string, editor.ICodeEditorViewState> = new Map()
+
 export class Editor extends EditorPluginStore<'code'> {
   private models: Record<string, editor.IModel | null> = {}
-  private viewStates: Record<string, editor.ICodeEditorViewState | null> = {}
   private callbacks: monaco.IDisposable[] = []
 
   private onSaveCallback: ((content: string) => string) | null = null
@@ -124,7 +127,10 @@ export class Editor extends EditorPluginStore<'code'> {
       return
     }
 
-    this.viewStates[model.uri.toString()] = this.editor.saveViewState()
+    const state = this.editor.saveViewState()
+    if (state !== null) {
+      viewStateCache.set(model.uri.toString(), state)
+    }
   }
 
   private restoreViewState() {
@@ -133,7 +139,9 @@ export class Editor extends EditorPluginStore<'code'> {
       return
     }
 
-    this.editor.restoreViewState(this.viewStates[model.uri.toString()] ?? null)
+    this.editor.restoreViewState(
+      viewStateCache.get(model.uri.toString()) ?? null,
+    )
   }
 
   resize() {
@@ -141,13 +149,13 @@ export class Editor extends EditorPluginStore<'code'> {
   }
 
   dispose() {
+    this.saveViewState()
     Object.values(this.models).forEach((model) => {
       if (model) {
         model.dispose()
       }
     })
     this.models = {}
-    this.viewStates = {}
     this.disposeCallbacks()
     this.disposePlugins()
     this.editor.dispose()


### PR DESCRIPTION
Resolves L2B-14040
Resolves L2B-14039

Template and config model stored the derived state in `useState` and synced it via `useEffect`. `useEffect` runs after commit, so for one render after the source changes, the committed output uses the old derived value while the parent already sees the new source. In `TemplatePanel`, that meant the `editor` briefly received `{ id: 'template-NEW', content: <OLD template content> }`. `setFile` then wrote that pair into the URI-keyed cache, corrupting it.

Fix: `TemplateModel` now adjusts state during render using prevX companion state + an in-render compare-and-setState. React detects `setState` on the same component during render, throws away the in-progress render, and re-runs with the new state — synchronously, before commit. The committed render always sees a consistent (source, derived) pair. No lag.


\+ ignored methods are now collapsed under a separate folder

@codex review