### PR TITLE
feat(daily-checks): rotate responsible person every week

### DIFF
--- a/packages/backend/src/modules/daily-checks/DailyChecksNotifierIndexer.ts
+++ b/packages/backend/src/modules/daily-checks/DailyChecksNotifierIndexer.ts
@@ -69,10 +69,9 @@ export class DailyChecksNotifierIndexer extends ManagedChildIndexer {
   }
 
   private pickResponsibleUser(timestamp: UnixTime): string {
-    // Rotate every 2 workdays.
-    const workdayIndex = this.getWorkdayIndex(UnixTime.toDate(timestamp))
-    const slot = Math.floor(workdayIndex / 2)
-    return this.$.discordUserIds[slot % this.$.discordUserIds.length]
+    // Rotate every week.
+    const weekIndex = this.getWeekIndex(UnixTime.toDate(timestamp))
+    return this.$.discordUserIds[weekIndex % this.$.discordUserIds.length]
   }
 
   private getHourInTimezone(timestamp: UnixTime): number {
@@ -100,7 +99,7 @@ export class DailyChecksNotifierIndexer extends ManagedChildIndexer {
     return weekday.value
   }
 
-  private getWorkdayIndex(date: Date): number {
+  private getWeekIndex(date: Date): number {
     const parts = new Intl.DateTimeFormat('en-GB', {
       timeZone: this.$.timezone,
       year: 'numeric',
@@ -115,9 +114,6 @@ export class DailyChecksNotifierIndexer extends ManagedChildIndexer {
     )
     // 1970-01-05 (epoch day 4) was a Monday.
     const daysSinceMonday = dayNumber - 4
-    const weeks = Math.floor(daysSinceMonday / 7)
-    const dow = daysSinceMonday - weeks * 7
-    const workdaysIntoWeek = Math.min(dow + 1, 5)
-    return weeks * 5 + workdaysIntoWeek - 1
+    return Math.floor(daysSinceMonday / 7)
   }
 }


### PR DESCRIPTION
## What

Switches the daily checks notifier (`DailyChecksNotifierIndexer`) from rotating the responsible person every 2 workdays to a **weekly rotation**. The same person is now on duty for a full work week (Mon–Fri), and the next person takes over the following Monday.

## Changes

- `pickResponsibleUser` now selects based on a week index (`weekIndex % discordUserIds.length`).
- Replaced `getWorkdayIndex` with `getWeekIndex`, reusing the same epoch-day/Monday-anchor math but returning `Math.floor(daysSinceMonday / 7)`. The intra-week workday calculation is no longer needed.

Weekend-skip behavior is unchanged — notifications still only fire on workdays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)