### PR TITLE
chore: bump postgres to 17 and refresh db-restore docs

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
-    image: postgres:15
+    image: postgres:17
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
       CONFIG_ALCHEMY_API_KEY: ${{ secrets.CONFIG_ALCHEMY_API_KEY }}
     services:
       postgres:
-        image: mirror.gcr.io/postgres:15
+        image: mirror.gcr.io/postgres:17
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/.github/workflows/validate-migrations.yml
+++ b/.github/workflows/validate-migrations.yml
@@ -20,7 +20,7 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/packages/backend/scripts/start_db.sh
+++ b/packages/backend/scripts/start_db.sh
@@ -19,7 +19,7 @@ if [ ! "$(docker ps -q -f name=${name})" ]; then
         fi
     else
         echo "${name} container doesn't exist. Creating it and setting up databases."
-        docker run -d --name=${name} -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:15
+        docker run -d --name=${name} -p 5432:5432 -e POSTGRES_PASSWORD=password postgres:17
         
         echo "Waiting for db container..."
         sleep 5

--- a/packages/database/scripts/db-restore/README.md
+++ b/packages/database/scripts/db-restore/README.md
@@ -7,8 +7,8 @@ Restore data from a remote database into your local DB, either by feature (`db-r
 ## Prerequisites
 
 1. Install the PostgreSQL client tools (`psql`, `pg_dump`, `pg_restore`) via the `postgres` or `libpq` package, and make sure they are on your `PATH`.
-2. Run the scripts from root (`packages/database`)
-3. Add variables to `.env` file:
+2. Run the scripts from the package root (`packages/database`) — Prisma needs it.
+3. Add variables to a `.env` file in `packages/database`:
 
    ```
    DEV_LOCAL_DB_URL=postgresql://postgres:password@localhost:5432/l2beat_local
@@ -20,7 +20,7 @@ Restore data from a remote database into your local DB, either by feature (`db-r
 ## Restore by feature
 
 ```bash
-./db-restore.sh <FEATURE>
+./scripts/db-restore/db-restore.sh <FEATURE>
 ```
 
 Run without arguments to list the available features. Currently:
@@ -31,8 +31,8 @@ Run without arguments to list the available features. Currently:
 Restore one or more specific tables:
 
 ```bash
-./table-restore.sh IndexerState
-./table-restore.sh IndexerState IndexerConfiguration
+./scripts/db-restore/table-restore.sh IndexerState
+./scripts/db-restore/table-restore.sh IndexerState IndexerConfiguration
 ```
 
 ## What the scripts do

--- a/packages/database/scripts/db-restore/README.md
+++ b/packages/database/scripts/db-restore/README.md
@@ -1,37 +1,43 @@
-# TVL restore script
+# DB restore scripts
 
-> ⚠️ **Running script will result in wiping local DB**: Be very careful here!
+Restore data from a remote database into your local DB, either by feature (`db-restore.sh`) or by individual tables (`table-restore.sh`).
 
+> ⚠️ **These scripts wipe the affected local tables before restoring.** Be careful.
 
-## How to use
+## Prerequisites
 
-0. If you do not have `psql`, `pg_dump` and `pg_restore`, please install either `postgres` or `libpq`. Remember to add it to `PATH`
+1. Install the PostgreSQL client tools (`psql`, `pg_dump`, `pg_restore`) via the `postgres` or `libpq` package, and make sure they are on your `PATH`.
+2. Run the scripts from root (`packages/database`)
+3. Add variables to `.env` file:
 
-1. Change directory to `database\scripts\db-restore` (This exact path is need for Prisma to work)
-2. Create .env & set variables
-> ⚠️ **Use readonly credential for remote**: Be very careful here!
-```
-DEV_LOCAL_DB_URL=postgresql://postgres:password@localhost:5432/l2beat_local
-DEV_REMOTE_DB_URL_READ_ONLY=
-```
-3. Run the script
-```
+   ```
+   DEV_LOCAL_DB_URL=postgresql://postgres:password@localhost:5432/l2beat_local
+   DEV_REMOTE_DB_URL_READ_ONLY=
+   ```
+
+   > ⚠️ **Use read-only credentials for the remote URL.**
+
+## Restore by feature
+
+```bash
 ./db-restore.sh <FEATURE>
 ```
 
-## Table restore script
+Run without arguments to list the available features. Currently:
+`da`, `liveness`, `tvs`, `activity`, `shared`, `interop`, `interop-aggregates`, `tokens-ui`, `tracked-txs`, `privacy`.
 
-The `table-restore.sh` script allows you to restore specific tables from the remote database instead of restoring entire features.
+## Restore by table
 
-### How to use
+Restore one or more specific tables:
 
-1. Follow steps 0-2 from the main restore script above (same prerequisites and setup)
-
-2. Run the script with one or more table names:
 ```bash
-# Restore a single table
 ./table-restore.sh IndexerState
-
-# Restore multiple tables
 ./table-restore.sh IndexerState IndexerConfiguration
 ```
+
+## What the scripts do
+
+1. Truncate the target tables locally.
+2. Apply pending Prisma migrations (`prisma migrate deploy`).
+3. Dump the tables' data from the remote DB.
+4. Restore the dump into the local DB and clean up the dump file.


### PR DESCRIPTION
## What

- Bump the pinned PostgreSQL image from `15` to `17` everywhere it appears:
  - `packages/backend/scripts/start_db.sh`
  - `.devcontainer/docker-compose.yml`
  - `.github/workflows/ci.yml`
  - `.github/workflows/validate-migrations.yml`
- Rewrite `packages/database/scripts/db-restore/README.md` to be concise and accurate: it now documents both `db-restore.sh` (by feature) and `table-restore.sh` (by table), lists the actual available features, and summarizes the truncate → migrate → dump → restore flow.

`packages/backend/README.md` already referenced `postgres:17`, so the docs were ahead of the real setup — this brings CI and the devcontainer in line.

## Notes

- The `start_db.sh` and devcontainer changes only affect **newly created** containers/volumes. An existing pg15 data volume cannot be started by a pg17 image — you'll need to drop the old `l2beat_postgres` container / `postgres-data` volume and recreate it.
- CI uses fresh service containers, so no migration needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)