### PR TITLE
Add "Approve all on page" button on token ingestion queue

### DIFF
--- a/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.test.ts
@@ -161,6 +161,30 @@ describe('tokenIngestionQueueRouter', () => {
     })
   })
 
+  describe('approveMany', () => {
+    it('approves supplied staged entries and returns the count', async () => {
+      const approve = mockFn().resolvesToOnce(1).resolvesToOnce(0)
+      const caller = createRouter(
+        mockObject<TokenDatabase>({
+          tokenIngestionQueue: mockObject<TokenDatabase['tokenIngestionQueue']>(
+            {
+              approve,
+            },
+          ),
+        }),
+      )
+
+      const first = { chain: 'ethereum', address: '0x111' }
+      const second = { chain: 'base', address: '0x222' }
+      const result = await caller.approveMany([first, second])
+
+      expect(result).toEqual({ success: true, approved: 1 })
+      expect(approve).toHaveBeenCalledTimes(2)
+      expect(approve.calls[0]?.args[0]).toEqual(first)
+      expect(approve.calls[1]?.args[0]).toEqual(second)
+    })
+  })
+
   describe('retry', () => {
     it('retries a conflict or error entry', async () => {
       const retry = mockFn().resolvesTo(1)

--- a/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.ts
+++ b/packages/token-backend/src/trpc/routers/tokenIngestionQueue/index.ts
@@ -60,6 +60,16 @@ export const tokenIngestionQueueRouter = router({
 
       return { success: true }
     }),
+  approveMany: readWriteProcedure
+    .input(v.array(QueueEntryAddress))
+    .mutation(async ({ ctx, input }) => {
+      let approved = 0
+      for (const entry of input) {
+        approved += await ctx.tokenDb.tokenIngestionQueue.approve(entry)
+      }
+
+      return { success: true, approved }
+    }),
   retry: readWriteProcedure
     .input(QueueEntryAddress)
     .mutation(async ({ ctx, input }) => {

--- a/packages/token-ui/src/pages/tokens/TokenIngestionQueuePage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenIngestionQueuePage.tsx
@@ -62,6 +62,7 @@ export function TokenIngestionQueuePage() {
   const queue = queuePage?.entries ?? []
   const predictedOutcomes = queuePage?.predictedOutcomes ?? []
   const totalCount = queuePage?.totalCount ?? 0
+  const stagedEntries = queue.filter((entry) => entry.state === 'staged')
   const pageCount = queuePage
     ? Math.max(1, Math.ceil(queuePage.totalCount / PAGE_SIZE))
     : page
@@ -83,6 +84,13 @@ export function TokenIngestionQueuePage() {
     },
     onError: (error) => toast.error(error.message),
     onSettled: () => setApprovingKey(undefined),
+  })
+  const approveMany = api.tokenIngestionQueue.approveMany.useMutation({
+    onSuccess: async ({ approved }) => {
+      await utils.tokenIngestionQueue.getPage.invalidate()
+      toast.success(`Approved ${approved} queue entries`)
+    },
+    onError: (error) => toast.error(error.message),
   })
   const retry = api.tokenIngestionQueue.retry.useMutation({
     onSuccess: async () => {
@@ -114,6 +122,23 @@ export function TokenIngestionQueuePage() {
     previewMutation.mutate({ chain: entry.chain, address: entry.address })
   }
 
+  function approveAllOnPage() {
+    if (stagedEntries.length === 0) {
+      return
+    }
+
+    const confirmed = window.confirm(
+      `Approve ${stagedEntries.length} staged queue entries on this page?`,
+    )
+    if (!confirmed) {
+      return
+    }
+
+    approveMany.mutate(
+      stagedEntries.map(({ chain, address }) => ({ chain, address })),
+    )
+  }
+
   return (
     <AppLayout>
       <Card className="flex h-[calc(100vh-16px)] flex-col">
@@ -124,32 +149,45 @@ export function TokenIngestionQueuePage() {
               {formatQueueRange(page, totalCount)}
             </CardDescription>
           )}
-          {queuePage && totalCount > PAGE_SIZE && (
+          {queuePage && (
             <CardAction>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
+              <div className="flex flex-wrap items-center justify-end gap-2">
+                <ButtonWithSpinner
                   size="sm"
-                  disabled={page <= 1}
-                  onClick={() => setPage((page) => Math.max(1, page - 1))}
+                  isLoading={approveMany.isPending}
+                  disabled={stagedEntries.length === 0}
+                  onClick={approveAllOnPage}
                 >
-                  <ChevronLeftIcon />
-                  Previous
-                </Button>
-                <div className="whitespace-nowrap text-muted-foreground text-sm tabular-nums">
-                  Page {page} of {pageCount}
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={page >= pageCount}
-                  onClick={() =>
-                    setPage((page) => Math.min(pageCount, page + 1))
-                  }
-                >
-                  Next
-                  <ChevronRightIcon />
-                </Button>
+                  <CheckIcon />
+                  Approve all on this page
+                </ButtonWithSpinner>
+                {totalCount > PAGE_SIZE && (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page <= 1}
+                      onClick={() => setPage((page) => Math.max(1, page - 1))}
+                    >
+                      <ChevronLeftIcon />
+                      Previous
+                    </Button>
+                    <div className="whitespace-nowrap text-muted-foreground text-sm tabular-nums">
+                      Page {page} of {pageCount}
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={page >= pageCount}
+                      onClick={() =>
+                        setPage((page) => Math.min(pageCount, page + 1))
+                      }
+                    >
+                      Next
+                      <ChevronRightIcon />
+                    </Button>
+                  </>
+                )}
               </div>
             </CardAction>
           )}


### PR DESCRIPTION
There are over 5k entries in ingestion queue waiting for manual approval. Approving all in one go feels risky. This "Approve all on page" button allows to do it in batches.