### PR TITLE
Show verifiers whose knownDeployments point at proxy implementations

### DIFF
--- a/packages/frontend/src/server/features/zk-catalog/utils/getTrustedSetupsWithVerifiersAndAttesters.ts
+++ b/packages/frontend/src/server/features/zk-catalog/utils/getTrustedSetupsWithVerifiersAndAttesters.ts
@@ -247,18 +247,23 @@ function getOnchainVerifier(
   contracts: ProjectContracts | undefined,
 ) {
   const addressKey = toPlainAddress(address)
+  const chainContracts = contracts?.addresses[chain] ?? []
 
-  const contract = contracts?.addresses[chain]?.find(
-    (c) => ChainSpecificAddress.address(c.address) === addressKey,
-  )
+  const contract =
+    chainContracts.find(
+      (c) => ChainSpecificAddress.address(c.address) === addressKey,
+    ) ??
+    chainContracts.find((c) =>
+      c.upgradeability?.implementations.some(
+        (impl) => ChainSpecificAddress.address(impl) === addressKey,
+      ),
+    )
 
   if (!contract?.url) return undefined
 
-  const plainEthAddress = ChainSpecificAddress.address(contract.address)
-
   return {
     name: contract.name,
-    href: explorerAddressPageUrl(contract.url, plainEthAddress),
+    href: explorerAddressPageUrl(contract.url, addressKey),
   }
 }
 


### PR DESCRIPTION
Verifiers whose ZK-catalog `knownDeployments` point at a proxy's implementation address (e.g. Lighter's `ZkLighterVerifier` impl `0xaa76aC…`) were dropped from a project's Trusted Setups panel because `getOnchainVerifier` only matched against proxy addresses in `contracts.addresses`.

Fall back to matching the searched address against each contract's `upgradeability.implementations`.