### PR TITLE
Introduce layout versioning

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/controls/LayoutFileButtons.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/controls/LayoutFileButtons.tsx
@@ -7,12 +7,17 @@ import { IconFileUp } from '../../../../icons/IconFileUp'
 import { cn } from '../../../../utils/cn'
 import type { ApplyLayoutMode } from '../store/actions/applyStoredLayout'
 import { useStore } from '../store/store'
-import { buildStoredNodeLayout, StoredNodeLayout } from '../store/utils/storage'
+import { migrateLayout } from '../store/utils/layout'
+import {
+  buildStoredNodeLayout,
+  type StoredNodeLayout,
+} from '../store/utils/storage'
 import { ControlButton } from './ControlButton'
 
 interface PendingLayout {
   filename: string
   data: StoredNodeLayout
+  migratedFrom: number
 }
 
 interface LoadError {
@@ -61,24 +66,27 @@ export function LayoutFileButtons(props?: {
     const file = event.target.files?.[0]
     event.target.value = ''
     if (!file) return
+    let raw: unknown
     try {
-      const raw = JSON.parse(await file.text())
-      const result = StoredNodeLayout.safeParse(raw)
-      if (!result.success) {
-        setError({
-          filename: file.name,
-          message: 'File is not a valid layout file.',
-        })
-        return
-      }
-      setPending({ filename: file.name, data: result.data })
-      setError(null)
+      raw = JSON.parse(await file.text())
     } catch (err) {
       setError({
         filename: file.name,
         message: err instanceof Error ? err.message : 'Failed to read file.',
       })
+      return
     }
+    const result = migrateLayout(raw)
+    if (!result.ok) {
+      setError({ filename: file.name, message: result.message })
+      return
+    }
+    setPending({
+      filename: file.name,
+      data: result.layout,
+      migratedFrom: result.migratedFrom,
+    })
+    setError(null)
   }
 
   return (
@@ -169,6 +177,11 @@ function ConfirmLoadDialog({
       <Dialog.Title>Load layout</Dialog.Title>
       <div className="mb-3 text-coffee-200 text-xs">
         <div>File: {pending.filename}</div>
+        <div>
+          Layout version: v{pending.migratedFrom}
+          {pending.migratedFrom !== pending.data.version &&
+            ` (migrated to v${pending.data.version})`}
+        </div>
         <div className="mt-1 grid grid-cols-2 gap-x-4">
           <span>Positions: {positions}</span>
           <span>Hidden nodes: {hiddenNodes}</span>

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/applyStoredLayout.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/applyStoredLayout.ts
@@ -21,7 +21,7 @@ export function applyStoredLayout(
     if (mode === 'replace') {
       return {
         ...node,
-        color: typeof savedColor === 'number' ? savedColor : 0,
+        color: savedColor ?? 0,
         hiddenFields: reconcileHiddenFields(
           fieldNamesOf(node),
           savedHiddenFields ?? [],
@@ -47,7 +47,7 @@ export function applyStoredLayout(
         },
       }
     }
-    if (typeof savedColor === 'number') {
+    if (savedColor !== undefined) {
       next = { ...next, color: savedColor }
     }
     if (savedHiddenFields !== undefined) {

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/loadNodes.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/actions/loadNodes.ts
@@ -60,7 +60,7 @@ export function loadNodes(
       BOTTOM_PADDING +
       hiddenFieldsHeight
     const savedColor = saved?.colors?.[node.id]
-    const color = typeof savedColor === 'number' ? savedColor : node.color
+    const color = savedColor ?? node.color
 
     if (!box) {
       nodesWithoutSavedLayout.add(node.id)

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/index.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/index.ts
@@ -1,0 +1,8 @@
+export {
+  CURRENT_LAYOUT_VERSION,
+  type MigrateFailureReason,
+  type MigrateResult,
+  migrateLayout,
+} from './migrate'
+export type { LayoutV2 as Layout, NodeLocationsV2 as NodeLocations } from './v2'
+export { LayoutV2 as LayoutSchema } from './v2'

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.test.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.test.ts
@@ -28,14 +28,24 @@ describe(migrateLayout.name, () => {
     expect(result.layout.projectId).toEqual('p')
   })
 
-  it('drops legacy oklch color objects to palette index 0', () => {
+  it('drops legacy oklch color objects instead of forcing squash color 0', () => {
     const result = migrateLayout({
       projectId: 'p',
       locations: { a: { x: 0, y: 0 }, b: { x: 1, y: 1 } },
       colors: { a: { l: 0.5, c: 0.1, h: 200 }, b: 4 },
     })
     if (!result.ok) throw new Error('expected success')
-    expect(result.layout.colors).toEqual({ a: 0, b: 4 })
+    expect(result.layout.colors).toEqual({ b: 4 })
+  })
+
+  it('omits colors when a v1 layout only contains legacy color objects', () => {
+    const result = migrateLayout({
+      projectId: 'p',
+      locations: { a: { x: 0, y: 0 } },
+      colors: { a: { l: 0.5, c: 0.1, h: 200 } },
+    })
+    if (!result.ok) throw new Error('expected success')
+    expect(result.layout.colors).toEqual(undefined)
   })
 
   it('refuses payloads from a newer version with too-new reason', () => {

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.test.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.test.ts
@@ -1,0 +1,85 @@
+import { expect } from 'earl'
+import { CURRENT_LAYOUT_VERSION, migrateLayout } from './migrate'
+
+describe(migrateLayout.name, () => {
+  it('accepts current-version payload as-is', () => {
+    const input = {
+      version: 2 as const,
+      projectId: 'p',
+      locations: { a: { x: 1, y: 2 } },
+      colors: { a: 3 },
+      hiddenFields: { a: ['f'] },
+      hiddenNodes: ['b'],
+    }
+    const result = migrateLayout(input)
+    if (!result.ok) throw new Error('expected success')
+    expect(result.layout).toEqual(input)
+    expect(result.migratedFrom).toEqual(2)
+  })
+
+  it('treats unversioned payload as v1 and migrates to current', () => {
+    const result = migrateLayout({
+      projectId: 'p',
+      locations: { a: { x: 0, y: 0 } },
+    })
+    if (!result.ok) throw new Error('expected success')
+    expect(result.migratedFrom).toEqual(1)
+    expect(result.layout.version).toEqual(CURRENT_LAYOUT_VERSION)
+    expect(result.layout.projectId).toEqual('p')
+  })
+
+  it('drops legacy oklch color objects to palette index 0', () => {
+    const result = migrateLayout({
+      projectId: 'p',
+      locations: { a: { x: 0, y: 0 }, b: { x: 1, y: 1 } },
+      colors: { a: { l: 0.5, c: 0.1, h: 200 }, b: 4 },
+    })
+    if (!result.ok) throw new Error('expected success')
+    expect(result.layout.colors).toEqual({ a: 0, b: 4 })
+  })
+
+  it('refuses payloads from a newer version with too-new reason', () => {
+    const result = migrateLayout({
+      version: CURRENT_LAYOUT_VERSION + 1,
+      projectId: 'p',
+      locations: {},
+    })
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toEqual('too-new')
+  })
+
+  it('refuses payloads that do not match any version schema', () => {
+    const result = migrateLayout({ projectId: 'p' })
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toEqual('invalid')
+  })
+
+  it('refuses non-object input', () => {
+    expect(migrateLayout(null).ok).toEqual(false)
+    expect(migrateLayout('not-a-layout').ok).toEqual(false)
+    expect(migrateLayout(42).ok).toEqual(false)
+  })
+
+  it('refuses non-integer version values', () => {
+    const result = migrateLayout({
+      version: 1.5,
+      projectId: 'p',
+      locations: {},
+    })
+    if (result.ok) throw new Error('expected failure')
+    expect(result.reason).toEqual('invalid')
+  })
+
+  it('preserves locations, hiddenFields, hiddenNodes through migration', () => {
+    const result = migrateLayout({
+      projectId: 'p',
+      locations: { a: { x: 1, y: 2, width: 100 } },
+      hiddenFields: { a: ['f1', 'f2'] },
+      hiddenNodes: ['z'],
+    })
+    if (!result.ok) throw new Error('expected success')
+    expect(result.layout.locations).toEqual({ a: { x: 1, y: 2, width: 100 } })
+    expect(result.layout.hiddenFields).toEqual({ a: ['f1', 'f2'] })
+    expect(result.layout.hiddenNodes).toEqual(['z'])
+  })
+})

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.ts
@@ -1,0 +1,122 @@
+import { LayoutV1 } from './v1'
+import { LayoutV2 } from './v2'
+
+export const CURRENT_LAYOUT_VERSION = 2
+
+export type Layout = LayoutV2
+
+export type MigrateFailureReason = 'invalid' | 'unsupported-version' | 'too-new'
+
+export interface MigrateFailure {
+  ok: false
+  reason: MigrateFailureReason
+  message: string
+}
+
+export interface MigrateSuccess {
+  ok: true
+  layout: Layout
+  migratedFrom: number
+}
+
+export type MigrateResult = MigrateSuccess | MigrateFailure
+
+// Migrates an arbitrary payload (from localStorage, a shared file, or a
+// future remote library) to the current layout version. The pipeline is:
+//   1. peek at the `version` field; absent ⇒ assume 1
+//   2. refuse versions newer than what we know
+//   3. parse against that version's schema; refuse on shape errors
+//   4. apply chained migrations up to the current version
+export function migrateLayout(raw: unknown): MigrateResult {
+  const version = peekVersion(raw)
+  if (version === undefined) {
+    return {
+      ok: false,
+      reason: 'invalid',
+      message: 'File is not a valid layout file.',
+    }
+  }
+  if (version > CURRENT_LAYOUT_VERSION) {
+    return {
+      ok: false,
+      reason: 'too-new',
+      message: `Layout was created with a newer version (v${version}) of Protocolbeat than this build supports (v${CURRENT_LAYOUT_VERSION}). Update Protocolbeat to load it.`,
+    }
+  }
+
+  switch (version) {
+    case 1: {
+      const parsed = LayoutV1.safeParse(raw)
+      if (!parsed.success) {
+        return {
+          ok: false,
+          reason: 'invalid',
+          message: 'File is not a valid layout file.',
+        }
+      }
+      return {
+        ok: true,
+        layout: migrateV1toV2(parsed.data),
+        migratedFrom: 1,
+      }
+    }
+    case 2: {
+      const parsed = LayoutV2.safeParse(raw)
+      if (!parsed.success) {
+        return {
+          ok: false,
+          reason: 'invalid',
+          message: 'File is not a valid layout file.',
+        }
+      }
+      return { ok: true, layout: parsed.data, migratedFrom: 2 }
+    }
+    default:
+      return {
+        ok: false,
+        reason: 'unsupported-version',
+        message: `Layout version v${version} is not supported.`,
+      }
+  }
+}
+
+// Reads `version` defensively without trusting the rest of the payload.
+// Absent / non-number means we treat it as v1 (legacy untagged shape).
+// Returns undefined only when the input is not an object at all, which
+// is a hard rejection upstream.
+function peekVersion(raw: unknown): number | undefined {
+  if (raw === null || typeof raw !== 'object') return undefined
+  const candidate = (raw as { version?: unknown }).version
+  if (candidate === undefined) return 1
+  if (typeof candidate !== 'number' || !Number.isInteger(candidate)) {
+    return undefined
+  }
+  return candidate
+}
+
+function migrateV1toV2(input: LayoutV1): LayoutV2 {
+  const colors =
+    input.colors === undefined ? undefined : normalizeColors(input.colors)
+  return {
+    version: 2,
+    projectId: input.projectId,
+    locations: input.locations,
+    colors,
+    hiddenFields: input.hiddenFields,
+    hiddenNodes: input.hiddenNodes,
+  }
+}
+
+// Legacy oklch color objects collapse to palette index 0. This matches the
+// coercion readers already apply for non-numeric color entries, so it's a
+// no-op against current runtime behavior; the difference is that the
+// on-disk shape is now uniform.
+function normalizeColors(
+  colors: NonNullable<LayoutV1['colors']>,
+): Record<string, number> {
+  const result: Record<string, number> = {}
+  for (const [id, color] of Object.entries(colors)) {
+    result[id] = typeof color === 'number' ? color : 0
+  }
+  return result
+}

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/migrate.ts
@@ -107,16 +107,14 @@ function migrateV1toV2(input: LayoutV1): LayoutV2 {
   }
 }
 
-// Legacy oklch color objects collapse to palette index 0. This matches the
-// coercion readers already apply for non-numeric color entries, so it's a
-// no-op against current runtime behavior; the difference is that the
-// on-disk shape is now uniform.
 function normalizeColors(
   colors: NonNullable<LayoutV1['colors']>,
-): Record<string, number> {
+): Record<string, number> | undefined {
   const result: Record<string, number> = {}
   for (const [id, color] of Object.entries(colors)) {
-    result[id] = typeof color === 'number' ? color : 0
+    if (typeof color === 'number') {
+      result[id] = color
+    }
   }
-  return result
+  return Object.keys(result).length > 0 ? result : undefined
 }

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/v1.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/v1.ts
@@ -1,0 +1,39 @@
+import { v } from '@l2beat/validate'
+
+// v1 captures the historical shape that lived in localStorage and shared
+// files before an explicit version field existed. Two notable looseness
+// points are preserved here so we can still ingest those payloads:
+//   - `version` is optional; absence means v1
+//   - `colors` accepts the legacy { l, c, h } oklch object form alongside
+//     the numeric palette index that superseded it
+const NodeLocations = v.record(
+  v.string(),
+  v.object({
+    x: v.number(),
+    y: v.number(),
+    width: v.number().optional(),
+    height: v.number().optional(),
+  }),
+)
+
+const LegacyOklchColor = v.object({
+  l: v.number(),
+  c: v.number(),
+  h: v.number(),
+})
+
+const NodeColors = v.record(v.string(), v.union([LegacyOklchColor, v.number()]))
+
+const NodeHiddenFields = v.record(v.string(), v.array(v.string()))
+const HiddenNodes = v.array(v.string())
+
+export const LayoutV1 = v.object({
+  version: v.literal(1).optional(),
+  projectId: v.string(),
+  locations: NodeLocations,
+  colors: NodeColors.optional(),
+  hiddenFields: NodeHiddenFields.optional(),
+  hiddenNodes: HiddenNodes.optional(),
+})
+
+export type LayoutV1 = v.infer<typeof LayoutV1>

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/v2.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/layout/v2.ts
@@ -1,0 +1,27 @@
+import { v } from '@l2beat/validate'
+
+const NodeLocations = v.record(
+  v.string(),
+  v.object({
+    x: v.number(),
+    y: v.number(),
+    width: v.number().optional(),
+    height: v.number().optional(),
+  }),
+)
+
+const NodeColors = v.record(v.string(), v.number())
+const NodeHiddenFields = v.record(v.string(), v.array(v.string()))
+const HiddenNodes = v.array(v.string())
+
+export const LayoutV2 = v.object({
+  version: v.literal(2),
+  projectId: v.string(),
+  locations: NodeLocations,
+  colors: NodeColors.optional(),
+  hiddenFields: NodeHiddenFields.optional(),
+  hiddenNodes: HiddenNodes.optional(),
+})
+
+export type LayoutV2 = v.infer<typeof LayoutV2>
+export type NodeLocationsV2 = v.infer<typeof NodeLocations>

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/storage.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/storage.ts
@@ -1,45 +1,14 @@
-import { v } from '@l2beat/validate'
-
 import type { State } from '../State'
+import {
+  CURRENT_LAYOUT_VERSION,
+  type Layout,
+  LayoutSchema,
+  migrateLayout,
+} from './layout'
 
-const NodeLocations = v.record(
-  v.string(),
-  v.object({
-    x: v.number(),
-    y: v.number(),
-    width: v.number().optional(),
-    height: v.number().optional(),
-  }),
-)
-
-// Accepts the legacy { l, c, h } oklch object form for backward compatibility
-// with localStorage entries written before colors became a numeric palette
-// index. Readers must coerce non-numeric entries to 0.
-const NodeColors = v.record(
-  v.string(),
-  v.union([
-    v.object({
-      l: v.number(),
-      c: v.number(),
-      h: v.number(),
-    }),
-    v.number(),
-  ]),
-)
-
-const NodeHiddenFields = v.record(v.string(), v.array(v.string()))
-const HiddenNodes = v.array(v.string())
-
-export const StoredNodeLayout = v.object({
-  projectId: v.string(),
-  locations: NodeLocations,
-  colors: NodeColors.optional(),
-  hiddenFields: NodeHiddenFields.optional(),
-  hiddenNodes: HiddenNodes.optional(),
-})
-
-export type NodeLocations = v.infer<typeof NodeLocations>
-export type StoredNodeLayout = v.infer<typeof StoredNodeLayout>
+export const StoredNodeLayout = LayoutSchema
+export type StoredNodeLayout = Layout
+export type { NodeLocations } from './layout'
 
 export function reconcileHiddenFields(
   fieldNames: readonly string[],
@@ -61,6 +30,7 @@ function getLayoutStorageKey(projectId: string): string {
 
 export function buildStoredNodeLayout(state: State): StoredNodeLayout {
   return {
+    version: CURRENT_LAYOUT_VERSION,
     projectId: state.projectId,
     locations: Object.fromEntries(state.nodes.map((n) => [n.id, n.box])),
     colors: Object.fromEntries(state.nodes.map((n) => [n.id, n.color])),
@@ -91,9 +61,19 @@ export function recallNodeLayout(
   if (storage === null) {
     return undefined
   }
-  const result = StoredNodeLayout.safeParse(JSON.parse(storage))
-  if (!result.success) {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(storage)
+  } catch {
     localStorage.removeItem(key)
+    return undefined
   }
-  return result.data
+  const result = migrateLayout(parsed)
+  if (!result.ok) {
+    if (result.reason !== 'too-new') {
+      localStorage.removeItem(key)
+    }
+    return undefined
+  }
+  return result.layout
 }


### PR DESCRIPTION
Moved legacy layout normalization into migration, where it belongs. In v1 -> v2, legacy OKLCH color objects are now dropped instead of coerced to 0, because 0 is not a neutral placeholder here, it is an explicit “use default chain color” sentinel, so coercing changed restore/merge behavior. With that fixed, applyStoredLayout and loadNodes only consume the normalized current layout shape and no longer need legacy color translation logic.