### PR TITLE
Add mock data to privacy server functions

### DIFF
--- a/packages/frontend/src/server/features/privacy/getPrivacyFlowsChart.ts
+++ b/packages/frontend/src/server/features/privacy/getPrivacyFlowsChart.ts
@@ -1,8 +1,10 @@
 import { UnixTime } from '@l2beat/shared-pure'
 import { v } from '@l2beat/validate'
+import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
 import { ChartRange } from '~/utils/range/range'
+import { rangeToDays } from '~/utils/range/rangeToDays'
 
 export const PrivacyFlowsChartParams = v.object({
   projectIds: v.array(v.string()),
@@ -29,6 +31,10 @@ export async function getPrivacyFlowsChart(
 ): Promise<PrivacyFlowsChartResponse> {
   if (params.projectIds.length === 0) {
     return { chart: [], syncedUntil: undefined }
+  }
+
+  if (env.MOCK) {
+    return getMockPrivacyFlowsChart(params)
   }
 
   const db = getDb()
@@ -116,6 +122,30 @@ export async function getPrivacyFlowsChart(
     }),
     syncedUntil: syncedUntil ? Number(syncedUntil) : Number(normalizedRange[1]),
   }
+}
+
+function getMockPrivacyFlowsChart(
+  params: PrivacyFlowsChartParams,
+): PrivacyFlowsChartResponse {
+  const days = rangeToDays(params.range) ?? 365
+  const to = UnixTime.toStartOf(UnixTime.now(), 'day')
+  const from = params.range[0] ?? to - days * UnixTime.DAY
+
+  const chart = generateTimestamps([UnixTime(from), UnixTime(to)], 'daily').map(
+    (timestamp): PrivacyFlowsChartPoint => {
+      const depositsCount = Math.round(Math.random() * 100)
+      const withdrawalsCount = Math.round(Math.random() * 100)
+      return [
+        timestamp,
+        depositsCount,
+        withdrawalsCount,
+        depositsCount * (Math.random() * 9000 + 1000),
+        withdrawalsCount * (Math.random() * 9000 + 1000),
+      ]
+    },
+  )
+
+  return { chart, syncedUntil: to }
 }
 
 function normalizePrivacyFlowsChartRange(

--- a/packages/frontend/src/server/features/privacy/getPrivacyProjectDetails.ts
+++ b/packages/frontend/src/server/features/privacy/getPrivacyProjectDetails.ts
@@ -16,7 +16,13 @@ import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { ps } from '~/server/projects'
 import { TOKEN_PLACEHOLDER_ICON_URL } from '~/utils/tokenPlaceholderIconUrl'
-import type { PrivacyAsset, PrivacyBucket } from './types'
+import type { PrivacyAsset, PrivacyBucket, PrivacyProject } from './types'
+
+interface PrivacyProjectFlowData {
+  totals: PrivacyFlowBucketTotalRecord[]
+  daily30d: PrivacyFlowDailyRecord[]
+  tokenValues: TokenValueRecord[]
+}
 
 export interface PrivacyProjectDetails {
   id: ProjectId
@@ -74,33 +80,12 @@ export async function getPrivacyProjectDetails(
   const last7dCutoff = currentDay - 6 * UnixTime.DAY
   const last30dCutoff = currentDay - 29 * UnixTime.DAY
 
-  let totals: PrivacyFlowBucketTotalRecord[]
-  let daily30d: PrivacyFlowDailyRecord[]
-  let tokenValues: TokenValueRecord[]
-  if (env.MOCK) {
-    const bucketIds = project.privacyInfo.tokens.flatMap((token) =>
-      token.buckets.map((bucket) => bucket.id),
-    )
-    const tokenIds = (project.tvsConfig ?? []).map((token) => token.id)
-    ;({ totals, daily30d, tokenValues } = getMockPrivacyProjectFlowData(
-      projectId,
-      bucketIds,
-      tokenIds,
-      last30dCutoff,
-      currentDay,
-    ))
-  } else {
-    const db = getDb()
-    ;[totals, daily30d, tokenValues] = await Promise.all([
-      db.privacyFlowEvent.getBucketTotalsByProjectIds([projectId]),
-      db.privacyFlowEvent.getDailyByProjectIds(
-        [projectId],
-        last30dCutoff,
-        currentDay,
-      ),
-      db.tvsTokenValue.getLastNonZeroValue(now, projectId),
-    ])
-  }
+  const { totals, daily30d, tokenValues } = await getPrivacyProjectFlowData(
+    project,
+    last30dCutoff,
+    currentDay,
+    now,
+  )
 
   const tvlBySymbol = new Map<string, number>()
   for (const tv of tokenValues) {
@@ -289,17 +274,38 @@ export async function getPrivacyProjectDetails(
   }
 }
 
-function getMockPrivacyProjectFlowData(
-  projectId: ProjectId,
-  bucketIds: string[],
-  tokenIds: string[],
+async function getPrivacyProjectFlowData(
+  project: PrivacyProject,
   from: UnixTime,
   to: UnixTime,
-): {
-  totals: PrivacyFlowBucketTotalRecord[]
-  daily30d: PrivacyFlowDailyRecord[]
-  tokenValues: TokenValueRecord[]
-} {
+  now: UnixTime,
+): Promise<PrivacyProjectFlowData> {
+  const projectId = project.id
+
+  if (env.MOCK) {
+    return getMockPrivacyProjectFlowData(project, from, to)
+  }
+
+  const db = getDb()
+  const [totals, daily30d, tokenValues] = await Promise.all([
+    db.privacyFlowEvent.getBucketTotalsByProjectIds([projectId]),
+    db.privacyFlowEvent.getDailyByProjectIds([projectId], from, to),
+    db.tvsTokenValue.getLastNonZeroValue(now, projectId),
+  ])
+  return { totals, daily30d, tokenValues }
+}
+
+function getMockPrivacyProjectFlowData(
+  project: PrivacyProject,
+  from: UnixTime,
+  to: UnixTime,
+): PrivacyProjectFlowData {
+  const projectId = project.id
+  const bucketIds = project.privacyInfo.tokens.flatMap((token) =>
+    token.buckets.map((bucket) => bucket.id),
+  )
+  const tokenIds = (project.tvsConfig ?? []).map((token) => token.id)
+
   const totals = bucketIds.map(
     (bucketId): PrivacyFlowBucketTotalRecord => ({
       projectId,

--- a/packages/frontend/src/server/features/privacy/getPrivacyProjectDetails.ts
+++ b/packages/frontend/src/server/features/privacy/getPrivacyProjectDetails.ts
@@ -8,9 +8,11 @@ import type {
 import type {
   PrivacyFlowBucketTotalRecord,
   PrivacyFlowDailyRecord,
+  TokenValueRecord,
 } from '@l2beat/database'
 import type { ProjectId } from '@l2beat/shared-pure'
 import { UnixTime } from '@l2beat/shared-pure'
+import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { ps } from '~/server/projects'
 import { TOKEN_PLACEHOLDER_ICON_URL } from '~/utils/tokenPlaceholderIconUrl'
@@ -65,7 +67,6 @@ export async function getPrivacyProjectDetails(
     return undefined
   }
 
-  const db = getDb()
   const projectId = project.id
 
   const now = UnixTime.now()
@@ -73,15 +74,33 @@ export async function getPrivacyProjectDetails(
   const last7dCutoff = currentDay - 6 * UnixTime.DAY
   const last30dCutoff = currentDay - 29 * UnixTime.DAY
 
-  const [totals, daily30d, tokenValues] = await Promise.all([
-    db.privacyFlowEvent.getBucketTotalsByProjectIds([projectId]),
-    db.privacyFlowEvent.getDailyByProjectIds(
-      [projectId],
+  let totals: PrivacyFlowBucketTotalRecord[]
+  let daily30d: PrivacyFlowDailyRecord[]
+  let tokenValues: TokenValueRecord[]
+  if (env.MOCK) {
+    const bucketIds = project.privacyInfo.tokens.flatMap((token) =>
+      token.buckets.map((bucket) => bucket.id),
+    )
+    const tokenIds = (project.tvsConfig ?? []).map((token) => token.id)
+    ;({ totals, daily30d, tokenValues } = getMockPrivacyProjectFlowData(
+      projectId,
+      bucketIds,
+      tokenIds,
       last30dCutoff,
       currentDay,
-    ),
-    db.tvsTokenValue.getLastNonZeroValue(now, projectId),
-  ])
+    ))
+  } else {
+    const db = getDb()
+    ;[totals, daily30d, tokenValues] = await Promise.all([
+      db.privacyFlowEvent.getBucketTotalsByProjectIds([projectId]),
+      db.privacyFlowEvent.getDailyByProjectIds(
+        [projectId],
+        last30dCutoff,
+        currentDay,
+      ),
+      db.tvsTokenValue.getLastNonZeroValue(now, projectId),
+    ])
+  }
 
   const tvlBySymbol = new Map<string, number>()
   for (const tv of tokenValues) {
@@ -268,4 +287,62 @@ export async function getPrivacyProjectDetails(
       },
     },
   }
+}
+
+function getMockPrivacyProjectFlowData(
+  projectId: ProjectId,
+  bucketIds: string[],
+  tokenIds: string[],
+  from: UnixTime,
+  to: UnixTime,
+): {
+  totals: PrivacyFlowBucketTotalRecord[]
+  daily30d: PrivacyFlowDailyRecord[]
+  tokenValues: TokenValueRecord[]
+} {
+  const totals = bucketIds.map(
+    (bucketId): PrivacyFlowBucketTotalRecord => ({
+      projectId,
+      bucketId,
+      depositCount: Math.round(Math.random() * 5000),
+      withdrawalCount: Math.round(Math.random() * 5000),
+      depositAmount: 0n,
+      withdrawalAmount: 0n,
+      depositValueUsd: Math.random() * 10_000_000,
+      withdrawalValueUsd: Math.random() * 10_000_000,
+    }),
+  )
+
+  const daily30d: PrivacyFlowDailyRecord[] = []
+  for (let timestamp = from; timestamp <= to; timestamp += UnixTime.DAY) {
+    for (const bucketId of bucketIds) {
+      daily30d.push({
+        projectId,
+        bucketId,
+        timestamp: UnixTime(timestamp),
+        depositCount: Math.round(Math.random() * 100),
+        withdrawalCount: Math.round(Math.random() * 100),
+        depositAmount: 0n,
+        withdrawalAmount: 0n,
+        depositValueUsd: Math.random() * 100_000,
+        withdrawalValueUsd: Math.random() * 100_000,
+      })
+    }
+  }
+
+  const tokenValues = tokenIds.map(
+    (tokenId): TokenValueRecord => ({
+      timestamp: to,
+      configurationId: tokenId,
+      projectId,
+      tokenId,
+      amount: 0,
+      value: 0,
+      valueForProject: Math.random() * 5_000_000,
+      valueForSummary: 0,
+      priceUsd: 0,
+    }),
+  )
+
+  return { totals, daily30d, tokenValues }
 }

--- a/packages/frontend/src/server/features/privacy/getPrivacySummaryEntries.ts
+++ b/packages/frontend/src/server/features/privacy/getPrivacySummaryEntries.ts
@@ -1,6 +1,7 @@
 import type { PrivacyAttribute, TrustedSetup } from '@l2beat/config'
 import { UnixTime } from '@l2beat/shared-pure'
 import groupBy from 'lodash/groupBy'
+import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { manifest } from '~/utils/Manifest'
 import type { PrivacyProject } from './types'
@@ -25,6 +26,10 @@ export interface PrivacySummaryEntry {
 export async function getPrivacySummaryEntries(
   projects: PrivacyProject[],
 ): Promise<PrivacySummaryEntry[]> {
+  if (env.MOCK) {
+    return getMockPrivacySummaryEntries(projects)
+  }
+
   const db = getDb()
   const projectIds = projects.map((p) => p.id)
 
@@ -88,4 +93,32 @@ export async function getPrivacySummaryEntries(
   })
 
   return entries.sort((a, b) => b.totalValueLockedUsd - a.totalValueLockedUsd)
+}
+
+function getMockPrivacySummaryEntries(
+  projects: PrivacyProject[],
+): PrivacySummaryEntry[] {
+  return projects
+    .map((project): PrivacySummaryEntry => {
+      return {
+        id: project.id,
+        slug: project.slug,
+        name: project.name,
+        shortName: project.shortName,
+        icon: manifest.getUrl(`/icons/${project.slug}.png`),
+        href: `/privacy/projects/${project.slug}`,
+        description: project.display.description,
+        totalValueLockedUsd: Math.random() * 1_000_000_000,
+        poolsTracked: project.privacyInfo.tokens.reduce(
+          (sum, t) => sum + t.buckets.length,
+          0,
+        ),
+        totalDeposits: Math.round(Math.random() * 10_000),
+        totalValueDeposited30dUsd: Math.random() * 100_000_000,
+        attributes: project.privacyInfo.attributes ?? [],
+        isUnderReview: !!project.statuses.reviewStatus,
+        trustedSetup: project.privacyInfo.trustedSetup,
+      }
+    })
+    .sort((a, b) => b.totalValueLockedUsd - a.totalValueLockedUsd)
 }

--- a/packages/frontend/src/server/features/privacy/getPrivacyTvlChart.ts
+++ b/packages/frontend/src/server/features/privacy/getPrivacyTvlChart.ts
@@ -1,8 +1,10 @@
 import { UnixTime } from '@l2beat/shared-pure'
 import { v } from '@l2beat/validate'
+import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
 import { ChartRange, rangeToResolution } from '~/utils/range/range'
+import { rangeToDays } from '~/utils/range/rangeToDays'
 
 export const PrivacyTvlChartParams = v.object({
   projectIds: v.array(v.string()),
@@ -21,6 +23,10 @@ export async function getPrivacyTvlChart(
 ): Promise<PrivacyTvlChartResponse> {
   if (params.projectIds.length === 0) {
     return { chart: [], syncedUntil: undefined }
+  }
+
+  if (env.MOCK) {
+    return getMockPrivacyTvlChart(params)
   }
 
   const db = getDb()
@@ -78,4 +84,34 @@ export async function getPrivacyTvlChart(
     chart,
     syncedUntil: maxTimestamp,
   }
+}
+
+function getMockPrivacyTvlChart(
+  params: PrivacyTvlChartParams,
+): PrivacyTvlChartResponse {
+  const days = rangeToDays(params.range) ?? 365
+  const to = UnixTime.toStartOf(UnixTime.now(), 'day')
+  const from = params.range[0] ?? to - days * UnixTime.DAY
+  const resolution = rangeToResolution(params.range)
+
+  const baseValueByProject = new Map(
+    params.projectIds.map((projectId) => [
+      projectId,
+      Math.random() * 100_000_000 + 1_000_000,
+    ]),
+  )
+
+  const chart = generateTimestamps(
+    [UnixTime(from), UnixTime(to)],
+    resolution,
+  ).map((timestamp): PrivacyTvlChartResponse['chart'][number] => {
+    const valuesByProject: Record<string, number | null> = {}
+    for (const projectId of params.projectIds) {
+      const base = baseValueByProject.get(projectId) ?? 0
+      valuesByProject[projectId] = base * (0.8 + Math.random() * 0.4)
+    }
+    return [timestamp, valuesByProject]
+  })
+
+  return { chart, syncedUntil: to }
 }


### PR DESCRIPTION
Resolves L2B-14154

## What

Adds the `env.MOCK` branch (plus matching private `getMock*` helpers) to the four privacy frontend server functions, so the privacy pages render with generated data when the app runs in mock mode:

- `getPrivacyFlowsChart` — `getMockPrivacyFlowsChart`
- `getPrivacyTvlChart` — `getMockPrivacyTvlChart`
- `getPrivacySummaryEntries` — `getMockPrivacySummaryEntries`
- `getPrivacyProjectDetails` — `getMockPrivacyProjectFlowData` (mocks only the DB-sourced inputs; `ps.getProject` and the existing transformation logic are reused)

## Why

Every other feature area (DA throughput, scaling activity/costs/tvs, etc.) has an `if (env.MOCK)` branch that returns generated data so the frontend can run without a database. The privacy functions were the only ones missing it.

## Notes

- Config-driven fields (ids, slugs, names, buckets, attributes, trusted setup) come from real project data; only DB-sourced numbers are randomized.
- `getDb()` is now guarded behind the non-mock path, matching sibling features.
- Mocks use `Math.random()`, consistent with existing mocks — values vary per request.

## Verification

- `tsc --noEmit` passes
- biome lint + format pass on all privacy files

🤖 Generated with [Claude Code](https://claude.com/claude-code)