### PR TITLE
Handle empty ecosystem TVS breakdowns

### DIFF
--- a/packages/frontend/src/pages/ecosystems/project/components/widgets/EcosystemTvsByStage.tsx
+++ b/packages/frontend/src/pages/ecosystems/project/components/widgets/EcosystemTvsByStage.tsx
@@ -99,6 +99,7 @@ export function EcosystemTvsByStage({
     (acc, data) => acc + data.tvs,
     0,
   )
+  const hasTvsData = totalTvs > 0
 
   return (
     <EcosystemWidget className={className}>
@@ -120,62 +121,72 @@ export function EcosystemTvsByStage({
         Total {totalProjects} projects
       </p>
       <div className="flex items-center justify-around">
-        <div>
-          {Object.entries(tvsByStage).map(([stage, data]) => {
-            if (stage === 'NotApplicable' && data.tvs === 0) return null
-            return (
-              <div key={stage} className="flex items-center gap-2">
-                <StageBadge stage={stage as Stage} isAppchain={false} />
-                <div>
-                  <span className="font-medium text-label-value-14 text-secondary">
-                    {formatPercent(data.tvs / totalTvs)}
-                  </span>{' '}
-                  <span className="font-medium text-[#9399A9] text-label-value-14">
-                    ({data.projectCount})
-                  </span>
-                </div>
-              </div>
-            )
-          })}
-        </div>
-        <SimpleChartContainer meta={chartMeta}>
-          <PieChart
-            responsive
-            className="aspect-square! h-[116px] xs:h-[140px] min-h-[116px] xs:min-h-[140px]"
-          >
-            <ChartTooltip
-              cursor={false}
-              content={<CustomTooltip />}
-              position={breakpoint === 'xs' ? { x: -22, y: -46 } : undefined}
-            />
-            <Pie
-              className={className}
-              data={chartData}
-              dataKey="tvs"
-              nameKey="stage"
-              isAnimationActive={false}
-              innerRadius={breakpoint === 'xs' ? 24 : 35}
-              outerRadius={breakpoint === 'xs' ? 58 : 70}
-            >
-              <Label
-                content={() => {
-                  return (
-                    <text x="50%" y="50%" textAnchor="middle">
-                      <tspan
-                        x="50%"
-                        y="50%"
-                        className="fill-secondary font-medium text-2xs leading-none"
-                        dy={5}
-                      >
-                        Stages
-                      </tspan>
-                    </text>
-                  )
-                }}
-              />
-            </Pie>
-          </PieChart>
-        </SimpleChartContainer>
+        {hasTvsData ? (
+          <>
+            <div>
+              {Object.entries(tvsByStage).map(([stage, data]) => {
+                if (stage === 'NotApplicable' && data.tvs === 0) return null
+                return (
+                  <div key={stage} className="flex items-center gap-2">
+                    <StageBadge stage={stage as Stage} isAppchain={false} />
+                    <div>
+                      <span className="font-medium text-label-value-14 text-secondary">
+                        {formatPercent(data.tvs / totalTvs)}
+                      </span>{' '}
+                      <span className="font-medium text-[#9399A9] text-label-value-14">
+                        ({data.projectCount})
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            <SimpleChartContainer meta={chartMeta}>
+              <PieChart
+                responsive
+                className="aspect-square! h-[116px] xs:h-[140px] min-h-[116px] xs:min-h-[140px]"
+              >
+                <ChartTooltip
+                  cursor={false}
+                  content={<CustomTooltip />}
+                  position={
+                    breakpoint === 'xs' ? { x: -22, y: -46 } : undefined
+                  }
+                />
+                <Pie
+                  className={className}
+                  data={chartData}
+                  dataKey="tvs"
+                  nameKey="stage"
+                  isAnimationActive={false}
+                  innerRadius={breakpoint === 'xs' ? 24 : 35}
+                  outerRadius={breakpoint === 'xs' ? 58 : 70}
+                >
+                  <Label
+                    content={() => {
+                      return (
+                        <text x="50%" y="50%" textAnchor="middle">
+                          <tspan
+                            x="50%"
+                            y="50%"
+                            className="fill-secondary font-medium text-2xs leading-none"
+                            dy={5}
+                          >
+                            Stages
+                          </tspan>
+                        </text>
+                      )
+                    }}
+                  />
+                </Pie>
+              </PieChart>
+            </SimpleChartContainer>
+          </>
+        ) : (
+          <div className="flex h-[140px] w-full items-center justify-center font-medium text-label-value-14 text-secondary">
+            No data
+          </div>
+        )}
       </div>
     </EcosystemWidget>
   )

--- a/packages/frontend/src/pages/ecosystems/project/components/widgets/EcosystemTvsByTokenType.tsx
+++ b/packages/frontend/src/pages/ecosystems/project/components/widgets/EcosystemTvsByTokenType.tsx
@@ -57,6 +57,7 @@ export function EcosystemTvsByTokenType({
   }, [tvsByTokenType])
 
   const totalTvs = chartData.reduce((acc, curr) => acc + curr.tvs, 0)
+  const hasTvsData = totalTvs > 0
 
   return (
     <EcosystemWidget className={className}>
@@ -68,75 +69,85 @@ export function EcosystemTvsByTokenType({
       </EcosystemWidgetTitle>
 
       <div className="flex items-center justify-around">
-        <table>
-          <tbody>
-            {chartData.map((data) => {
-              return (
-                <tr key={data.tokenType}>
-                  <td className="pr-2">
-                    <div className="flex items-center gap-2">
-                      <ChartDataIndicator
-                        backgroundColor={data.fill}
-                        type={{ shape: 'square' }}
-                      />
-                      <div className="font-medium text-xs">
-                        {chartMeta[data.tokenType].label}
-                      </div>
-                    </div>
-                  </td>
-                  <td className="font-medium text-secondary text-xs">
-                    {formatPercent(data.tvs / totalTvs)}
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-        <SimpleChartContainer meta={chartMeta}>
-          <PieChart
-            responsive
-            className="aspect-square! h-[116px] xs:h-[140px] min-h-[116px] xs:min-h-[140px]"
-          >
-            <ChartTooltip
-              cursor={false}
-              content={<CustomTooltip />}
-              position={breakpoint === 'xs' ? { x: -44, y: -46 } : undefined}
-            />
-            <Pie
-              data={chartData}
-              dataKey="tvs"
-              nameKey="tokenType"
-              isAnimationActive={false}
-              innerRadius={breakpoint === 'xs' ? 24 : 35}
-              outerRadius={breakpoint === 'xs' ? 58 : 70}
-            >
-              <Label
-                content={({ viewBox }) => {
-                  if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
-                    return (
-                      <text x="50%" y="50%" textAnchor="middle">
-                        <tspan
-                          x="50%"
-                          dy={-1}
-                          className="fill-secondary font-medium text-2xs leading-none"
-                        >
-                          Token
-                        </tspan>
-                        <tspan
-                          x="50%"
-                          dy={12}
-                          className="fill-secondary font-medium text-2xs leading-none"
-                        >
-                          types
-                        </tspan>
-                      </text>
-                    )
+        {hasTvsData ? (
+          <>
+            <table>
+              <tbody>
+                {chartData.map((data) => {
+                  return (
+                    <tr key={data.tokenType}>
+                      <td className="pr-2">
+                        <div className="flex items-center gap-2">
+                          <ChartDataIndicator
+                            backgroundColor={data.fill}
+                            type={{ shape: 'square' }}
+                          />
+                          <div className="font-medium text-xs">
+                            {chartMeta[data.tokenType].label}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="font-medium text-secondary text-xs">
+                        {formatPercent(data.tvs / totalTvs)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+            <SimpleChartContainer meta={chartMeta}>
+              <PieChart
+                responsive
+                className="aspect-square! h-[116px] xs:h-[140px] min-h-[116px] xs:min-h-[140px]"
+              >
+                <ChartTooltip
+                  cursor={false}
+                  content={<CustomTooltip />}
+                  position={
+                    breakpoint === 'xs' ? { x: -44, y: -46 } : undefined
                   }
-                }}
-              />
-            </Pie>
-          </PieChart>
-        </SimpleChartContainer>
+                />
+                <Pie
+                  data={chartData}
+                  dataKey="tvs"
+                  nameKey="tokenType"
+                  isAnimationActive={false}
+                  innerRadius={breakpoint === 'xs' ? 24 : 35}
+                  outerRadius={breakpoint === 'xs' ? 58 : 70}
+                >
+                  <Label
+                    content={({ viewBox }) => {
+                      if (viewBox && 'cx' in viewBox && 'cy' in viewBox) {
+                        return (
+                          <text x="50%" y="50%" textAnchor="middle">
+                            <tspan
+                              x="50%"
+                              dy={-1}
+                              className="fill-secondary font-medium text-2xs leading-none"
+                            >
+                              Token
+                            </tspan>
+                            <tspan
+                              x="50%"
+                              dy={12}
+                              className="fill-secondary font-medium text-2xs leading-none"
+                            >
+                              types
+                            </tspan>
+                          </text>
+                        )
+                      }
+                    }}
+                  />
+                </Pie>
+              </PieChart>
+            </SimpleChartContainer>
+          </>
+        ) : (
+          <div className="flex h-[140px] w-full items-center justify-center font-medium text-label-value-14 text-secondary">
+            No data
+          </div>
+        )}
       </div>
     </EcosystemWidget>
   )

--- a/packages/frontend/src/utils/calculatePercentageChange.test.ts
+++ b/packages/frontend/src/utils/calculatePercentageChange.test.ts
@@ -54,4 +54,9 @@ describe('formatPercent', () => {
   it('formats values less than 10 with two decimal places', () => {
     expect(formatPercent(0.075)).toEqual('7.50%')
   })
+
+  it('formats invalid values as 0', () => {
+    expect(formatPercent(Number.NaN)).toEqual('0.00%')
+    expect(formatPercent(Number.POSITIVE_INFINITY)).toEqual('0.00%')
+  })
 })

--- a/packages/frontend/src/utils/calculatePercentageChange.ts
+++ b/packages/frontend/src/utils/calculatePercentageChange.ts
@@ -10,7 +10,7 @@ export function calculatePercentageChange(now: number, then: number) {
 }
 
 export function formatPercent(value: number) {
-  const percent = value * 100
+  const percent = Number.isFinite(value) ? value * 100 : 0
 
   if (percent >= 1000) {
     return '>1K%'


### PR DESCRIPTION
Handle ecosystem TVS breakdown widgets when all values are zero.

Stage and token type widgets now render an explicit no-data state instead of dividing by a zero total or leaving the breakdown area empty. `formatPercent` also treats non-finite inputs as zero to avoid leaking `NaN%`.