### PR TITLE
Fix tRPC prefetch input mismatches

### DIFF
--- a/packages/frontend/src/components/chart/liveness/ProjectLivenessChart.tsx
+++ b/packages/frontend/src/components/chart/liveness/ProjectLivenessChart.tsx
@@ -43,8 +43,8 @@ export function ProjectLivenessChart({
 
   const { data: chart, isLoading } = useQuery(
     trpc.liveness.projectChart.queryOptions({
-      range,
       projectId: project.id,
+      range,
       subtype,
     }),
   )

--- a/packages/frontend/src/pages/interop/summary/getInteropSummaryData.ts
+++ b/packages/frontend/src/pages/interop/summary/getInteropSummaryData.ts
@@ -136,11 +136,15 @@ async function getCachedData(
   let defaultFlowChainOrder = initialFlowsChains
 
   if (shouldPrefetchFlows) {
+    const protocolIds = protocols.map((protocol) => protocol.id)
+    // Determine the volume order across all chains on a throwaway client so the
+    // all-chains query is not dehydrated (the client never requests it).
+    const ordering = getSsrHelpers()
     const flowsData: RouterOutputs['interop']['flows'] =
-      await helpers.queryClient.fetchQuery(
-        helpers.trpc.interop.flows.queryOptions({
+      await ordering.queryClient.fetchQuery(
+        ordering.trpc.interop.flows.queryOptions({
           chains: initialFlowsChains,
-          protocolIds: protocols.map((protocol) => protocol.id),
+          protocolIds,
         }),
       )
     const chainsByVolume = flowsData.chainData
@@ -150,6 +154,15 @@ async function getCachedData(
     if (chainsByVolume.length > 0) {
       defaultFlowChainOrder = chainsByVolume
     }
+
+    // The client's flows chart defaults to the top chains by volume, so
+    // prefetch that exact query to hydrate it from cache.
+    await helpers.queryClient.prefetchQuery(
+      helpers.trpc.interop.flows.queryOptions({
+        chains: defaultFlowChainOrder.slice(0, MAX_SELECTED_CHAINS),
+        protocolIds,
+      }),
+    )
   }
 
   return {

--- a/packages/frontend/src/pages/interop/token-frameworks/components/transfer-speed/FrameworkTransferSpeedWidget.tsx
+++ b/packages/frontend/src/pages/interop/token-frameworks/components/transfer-speed/FrameworkTransferSpeedWidget.tsx
@@ -8,6 +8,10 @@ import { useTRPC } from '~/trpc/React'
 import type { InteropChainWithIcon } from '../../../components/chain-selector/types'
 import type { InteropTokenFramework } from '../../getInteropTokenFrameworksData'
 import { ChainSelect } from './ChainSelect'
+import {
+  TRANSFER_SPEED_DEFAULT_FROM,
+  TRANSFER_SPEED_DEFAULT_TO,
+} from './consts'
 import { FrameworkRow } from './FrameworkRow'
 
 export function FrameworkTransferSpeedWidget({
@@ -18,8 +22,8 @@ export function FrameworkTransferSpeedWidget({
   interopChains: InteropChainWithIcon[]
 }) {
   const trpc = useTRPC()
-  const [src, setSrc] = useState('arbitrum')
-  const [dst, setDst] = useState('base')
+  const [src, setSrc] = useState(TRANSFER_SPEED_DEFAULT_FROM)
+  const [dst, setDst] = useState(TRANSFER_SPEED_DEFAULT_TO)
 
   const { data, isLoading } = useQuery(
     trpc.interop.tokenFrameworks.queryOptions({

--- a/packages/frontend/src/pages/interop/token-frameworks/components/transfer-speed/consts.ts
+++ b/packages/frontend/src/pages/interop/token-frameworks/components/transfer-speed/consts.ts
@@ -1,0 +1,4 @@
+// Default chain pair shown by FrameworkTransferSpeedWidget on initial render.
+// Kept here so the SSR prefetch can hydrate the exact same query.
+export const TRANSFER_SPEED_DEFAULT_FROM = 'arbitrum'
+export const TRANSFER_SPEED_DEFAULT_TO = 'base'

--- a/packages/frontend/src/pages/interop/token-frameworks/getInteropTokenFrameworksData.ts
+++ b/packages/frontend/src/pages/interop/token-frameworks/getInteropTokenFrameworksData.ts
@@ -8,11 +8,11 @@ import { getMetadata } from '~/ssr/head/getMetadata'
 import type { RenderData } from '~/ssr/types'
 import { getSsrHelpers } from '~/trpc/server'
 import type { Manifest } from '~/utils/Manifest'
+import { mapInteropChainsToWithIcons } from '../utils/mapInteropChainsToWithIcons'
 import {
   TRANSFER_SPEED_DEFAULT_FROM,
   TRANSFER_SPEED_DEFAULT_TO,
 } from './components/transfer-speed/consts'
-import { mapInteropChainsToWithIcons } from '../utils/mapInteropChainsToWithIcons'
 
 export type InteropTokenFramework = {
   id: string

--- a/packages/frontend/src/pages/interop/token-frameworks/getInteropTokenFrameworksData.ts
+++ b/packages/frontend/src/pages/interop/token-frameworks/getInteropTokenFrameworksData.ts
@@ -8,6 +8,10 @@ import { getMetadata } from '~/ssr/head/getMetadata'
 import type { RenderData } from '~/ssr/types'
 import { getSsrHelpers } from '~/trpc/server'
 import type { Manifest } from '~/utils/Manifest'
+import {
+  TRANSFER_SPEED_DEFAULT_FROM,
+  TRANSFER_SPEED_DEFAULT_TO,
+} from './components/transfer-speed/consts'
 import { mapInteropChainsToWithIcons } from '../utils/mapInteropChainsToWithIcons'
 
 export type InteropTokenFramework = {
@@ -80,12 +84,21 @@ export async function getInteropTokenFrameworksData(
 async function getCachedData(initialChainIds: string[]) {
   const helpers = getSsrHelpers()
   if (initialChainIds.length > 0) {
-    await helpers.queryClient.prefetchQuery(
-      helpers.trpc.interop.tokenFrameworks.queryOptions({
-        from: initialChainIds,
-        to: initialChainIds,
-      }),
-    )
+    await Promise.all([
+      helpers.queryClient.prefetchQuery(
+        helpers.trpc.interop.tokenFrameworks.queryOptions({
+          from: initialChainIds,
+          to: initialChainIds,
+        }),
+      ),
+      // FrameworkTransferSpeedWidget fetches this exact pair on initial render.
+      helpers.queryClient.prefetchQuery(
+        helpers.trpc.interop.tokenFrameworks.queryOptions({
+          from: [TRANSFER_SPEED_DEFAULT_FROM],
+          to: [TRANSFER_SPEED_DEFAULT_TO],
+        }),
+      ),
+    ])
   }
   return { queryState: helpers.dehydrate() }
 }

--- a/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryChartsSection.tsx
+++ b/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryChartsSection.tsx
@@ -20,7 +20,7 @@ interface Props {
 export function PrivacySummaryChartsSection({ projects, defaultRange }: Props) {
   const trpc = useTRPC()
   const [range, setRange] = useState<ChartRange>(defaultRange)
-  const projectIds = useMemo(() => projects.map((p) => p.id), [projects])
+  const projectIds = useMemo(() => projects.map((p) => p.id).sort(), [projects])
   const { data: flowsData, isLoading: isFlowsLoading } = useQuery(
     trpc.privacy.flowsChart.queryOptions({ projectIds, range }),
   )

--- a/packages/frontend/src/pages/privacy/summary/getPrivacySummaryData.ts
+++ b/packages/frontend/src/pages/privacy/summary/getPrivacySummaryData.ts
@@ -63,7 +63,7 @@ async function getCachedData() {
     })
   ).sort((a, b) => a.slug.localeCompare(b.slug))
 
-  const projectIds = projects.map((e) => e.id)
+  const projectIds = projects.map((e) => e.id).sort()
   const [appLayoutProps, entries] = await Promise.all([
     getAppLayoutProps(),
     getPrivacySummaryEntries(projects),

--- a/packages/frontend/src/pages/scaling/tvs/getScalingTvsData.ts
+++ b/packages/frontend/src/pages/scaling/tvs/getScalingTvsData.ts
@@ -86,7 +86,8 @@ async function getQueryState(
     helpers.queryClient.prefetchQuery(
       helpers.trpc.tvs.detailedChart.queryOptions({
         filter: {
-          type: tab,
+          type: 'projects',
+          projectIds: entries[tab].map((entry) => entry.id),
         },
         range: optionToRange('1y'),
         excludeAssociatedTokens: false,

--- a/packages/frontend/src/server/features/scaling/interop/getProjectInteropData.ts
+++ b/packages/frontend/src/server/features/scaling/interop/getProjectInteropData.ts
@@ -62,7 +62,6 @@ export async function getProjectInteropData(
   const defaultSelectedChains = orderedInteropChains
     .map((chain) => chain.id)
     .slice(0, MAX_SELECTED_CHAINS)
-  const allInteropChainIds = orderedInteropChains.map((chain) => chain.id)
   const protocols = interopProjects.map((protocol) => ({
     id: protocol.id,
     slug: protocol.slug,
@@ -72,7 +71,7 @@ export async function getProjectInteropData(
   const interopFlows: RouterOutputs['interop']['flows'] =
     await helpers.queryClient.fetchQuery(
       helpers.trpc.interop.flows.queryOptions({
-        chains: allInteropChainIds,
+        chains: defaultSelectedChains,
         protocolIds: protocols.map((protocol) => protocol.id),
       }),
     )

--- a/packages/frontend/src/utils/project/liveness/getLivenessSection.ts
+++ b/packages/frontend/src/utils/project/liveness/getLivenessSection.ts
@@ -54,13 +54,15 @@ export async function getLivenessSection(
     (subtype) => project.livenessInfo?.overwrites?.[subtype] !== 'no-data', // we do not want to show disabled subtypes
   )
 
-  const range = optionToRange('max')
+  const defaultRange = project.archivedAt
+    ? optionToRange('max')
+    : optionToRange('30d')
   const subtype = getDefaultSubtype(configuredSubtypes)
 
   const data = await helpers.queryClient.fetchQuery(
     helpers.trpc.liveness.projectChart.queryOptions({
       projectId: project.id,
-      range,
+      range: defaultRange,
       subtype,
     }),
   )
@@ -79,9 +81,7 @@ export async function getLivenessSection(
     anomalies: liveness?.anomalies ?? [],
     hasTrackedContractsChanged,
     trackedTransactions,
-    defaultRange: project.archivedAt
-      ? optionToRange('max')
-      : optionToRange('30d'),
+    defaultRange,
     isArchived: project.archivedAt !== undefined,
   }
 }


### PR DESCRIPTION
## What

Aligns SSR prefetch query inputs with what client components actually request on initial render, so hydration serves them from the cache instead of refetching with a different key.

| Page(s) | Query | Fix |
|---|---|---|
| `/scaling/projects/*`, `/data-availability/projects/ethereum/ethereum` | `interop.flows` | Prefetch the default-selected 15 chains (`MAX_SELECTED_CHAINS`) instead of all chains |
| `/scaling/projects/*` | `liveness.projectChart` | Prefetch with the same `defaultRange` the client initializes with (`30d` for non-archived) instead of `max` |
| `/interop/summary` | `interop.flows` | Prefetch the top-15-by-volume query the client runs; compute the volume ordering on a throwaway SSR client so the unused all-chains query isn't dehydrated |
| `/interop/token-frameworks` | `interop.tokenFrameworks` | Also prefetch the `arbitrum`→`base` pair that `FrameworkTransferSpeedWidget` fetches on mount; default pair shared via a `consts` module |
| `/scaling/tvs` | `tvs.detailedChart` | Prefetch with `type: 'projects'` + explicit `projectIds` matching the client |
| `/privacy/summary` | `privacy.flowsChart` / `tvlChart` | Sort `projectIds` on both server and client so the keys match |

## Verification

Verified end-to-end with the prefetch test harness (not included in this PR): all 20 pages pass both layers — **✓ All prefetches verified (no hydration regressions)**, with no remaining input-mismatch warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)