### PR TITLE
Use symbol from RPC, not  from Coingecko, in token ingestion

### DIFF
--- a/docs/mdbook/specs/l2b_specs/token_db/automatic_token_ingestion.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/automatic_token_ingestion.md
@@ -16,6 +16,7 @@
   - [Propagation](#propagation)
   - [Reading the interop transfer table](#reading-the-interop-transfer-table)
   - [CoinGecko: never called from `plan`](#coingecko-never-called-from-plan)
+  - [CoinGecko symbol casing](#coingecko-symbol-casing)
   - [Address normalization](#address-normalization)
   - [What runs where](#what-runs-where)
   - [What this replaces](#what-this-replaces)
@@ -184,7 +185,10 @@ strategies, tried in order:
    if the deployed token symbol matches the new abstract token symbol. Since
    inserts learn the deployed token symbol from RPC/explorer facts, this
    mismatch check happens in `fetch`; a mismatch becomes `conflict`, while
-   a missing deployed token symbol remains an `error`.
+   a missing deployed token symbol remains an `error`. The symbol comparison
+   is case-insensitive, because the CoinGecko endpoints we call
+   (`/coins/list` and `/coins/{id}`) return symbols lower-cased (`susde`,
+   `wsteth`) — see *CoinGecko symbol casing* below.
 
 If none of the three resolves anything, the outcome is `skip` and the
 entry is removed. RPC/explorer fact fetching only runs in the `fetch`
@@ -360,6 +364,40 @@ There is no "we tried this address and dropped it" record. A dropped
 address simply disappears from the queue. If audit history is needed
 later, the natural place to store it is alongside the deployed token
 itself — see *Future: persistent audit*.
+
+## CoinGecko symbol casing
+
+The two CoinGecko endpoints this pipeline calls — `/coins/list`
+(used by `plan` to find the coin from `(chain, address)`) and
+`/coins/{id}` (used by `fetch` to materialize a new abstract token) —
+both return the `symbol` field lower-cased regardless of the token's
+actual casing (`susde` for `sUSDe`, `wsteth` for `wstETH`, `susd` for
+`sUSD`). The `name` field preserves casing across both endpoints, but
+it's a full name rather than a symbol. The RPC call against the
+deployed token returns the true casing, so RPC is the source of truth
+for the symbol.
+
+Two places treat this as a casing-only normalization rather than a real
+mismatch:
+
+- The conflict check that gates creating a new CoinGecko-sourced abstract
+  compares the candidate symbol against the deployed-token symbol
+  **case-insensitively**. A casing-only difference is not a conflict; a
+  real symbol mismatch (e.g. `USDC` vs. `DAI`) still is.
+- When the check passes and a new abstract is about to be written, `fetch`
+  copies the deployed-token's casing onto the abstract record so the row
+  persisted to TokenDB carries the canonical casing — not CoinGecko's
+  lower-cased value or our previous upper-cased placeholder. A
+  `corrected-coingecko-symbol-casing` step is appended to the trace so the
+  preview dialog and the persisted ingestion log both make the correction
+  visible.
+
+Both of these live inside the existing `fetch` phase: that's the moment we
+already have both the materialized CoinGecko abstract and the
+deployed-token symbol in hand, so no additional plumbing is needed. If
+CoinGecko ever starts returning properly cased symbols, the substitution
+becomes a no-op (the values already match) and can be removed without
+touching the rest of the pipeline.
 
 ## Address normalization
 

--- a/packages/token-backend/src/ingestion/IngestionTrace.ts
+++ b/packages/token-backend/src/ingestion/IngestionTrace.ts
@@ -41,6 +41,7 @@ export type IngestionStep =
       symbol: string
     }
   | { kind: 'fetched-coingecko-abstract'; record: AbstractTokenRecord }
+  | { kind: 'corrected-coingecko-symbol-casing'; from: string; to: string }
   | { kind: 'fetched-facts'; facts: DeployedTokenFacts }
 
 export type IngestionOutcome =

--- a/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
@@ -662,6 +662,114 @@ describe(TokenIngestionLoop.name, () => {
       })
     })
 
+    it('adopts the deployed-token casing when CoinGecko symbol differs only in case', async () => {
+      const address = token('ethereum', '0xaaa')
+      const abstractInsert = mockFn().resolvesTo('ABC123')
+      const deployedInsert = mockFn().resolvesTo(undefined)
+
+      const loop = createLoop({
+        db: mockObject<Database>({
+          interopTransfer: mockObject<Database['interopTransfer']>({
+            getTokenAddressesAfterSerialId: mockFn().resolvesTo({
+              latestSerialId: undefined,
+              transferCount: 0,
+              tokenAddresses: [],
+            }),
+            getAll: mockFn().resolvesTo([]),
+          }),
+        }),
+        tokenDb: mockObject<TokenDatabase>({
+          transaction: async (callback) => await callback(),
+          tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
+            get: mockFn().resolvesTo(undefined),
+          }),
+          tokenIngestionQueue: mockObject<TokenDatabase['tokenIngestionQueue']>(
+            {
+              findNextPending: mockFn()
+                .resolvesToOnce(queueEntry(address))
+                .resolvesToOnce(undefined),
+              remove: mockFn().resolvesTo(1),
+            },
+          ),
+          tokenDbHistory: mockObject<TokenDatabase['tokenDbHistory']>({
+            insert: mockFn().resolvesTo(undefined),
+          }),
+          deployedToken: mockObject<TokenDatabase['deployedToken']>({
+            findByChainAndAddress: mockFn().resolvesTo(undefined),
+            getByPrimaryKeys: mockFn().resolvesTo([]),
+            insert: deployedInsert,
+          }),
+          abstractToken: mockObject<TokenDatabase['abstractToken']>({
+            findByCoingeckoId: mockFn().resolvesTo(undefined),
+            findById: mockFn().resolvesTo(undefined),
+            insert: abstractInsert,
+          }),
+          chain: mockObject<TokenDatabase['chain']>({
+            getAll: mockFn().resolvesTo([
+              {
+                name: 'ethereum',
+                chainId: 1,
+                explorerUrl: null,
+                aliases: ['eth'],
+                apis: null,
+              },
+            ]),
+            findByName: mockFn().resolvesTo({
+              name: 'ethereum',
+              chainId: 1,
+              explorerUrl: null,
+              aliases: null,
+              apis: null,
+            }),
+          }),
+        }),
+        coingeckoClient: mockObject<CoingeckoClient>({
+          getCoinList: mockFn().resolvesTo([
+            {
+              id: 'ethena-staked-usde',
+              name: 'Ethena Staked USDe',
+              symbol: 'susde',
+              platforms: { eth: address.address },
+            },
+          ]),
+          getCoinDataById: mockFn().resolvesTo({
+            id: 'ethena-staked-usde',
+            symbol: 'susde',
+            image: { large: 'https://example.com/susde.png' },
+            platforms: {},
+          }),
+          getCoinMarketChartRange: mockFn().resolvesTo({
+            prices: [{ date: new Date('2024-01-01T00:00:00Z'), value: 1 }],
+            marketCaps: [],
+          }),
+        }),
+        fetchDeployedTokenFacts: mockFn().resolvesTo({
+          isContract: true,
+          symbol: 'sUSDe',
+          symbolSource: 'rpc',
+          decimals: 18,
+          deploymentTimestamp: UnixTime(1),
+          warnings: [],
+        } satisfies DeployedTokenFacts),
+        generateAbstractTokenId: () => 'ABC123',
+      })
+
+      await loop.runOnce()
+
+      expect(abstractInsert.calls[0]?.args[0]).toHaveSubset({
+        id: 'ABC123',
+        symbol: 'sUSDe',
+        coingeckoId: 'ethena-staked-usde',
+        reviewed: false,
+      })
+      expect(deployedInsert.calls[0]?.args[0]).toHaveSubset({
+        ...address,
+        abstractTokenId: 'ABC123',
+        symbol: 'sUSDe',
+        decimals: 18,
+      })
+    })
+
     it('marks a conflict instead of creating a CoinGecko abstract when symbols differ', async () => {
       const address = token('ethereum', '0xaaa')
       const markConflict = mockFn().resolvesTo(1)

--- a/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
@@ -413,6 +413,83 @@ describe(TokenIngestionProcessor.name, () => {
       ).toEqual(true)
     })
 
+    it('adopts deployed-token casing on the new CoinGecko abstract when symbols match case-insensitively', async () => {
+      const address = token('ethereum', '0xaaa')
+
+      const processor = createProcessor({
+        tokenDb: mockObject<TokenDatabase>({
+          chain: mockObject<TokenDatabase['chain']>({
+            findByName: mockFn().resolvesTo({
+              name: 'ethereum',
+              chainId: 1,
+              explorerUrl: null,
+              aliases: null,
+              apis: null,
+            }),
+          }),
+          abstractToken: mockObject<TokenDatabase['abstractToken']>({
+            findById: mockFn().resolvesTo(undefined),
+          }),
+        }),
+        coingeckoClient: mockObject<CoingeckoClient>({
+          getCoinDataById: mockFn().resolvesTo({
+            id: 'ethena-staked-usde',
+            symbol: 'susde',
+            image: { large: 'https://example.com/susde.png' },
+            platforms: {},
+          }),
+          getCoinMarketChartRange: mockFn().resolvesTo({
+            prices: [{ date: new Date('2024-01-01T00:00:00Z'), value: 1 }],
+            marketCaps: [],
+          }),
+        }),
+        fetchDeployedTokenFacts: mockFn().resolvesTo({
+          isContract: true,
+          symbol: 'sUSDe',
+          symbolSource: 'rpc' as const,
+          decimals: 18,
+          deploymentTimestamp: UnixTime(1),
+          warnings: [],
+        }),
+        generateAbstractTokenId: () => 'ABC123',
+      })
+
+      const result = await processor.fetch({
+        id: 'ing_test',
+        address,
+        steps: [],
+        outcome: {
+          kind: 'pending',
+          operation: 'insert',
+          existing: undefined,
+          abstract: {
+            kind: 'new-coingecko',
+            coingeckoId: 'ethena-staked-usde',
+            symbol: 'susde',
+          },
+          symbolFallback: 'SUSDE',
+          neighborsToEnqueue: [],
+          proof: { kind: 'coingecko' },
+        },
+      })
+
+      expect(result.outcome.kind).toEqual('write')
+      if (result.outcome.kind !== 'write') return
+      expect(result.outcome.newAbstractToken?.symbol).toEqual('sUSDe')
+      expect(
+        result.outcome.deployedToken.type === 'insert' &&
+          result.outcome.deployedToken.record.symbol,
+      ).toEqual('sUSDe')
+      const correctionStep = result.steps.find(
+        (step) => step.kind === 'corrected-coingecko-symbol-casing',
+      )
+      expect(correctionStep).toEqual({
+        kind: 'corrected-coingecko-symbol-casing',
+        from: 'SUSDE',
+        to: 'sUSDe',
+      })
+    })
+
     it('downgrades pending insert with a new CoinGecko abstract to conflict when symbols differ', async () => {
       const address = token('ethereum', '0xaaa')
 

--- a/packages/token-backend/src/ingestion/TokenIngestionProcessor.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionProcessor.ts
@@ -223,12 +223,17 @@ export class TokenIngestionProcessor {
           outcome: { kind: 'conflict', message: conflict },
         }
       }
+      const finalAbstract = adoptDeployedTokenSymbolCasing(
+        newAbstractToken,
+        pending.existing.symbol,
+        steps,
+      )
       return {
         ...trace,
         steps,
         outcome: {
           kind: 'write',
-          newAbstractToken,
+          newAbstractToken: finalAbstract,
           deployedToken: {
             type: 'update',
             pk: { chain: trace.address.chain, address: trace.address.address },
@@ -270,12 +275,18 @@ export class TokenIngestionProcessor {
       }
     }
 
+    const finalAbstract = adoptDeployedTokenSymbolCasing(
+      newAbstractToken,
+      built.record.symbol,
+      steps,
+    )
+
     return {
       ...trace,
       steps,
       outcome: {
         kind: 'write',
-        newAbstractToken,
+        newAbstractToken: finalAbstract,
         deployedToken: {
           type: 'insert',
           record: {
@@ -878,9 +889,42 @@ function getNewCoingeckoSymbolConflict(
   deployedTokenSymbol: string,
 ): string | undefined {
   if (!newAbstractToken) return undefined
-  if (newAbstractToken.symbol === deployedTokenSymbol) return undefined
+  // CoinGecko's /coins/list and /coins/{platform}/contract/{addr} endpoints
+  // return symbols lower-cased (e.g. "susde", "wsteth"), so a casing-only
+  // difference vs. the RPC symbol never reflects a real mismatch. Compare
+  // case-insensitively here; the canonical casing is restored from the
+  // deployed-token symbol in `adoptDeployedTokenSymbolCasing`.
+  if (
+    newAbstractToken.symbol.toLowerCase() === deployedTokenSymbol.toLowerCase()
+  ) {
+    return undefined
+  }
 
   return `CoinGecko would create abstract token ${newAbstractToken.id}:${newAbstractToken.symbol}, but the deployed token symbol is ${deployedTokenSymbol}.`
+}
+
+/**
+ * CoinGecko returns symbols lower-cased, so a brand-new abstract built from a
+ * CoinGecko coin can't carry the correct casing on its own. The deployed
+ * token's symbol — read from RPC for inserts, or already canonical on the
+ * existing record for updates — is the source of truth, so we copy its
+ * casing onto the abstract before the write. The conflict check above has
+ * already proven the two symbols match case-insensitively. No-op when the
+ * casings already agree, so we don't pollute the trace with empty steps.
+ */
+function adoptDeployedTokenSymbolCasing(
+  newAbstractToken: AbstractTokenRecord | undefined,
+  deployedTokenSymbol: string,
+  steps: IngestionStep[],
+): AbstractTokenRecord | undefined {
+  if (!newAbstractToken) return undefined
+  if (newAbstractToken.symbol === deployedTokenSymbol) return newAbstractToken
+  steps.push({
+    kind: 'corrected-coingecko-symbol-casing',
+    from: newAbstractToken.symbol,
+    to: deployedTokenSymbol,
+  })
+  return { ...newAbstractToken, symbol: deployedTokenSymbol }
 }
 
 function generateAbstractTokenId() {

--- a/packages/token-backend/src/ingestion/formatIngestionTrace.ts
+++ b/packages/token-backend/src/ingestion/formatIngestionTrace.ts
@@ -62,6 +62,8 @@ export function describeIngestionStep(step: IngestionStep): string {
       return `Will create new abstract token for CoinGecko coin ${step.coingeckoId} (${step.symbol}).`
     case 'fetched-coingecko-abstract':
       return `Built abstract token ${step.record.id} (${step.record.symbol}) from CoinGecko coin ${step.record.coingeckoId}.`
+    case 'corrected-coingecko-symbol-casing':
+      return `Corrected CoinGecko symbol casing ${step.from} → ${step.to} from the deployed-token symbol.`
     case 'fetched-facts': {
       const base = `Fetched deployed-token facts: symbol=${String(step.facts.symbol)}, decimals=${String(step.facts.decimals)}, deploymentTimestamp=${String(step.facts.deploymentTimestamp)}, isContract=${String(step.facts.isContract)}.`
       if (step.facts.warnings.length === 0) return base


### PR DESCRIPTION
It turns out that Coingecko API returns token symbols lowercased (e.g. wsteth instead of wstETH). But we can assume that symbol returned from RPC call to a deployed token has proper casing (with additional check that all letters match with case ignored). Since we always have access to at least one deployed token during ingestion, we use symbol from RPC when creating new abstract token.