### PR TITLE
Fix hyperliquid-bridge misclassifying non-USDC transfers as deposits

### DIFF
--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -304,6 +304,10 @@
       {
         "chain": "arbitrum",
         "tx": "0xfea525a89c615980ce8a77407a7cabd25e44a4b42b94f7ad01f352ff45475d11"
+      },
+      {
+        "chain": "arbitrum",
+        "tx": "0x0fa1d62afe91f99fa5292db2afd0988e5a9fcc5346ae44296814722e5011ef49"
       }
     ],
     "expects": {

--- a/packages/backend/src/modules/interop/plugins/hyperliquid-bridge.ts
+++ b/packages/backend/src/modules/interop/plugins/hyperliquid-bridge.ts
@@ -24,7 +24,8 @@ const ARB_USDC = ChainSpecificAddress(
 
 const HYPERLIQUID_BRIDGE_ADDRESS =
   ChainSpecificAddress.address(HYPERLIQUID_BRIDGE)
-const ARB_USDC_TOKEN = Address32.from(ChainSpecificAddress.address(ARB_USDC))
+const ARB_USDC_ADDRESS = ChainSpecificAddress.address(ARB_USDC)
+const ARB_USDC_TOKEN = Address32.from(ARB_USDC_ADDRESS)
 
 const transferLog =
   'event Transfer(address indexed from, address indexed to, uint256 value)'
@@ -96,7 +97,7 @@ export class HyperliquidBridgePlugin implements InteropPluginResyncable {
       ]
     }
 
-    const transfer = parseTransfer(input.log, null)
+    const transfer = parseTransfer(input.log, [ARB_USDC_ADDRESS])
     if (!transfer) return
     if (EthereumAddress(transfer.to) !== HYPERLIQUID_BRIDGE_ADDRESS) return
 


### PR DESCRIPTION
## Summary
- The hyperliquid-bridge plugin called `parseTransfer(log, null)`, accepting any ERC-20 `Transfer` to the bridge address and labeling it as USDC. This produced bogus Deposit/Transfer events when a user accidentally sent a non-USDC token (e.g. JOE in `0x0fa1d62a...`).
- Restricted the parser to the USDC contract via an address whitelist, so unrelated token transfers are now ignored.
- Added the JOE transfer tx to the `hyperliquid-bridge` example so this case is covered going forward.

## Test plan
- [x] `pnpm interop:example hyperliquid-bridge --simple` passes with no `[XTRA]` events