### PR TITLE
Add retry button for failed token ingestions

### DIFF
--- a/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.test.ts
@@ -160,6 +160,43 @@ describe('tokenIngestionQueueRouter', () => {
       ).toBeRejectedWith(TRPCError)
     })
   })
+
+  describe('retry', () => {
+    it('retries a conflict or error entry', async () => {
+      const retry = mockFn().resolvesTo(1)
+      const caller = createRouter(
+        mockObject<TokenDatabase>({
+          tokenIngestionQueue: mockObject<TokenDatabase['tokenIngestionQueue']>(
+            {
+              retry,
+            },
+          ),
+        }),
+      )
+
+      const input = { chain: 'ethereum', address: '0x111' }
+      const result = await caller.retry(input)
+
+      expect(result).toEqual({ success: true })
+      expect(retry).toHaveBeenCalledWith(input)
+    })
+
+    it('fails when the entry is not in conflict or error', async () => {
+      const caller = createRouter(
+        mockObject<TokenDatabase>({
+          tokenIngestionQueue: mockObject<TokenDatabase['tokenIngestionQueue']>(
+            {
+              retry: mockFn().resolvesTo(0),
+            },
+          ),
+        }),
+      )
+
+      await expect(
+        caller.retry({ chain: 'ethereum', address: '0x111' }),
+      ).toBeRejectedWith(TRPCError)
+    })
+  })
 })
 
 function createRouter(

--- a/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.ts
+++ b/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.ts
@@ -60,6 +60,19 @@ export const tokenIngestionQueueRouter = router({
 
       return { success: true }
     }),
+  retry: readWriteProcedure
+    .input(QueueEntryAddress)
+    .mutation(async ({ ctx, input }) => {
+      const retried = await ctx.tokenDb.tokenIngestionQueue.retry(input)
+      if (retried !== 1) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Queue entry is not in conflict or error state',
+        })
+      }
+
+      return { success: true }
+    }),
   preview: readOnlyProcedure
     .input(QueueEntryAddress)
     .mutation(async ({ ctx, input }) => {

--- a/packages/token-ui/src/pages/tokens/TokenIngestionQueuePage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenIngestionQueuePage.tsx
@@ -5,6 +5,7 @@ import {
   ChevronRightIcon,
   EyeIcon,
   ListChecksIcon,
+  RotateCwIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -49,6 +50,7 @@ const PAGE_SIZE = 100
 export function TokenIngestionQueuePage() {
   const utils = api.useUtils()
   const [approvingKey, setApprovingKey] = useState<string | undefined>()
+  const [retryingKey, setRetryingKey] = useState<string | undefined>()
   const [preview, setPreview] = useState<IngestionPreviewState | undefined>()
   const [page, setPage] = useState(1)
   const { data: queuePage, isLoading } =
@@ -81,6 +83,14 @@ export function TokenIngestionQueuePage() {
     },
     onError: (error) => toast.error(error.message),
     onSettled: () => setApprovingKey(undefined),
+  })
+  const retry = api.tokenIngestionQueue.retry.useMutation({
+    onSuccess: async () => {
+      await utils.tokenIngestionQueue.getPage.invalidate()
+      toast.success('Queue entry queued for retry')
+    },
+    onError: (error) => toast.error(error.message),
+    onSettled: () => setRetryingKey(undefined),
   })
   const previewMutation = api.tokenIngestionQueue.preview.useMutation({
     onSuccess: (trace) => {
@@ -235,6 +245,24 @@ export function TokenIngestionQueuePage() {
                             >
                               <CheckIcon />
                               Approve
+                            </ButtonWithSpinner>
+                          )}
+                          {(entry.state === 'conflict' ||
+                            entry.state === 'error') && (
+                            <ButtonWithSpinner
+                              variant="outline"
+                              size="sm"
+                              isLoading={retry.isPending && retryingKey === key}
+                              onClick={() => {
+                                setRetryingKey(key)
+                                retry.mutate({
+                                  chain: entry.chain,
+                                  address: entry.address,
+                                })
+                              }}
+                            >
+                              <RotateCwIcon />
+                              Retry
                             </ButtonWithSpinner>
                           )}
                         </div>


### PR DESCRIPTION
Adding "Retry" button. Previously there was no way to retry ingestion that failed.