### PR TITLE
Adjust thresholds 

### DIFF
--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationAnalyzer.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationAnalyzer.ts
@@ -5,6 +5,7 @@ import type {
 import { type InteropBridgeType, UnixTime } from '@l2beat/shared-pure'
 import {
   type AnomalyEvaluation,
+  type BridgeTotal,
   evaluateAnomalies,
   formatAnomalyReasons,
   type SeriesPoint,
@@ -57,6 +58,7 @@ export class DefaultInteropAggregationAnalyzer
     candidateTransfers: AggregatedInteropTransferRecord[],
   ): Promise<InteropAggregationAnalysis> {
     const groupedTransfers = groupTransfers(candidateTransfers)
+    const bridgeTotals = computeBridgeTotals(groupedTransfers)
     const candidateDay = UnixTime.toStartOf(candidateTimestamp, 'day')
     const historyFrom = candidateDay - (Z_WINDOW_DAYS - 1) * UnixTime.DAY
     const historicalGroups =
@@ -82,7 +84,7 @@ export class DefaultInteropAggregationAnalyzer
         )
 
       const series = buildSeries(candidateDay, group.metrics, historicalStats)
-      const evaluation = evaluateAnomalies(series)
+      const evaluation = evaluateAnomalies(series, bridgeTotals.get(group.id))
       if (evaluation.signals.length === 0 && !evaluation.sideMismatch) {
         continue
       }
@@ -151,6 +153,23 @@ function buildSeries(
   })
 
   return series
+}
+
+function computeBridgeTotals(
+  groupedTransfers: Map<string, GroupedTransferCandidate>,
+): Map<string, BridgeTotal> {
+  const totals = new Map<string, BridgeTotal>()
+  for (const group of groupedTransfers.values()) {
+    const existing = totals.get(group.id) ?? {
+      transferCount: 0,
+      volumeUsd: 0,
+    }
+    existing.transferCount += group.metrics.transferCount
+    existing.volumeUsd +=
+      group.metrics.srcVolumeUsd + group.metrics.dstVolumeUsd
+    totals.set(group.id, existing)
+  }
+  return totals
 }
 
 function groupTransfers(transfers: AggregatedInteropTransferRecord[]) {

--- a/packages/backend/src/modules/interop/engine/anomalies/evaluator.test.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/evaluator.test.ts
@@ -62,9 +62,9 @@ describe(evaluateAnomalies.name, () => {
   })
 
   describe('ratio drops and spikes', () => {
-    it('flags a sudden 90% ratio drop in count', () => {
+    it('flags a near-total ratio drop in count', () => {
       const series = countSeries([
-        100, 110, 90, 105, 95, 100, 98, 102, 101, 99, 100, 97, 103, 5,
+        100, 110, 90, 105, 95, 100, 98, 102, 101, 99, 100, 97, 103, 1,
       ])
       const result = evaluateAnomalies(series)
       const count = result.signals.find((s) => s.metric === 'count')
@@ -72,9 +72,9 @@ describe(evaluateAnomalies.name, () => {
       expect(count?.severity).toEqual('severe')
     })
 
-    it('flags a 90%+ ratio spike in count', () => {
+    it('flags a 10x+ ratio spike in count', () => {
       const series = countSeries([
-        100, 110, 90, 105, 95, 100, 98, 102, 101, 99, 100, 97, 103, 250,
+        100, 110, 90, 105, 95, 100, 98, 102, 101, 99, 100, 97, 103, 5_000,
       ])
       const result = evaluateAnomalies(series)
       const count = result.signals.find((s) => s.metric === 'count')
@@ -82,7 +82,7 @@ describe(evaluateAnomalies.name, () => {
       expect(count?.severity).toEqual('severe')
     })
 
-    it('flags a 10x ratio spike in src volume', () => {
+    it('flags a 30x+ ratio spike in src volume', () => {
       const series = volumeSeries(
         Array.from({ length: 14 }, () => 100),
         [
@@ -97,7 +97,7 @@ describe(evaluateAnomalies.name, () => {
       expect(src?.severity).toEqual('severe')
     })
 
-    it('does not flag a 5x volume spike (under 10x threshold) as ratio spike', () => {
+    it('does not flag a 5x volume spike (under 30x threshold) as ratio spike', () => {
       const series = volumeSeries(
         Array.from({ length: 14 }, () => 100),
         [
@@ -123,16 +123,15 @@ describe(evaluateAnomalies.name, () => {
       expect(count?.severity).toEqual('severe')
     })
 
-    it('flags moderate when robust z-score is in the warn band only', () => {
-      // Tight baseline + a jump that lands robust-Z in (4, 6), below the
-      // 1.9x ratio threshold and well under the classic-Z cap.
+    it('does not emit anything for a moderate robust-Z anomaly', () => {
+      // Tight baseline + a small jump — moderate tier is gone, so nothing
+      // should fire here.
       const series = countSeries([
         95, 100, 105, 95, 100, 105, 95, 100, 105, 95, 100, 105, 95, 145,
       ])
       const result = evaluateAnomalies(series)
       const count = result.signals.find((s) => s.metric === 'count')
-      expect(count).not.toBeNullish()
-      expect(count?.severity).toEqual('moderate')
+      expect(count).toBeNullish()
     })
   })
 
@@ -230,6 +229,146 @@ describe(evaluateAnomalies.name, () => {
           (s) => s.metric === 'srcVolume' || s.metric === 'dstVolume',
         ),
       ).toEqual([])
+    })
+  })
+
+  describe('relevance gate', () => {
+    it('suppresses a volume spike on a lane below the absolute USD floor', () => {
+      // Baseline clears the $10K mean floor (15K), but the spike lands the
+      // current value at $200K — below the $250K materiality floor — and
+      // we pass no bridge total, so share-of-bridge cannot rescue it.
+      const series = volumeSeries(
+        Array.from({ length: 14 }, () => 100),
+        [
+          15_000, 15_000, 15_000, 15_000, 15_000, 15_000, 15_000, 15_000,
+          15_000, 15_000, 15_000, 15_000, 15_000, 200_000,
+        ],
+        15_000,
+      )
+      const result = evaluateAnomalies(series)
+      const src = result.signals.find((s) => s.metric === 'srcVolume')
+      expect(src).toBeNullish()
+    })
+
+    it('suppresses a volume drop when the baseline lane is immaterial within the bridge', () => {
+      // Lane baseline is $50K — above the per-day floor but only 0.5% of
+      // a $10M bridge. A 100% drop should not page.
+      const series = volumeSeries(
+        Array.from({ length: 14 }, () => 100),
+        Array.from({ length: 13 }, () => 50_000).concat([0]),
+        Array.from({ length: 13 }, () => 50_000).concat([0]),
+      )
+      const result = evaluateAnomalies(series, {
+        transferCount: 100_000,
+        volumeUsd: 10_000_000,
+      })
+      const src = result.signals.find((s) => s.metric === 'srcVolume')
+      expect(src).toBeNullish()
+    })
+
+    it('keeps a volume signal that clears the bridge-share gate', () => {
+      // Lane lands at $200K — below the $250K absolute floor — but
+      // represents 4% of a $5M bridge, above the 2% share gate. Tight
+      // baseline + log jump makes classic-Z trip.
+      const baselineVolumes = [
+        48_000, 52_000, 50_000, 49_000, 51_000, 50_000, 48_000, 52_000, 49_000,
+        51_000, 50_000, 49_000, 51_000,
+      ]
+      const series = volumeSeries(
+        Array.from({ length: 14 }, () => 100),
+        baselineVolumes.concat([200_000]),
+        baselineVolumes.concat([200_000]),
+      )
+      const result = evaluateAnomalies(series, {
+        transferCount: 1_000,
+        volumeUsd: 5_000_000,
+      })
+      const src = result.signals.find((s) => s.metric === 'srcVolume')
+      expect(src?.kind).toEqual('zScoreSpike')
+    })
+
+    it('suppresses a flat line on a low-count lane', () => {
+      // Three identical days at 50 transfers — clears the baseline floor
+      // (50 > 10/day) but the median is below the flat-line relevance
+      // floor of 100, so it should not alert.
+      const series = countSeries([
+        50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50, 50,
+      ])
+      const result = evaluateAnomalies(series)
+      const count = result.signals.find((s) => s.metric === 'count')
+      expect(count).toBeNullish()
+    })
+  })
+
+  describe('real-world scenarios', () => {
+    it('fires on the legitimate volume spike for layerzero polygonpos→ethereum', () => {
+      // Baseline two-sided lane volumes range from $230K to $2.4M; the
+      // candidate day jumps to ~$19M, ~35x the baseline median.
+      const counts = [18, 28, 10, 22, 23, 36, 35, 26, 35, 19, 30, 24, 29, 32]
+      const srcVolumes = [
+        453_628, 721_302, 231_492, 416_757, 539_322, 1_931_100, 2_358_880,
+        246_215, 1_798_860, 398_666, 301_266, 635_919, 1_560_370, 19_084_500,
+      ]
+      const dstVolumes = [
+        453_652, 721_376, 231_492, 416_829, 539_300, 1_931_120, 2_358_940,
+        246_208, 1_798_650, 398_739, 301_336, 635_887, 1_560_280, 19_089_200,
+      ]
+      const series = volumeSeries(counts, srcVolumes, dstVolumes)
+      const result = evaluateAnomalies(series, {
+        transferCount: 4_971,
+        volumeUsd: 493_321_000,
+      })
+      const src = result.signals.find((s) => s.metric === 'srcVolume')
+      const dst = result.signals.find((s) => s.metric === 'dstVolume')
+      expect(src?.kind).toEqual('ratioSpike')
+      expect(dst?.kind).toEqual('ratioSpike')
+      expect(result.sideMismatch).toEqual(null)
+    })
+
+    it('fires on the legitimate volume drop for circlegateway ethereum→polygonpos', () => {
+      // Baseline two-sided lane volumes $1M-$7M; candidate collapses to
+      // ~$22K — a 98.5% drop, well past the 98% drop threshold.
+      const counts = [
+        95, 104, 85, 118, 78, 46, 90, 139, 269, 275, 236, 198, 75, 15,
+      ]
+      const volumes = [
+        3_472_660, 7_234_100, 3_638_220, 7_071_300, 4_455_340, 2_499_480,
+        1_475_200, 1_303_910, 1_117_900, 1_230_350, 1_159_630, 1_373_830,
+        243_377, 21_808,
+      ]
+      const series = volumeSeries(counts, volumes, volumes)
+      const result = evaluateAnomalies(series, {
+        transferCount: 1_040,
+        volumeUsd: 59_513_600,
+      })
+      const src = result.signals.find((s) => s.metric === 'srcVolume')
+      const dst = result.signals.find((s) => s.metric === 'dstVolume')
+      expect(src?.kind).toEqual('ratioDrop')
+      expect(dst?.kind).toEqual('ratioDrop')
+    })
+
+    it('stays silent on across base→bsc — a "moderate" noisy case from the old policy', () => {
+      // Old policy flagged this lane as a "moderate" count spike at +33%
+      // (313 → 416). Volumes drift around $130K-$270K. Nothing here is
+      // an extremum, so the new policy should keep quiet.
+      const counts = [
+        310, 228, 211, 324, 307, 383, 326, 320, 311, 314, 327, 362, 349, 416,
+      ]
+      const srcVolumes = [
+        126_459, 67_887, 214_260, 126_571, 158_633, 247_725, 267_804, 213_252,
+        203_659, 144_967, 231_425, 217_051, 171_430, 275_284,
+      ]
+      const dstVolumes = [
+        126_369, 67_835, 214_183, 126_477, 158_574, 247_614, 267_695, 213_133,
+        203_561, 144_841, 231_289, 216_954, 171_337, 275_169,
+      ]
+      const series = volumeSeries(counts, srcVolumes, dstVolumes)
+      const result = evaluateAnomalies(series, {
+        transferCount: 15_076,
+        volumeUsd: 57_833_300,
+      })
+      expect(result.signals).toEqual([])
+      expect(result.sideMismatch).toEqual(null)
     })
   })
 

--- a/packages/backend/src/modules/interop/engine/anomalies/evaluator.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/evaluator.ts
@@ -8,6 +8,9 @@ import {
   RATIO_COUNT_SPIKE_THRESHOLD,
   RATIO_DROP_THRESHOLD,
   RATIO_VOLUME_SPIKE_THRESHOLD,
+  RELEVANCE_MIN_BRIDGE_SHARE,
+  RELEVANCE_MIN_COUNT,
+  RELEVANCE_MIN_VOLUME_USD,
   SIDE_MISMATCH_DIFF_PERCENT,
   SIDE_MISMATCH_MIN_VOLUME_USD,
   Z_CLASSIC_THRESHOLD,
@@ -23,6 +26,11 @@ export interface SeriesPoint {
   dstVolumeUsd: number
 }
 
+export interface BridgeTotal {
+  transferCount: number
+  volumeUsd: number
+}
+
 export type AnomalyMetric = 'count' | 'srcVolume' | 'dstVolume'
 export type AnomalyKind =
   | 'flatLine'
@@ -30,7 +38,7 @@ export type AnomalyKind =
   | 'ratioSpike'
   | 'zScoreDrop'
   | 'zScoreSpike'
-export type AnomalySeverity = 'moderate' | 'severe'
+export type AnomalySeverity = 'severe'
 
 export interface MetricSignal {
   metric: AnomalyMetric
@@ -53,7 +61,10 @@ export interface AnomalyEvaluation {
   sideMismatch: SideMismatchSignal | null
 }
 
-export function evaluateAnomalies(series: SeriesPoint[]): AnomalyEvaluation {
+export function evaluateAnomalies(
+  series: SeriesPoint[],
+  bridgeTotal?: BridgeTotal,
+): AnomalyEvaluation {
   if (series.length === 0) {
     return { signals: [], sideMismatch: null }
   }
@@ -66,15 +77,26 @@ export function evaluateAnomalies(series: SeriesPoint[]): AnomalyEvaluation {
   }
 
   const signals: MetricSignal[] = []
-  const countSignal = evaluateMetric('count', window, (p) => p.transferCount)
+  const countSignal = evaluateMetric(
+    'count',
+    window,
+    (p) => p.transferCount,
+    bridgeTotal,
+  )
   if (countSignal) signals.push(countSignal)
 
   if (isVolumeReliable(candidate)) {
-    const srcSignal = evaluateMetric('srcVolume', window, (p) =>
-      isVolumeReliable(p) ? p.srcVolumeUsd : 0,
+    const srcSignal = evaluateMetric(
+      'srcVolume',
+      window,
+      (p) => (isVolumeReliable(p) ? p.srcVolumeUsd : 0),
+      bridgeTotal,
     )
-    const dstSignal = evaluateMetric('dstVolume', window, (p) =>
-      isVolumeReliable(p) ? p.dstVolumeUsd : 0,
+    const dstSignal = evaluateMetric(
+      'dstVolume',
+      window,
+      (p) => (isVolumeReliable(p) ? p.dstVolumeUsd : 0),
+      bridgeTotal,
     )
     if (srcSignal) signals.push(srcSignal)
     if (dstSignal) signals.push(dstSignal)
@@ -90,6 +112,7 @@ function evaluateMetric(
   metric: AnomalyMetric,
   window: SeriesPoint[],
   pick: (p: SeriesPoint) => number,
+  bridgeTotal: BridgeTotal | undefined,
 ): MetricSignal | null {
   if (window.length < 2) return null
 
@@ -106,8 +129,14 @@ function evaluateMetric(
 
   if (!hasEnoughNonZeroHistory(values)) return null
 
-  if (metric === 'count' && detectFlatLine(values)) {
-    return buildSignal('flatLine', metric, 'severe', baselineMean, current)
+  const baselineMedian = median(baseline)
+
+  if (
+    metric === 'count' &&
+    detectFlatLine(values) &&
+    baselineMedian >= RELEVANCE_MIN_COUNT
+  ) {
+    return buildSignal('flatLine', metric, baselineMean, current)
   }
 
   const spikeRatioThreshold =
@@ -122,10 +151,10 @@ function evaluateMetric(
   const robustSpike = z.robust !== null && z.robust > Z_ROBUST_THRESHOLD.spike
 
   if (isRatioSpike || classicSpike || robustSpike) {
+    if (!isRelevant(metric, current, bridgeTotal)) return null
     return buildSignal(
       isRatioSpike ? 'ratioSpike' : 'zScoreSpike',
       metric,
-      'severe',
       baselineMean,
       current,
     )
@@ -135,23 +164,35 @@ function evaluateMetric(
   const robustDrop = z.robust !== null && z.robust < Z_ROBUST_THRESHOLD.drop
 
   if (isRatioDrop || classicDrop || robustDrop) {
+    if (!isRelevant(metric, baselineMedian, bridgeTotal)) return null
     return buildSignal(
       isRatioDrop ? 'ratioDrop' : 'zScoreDrop',
       metric,
-      'severe',
       baselineMean,
       current,
     )
   }
 
-  if (z.robust !== null && z.robust > Z_ROBUST_THRESHOLD.warn) {
-    return buildSignal('zScoreSpike', metric, 'moderate', baselineMean, current)
-  }
-  if (z.robust !== null && z.robust < -Z_ROBUST_THRESHOLD.warn) {
-    return buildSignal('zScoreDrop', metric, 'moderate', baselineMean, current)
-  }
-
   return null
+}
+
+function isRelevant(
+  metric: AnomalyMetric,
+  value: number,
+  bridgeTotal: BridgeTotal | undefined,
+): boolean {
+  if (metric === 'count') {
+    if (value >= RELEVANCE_MIN_COUNT) return true
+    if (bridgeTotal && bridgeTotal.transferCount > 0) {
+      return value / bridgeTotal.transferCount >= RELEVANCE_MIN_BRIDGE_SHARE
+    }
+    return false
+  }
+  if (value >= RELEVANCE_MIN_VOLUME_USD) return true
+  if (bridgeTotal && bridgeTotal.volumeUsd > 0) {
+    return value / bridgeTotal.volumeUsd >= RELEVANCE_MIN_BRIDGE_SHARE
+  }
+  return false
 }
 
 function evaluateSideMismatch(
@@ -178,14 +219,13 @@ function evaluateSideMismatch(
 function buildSignal(
   kind: AnomalyKind,
   metric: AnomalyMetric,
-  severity: AnomalySeverity,
   baseline: number,
   current: number,
 ): MetricSignal {
   return {
     metric,
     kind,
-    severity,
+    severity: 'severe',
     baseline,
     current,
     changePercent: getChangePercent(baseline, current),

--- a/packages/backend/src/modules/interop/engine/anomalies/formatter.test.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/formatter.test.ts
@@ -32,17 +32,19 @@ describe(describeSignal.name, () => {
     ).toEqual('Source volume dropped (-90%, $1M → $100K)')
   })
 
-  it('describes a moderate dst-volume spike with the "moderately" qualifier', () => {
+  it('labels the action by the sign of the change, not the signal kind', () => {
+    // Robust-Z spike can fire on a sharp drop when prior history is tight.
+    // The action word must follow the actual direction.
     expect(
       describeSignal({
-        metric: 'dstVolume',
+        metric: 'srcVolume',
         kind: 'zScoreSpike',
-        severity: 'moderate',
-        baseline: 1_000_000,
-        current: 1_300_000,
-        changePercent: 30,
+        severity: 'severe',
+        baseline: 143_000,
+        current: 7_600,
+        changePercent: -95,
       }),
-    ).toEqual('Destination volume moderately spiked (+30%, $1M → $1.3M)')
+    ).toEqual('Source volume dropped (-95%, $143K → $7.6K)')
   })
 
   it('describes a flat line', () => {
@@ -86,11 +88,11 @@ describe(formatAnomalyReasons.name, () => {
         },
         {
           metric: 'srcVolume',
-          kind: 'zScoreSpike',
-          severity: 'moderate',
-          baseline: 1_000_000,
-          current: 1_300_000,
-          changePercent: 30,
+          kind: 'ratioSpike',
+          severity: 'severe',
+          baseline: 100_000,
+          current: 5_000_000,
+          changePercent: 4_900,
         },
       ],
       sideMismatch: {
@@ -103,8 +105,65 @@ describe(formatAnomalyReasons.name, () => {
 
     expect(reasons).toHaveLength(3)
     expect(reasons[0]).toEqual('Transfer count spiked (+200%, 100 → 300)')
+    expect(reasons[1]).toEqual('Source volume spiked (+4900%, $100K → $5M)')
     expect(reasons[2]).toEqual(
       'Src/Dst volume mismatch (40%, $2M src vs $1.2M dst)',
+    )
+  })
+
+  it('collapses paired src+dst signals of the same kind into a single Volume row', () => {
+    const reasons = formatAnomalyReasons({
+      signals: [
+        {
+          metric: 'srcVolume',
+          kind: 'ratioSpike',
+          severity: 'severe',
+          baseline: 100_000,
+          current: 5_000_000,
+          changePercent: 4_900,
+        },
+        {
+          metric: 'dstVolume',
+          kind: 'ratioSpike',
+          severity: 'severe',
+          baseline: 100_000,
+          current: 5_000_000,
+          changePercent: 4_900,
+        },
+      ],
+      sideMismatch: null,
+    })
+
+    expect(reasons).toEqual(['Volume spiked (+4900%, $100K → $5M)'])
+  })
+
+  it('keeps separate rows when src and dst have different signal kinds', () => {
+    const reasons = formatAnomalyReasons({
+      signals: [
+        {
+          metric: 'srcVolume',
+          kind: 'ratioSpike',
+          severity: 'severe',
+          baseline: 100_000,
+          current: 5_000_000,
+          changePercent: 4_900,
+        },
+        {
+          metric: 'dstVolume',
+          kind: 'ratioDrop',
+          severity: 'severe',
+          baseline: 100_000,
+          current: 500,
+          changePercent: -99.5,
+        },
+      ],
+      sideMismatch: null,
+    })
+
+    expect(reasons).toHaveLength(2)
+    expect(reasons[0]).toEqual('Source volume spiked (+4900%, $100K → $5M)')
+    expect(reasons[1]).toEqual(
+      'Destination volume dropped (-100%, $100K → $500)',
     )
   })
 

--- a/packages/backend/src/modules/interop/engine/anomalies/formatter.test.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/formatter.test.ts
@@ -137,6 +137,32 @@ describe(formatAnomalyReasons.name, () => {
     expect(reasons).toEqual(['Volume spiked (+4900%, $100K → $5M)'])
   })
 
+  it('uses the larger collapsed side when merging paired drops', () => {
+    const reasons = formatAnomalyReasons({
+      signals: [
+        {
+          metric: 'srcVolume',
+          kind: 'ratioDrop',
+          severity: 'severe',
+          baseline: 10_000_000,
+          current: 0,
+          changePercent: -100,
+        },
+        {
+          metric: 'dstVolume',
+          kind: 'ratioDrop',
+          severity: 'severe',
+          baseline: 100_000,
+          current: 1,
+          changePercent: -99.999,
+        },
+      ],
+      sideMismatch: null,
+    })
+
+    expect(reasons).toEqual(['Volume dropped (-100%, $10M → $0)'])
+  })
+
   it('keeps separate rows when src and dst have different signal kinds', () => {
     const reasons = formatAnomalyReasons({
       signals: [

--- a/packages/backend/src/modules/interop/engine/anomalies/formatter.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/formatter.ts
@@ -54,13 +54,13 @@ function describeMetricSignals(signals: MetricSignal[]): string[] {
   const shouldMerge = src && dst && src.kind === dst.kind
   if (!shouldMerge) return signals.map(describeSignal)
 
-  const larger = src.current >= dst.current ? src : dst
+  const representative = pickMergedVolumeSignal(src, dst)
   const out: string[] = []
   let mergedEmitted = false
   for (const signal of signals) {
     if (signal.metric === 'srcVolume' || signal.metric === 'dstVolume') {
       if (!mergedEmitted) {
-        out.push(describeVolumeMerged(larger))
+        out.push(describeVolumeMerged(representative))
         mergedEmitted = true
       }
       continue
@@ -68,6 +68,22 @@ function describeMetricSignals(signals: MetricSignal[]): string[] {
     out.push(describeSignal(signal))
   }
   return out
+}
+
+function pickMergedVolumeSignal(
+  src: MetricSignal,
+  dst: MetricSignal,
+): MetricSignal {
+  if (isDropSignal(src) && isDropSignal(dst)) {
+    const srcLoss = src.baseline - src.current
+    const dstLoss = dst.baseline - dst.current
+    if (srcLoss !== dstLoss) {
+      return srcLoss >= dstLoss ? src : dst
+    }
+    return src.baseline >= dst.baseline ? src : dst
+  }
+
+  return src.current >= dst.current ? src : dst
 }
 
 function describeVolumeMerged(signal: MetricSignal): string {
@@ -87,6 +103,13 @@ function metricLabel(metric: AnomalyMetric): string {
     case 'dstVolume':
       return 'Destination volume'
   }
+}
+
+function isDropSignal(signal: MetricSignal): boolean {
+  if (signal.changePercent !== null) {
+    return signal.changePercent < 0
+  }
+  return signal.kind === 'ratioDrop' || signal.kind === 'zScoreDrop'
 }
 
 // Action word follows the sign of the actual change, not the signal kind.

--- a/packages/backend/src/modules/interop/engine/anomalies/formatter.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/formatter.ts
@@ -23,18 +23,14 @@ export function describeSignal(signal: MetricSignal): string {
     signal.metric === 'count' ? formatCount : formatDollarsCompact
   const baselineFmt = formatValue(signal.baseline)
   const currentFmt = formatValue(signal.current)
-  const moderate = signal.severity === 'moderate' ? 'moderately ' : ''
 
   if (signal.kind === 'flatLine') {
     return `${label} was flat (${currentFmt})`
   }
 
-  const action =
-    signal.kind === 'ratioSpike' || signal.kind === 'zScoreSpike'
-      ? 'spiked'
-      : 'dropped'
+  const action = describeAction(signal)
   const changePart = formatChange(signal.changePercent)
-  return `${label} ${moderate}${action} (${changePart}${baselineFmt} → ${currentFmt})`
+  return `${label} ${action} (${changePart}${baselineFmt} → ${currentFmt})`
 }
 
 export function describeSideMismatch(signal: SideMismatchSignal): string {
@@ -45,11 +41,41 @@ export function describeSideMismatch(signal: SideMismatchSignal): string {
 }
 
 export function formatAnomalyReasons(evaluation: AnomalyEvaluation): string[] {
-  const reasons = evaluation.signals.map(describeSignal)
+  const reasons = describeMetricSignals(evaluation.signals)
   if (evaluation.sideMismatch) {
     reasons.push(describeSideMismatch(evaluation.sideMismatch))
   }
   return reasons
+}
+
+function describeMetricSignals(signals: MetricSignal[]): string[] {
+  const src = signals.find((s) => s.metric === 'srcVolume')
+  const dst = signals.find((s) => s.metric === 'dstVolume')
+  const shouldMerge = src && dst && src.kind === dst.kind
+  if (!shouldMerge) return signals.map(describeSignal)
+
+  const larger = src.current >= dst.current ? src : dst
+  const out: string[] = []
+  let mergedEmitted = false
+  for (const signal of signals) {
+    if (signal.metric === 'srcVolume' || signal.metric === 'dstVolume') {
+      if (!mergedEmitted) {
+        out.push(describeVolumeMerged(larger))
+        mergedEmitted = true
+      }
+      continue
+    }
+    out.push(describeSignal(signal))
+  }
+  return out
+}
+
+function describeVolumeMerged(signal: MetricSignal): string {
+  const baselineFmt = formatDollarsCompact(signal.baseline)
+  const currentFmt = formatDollarsCompact(signal.current)
+  const action = describeAction(signal)
+  const changePart = formatChange(signal.changePercent)
+  return `Volume ${action} (${changePart}${baselineFmt} → ${currentFmt})`
 }
 
 function metricLabel(metric: AnomalyMetric): string {
@@ -61,6 +87,18 @@ function metricLabel(metric: AnomalyMetric): string {
     case 'dstVolume':
       return 'Destination volume'
   }
+}
+
+// Action word follows the sign of the actual change, not the signal kind.
+// A robust-Z "spike" can fire on a sharp drop when prior history is tight
+// enough for MAD to collapse, and labeling that as "spiked" misleads.
+function describeAction(signal: MetricSignal): string {
+  if (signal.changePercent !== null) {
+    return signal.changePercent >= 0 ? 'spiked' : 'dropped'
+  }
+  return signal.kind === 'ratioDrop' || signal.kind === 'zScoreDrop'
+    ? 'dropped'
+    : 'spiked'
 }
 
 function formatChange(changePercent: number | null): string {

--- a/packages/backend/src/modules/interop/engine/anomalies/index.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/index.ts
@@ -3,6 +3,7 @@ export {
   type AnomalyKind,
   type AnomalyMetric,
   type AnomalySeverity,
+  type BridgeTotal,
   evaluateAnomalies,
   type MetricSignal,
   type SeriesPoint,

--- a/packages/backend/src/modules/interop/engine/anomalies/thresholds.ts
+++ b/packages/backend/src/modules/interop/engine/anomalies/thresholds.ts
@@ -11,9 +11,21 @@ export const MIN_BASELINE_COUNT_PER_DAY = 10
 export const MIN_BASELINE_VOLUME_USD_PER_DAY = 10_000
 export const MIN_VOLUME_IDENTIFICATION_RATE = 0.5
 
-export const RATIO_DROP_THRESHOLD = 0.1
-export const RATIO_COUNT_SPIKE_THRESHOLD = 1.9
-export const RATIO_VOLUME_SPIKE_THRESHOLD = 10
+// Only extreme moves alert — insane spikes and insane drops.
+export const RATIO_DROP_THRESHOLD = 0.02
+export const RATIO_COUNT_SPIKE_THRESHOLD = 10
+export const RATIO_VOLUME_SPIKE_THRESHOLD = 30
+
+// Relevance gate — a lane must be material (in absolute or share-of-bridge
+// terms) to be worth alerting on. Spikes are gated on the candidate-day
+// value; drops are gated on the baseline median.
+//
+// Share is computed as single-side lane value over two-sided bridge total
+// (src + dst). For a balanced burn/mint bridge that means the effective
+// floor on a single side is ~2x the constant.
+export const RELEVANCE_MIN_VOLUME_USD = 250_000
+export const RELEVANCE_MIN_BRIDGE_SHARE = 0.02
+export const RELEVANCE_MIN_COUNT = 100
 
 export const SIDE_MISMATCH_DIFF_PERCENT = 30
 export const SIDE_MISMATCH_MIN_VOLUME_USD = 500_000

--- a/packages/backend/src/modules/interop/engine/dashboard/stats.test.ts
+++ b/packages/backend/src/modules/interop/engine/dashboard/stats.test.ts
@@ -57,6 +57,29 @@ describe(explore.name, () => {
     expect(result?.dstVolume.valueUsd.last).toEqual(1_000_000)
   })
 
+  it('passes bridge totals to the evaluator for share-material route spikes', () => {
+    const baselineVolumes = [
+      48_000, 52_000, 50_000, 49_000, 51_000, 50_000, 48_000, 52_000, 49_000,
+      51_000, 50_000, 49_000, 51_000,
+    ]
+    const rows = [
+      ...baselineVolumes.map((value, i) =>
+        row(i, 'across', 100, value, value, 'ethereum', 'arbitrum'),
+      ),
+      row(13, 'across', 100, 200_000, 200_000, 'ethereum', 'arbitrum'),
+      ...Array.from({ length: 14 }, (_, i) =>
+        row(i, 'across', 100, 2_300_000, 2_300_000, 'ethereum', 'base'),
+      ),
+    ]
+
+    const target = explore(rows).find((r) => r.dstChain === 'arbitrum')
+    const srcSignal = target?.evaluation.signals.find(
+      (signal) => signal.metric === 'srcVolume',
+    )
+
+    expect(srcSignal?.kind).toEqual('zScoreSpike')
+  })
+
   function row(
     offsetDays: number,
     id: string,

--- a/packages/backend/src/modules/interop/engine/dashboard/stats.ts
+++ b/packages/backend/src/modules/interop/engine/dashboard/stats.ts
@@ -3,6 +3,7 @@ import { assert, type InteropBridgeType, UnixTime } from '@l2beat/shared-pure'
 import groupBy from 'lodash/groupBy'
 import {
   type AnomalyEvaluation,
+  type BridgeTotal,
   evaluateAnomalies,
   formatAnomalyReasons,
   type SeriesPoint,
@@ -89,6 +90,7 @@ export function prepare(rows: DataRow[]): DataRow[] {
 
 export function explore(rows: DataRow[]): DataRowResult[] {
   const byRoute = groupBy(rows, groupKey)
+  const bridgeTotals = computeBridgeTotals(rows)
   const results: DataRowResult[] = []
 
   for (const key in byRoute) {
@@ -100,7 +102,10 @@ export function explore(rows: DataRow[]): DataRowResult[] {
     const prevDay = dataPoints.at(-2) ?? null
     const prev7d = dataPoints.at(-8) ?? null
 
-    const evaluation = evaluateAnomalies(dataPoints.map(toSeriesPoint))
+    const evaluation = evaluateAnomalies(
+      dataPoints.map(toSeriesPoint),
+      bridgeTotals.get(bridgeTotalKey(last)),
+    )
     const reasons = formatAnomalyReasons(evaluation)
 
     results.push({
@@ -133,6 +138,23 @@ export function explore(rows: DataRow[]): DataRowResult[] {
 
 export function interpret(result: DataRowResult): string {
   return result.interpretation
+}
+
+function computeBridgeTotals(rows: DataRow[]): Map<string, BridgeTotal> {
+  const totals = new Map<string, BridgeTotal>()
+
+  for (const row of rows) {
+    const key = bridgeTotalKey(row)
+    const existing = totals.get(key) ?? {
+      transferCount: 0,
+      volumeUsd: 0,
+    }
+    existing.transferCount += row.transferCount
+    existing.volumeUsd += row.totalSrcValueUsd + row.totalDstValueUsd
+    totals.set(key, existing)
+  }
+
+  return totals
 }
 
 function buildVolume(
@@ -180,6 +202,10 @@ function percentDiff(left: number, right: number): number | null {
   const base = Math.max(Math.abs(left), Math.abs(right))
   if (base === 0) return null
   return (Math.abs(left - right) / base) * 100
+}
+
+function bridgeTotalKey(row: Pick<DataRow, 'id' | 'day'>): string {
+  return `${row.id}::${row.day}`
 }
 
 function toSeriesPoint(row: DataRow): SeriesPoint {

--- a/packages/backend/src/modules/interop/engine/zScore.ts
+++ b/packages/backend/src/modules/interop/engine/zScore.ts
@@ -2,9 +2,8 @@ import { assert } from '@l2beat/shared-pure'
 
 export const Z_CLASSIC_THRESHOLD = 15
 export const Z_ROBUST_THRESHOLD = {
-  warn: 4,
-  drop: -6,
-  spike: 6,
+  drop: -10,
+  spike: 10,
 }
 export const MIN_NON_ZERO_HISTORY_POINTS = 3
 export const Z_WINDOW_DAYS = 14


### PR DESCRIPTION
<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Problem.</strong> The unified-anomaly notifier was paging 100-200 lanes per Discord message — most on lanes representing &lt;0.01% of bridge volume or with current values under $10K. 29 alerts in the latest dump were also mislabeled (<code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">spiked (-95%, $143K → $7.6K)</code>) due to a sign bug.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Policy change.</strong> Drop the "moderate" tier entirely. Keep only extremums: insane spikes, insane drops, flat lines, and side mismatches. Apply the same policy in dashboard and Discord — single source of truth in the evaluator.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Thresholds.</strong></p>
  | Before | After
-- | -- | --
Count spike ratio | 1.9× | 10×
Volume spike ratio | 10× | 30×
Drop ratio | 0.10 (90%) | 0.02 (98%)
Robust-Z spike/drop | ±6 | ±10
Moderate tier | yes | removed

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Relevance gate (new).</strong> A lane must be material to alert:</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Spikes: candidate value ≥ $250K<span> </span><em>or</em><span> </span>≥ 2% of bridge total.</li><li>Drops: baseline median ≥ $250K<span> </span><em>or</em><span> </span>≥ 2% of bridge total.</li><li>Flat-line on count: baseline median ≥ 100 transfers/day.</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The analyzer computes per-bridge totals from the candidate batch and threads them into <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">evaluateAnomalies</code>.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Bug fix.</strong> <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">formatter.describeAction</code> now reads the sign of <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">changePercent</code>, not the signal <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">kind</code>. No more "spiked (-95%)".</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Cosmetic.</strong> When <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">srcVolume</code> and <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">dstVolume</code> fire with the same kind (common for burn/mint and lock/mint), they collapse into a single <code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Volume ...</code> row instead of two redundant lines.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Backtest (30 days, real DB).</strong> 4,625 → <strong>622 alerts</strong> (−87%, ~21/day). Every surviving alert on the latest day was a visible extremum (35× to 7,544× spikes, $1.47M → $22K drops). Three of those real lanes are pinned as fixture tests.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Files</strong></p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(37, 37, 38); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li><a href="vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/zScore.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">zScore.ts</a>,<span> </span><a href="vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/anomalies/thresholds.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">thresholds.ts</a><span> </span>— threshold values + new relevance constants.</li><li><a href="vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/anomalies/evaluator.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">evaluator.ts</a><span> </span>— moderate tier removed,<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">BridgeTotal</code><span> </span>param + asymmetric<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">isRelevant</code><span> </span>gate.</li><li><a href="vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/anomalies/formatter.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">formatter.ts</a><span> </span>— sign-bug fix, src+dst merge.</li><li><a href="vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationAnalyzer.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(55, 148, 255);">InteropAggregationAnalyzer.ts</a><span> </span>—<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">computeBridgeTotals</code><span> </span>from the candidate batch.</li></ul><br class="Apple-interchange-newline">Problem. The unified-anomaly notifier was paging 100-200 lanes per Discord message — most on lanes representing <0.01% of bridge volume or with current values under $10K. 29 alerts in the latest dump were also mislabeled (spiked (-95%, $143K → $7.6K)) due to a sign bug.

Policy change. Drop the "moderate" tier entirely. Keep only extremums: insane spikes, insane drops, flat lines, and side mismatches. Apply the same policy in dashboard and Discord — single source of truth in the evaluator.

Thresholds.

Before	After
Count spike ratio	1.9×	10×
Volume spike ratio	10×	30×
Drop ratio	0.10 (90%)	0.02 (98%)
Robust-Z spike/drop	±6	±10
Moderate tier	yes	removed
Relevance gate (new). A lane must be material to alert:

Spikes: candidate value ≥ $250K or ≥ 2% of bridge total.
Drops: baseline median ≥ $250K or ≥ 2% of bridge total.
Flat-line on count: baseline median ≥ 100 transfers/day.
The analyzer computes per-bridge totals from the candidate batch and threads them into evaluateAnomalies.

Bug fix. formatter.describeAction now reads the sign of changePercent, not the signal kind. No more "spiked (-95%)".

Cosmetic. When srcVolume and dstVolume fire with the same kind (common for burn/mint and lock/mint), they collapse into a single Volume ... row instead of two redundant lines.

Backtest (30 days, real DB). 4,625 → 622 alerts (−87%, ~21/day). Every surviving alert on the latest day was a visible extremum (35× to 7,544× spikes, $1.47M → $22K drops). Three of those real lanes are pinned as fixture tests.

Files

[zScore.ts](vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/zScore.ts), [thresholds.ts](vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/anomalies/thresholds.ts) — threshold values + new relevance constants.
[evaluator.ts](vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/anomalies/evaluator.ts) — moderate tier removed, BridgeTotal param + asymmetric isRelevant gate.
[formatter.ts](vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/anomalies/formatter.ts) — sign-bug fix, src+dst merge.
[InteropAggregationAnalyzer.ts](vscode-webview://114h5v3m89tevqpbm99mfeko1siemmn770nnbngqma06gtn0gofj/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationAnalyzer.ts) — computeBridgeTotals from the candidate batch.

@codex review