### PR TITLE
DiscoUI hygiene 

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-code/CodePanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-code/CodePanel.tsx
@@ -46,11 +46,17 @@ export function CodePanel() {
     }
 
     return sources.length > 1
-  }, [codeResponse.isPending, selectedAddress])
+  }, [codeResponse.data])
 
   const files = useMemo(
     () => getCodeFiles(codeResponse, selectedAddress, hasCode),
-    [codeResponse, selectedAddress, hasCode],
+    [
+      codeResponse.data,
+      codeResponse.isPending,
+      codeResponse.isError,
+      selectedAddress,
+      hasCode,
+    ],
   )
 
   const showRediscoverInfo = codeResponse.isError && !IS_READONLY

--- a/packages/protocolbeat/src/components/editor/code/CodeEditorComponent.tsx
+++ b/packages/protocolbeat/src/components/editor/code/CodeEditorComponent.tsx
@@ -18,22 +18,13 @@ export function CodeEditorComponent({
 }: CodeEditorComponentProps) {
   const monacoEl = useRef<HTMLDivElement>(null)
   const resizeObserverRef = useRef<ResizeObserver | null>(null)
-  const { setEditor, getEditor, removeEditor } = useCodeStore()
+  const { setEditor, removeEditor } = useCodeStore()
 
   useEffect(() => {
     const element = monacoEl.current
 
     if (!element) {
       return
-    }
-
-    const existingEditor = getEditor(editorKey)
-
-    if (existingEditor) {
-      return () => {
-        existingEditor.dispose()
-        removeEditor(editorKey)
-      }
     }
 
     const editor = new Editor(element)
@@ -59,7 +50,7 @@ export function CodeEditorComponent({
       editor.dispose()
       removeEditor(editorKey)
     }
-  }, [editorKey, setEditor, getEditor, removeEditor])
+  }, [editorKey, setEditor, removeEditor])
 
   return (
     <div

--- a/packages/protocolbeat/src/components/editor/code/editor.ts
+++ b/packages/protocolbeat/src/components/editor/code/editor.ts
@@ -23,6 +23,7 @@ const viewStateCache: Map<string, editor.ICodeEditorViewState> = new Map()
 export class Editor extends EditorPluginStore<'code'> {
   private models: Record<string, editor.IModel | null> = {}
   private callbacks: monaco.IDisposable[] = []
+  private disposed = false
 
   private onSaveCallback: ((content: string) => string) | null = null
 
@@ -149,6 +150,10 @@ export class Editor extends EditorPluginStore<'code'> {
   }
 
   dispose() {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
     this.saveViewState()
     Object.values(this.models).forEach((model) => {
       if (model) {

--- a/packages/protocolbeat/src/components/editor/code/hooks/useCodeSettings.ts
+++ b/packages/protocolbeat/src/components/editor/code/hooks/useCodeSettings.ts
@@ -18,10 +18,10 @@ export function useCodeSettings() {
 
   useEffect(() => {
     if (shareableUrl) {
-      window.history.pushState(null, '', shareableUrl)
+      window.history.replaceState(null, '', shareableUrl)
     } else {
       const url = getCleanUrl()
-      window.history.pushState(null, '', url)
+      window.history.replaceState(null, '', url)
     }
   }, [shareableUrl])
 

--- a/packages/protocolbeat/src/utils/debounce.ts
+++ b/packages/protocolbeat/src/utils/debounce.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useCallback, useLayoutEffect, useRef } from 'react'
 
 const DEFAULT_DELAY_MS = 2_000
 
@@ -26,7 +26,10 @@ export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
 ) {
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
   const callbackRef = useRef(callback)
-  callbackRef.current = callback
+
+  useLayoutEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
 
   return useCallback(
     (...args: Parameters<T>) => {

--- a/packages/protocolbeat/src/utils/debounce.ts
+++ b/packages/protocolbeat/src/utils/debounce.ts
@@ -25,14 +25,16 @@ export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
   delay = DEFAULT_DELAY_MS,
 ) {
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+  const callbackRef = useRef(callback)
+  callbackRef.current = callback
 
   return useCallback(
     (...args: Parameters<T>) => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
       timeoutRef.current = setTimeout(() => {
-        callback(...args)
+        callbackRef.current(...args)
       }, delay)
     },
-    [callback, delay],
+    [delay],
   )
 }


### PR DESCRIPTION

| File | What changed | Why |
|---|---|---|
| `useCodeSettings` | window.history.pushState` → `replaceState` in the URL-sync effect | Line selection changes were creating a new browser history entry each time. Back button stepped through every cursor change instead of leaving the page. |
| `CodePanel` | `files` memo now keyed on `codeResponse.data` + `.isPending` + `.isError` instead of the whole `codeResponse` object. `hasProxy` memo similarly fixed to depend on `codeResponse.data`. | `codeResponse` is a fresh `useQuery` return object every render, so the memo never hit. `files` was a new array reference each time, which churned `EditorView`'s setFile path on every parent re-render — calling Monaco's `saveViewState`/`setModel`/`restoreViewState` for nothing. |
| `debounce.ts` | `useDebouncedCallback` holds the latest callback in a ref and drops `callback` from `useCallback` deps, returning a stable function | Every caller passes an inline arrow, so `callback` was unstable and `useCallback` was effectively a no-op — the returned debounced function changed on every render. Debounce semantics were preserved by the shared `timeoutRef`, but the hook violated its own "stable returned function" contract. |
| `editor.ts` | Added `disposed` flag, early-return in `dispose()` if already disposed | Stray double `dispose()` (e.g., during odd HMR or React reconciliation) would re-run `saveViewState()` on a torn-down Monaco editor and could write garbage into the URI-keyed view-state cache. |
| `CodeEditorComponent.tsx` | Removed the `if (existingEditor) { return cleanup }` branch and dropped `getEditor` from destructure/deps | Dead code that was actively broken: if it ever fired, the component would render an empty `<div>` with no Monaco instance, and on unmount would dispose someone else's editor. Removing surfaces the underlying programmer error (two components with same `editorKey`) instead of silently clobbering. |

