### PR TITLE
fix(env): preserve separators in Env.key normalization

### DIFF
--- a/packages/backend-tools/src/env.test.ts
+++ b/packages/backend-tools/src/env.test.ts
@@ -6,7 +6,11 @@ describe(Env.name, () => {
   describe(Env.key.name, () => {
     it('returns correct environment variable key', () => {
       const result = Env.key('polygon-pos', 'RPC_URL')
-      expect(result).toEqual('POLYGONPOS_RPC_URL')
+      expect(result).toEqual('POLYGON_POS_RPC_URL')
+    })
+
+    it('does not collapse distinct identifiers', () => {
+      expect(Env.key('service-a')).not.toEqual(Env.key('servicea'))
     })
   })
 

--- a/packages/backend-tools/src/env.ts
+++ b/packages/backend-tools/src/env.ts
@@ -25,7 +25,7 @@ export class Env {
   }
 
   static key(...inputs: string[]): string {
-    return inputs.join('_').replace(/-/g, '').toUpperCase()
+    return inputs.flatMap((x) => x.trim().split(/[-_\s]+/)).filter(Boolean).join('_').toUpperCase()
   }
 
   string(key: string | string[], fallback?: string): string {


### PR DESCRIPTION
Env.Env.key() was removing hyphens instead of converting them to underscores, causing distinct identifiers like service-a and servicea to collapse into the same environment key. This could silently resolve the wrong env var with no exception thrown. Fixed by canonicalizing separators via split(/[-_\s]+/) and added a regression test to prevent future collisions.