### PR TITLE
Fix search dialog flashing recently added on item select

### DIFF
--- a/packages/frontend/src/components/search-bar/SearchBarDialog.tsx
+++ b/packages/frontend/src/components/search-bar/SearchBarDialog.tsx
@@ -74,11 +74,13 @@ export function SearchBarDialog({ recentlyAdded }: Props) {
 
   function onItemSelect(item: SearchBarProject | AnySearchBarEntry) {
     setOpen(false)
-    setValue('')
     router.push(item.href)
     track('searchBarProjectSelected', {
       name: item.name,
     })
+    // Clear after the dialog's close animation (duration-200) so the input
+    // doesn't visibly reset and flash the "Recently added" list mid-close.
+    setTimeout(() => setValue(''), 200)
   }
 
   // Hide virtual keyboard on touch start


### PR DESCRIPTION
## Summary
- When picking an item in the Search Dialog, the input was being cleared before the dialog finished its 200ms close animation, causing the "Recently added projects" group to briefly flash.
- Defer the `setValue('')` reset until after the close animation completes so the dialog fades out with the user's query still visible.

## Test plan
- [ ] Open the search bar (`/`), type a query, click a result — confirm no flash of "Recently added projects" during the close animation.
- [ ] Reopen the search bar — confirm the input starts empty.
- [ ] Press Escape with text in the input — confirm it still clears the input without closing.
- [ ] Press Escape with empty input — confirm it closes the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)