### PR TITLE
Don't break ingestion loop on single error

### DIFF
--- a/packages/database/src/repositories/TokenIngestionQueueRepository.test.ts
+++ b/packages/database/src/repositories/TokenIngestionQueueRepository.test.ts
@@ -118,6 +118,16 @@ describeTokenDatabase(TokenIngestionQueueRepository.name, (db) => {
         { ...error, state: 'error', message: 'RPC failed' },
       ])
     })
+
+    it('escapes NUL bytes in messages before writing them', async () => {
+      const address = { chain: 'ethereum', address: '0x111' }
+      await repository.enqueue(address)
+
+      await repository.markError(address, 'RPC returned U\0SDC')
+
+      const entries = await repository.getByStates(['error'])
+      expect(entries[0]?.message).toEqual('RPC returned U\\0SDC')
+    })
   })
 
   describe(TokenIngestionQueueRepository.prototype.getPage.name, () => {

--- a/packages/database/src/repositories/TokenIngestionQueueRepository.ts
+++ b/packages/database/src/repositories/TokenIngestionQueueRepository.ts
@@ -224,7 +224,7 @@ export class TokenIngestionQueueRepository extends BaseRepository {
       .updateTable('TokenIngestionQueue')
       .set({
         state,
-        message,
+        message: sanitizePostgresText(message),
         updatedAt: new Date(),
       })
       .where('chain', '=', normalized.chain)
@@ -233,4 +233,8 @@ export class TokenIngestionQueueRepository extends BaseRepository {
 
     return Number(result.numUpdatedRows)
   }
+}
+
+function sanitizePostgresText(value: string): string {
+  return value.replace(/\0/g, '\\0')
 }

--- a/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
@@ -561,6 +561,63 @@ describe(TokenIngestionLoop.name, () => {
       expect(remove).toHaveBeenOnlyCalledWith(queueEntry(secondAddress))
     })
 
+    it('marks an unexpected entry failure as an error and continues draining', async () => {
+      const firstAddress = token('ethereum', '0xaaa')
+      const secondAddress = token('ethereum', '0xbbb')
+      const transferIndex = { findInvolving: mockFn().returns([]) }
+      const refreshInteropTransferIndex = mockFn().resolvesTo(transferIndex)
+      const process = mockFn()
+        .rejectsWithOnce(new Error('boom'))
+        .resolvesToOnce({
+          id: 'ing_test',
+          address: secondAddress,
+          steps: [],
+          outcome: { kind: 'skip', reason: 'test' },
+        } satisfies IngestionTrace)
+      const markError = mockFn().resolvesTo(1)
+
+      const loop = new TokenIngestionLoop(
+        mockObject<Database>({
+          interopTransfer: mockObject<Database['interopTransfer']>({
+            getTokenAddressesAfterSerialId: mockFn().resolvesTo({
+              latestSerialId: undefined,
+              transferCount: 0,
+              tokenAddresses: [],
+            }),
+            getAll: mockFn().resolvesTo([]),
+          }),
+        }),
+        mockObject<TokenDatabase>({
+          tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
+            get: mockFn().resolvesTo(undefined),
+          }),
+          tokenIngestionQueue: mockObject<TokenDatabase['tokenIngestionQueue']>(
+            {
+              findNextPending: mockFn()
+                .resolvesToOnce(queueEntry(firstAddress))
+                .resolvesToOnce(queueEntry(secondAddress))
+                .resolvesToOnce(undefined),
+              markError,
+            },
+          ),
+        }),
+        mockObject({
+          process,
+          refreshInteropTransferIndex,
+        }) as unknown as TokenIngestionProcessor,
+        Logger.SILENT,
+        { intervalMs: 60_000 },
+      )
+
+      await loop.runOnce()
+
+      expect(process).toHaveBeenCalledTimes(2)
+      expect(markError).toHaveBeenOnlyCalledWith(
+        queueEntry(firstAddress),
+        'Unexpected token ingestion error: boom.',
+      )
+    })
+
     it('creates an abstract token from CoinGecko before inserting a deployed token', async () => {
       const address = token('ethereum', '0xaaa')
       const abstractInsert = mockFn().resolvesTo('ABC123')

--- a/packages/token-backend/src/ingestion/TokenIngestionLoop.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionLoop.ts
@@ -4,6 +4,7 @@ import type {
   TokenDatabase,
   TokenIngestionQueueState,
 } from '@l2beat/database'
+import { formatError } from '../utils/formatError'
 import type { IngestionOutcome } from './IngestionTrace'
 import type { TokenIngestionProcessor } from './TokenIngestionProcessor'
 import { normalizeInteropTokenAddress } from './tokenIngestionUtils'
@@ -131,8 +132,20 @@ export class TokenIngestionLoop {
       }
       seenAddresses.add(addressKey)
 
-      const trace = await this.processor.process(entry, transferIndex)
-      outcomeCounts[trace.outcome.kind] += 1
+      try {
+        const trace = await this.processor.process(entry, transferIndex)
+        outcomeCounts[trace.outcome.kind] += 1
+      } catch (error) {
+        this.logger.error('Token ingestion entry processing failed', error, {
+          chain: entry.chain,
+          address: entry.address,
+        })
+        await this.tokenDb.tokenIngestionQueue.markError(
+          entry,
+          `Unexpected token ingestion error: ${formatError(error)}.`,
+        )
+        outcomeCounts.error += 1
+      }
       processed += 1
       entry = await this.tokenDb.tokenIngestionQueue.findNextPending()
     }


### PR DESCRIPTION
Currently a single token with malformed symbol (NULL byte) breaks the ingestion loop and it doesn't process any entries.

This PR introduces a change that persist error (catch-all) in queue entry that's being processed and moves to next entry.