### PR TITLE
Gate privacy search entries behind feature flag

### DIFF
--- a/packages/frontend/src/server/features/projects/search-bar/utils/getSearchBarProjectEntries.ts
+++ b/packages/frontend/src/server/features/projects/search-bar/utils/getSearchBarProjectEntries.ts
@@ -4,6 +4,7 @@ import type {
   ProjectPermissions,
 } from '@l2beat/config'
 import { ChainSpecificAddress, type EthereumAddress } from '@l2beat/shared-pure'
+import { env } from '~/env'
 import { manifest } from '~/utils/Manifest'
 import type { SearchBarProjectEntry } from '../types'
 
@@ -148,7 +149,7 @@ export function getSearchBarProjectEntries<
     })
   }
 
-  if (project.privacyInfo) {
+  if (project.privacyInfo && env.CLIENT_SIDE_PRIVACY_ENABLED) {
     results.push({
       ...common,
       href: `/privacy/projects/${project.slug}`,


### PR DESCRIPTION
## Summary
- Privacy pages, sitemap, and side nav are already gated by `CLIENT_SIDE_PRIVACY_ENABLED`, but search bar entries weren't.
- Without this gate, search results would link to `/privacy/projects/{slug}` and 404 when the flag is off.

## Test plan
- [x] With `CLIENT_SIDE_PRIVACY_ENABLED=false` (default), search for a privacy project (e.g. "railgun", "tornado") and confirm no `/privacy/projects/...` results appear.
- [x] With `CLIENT_SIDE_PRIVACY_ENABLED=true`, confirm privacy results still appear in search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)