### PR TITLE
Interop detailed pages updates [prototype]

### DIFF
--- a/packages/frontend/src/components/projects/sections/ProjectSection.tsx
+++ b/packages/frontend/src/components/projects/sections/ProjectSection.tsx
@@ -55,6 +55,9 @@ export function ProjectSection(props: ExtendedProjectSectionProps) {
         !props.nested &&
           'border-t-branding-primary md:group-data-[has-colors=true]/section-wrapper:border-t-4',
         props.nested && 'mt-10 p-0 md:p-0',
+        // Collapsible (sub)sections read as bordered cards inside their parent.
+        props.collapsible &&
+          'mt-0 rounded-lg border border-divider p-4 md:mt-0 md:p-4',
         props.className,
       )}
       asChild

--- a/packages/frontend/src/components/projects/sections/ProjectSection.tsx
+++ b/packages/frontend/src/components/projects/sections/ProjectSection.tsx
@@ -1,6 +1,12 @@
 import type { ReactNode } from 'react'
 
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '~/components/core/Collapsible'
 import { HighlightablePrimaryCard } from '~/components/primary-card/HighlightablePrimaryCard'
+import { ChevronIcon } from '~/icons/Chevron'
 import { cn } from '~/utils/cn'
 import { UnderReviewCallout } from '../UnderReviewCallout'
 import type { ProjectSectionId } from './types'
@@ -16,10 +22,28 @@ export interface ExtendedProjectSectionProps {
   isUnderReview?: boolean
   hideChildrenIfUnderReview?: boolean
   as?: 'section' | 'div'
+  /** Render the section as an expand/collapse block (header is the toggle). */
+  collapsible?: boolean
+  /** Initial open state when `collapsible` (defaults to closed). */
+  defaultOpen?: boolean
 }
 
 export function ProjectSection(props: ExtendedProjectSectionProps) {
   const Component = props.as ?? 'section'
+
+  const body = props.isUnderReview ? (
+    !props.hideChildrenIfUnderReview ? (
+      <>
+        <UnderReviewCallout className="mb-4" />
+        {props.children}
+      </>
+    ) : (
+      <UnderReviewCallout />
+    )
+  ) : (
+    props.children
+  )
+
   return (
     <HighlightablePrimaryCard
       id={props.id}
@@ -36,25 +60,30 @@ export function ProjectSection(props: ExtendedProjectSectionProps) {
       asChild
     >
       <Component>
-        <ProjectDetailsSectionHeader
-          title={props.title}
-          id={props.id}
-          sectionOrder={props.sectionOrder}
-          nested={props.nested}
-          headerAccessory={props.headerAccessory}
-          className="mb-4"
-        />
-        {props.isUnderReview ? (
-          !props.hideChildrenIfUnderReview ? (
-            <>
-              <UnderReviewCallout className="mb-4" />
-              {props.children}
-            </>
-          ) : (
-            <UnderReviewCallout />
-          )
+        {props.collapsible ? (
+          <Collapsible defaultOpen={props.defaultOpen ?? false}>
+            <ProjectDetailsSectionHeader
+              title={props.title}
+              id={props.id}
+              sectionOrder={props.sectionOrder}
+              nested={props.nested}
+              headerAccessory={props.headerAccessory}
+              collapsible
+            />
+            <CollapsibleContent className="mt-4">{body}</CollapsibleContent>
+          </Collapsible>
         ) : (
-          props.children
+          <>
+            <ProjectDetailsSectionHeader
+              title={props.title}
+              id={props.id}
+              sectionOrder={props.sectionOrder}
+              nested={props.nested}
+              headerAccessory={props.headerAccessory}
+              className="mb-4"
+            />
+            {body}
+          </>
         )}
       </Component>
     </HighlightablePrimaryCard>
@@ -68,9 +97,36 @@ interface ProjectDetailsSectionHeaderProps {
   nested: boolean | undefined
   className?: string
   headerAccessory?: ReactNode
+  collapsible?: boolean
 }
 
 function ProjectDetailsSectionHeader(props: ProjectDetailsSectionHeaderProps) {
+  const titleContent = (
+    <>
+      {props.sectionOrder && (
+        <div
+          className={cn(
+            'hidden size-10 items-center justify-center rounded bg-surface-secondary font-bold text-label-value-24 text-secondary tabular-nums md:flex',
+            props.nested && 'h-8 w-12 text-label-value-18',
+          )}
+        >
+          {props.sectionOrder}
+        </div>
+      )}
+      <span
+        className={cn(
+          'text-heading-28',
+          props.nested && 'text-heading-24 leading-none!',
+        )}
+      >
+        {props.title}
+      </span>
+      {props.collapsible && (
+        <ChevronIcon className="size-3 shrink-0 transition-transform group-data-[state=open]/Collapsible:rotate-180" />
+      )}
+    </>
+  )
+
   return (
     <div
       className={cn(
@@ -78,29 +134,23 @@ function ProjectDetailsSectionHeader(props: ProjectDetailsSectionHeaderProps) {
         props.className,
       )}
     >
-      <a
-        href={`#${props.id}`}
-        className={cn('flex items-center gap-4', props.nested && 'gap-3')}
-      >
-        {props.sectionOrder && (
-          <div
-            className={cn(
-              'hidden size-10 items-center justify-center rounded bg-surface-secondary font-bold text-label-value-24 text-secondary tabular-nums md:flex',
-              props.nested && 'h-8 w-12 text-label-value-18',
-            )}
-          >
-            {props.sectionOrder}
-          </div>
-        )}
-        <span
+      {props.collapsible ? (
+        <CollapsibleTrigger
           className={cn(
-            'text-heading-28',
-            props.nested && 'text-heading-24 leading-none!',
+            'flex cursor-pointer items-center gap-4',
+            props.nested && 'gap-3',
           )}
         >
-          {props.title}
-        </span>
-      </a>
+          {titleContent}
+        </CollapsibleTrigger>
+      ) : (
+        <a
+          href={`#${props.id}`}
+          className={cn('flex items-center gap-4', props.nested && 'gap-3')}
+        >
+          {titleContent}
+        </a>
+      )}
       {props.headerAccessory}
     </div>
   )

--- a/packages/frontend/src/components/projects/sections/interop/BridgeFlowStats.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/BridgeFlowStats.tsx
@@ -1,0 +1,126 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { ReactNode } from 'react'
+import { ArrowRightIcon } from '~/icons/ArrowRight'
+import { useInteropFlows } from '~/pages/interop/components/flows/utils/InteropFlowsContext'
+import type { InteropFlowsData } from '~/server/features/scaling/interop/getInteropFlows'
+import { cn } from '~/utils/cn'
+import { formatCurrency } from '~/utils/number-format/formatCurrency'
+import { formatInteger } from '~/utils/number-format/formatInteger'
+
+interface StatItem {
+  label: string
+  value: ReactNode
+  onClick?: () => void
+}
+
+/**
+ * Stats panel for the single-bridge (canonical) selection in "Volume and
+ * flows": the chain stats for the pinned chain, scoped to the selected bridge,
+ * with the values split into two columns inside a lighter nested card. A single
+ * "Top route" is shown only when more than one route exists.
+ */
+export function BridgeFlowStats({
+  data,
+  chainId,
+  protocolName,
+}: {
+  data: InteropFlowsData
+  chainId: string
+  protocolName: string
+}) {
+  const { allChains, setHighlightedChainPair } = useInteropFlows()
+
+  const chainData = data.chainData.find((c) => c.chainId === chainId)
+  if (!chainData) return null
+
+  const totalTransfers = chainData.transfersIn + chainData.transfersOut
+  const avg = totalTransfers > 0 ? chainData.totalVolume / totalTransfers : 0
+  const routes = data.flows
+    .filter((f) => f.srcChain === chainId || f.dstChain === chainId)
+    .sort((a, b) => b.volume - a.volume)
+  const topFlow = routes.length > 1 ? routes[0] : undefined
+
+  const items: StatItem[] = [
+    {
+      label: 'Total volume',
+      value: formatCurrency(chainData.totalVolume, 'usd'),
+    },
+    { label: 'Volume in', value: formatCurrency(chainData.inflow, 'usd') },
+    { label: 'Volume out', value: formatCurrency(chainData.outflow, 'usd') },
+    { label: 'Net flow', value: formatCurrency(chainData.netFlow, 'usd') },
+    { label: 'Total transfers', value: formatInteger(totalTransfers) },
+    { label: 'Transfers in', value: formatInteger(chainData.transfersIn) },
+    { label: 'Transfers out', value: formatInteger(chainData.transfersOut) },
+    { label: 'Avg. transfer value', value: formatCurrency(avg, 'usd') },
+    {
+      label: 'Avg. value per second',
+      value: `${formatCurrency(chainData.totalVolume / UnixTime.DAY, 'usd')}/s`,
+    },
+  ]
+
+  if (topFlow) {
+    const src = allChains.find((c) => c.id === topFlow.srcChain)
+    const dst = allChains.find((c) => c.id === topFlow.dstChain)
+    items.push({
+      label: 'Top route',
+      value: (
+        <span className="flex items-center gap-1">
+          {src && <img src={src.iconUrl} alt={src.name} className="size-4" />}
+          <ArrowRightIcon className="size-3 fill-brand" />
+          {dst && <img src={dst.iconUrl} alt={dst.name} className="size-4" />}
+          <span className="ml-1">{formatCurrency(topFlow.volume, 'usd')}</span>
+        </span>
+      ),
+      onClick: () =>
+        setHighlightedChainPair(topFlow.srcChain, topFlow.dstChain),
+    })
+  }
+
+  const half = Math.ceil(items.length / 2)
+  const columns = [items.slice(0, half), items.slice(half)]
+
+  return (
+    <div className="rounded-lg bg-surface-secondary p-4 dark:bg-header-secondary">
+      <div className="mb-3 font-bold text-label-value-12 text-secondary uppercase">
+        {protocolName} stats
+      </div>
+      <div className="rounded-lg border border-divider bg-surface-primary px-4 py-3">
+        <div className="mb-1.5 font-bold text-label-value-12 uppercase">
+          Stats
+        </div>
+        <div className="grid grid-cols-1 gap-x-12 md:grid-cols-2">
+          {columns.map((column, i) => (
+            <div key={i} className="flex flex-col gap-1.5">
+              {column.map((item) => (
+                <StatRow key={item.label} item={item} />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function StatRow({ item }: { item: StatItem }) {
+  const content = (
+    <>
+      <span className="font-medium text-secondary leading-none">
+        {item.label}
+      </span>
+      <span className="font-semibold leading-[1.15]">{item.value}</span>
+    </>
+  )
+  const className = 'flex items-center justify-between gap-2 text-[13px]'
+  return item.onClick ? (
+    <button
+      type="button"
+      onClick={item.onClick}
+      className={cn(className, 'rounded transition-opacity hover:opacity-80')}
+    >
+      {content}
+    </button>
+  ) : (
+    <div className={className}>{content}</div>
+  )
+}

--- a/packages/frontend/src/components/projects/sections/interop/BridgeFlowStats.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/BridgeFlowStats.tsx
@@ -22,11 +22,11 @@ interface StatItem {
 export function BridgeFlowStats({
   data,
   chainId,
-  protocolName,
+  label,
 }: {
   data: InteropFlowsData
   chainId: string
-  protocolName: string
+  label: string
 }) {
   const { allChains, setHighlightedChainPair } = useInteropFlows()
 
@@ -82,7 +82,7 @@ export function BridgeFlowStats({
   return (
     <div className="rounded-lg bg-surface-secondary p-4 dark:bg-header-secondary">
       <div className="mb-3 font-bold text-label-value-12 text-secondary uppercase">
-        {protocolName} stats
+        {label}
       </div>
       <div className="rounded-lg border border-divider bg-surface-primary px-4 py-3">
         <div className="mb-1.5 font-bold text-label-value-12 uppercase">

--- a/packages/frontend/src/components/projects/sections/interop/InteropBridgeSubsections.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropBridgeSubsections.tsx
@@ -1,0 +1,121 @@
+import { ProjectId } from '@l2beat/shared-pure'
+import { useQuery } from '@tanstack/react-query'
+import { EM_DASH } from '~/consts/characters'
+import type { InteropChainWithIcon } from '~/pages/interop/components/chain-selector/types'
+import { InteropNoDataBadge } from '~/pages/interop/components/InteropNoDataBadge'
+import { InteropTopPathValue } from '~/pages/interop/components/InteropTopPathValue'
+import { AvgDurationCell } from '~/pages/interop/components/table/AvgDurationCell'
+import {
+  InteropSummaryStat,
+  InteropTransferSizeBreakdown,
+  InteropTransferTypeBreakdown,
+} from '~/pages/interop/protocol/components/InteropSummaryParts'
+import { useTRPC } from '~/trpc/React'
+import { formatCurrency } from '~/utils/number-format/formatCurrency'
+import { ProjectSection } from '../ProjectSection'
+import { InteropTokensSection } from './InteropTokensSection'
+import { InteropTransfersSection } from './InteropTransfersSection'
+
+/**
+ * Bridge-specific detail for the single selected protocol, shown as collapsible
+ * subsections (collapsed by default) inside the "Volume and flows" section.
+ */
+export function InteropBridgeSubsections({
+  protocolId,
+  selectedChains,
+  interopChains,
+}: {
+  protocolId: string
+  selectedChains: string[]
+  interopChains: InteropChainWithIcon[]
+}) {
+  const trpc = useTRPC()
+  const apiSelection = { from: selectedChains, to: selectedChains }
+  const { data } = useQuery(
+    trpc.interop.protocol.queryOptions({
+      id: protocolId,
+      ...apiSelection,
+    }),
+  )
+
+  if (!data?.entry) return null
+
+  const projectId = ProjectId(protocolId)
+
+  return (
+    <div className="flex flex-col">
+      <ProjectSection
+        as="div"
+        id="interop-volume"
+        title="Bridge summary"
+        sectionOrder={undefined}
+        nested
+        collapsible
+      >
+        <div className="flex flex-col gap-4">
+          <div className="grid gap-x-8 gap-y-4 max-md:grid-cols-1 md:grid-cols-3">
+            <InteropSummaryStat
+              title="Last 24h top path"
+              value={
+                data.topPath ? (
+                  <InteropTopPathValue path={data.topPath} />
+                ) : (
+                  EM_DASH
+                )
+              }
+            />
+            <InteropSummaryStat
+              title="Last 24h avg. transfer time"
+              value={
+                data.entry.averageDuration ? (
+                  <AvgDurationCell
+                    className="font-bold text-label-value-16"
+                    splitClassName="flex-row text-label-value-16 font-bold"
+                    averageDuration={data.entry.averageDuration}
+                  />
+                ) : (
+                  <InteropNoDataBadge size="extraSmall" />
+                )
+              }
+            />
+            <InteropSummaryStat
+              title="Last 24h avg. transfer value"
+              value={
+                data.entry.averageValue
+                  ? formatCurrency(data.entry.averageValue, 'usd')
+                  : EM_DASH
+              }
+            />
+          </div>
+          <InteropTransferSizeBreakdown protocolData={data} />
+          <InteropTransferTypeBreakdown protocolData={data} />
+        </div>
+      </ProjectSection>
+
+      <InteropTokensSection
+        as="div"
+        id="interop-tokens"
+        title="Top tokens by volume"
+        sectionOrder={undefined}
+        nested
+        collapsible
+        projectId={projectId}
+        apiSelection={apiSelection}
+        data={data}
+      />
+
+      <InteropTransfersSection
+        as="div"
+        id="interop-transfers"
+        title="Transfers"
+        sectionOrder={undefined}
+        nested
+        collapsible
+        projectId={projectId}
+        apiSelection={apiSelection}
+        data={data}
+        interopChains={interopChains}
+      />
+    </div>
+  )
+}

--- a/packages/frontend/src/components/projects/sections/interop/InteropBridgeSubsections.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropBridgeSubsections.tsx
@@ -1,96 +1,43 @@
-import { ProjectId } from '@l2beat/shared-pure'
 import { useQuery } from '@tanstack/react-query'
-import { EM_DASH } from '~/consts/characters'
 import type { InteropChainWithIcon } from '~/pages/interop/components/chain-selector/types'
-import { InteropNoDataBadge } from '~/pages/interop/components/InteropNoDataBadge'
-import { InteropTopPathValue } from '~/pages/interop/components/InteropTopPathValue'
-import { AvgDurationCell } from '~/pages/interop/components/table/AvgDurationCell'
-import {
-  InteropSummaryStat,
-  InteropTransferSizeBreakdown,
-  InteropTransferTypeBreakdown,
-} from '~/pages/interop/protocol/components/InteropSummaryParts'
+import { InteropTransferSizeBreakdown } from '~/pages/interop/protocol/components/InteropSummaryParts'
 import { useTRPC } from '~/trpc/React'
-import { formatCurrency } from '~/utils/number-format/formatCurrency'
-import { ProjectSection } from '../ProjectSection'
 import { InteropTokensSection } from './InteropTokensSection'
 import { InteropTransfersSection } from './InteropTransfersSection'
 
 /**
- * Bridge-specific detail for the single selected protocol, shown as collapsible
- * subsections (collapsed by default) inside the "Volume and flows" section.
+ * Detail for the current protocol + chain selection, shown within the "Volume
+ * and flows" section: the aggregate transfer-size breakdown inline, plus the
+ * Top tokens and Transfers tables as collapsible (card) subsections. Always
+ * rendered — the data reflects the selected protocols and chains.
  */
 export function InteropBridgeSubsections({
-  protocolId,
+  protocolIds,
   selectedChains,
   interopChains,
 }: {
-  protocolId: string
+  protocolIds: string[]
   selectedChains: string[]
   interopChains: InteropChainWithIcon[]
 }) {
   const trpc = useTRPC()
   const apiSelection = { from: selectedChains, to: selectedChains }
   const { data } = useQuery(
-    trpc.interop.protocol.queryOptions({
-      id: protocolId,
-      ...apiSelection,
-    }),
+    trpc.interop.selectionDetails.queryOptions(
+      { ...apiSelection, protocolIds },
+      {
+        enabled: protocolIds.length > 0 && selectedChains.length > 0,
+      },
+    ),
   )
 
-  if (!data?.entry) return null
-
-  const projectId = ProjectId(protocolId)
+  if (protocolIds.length === 0) return null
 
   return (
-    <div className="flex flex-col">
-      <ProjectSection
-        as="div"
-        id="interop-volume"
-        title="Bridge summary"
-        sectionOrder={undefined}
-        nested
-        collapsible
-      >
-        <div className="flex flex-col gap-4">
-          <div className="grid gap-x-8 gap-y-4 max-md:grid-cols-1 md:grid-cols-3">
-            <InteropSummaryStat
-              title="Last 24h top path"
-              value={
-                data.topPath ? (
-                  <InteropTopPathValue path={data.topPath} />
-                ) : (
-                  EM_DASH
-                )
-              }
-            />
-            <InteropSummaryStat
-              title="Last 24h avg. transfer time"
-              value={
-                data.entry.averageDuration ? (
-                  <AvgDurationCell
-                    className="font-bold text-label-value-16"
-                    splitClassName="flex-row text-label-value-16 font-bold"
-                    averageDuration={data.entry.averageDuration}
-                  />
-                ) : (
-                  <InteropNoDataBadge size="extraSmall" />
-                )
-              }
-            />
-            <InteropSummaryStat
-              title="Last 24h avg. transfer value"
-              value={
-                data.entry.averageValue
-                  ? formatCurrency(data.entry.averageValue, 'usd')
-                  : EM_DASH
-              }
-            />
-          </div>
-          <InteropTransferSizeBreakdown protocolData={data} />
-          <InteropTransferTypeBreakdown protocolData={data} />
-        </div>
-      </ProjectSection>
+    <div className="flex flex-col gap-4">
+      <div className="rounded-lg border border-divider bg-surface-primary px-4 pt-2.5 pb-4">
+        <InteropTransferSizeBreakdown transferSize={data?.transferSize} />
+      </div>
 
       <InteropTokensSection
         as="div"
@@ -99,9 +46,8 @@ export function InteropBridgeSubsections({
         sectionOrder={undefined}
         nested
         collapsible
-        projectId={projectId}
+        protocolIds={protocolIds}
         apiSelection={apiSelection}
-        data={data}
       />
 
       <InteropTransfersSection
@@ -111,9 +57,9 @@ export function InteropBridgeSubsections({
         sectionOrder={undefined}
         nested
         collapsible
-        projectId={projectId}
+        protocolIds={protocolIds}
         apiSelection={apiSelection}
-        data={data}
+        snapshotTimestamp={data?.snapshotTimestamp}
         interopChains={interopChains}
       />
     </div>

--- a/packages/frontend/src/components/projects/sections/interop/InteropBridgeSubsections.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropBridgeSubsections.tsx
@@ -1,6 +1,9 @@
 import { useQuery } from '@tanstack/react-query'
 import type { InteropChainWithIcon } from '~/pages/interop/components/chain-selector/types'
-import { InteropTransferSizeBreakdown } from '~/pages/interop/protocol/components/InteropSummaryParts'
+import {
+  InteropTransferSizeBreakdown,
+  InteropTransferTypeBreakdown,
+} from '~/pages/interop/protocol/components/InteropSummaryParts'
 import { useTRPC } from '~/trpc/React'
 import { InteropTokensSection } from './InteropTokensSection'
 import { InteropTransfersSection } from './InteropTransfersSection'
@@ -35,8 +38,13 @@ export function InteropBridgeSubsections({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="rounded-lg border border-divider bg-surface-primary px-4 pt-2.5 pb-4">
-        <InteropTransferSizeBreakdown transferSize={data?.transferSize} />
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="rounded-lg border border-divider bg-surface-primary px-4 pt-2.5 pb-4">
+          <InteropTransferSizeBreakdown transferSize={data?.transferSize} />
+        </div>
+        <div className="rounded-lg border border-divider bg-surface-primary px-4 pt-2.5 pb-4">
+          <InteropTransferTypeBreakdown byType={data?.transferType} />
+        </div>
       </div>
 
       <InteropTokensSection

--- a/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
@@ -9,7 +9,10 @@ import {
 } from '~/pages/interop/components/flows/consts'
 import { FlowsChainsSelector } from '~/pages/interop/components/flows/FlowsChainsSelector'
 import { FlowsParticleLegend } from '~/pages/interop/components/flows/FlowsParticleLegend'
-import { FlowsProtocolsSelector } from '~/pages/interop/components/flows/FlowsProtocolsSelector'
+import {
+  FlowsCanonicalBridgeButton,
+  FlowsProtocolsSelector,
+} from '~/pages/interop/components/flows/FlowsProtocolsSelector'
 import { FlowsGraphPanel } from '~/pages/interop/components/flows/graph/FlowsGraphPanel'
 import { InactiveChainsDialog } from '~/pages/interop/components/flows/graph/InactiveChainsDialog'
 import { useScaledParticleCounts } from '~/pages/interop/components/flows/graph/utils/useScaledParticleCounts'
@@ -126,11 +129,22 @@ function Content({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-start">
-        <FlowsChainsSelector allChains={interopChains} />
-        <FlowsProtocolsSelector
-          allProtocols={protocols}
-          canonicalProtocolId={canonicalProtocolId}
-        />
+        {/* Chain + protocol selectors share a row on mobile; on desktop the
+            wrapper dissolves so all three controls flow in the same row. */}
+        <div className="flex gap-2 max-md:w-full md:contents">
+          <FlowsChainsSelector allChains={interopChains} />
+          <FlowsProtocolsSelector
+            allProtocols={protocols}
+            canonicalProtocolId={canonicalProtocolId}
+          />
+        </div>
+        {/* Canonical bridge drops to its own full-width row below on mobile. */}
+        {canonicalProtocolId && (
+          <FlowsCanonicalBridgeButton
+            allProtocols={protocols}
+            canonicalProtocolId={canonicalProtocolId}
+          />
+        )}
       </div>
       <div className="flex h-full min-w-0 flex-col">
         <div className="group/flows flex h-full w-full min-w-0 flex-col items-center gap-10 pb-4">

--- a/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
@@ -23,6 +23,7 @@ import type { ProtocolDisplayable } from '~/server/features/scaling/interop/type
 import { useTRPC } from '~/trpc/React'
 import { ProjectSection } from '../ProjectSection'
 import type { ProjectSectionProps } from '../types'
+import { BridgeFlowStats } from './BridgeFlowStats'
 import { ExploreInteropButton } from './ExploreInteropButton'
 import { InteropBridgeSubsections } from './InteropBridgeSubsections'
 
@@ -124,22 +125,12 @@ function Content({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-col justify-between gap-3 md:flex-row md:items-start">
-        <div className="flex flex-col gap-3 md:flex-row md:items-start">
-          <FlowsChainsSelector allChains={interopChains} />
-          <FlowsProtocolsSelector
-            allProtocols={protocols}
-            canonicalProtocolId={canonicalProtocolId}
-          />
-        </div>
-        {!isLoading && data && (
-          <FlowsParticleLegend
-            layout="inline"
-            className="justify-end text-right text-label-value-13"
-            totalVolume={data.stats.totalVolume}
-            dollarsPerParticle={dollarsPerParticle}
-          />
-        )}
+      <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-start">
+        <FlowsChainsSelector allChains={interopChains} />
+        <FlowsProtocolsSelector
+          allProtocols={protocols}
+          canonicalProtocolId={canonicalProtocolId}
+        />
       </div>
       <div className="flex h-full min-w-0 flex-col">
         <div className="group/flows flex h-full w-full min-w-0 flex-col items-center gap-10 pb-4">
@@ -152,6 +143,14 @@ function Content({
             topChainId={defaultStatsChainId}
           />
         </div>
+        {!isLoading && data && (
+          <FlowsParticleLegend
+            layout="inline"
+            className="mt-2 justify-center text-center text-label-value-13"
+            totalVolume={data.stats.totalVolume}
+            dollarsPerParticle={dollarsPerParticle}
+          />
+        )}
         {shouldRenderInactiveChainsInfo && (
           <div className="mt-3 flex min-h-6 w-full items-center justify-center gap-1 pt-1 max-lg:order-2">
             {shouldShowInactiveChainsInfo ? (
@@ -167,36 +166,44 @@ function Content({
           </div>
         )}
       </div>
-      <div className="rounded-lg bg-surface-secondary p-4 dark:bg-header-secondary">
-        <div className="mb-3 font-bold text-label-value-12 text-secondary uppercase">
-          {hasRouteSelection ? 'Route stats' : 'Chain stats'}
+      {singleProtocolId ? (
+        data && (
+          <BridgeFlowStats
+            data={data}
+            chainId={statsChainA}
+            protocolName={
+              protocols.find((p) => p.id === singleProtocolId)?.name ?? 'Bridge'
+            }
+          />
+        )
+      ) : (
+        <div className="rounded-lg bg-surface-secondary p-4 dark:bg-header-secondary">
+          <div className="mb-3 font-bold text-label-value-12 text-secondary uppercase">
+            {hasRouteSelection ? 'Route stats' : 'Chain stats'}
+          </div>
+          <div className="grid grid-cols-1 gap-2 lg:grid-cols-4 lg:[&>*:first-child]:row-span-3 lg:[&>*]:col-span-2">
+            {hasRouteSelection ? (
+              <MultipleChainsStats
+                chainIdA={statsChainA}
+                chainIdB={statsChainB}
+                selectedChains={selectedChains}
+                linkTopProtocols
+              />
+            ) : (
+              <SingleChainStats
+                chainId={statsChainA}
+                selectedChains={selectedChains}
+                linkTopProtocols
+              />
+            )}
+          </div>
         </div>
-        <div className="grid grid-cols-1 gap-2 lg:grid-cols-4 lg:[&>*:first-child]:row-span-3 lg:[&>*]:col-span-2">
-          {hasRouteSelection ? (
-            <MultipleChainsStats
-              chainIdA={statsChainA}
-              chainIdB={statsChainB}
-              selectedChains={selectedChains}
-              linkTopProtocols
-              hideTopProtocols={!!singleProtocolId}
-            />
-          ) : (
-            <SingleChainStats
-              chainId={statsChainA}
-              selectedChains={selectedChains}
-              linkTopProtocols
-              hideTopProtocols={!!singleProtocolId}
-            />
-          )}
-        </div>
-      </div>
-      {singleProtocolId && (
-        <InteropBridgeSubsections
-          protocolId={singleProtocolId}
-          selectedChains={selectedChains}
-          interopChains={interopChains}
-        />
       )}
+      <InteropBridgeSubsections
+        protocolIds={selectedProtocols}
+        selectedChains={selectedChains}
+        interopChains={interopChains}
+      />
     </div>
   )
 }

--- a/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
@@ -9,6 +9,7 @@ import {
 } from '~/pages/interop/components/flows/consts'
 import { FlowsChainsSelector } from '~/pages/interop/components/flows/FlowsChainsSelector'
 import { FlowsParticleLegend } from '~/pages/interop/components/flows/FlowsParticleLegend'
+import { FlowsProtocolsSelector } from '~/pages/interop/components/flows/FlowsProtocolsSelector'
 import { FlowsGraphPanel } from '~/pages/interop/components/flows/graph/FlowsGraphPanel'
 import { InactiveChainsDialog } from '~/pages/interop/components/flows/graph/InactiveChainsDialog'
 import { useScaledParticleCounts } from '~/pages/interop/components/flows/graph/utils/useScaledParticleCounts'
@@ -23,6 +24,7 @@ import { useTRPC } from '~/trpc/React'
 import { ProjectSection } from '../ProjectSection'
 import type { ProjectSectionProps } from '../types'
 import { ExploreInteropButton } from './ExploreInteropButton'
+import { InteropBridgeSubsections } from './InteropBridgeSubsections'
 
 export interface InteropFlowsSectionProps extends ProjectSectionProps {
   interopChains: InteropChainWithIcon[]
@@ -31,6 +33,8 @@ export interface InteropFlowsSectionProps extends ProjectSectionProps {
   })[]
   defaultSelectedChains: string[]
   defaultStatsChainId: string
+  /** This chain's own canonical bridge protocol id, if it has one. */
+  canonicalProtocolId?: string
 }
 
 export function InteropFlowsSection({
@@ -38,6 +42,7 @@ export function InteropFlowsSection({
   protocols,
   defaultSelectedChains,
   defaultStatsChainId,
+  canonicalProtocolId,
   ...sectionProps
 }: InteropFlowsSectionProps) {
   return (
@@ -53,7 +58,9 @@ export function InteropFlowsSection({
       >
         <Content
           interopChains={interopChains}
+          protocols={protocols}
           defaultStatsChainId={defaultStatsChainId}
+          canonicalProtocolId={canonicalProtocolId}
         />
       </InteropFlowsProvider>
       <div className="mt-4 md:hidden">
@@ -65,11 +72,18 @@ export function InteropFlowsSection({
 
 function Content({
   interopChains,
+  protocols,
   defaultStatsChainId,
-}: Pick<InteropFlowsSectionProps, 'interopChains' | 'defaultStatsChainId'>) {
+  canonicalProtocolId,
+}: Pick<
+  InteropFlowsSectionProps,
+  'interopChains' | 'protocols' | 'defaultStatsChainId' | 'canonicalProtocolId'
+>) {
   const trpc = useTRPC()
   const { highlightedChains, selectedChains, selectedProtocols } =
     useInteropFlows()
+  const singleProtocolId =
+    selectedProtocols.length === 1 ? selectedProtocols[0] : undefined
   const hasEnoughChains = selectedChains.length >= MIN_SELECTED_CHAINS
   const hasEnoughProtocols = selectedProtocols.length >= MIN_SELECTED_PROTOCOLS
   const { data, isLoading } = useQuery(
@@ -111,7 +125,13 @@ function Content({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col justify-between gap-3 md:flex-row md:items-start">
-        <FlowsChainsSelector allChains={interopChains} />
+        <div className="flex flex-col gap-3 md:flex-row md:items-start">
+          <FlowsChainsSelector allChains={interopChains} />
+          <FlowsProtocolsSelector
+            allProtocols={protocols}
+            canonicalProtocolId={canonicalProtocolId}
+          />
+        </div>
         {!isLoading && data && (
           <FlowsParticleLegend
             layout="inline"
@@ -158,16 +178,25 @@ function Content({
               chainIdB={statsChainB}
               selectedChains={selectedChains}
               linkTopProtocols
+              hideTopProtocols={!!singleProtocolId}
             />
           ) : (
             <SingleChainStats
               chainId={statsChainA}
               selectedChains={selectedChains}
               linkTopProtocols
+              hideTopProtocols={!!singleProtocolId}
             />
           )}
         </div>
       </div>
+      {singleProtocolId && (
+        <InteropBridgeSubsections
+          protocolId={singleProtocolId}
+          selectedChains={selectedChains}
+          interopChains={interopChains}
+        />
+      )}
     </div>
   )
 }

--- a/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropFlowsSection.tsx
@@ -126,6 +126,26 @@ function Content({
   const statsChainB = visibleHighlightedChains[1]
   const hasRouteSelection = hasGraphSelection && !!statsChainB
 
+  const chainName = (chainId: string | undefined) =>
+    interopChains.find((c) => c.id === chainId)?.name ?? chainId ?? ''
+
+  // Base reflects the chain/route selection; a protocol suffix is appended only
+  // when the selection is narrowed down from "all protocols".
+  const baseLabel = hasRouteSelection
+    ? `${chainName(statsChainA)} <> ${chainName(statsChainB)} route stats`
+    : 'Chain stats'
+  const allProtocolsSelected = selectedProtocols.length === protocols.length
+  const protocolSuffix = allProtocolsSelected
+    ? undefined
+    : selectedProtocols.length === 1
+      ? singleProtocolId === canonicalProtocolId
+        ? 'Canonical bridge'
+        : (protocols.find((p) => p.id === singleProtocolId)?.name ?? 'protocol')
+      : `${selectedProtocols.length} protocols`
+  const statsLabel = protocolSuffix
+    ? `${baseLabel} · ${protocolSuffix}`
+    : baseLabel
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-3 md:flex-row md:flex-wrap md:items-start">
@@ -180,20 +200,18 @@ function Content({
           </div>
         )}
       </div>
-      {singleProtocolId ? (
+      {singleProtocolId && !hasRouteSelection ? (
         data && (
           <BridgeFlowStats
             data={data}
             chainId={statsChainA}
-            protocolName={
-              protocols.find((p) => p.id === singleProtocolId)?.name ?? 'Bridge'
-            }
+            label={statsLabel}
           />
         )
       ) : (
         <div className="rounded-lg bg-surface-secondary p-4 dark:bg-header-secondary">
           <div className="mb-3 font-bold text-label-value-12 text-secondary uppercase">
-            {hasRouteSelection ? 'Route stats' : 'Chain stats'}
+            {statsLabel}
           </div>
           <div className="grid grid-cols-1 gap-2 lg:grid-cols-4 lg:[&>*:first-child]:row-span-3 lg:[&>*]:col-span-2">
             {hasRouteSelection ? (

--- a/packages/frontend/src/components/projects/sections/interop/InteropTokensSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropTokensSection.tsx
@@ -21,7 +21,6 @@ import {
   type TokenRow,
 } from '~/pages/interop/components/tokens/columns'
 import type { InteropSelection } from '~/pages/interop/utils/types'
-import type { InteropProtocolDashboardData } from '~/server/features/scaling/interop/getInteropProtocolData'
 import { useTRPC } from '~/trpc/React'
 import { ProjectSection } from '../ProjectSection'
 import type { ProjectSectionProps } from '../types'
@@ -30,15 +29,16 @@ const TOKENS_PER_PAGE = 6
 const ALL_TOKENS_LIMIT = 10_000
 
 export interface InteropTokensSectionProps extends ProjectSectionProps {
-  projectId: ProjectId
+  /** A single protocol, or `protocolIds` for a selection. */
+  projectId?: ProjectId
+  protocolIds?: string[]
   apiSelection: InteropSelection
-  data: InteropProtocolDashboardData
 }
 
 export function InteropTokensSection({
   projectId,
+  protocolIds,
   apiSelection,
-  data,
   ...sectionProps
 }: InteropTokensSectionProps) {
   const trpc = useTRPC()
@@ -47,10 +47,14 @@ export function InteropTokensSection({
       {
         ...apiSelection,
         id: projectId,
+        protocolIds,
         limit: ALL_TOKENS_LIMIT,
       },
       {
-        enabled: !!data.entry,
+        enabled:
+          apiSelection.from.length > 0 &&
+          apiSelection.to.length > 0 &&
+          (!!projectId || (protocolIds?.length ?? 0) > 0),
       },
     ),
   )

--- a/packages/frontend/src/components/projects/sections/interop/InteropTransfersSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropTransfersSection.tsx
@@ -18,7 +18,6 @@ import {
   type TransferRow,
 } from '~/pages/interop/components/table/transfer-count-cell/columns'
 import type { InteropSelection } from '~/pages/interop/utils/types'
-import type { InteropProtocolDashboardData } from '~/server/features/scaling/interop/getInteropProtocolData'
 import { useTRPC } from '~/trpc/React'
 import { cn } from '~/utils/cn'
 import { ProjectSection } from '../ProjectSection'
@@ -28,21 +27,23 @@ import { ChainMultiSelect } from './ChainMultiSelect'
 const TRANSFERS_PER_PAGE = 8
 
 export interface InteropTransfersSectionProps extends ProjectSectionProps {
-  projectId: ProjectId
+  /** A single protocol, or `protocolIds` for a selection. */
+  projectId?: ProjectId
+  protocolIds?: string[]
   apiSelection: InteropSelection
-  data: InteropProtocolDashboardData
+  snapshotTimestamp: number | undefined
   interopChains: InteropChainWithIcon[]
 }
 
 export function InteropTransfersSection({
   projectId,
+  protocolIds,
   apiSelection,
-  data,
+  snapshotTimestamp,
   interopChains,
   ...sectionProps
 }: InteropTransfersSectionProps) {
   const trpc = useTRPC()
-  const entry = data.entry
 
   const [selectedFrom, setSelectedFrom] = useState<string[]>(apiSelection.from)
   const [selectedTo, setSelectedTo] = useState<string[]>(apiSelection.to)
@@ -59,13 +60,14 @@ export function InteropTransfersSection({
         from: selectedFrom,
         to: selectedTo,
         id: projectId,
-        snapshotTimestamp: entry?.snapshotTimestamp ?? 0,
+        protocolIds,
+        snapshotTimestamp: snapshotTimestamp ?? 0,
         limit: TRANSFERS_PER_PAGE,
       },
       {
         enabled:
-          !!entry?.snapshotTimestamp &&
-          (entry?.transferCount ?? 0) > 0 &&
+          !!snapshotTimestamp &&
+          (!!projectId || (protocolIds?.length ?? 0) > 0) &&
           selectedFrom.length > 0 &&
           selectedTo.length > 0,
         getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/packages/frontend/src/pages/interop/InteropRouter.ts
+++ b/packages/frontend/src/pages/interop/InteropRouter.ts
@@ -1,6 +1,7 @@
 import type { InMemoryCache } from '@l2beat/shared-pure'
 import { v } from '@l2beat/validate'
 import express from 'express'
+import { ps } from '~/server/projects'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
@@ -97,6 +98,22 @@ export function createInteropRouter(
       params: v.object({ slug: v.string() }),
     }),
     async (req, res) => {
+      // Projects that also have a chain (scaling) page are served as a unified
+      // page; redirect the standalone bridge page to the chain page, landing on
+      // the "Volume and flows" section with this canonical bridge pre-selected
+      // (so its bridge subsections are shown).
+      const project = await ps.getProject({
+        slug: req.params.slug,
+        optional: ['scalingInfo', 'interopConfig'],
+      })
+      if (project?.scalingInfo && project.interopConfig) {
+        res.redirect(
+          302,
+          `/scaling/projects/${project.slug}?protocols=${project.id}#interop-flows`,
+        )
+        return
+      }
+
       const data = await getInteropProtocolPageData(req, manifest, cache)
       if (!data) {
         res.status(404).send('Not found')

--- a/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
@@ -25,17 +25,29 @@ import { useInteropFlows } from './utils/InteropFlowsContext'
 
 export function FlowsProtocolsSelector({
   allProtocols,
+  canonicalProtocolId,
 }: {
   allProtocols: (ProtocolDisplayable & {
     id: string
   })[]
+  /** The chain's own canonical bridge protocol id (from its interopConfig), if any. */
+  canonicalProtocolId?: string
 }) {
   const {
     selectedProtocols,
     toggleProtocolSelection,
     selectAllProtocols,
     deselectAllProtocols,
+    setSelectedProtocols,
   } = useInteropFlows()
+
+  const hasCanonical =
+    !!canonicalProtocolId &&
+    allProtocols.some((p) => p.id === canonicalProtocolId)
+  const onlyCanonicalSelected =
+    hasCanonical &&
+    selectedProtocols.length === 1 &&
+    selectedProtocols[0] === canonicalProtocolId
 
   const protocolsWithDetails = allProtocols.map(
     ({ id, name, iconUrl, slug }) => ({
@@ -108,6 +120,16 @@ export function FlowsProtocolsSelector({
       >
         Deselect all
       </button>
+      {hasCanonical && canonicalProtocolId && (
+        <button
+          type="button"
+          onClick={() => setSelectedProtocols([canonicalProtocolId])}
+          disabled={onlyCanonicalSelected}
+          className="ml-auto w-fit cursor-pointer font-medium text-brand text-label-value-15 underline disabled:cursor-not-allowed disabled:text-secondary"
+        >
+          Canonical bridge only
+        </button>
+      )}
     </div>
   )
 
@@ -135,6 +157,7 @@ export function FlowsProtocolsSelector({
                 key={protocol.id}
                 protocol={protocol}
                 onToggle={toggleProtocolSelection}
+                isCanonical={protocol.id === canonicalProtocolId}
                 nameClassName="font-semibold text-xs leading-none"
                 rowClassName="px-4"
               />
@@ -162,6 +185,7 @@ export function FlowsProtocolsSelector({
                 key={protocol.id}
                 protocol={protocol}
                 onToggle={toggleProtocolSelection}
+                isCanonical={protocol.id === canonicalProtocolId}
                 nameClassName="font-bold text-label-value-16"
                 rowClassName="px-3"
               />
@@ -177,6 +201,7 @@ export function FlowsProtocolsSelector({
 function ProtocolRow({
   protocol,
   onToggle,
+  isCanonical,
   nameClassName,
   rowClassName,
 }: {
@@ -188,6 +213,7 @@ function ProtocolRow({
     isSelected: boolean
   }
   onToggle: (id: string) => void
+  isCanonical?: boolean
   nameClassName: string
   rowClassName?: string
 }) {
@@ -210,6 +236,11 @@ function ProtocolRow({
           <span className={nameClassName}>{protocol.name}</span>
           <ArrowRightIcon className="size-3 shrink-0 fill-brand opacity-0 transition-opacity group-hover:opacity-100" />
         </a>
+        {isCanonical && (
+          <span className="rounded bg-surface-secondary px-1.5 py-0.5 font-medium text-2xs text-secondary uppercase leading-none">
+            Canonical
+          </span>
+        )}
       </div>
     </Checkbox>
   )

--- a/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
@@ -49,15 +49,24 @@ export function FlowsProtocolsSelector({
     selectedProtocols.length === 1 &&
     selectedProtocols[0] === canonicalProtocolId
 
-  const protocolsWithDetails = allProtocols.map(
-    ({ id, name, iconUrl, slug }) => ({
+  const canonicalProtocol = hasCanonical
+    ? allProtocols.find((p) => p.id === canonicalProtocolId)
+    : undefined
+
+  const protocolsWithDetails = allProtocols
+    .map(({ id, name, iconUrl, slug }) => ({
       id,
       name,
       iconUrl,
       slug,
       isSelected: selectedProtocols.includes(id),
-    }),
-  )
+    }))
+    // Surface the chain's own canonical bridge at the top of the list.
+    .sort(
+      (a, b) =>
+        Number(b.id === canonicalProtocolId) -
+        Number(a.id === canonicalProtocolId),
+    )
 
   const selectedProtocolsWithDetails = protocolsWithDetails.filter(
     (protocol) => protocol.isSelected,
@@ -78,7 +87,7 @@ export function FlowsProtocolsSelector({
   ) : null
 
   const trigger = (
-    <div className="flex h-9.5 items-center justify-center gap-1.5 rounded-lg border border-divider bg-surface-primary! p-2">
+    <div className="flex h-9.5 shrink-0 items-center justify-center gap-1.5 rounded-lg border border-divider bg-surface-primary! p-2">
       <span className="rounded-full bg-pink-900 px-2 py-[3px] font-semibold text-white text-xs leading-none">{`${selectedProtocols.length}/${allProtocols.length}`}</span>
       <span className="font-bold text-lg leading-none">Protocols</span>
       <div className="flex items-center gap-1 max-md:hidden lg:max-xl:hidden">
@@ -120,21 +129,45 @@ export function FlowsProtocolsSelector({
       >
         Deselect all
       </button>
-      {hasCanonical && canonicalProtocolId && (
-        <button
-          type="button"
-          onClick={() => setSelectedProtocols([canonicalProtocolId])}
-          disabled={onlyCanonicalSelected}
-          className="ml-auto w-fit cursor-pointer font-medium text-brand text-label-value-15 underline disabled:cursor-not-allowed disabled:text-secondary"
-        >
-          Canonical bridge only
-        </button>
-      )}
     </div>
   )
 
   return (
-    <div className="flex items-start gap-1 max-md:w-full max-md:flex-col md:items-center md:gap-3">
+    <div className="flex items-start gap-1 max-md:w-full max-md:flex-col md:items-center md:gap-2">
+      {/* Direct "Canonical bridge" shortcut, sitting next to the selector. */}
+      {hasCanonical && canonicalProtocolId && (
+        <button
+          type="button"
+          onClick={() => {
+            if (onlyCanonicalSelected) {
+              selectAllProtocols()
+              return
+            }
+            setSelectedProtocols([canonicalProtocolId])
+            // Anchor the URL to the Volume & flows section (sets the hash and
+            // scrolls there) so the selected-bridge link is shareable.
+            if (typeof window !== 'undefined') {
+              window.location.hash = 'interop-flows'
+            }
+          }}
+          aria-pressed={onlyCanonicalSelected}
+          className={cn(
+            'flex h-9.5 shrink-0 items-center gap-2 rounded-lg border py-2 pr-4 pl-2 font-bold text-sm leading-none transition-colors max-md:w-full md:order-2',
+            onlyCanonicalSelected
+              ? 'border-brand text-brand'
+              : 'border-divider bg-surface-primary! hover:bg-surface-secondary',
+          )}
+        >
+          {canonicalProtocol?.iconUrl && (
+            <img
+              src={canonicalProtocol.iconUrl}
+              alt=""
+              className="size-5 rounded-full bg-white"
+            />
+          )}
+          Canonical bridge
+        </button>
+      )}
       {/* Mobile */}
       <Drawer>
         <DrawerTrigger className="w-full md:hidden">{trigger}</DrawerTrigger>
@@ -222,6 +255,7 @@ function ProtocolRow({
       name={protocol.name}
       className={cn(
         'flex h-10 w-full flex-row-reverse items-center justify-between py-2.5 hover:bg-surface-secondary',
+        isCanonical && 'rounded-md bg-surface-secondary',
         rowClassName,
       )}
       checked={protocol.isSelected}
@@ -229,13 +263,18 @@ function ProtocolRow({
     >
       <div className="flex items-center gap-2">
         <img src={protocol.iconUrl} alt={protocol.name} className="size-4" />
-        <a
-          href={`/interop/protocols/${protocol.slug}`}
-          className="group inline-flex items-center gap-1"
-        >
+        {isCanonical ? (
+          // Canonical bridge detail is part of this very section — no link out.
           <span className={nameClassName}>{protocol.name}</span>
-          <ArrowRightIcon className="size-3 shrink-0 fill-brand opacity-0 transition-opacity group-hover:opacity-100" />
-        </a>
+        ) : (
+          <a
+            href={`/interop/protocols/${protocol.slug}`}
+            className="group inline-flex items-center gap-1"
+          >
+            <span className={nameClassName}>{protocol.name}</span>
+            <ArrowRightIcon className="size-3 shrink-0 fill-brand opacity-0 transition-opacity group-hover:opacity-100" />
+          </a>
+        )}
         {isCanonical && (
           <span className="rounded bg-surface-secondary px-1.5 py-0.5 font-medium text-2xs text-secondary uppercase leading-none">
             Canonical

--- a/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
@@ -17,6 +17,7 @@ import {
 } from '~/components/core/Drawer'
 import { ScrollWithGradient } from '~/components/ScrollWithGradient'
 import { ArrowRightIcon } from '~/icons/ArrowRight'
+import { CheckIcon } from '~/icons/Check'
 import { InfoIcon } from '~/icons/Info'
 import type { ProtocolDisplayable } from '~/server/features/scaling/interop/types'
 import { cn } from '~/utils/cn'
@@ -226,6 +227,8 @@ export function FlowsCanonicalBridgeButton({
         }
       }}
       aria-pressed={onlyCanonicalSelected}
+      role="checkbox"
+      aria-checked={onlyCanonicalSelected}
       className={cn(
         'flex h-9.5 shrink-0 items-center gap-2 rounded-lg border py-2 pr-4 pl-2 font-bold text-sm leading-none transition-colors max-md:w-full max-md:justify-center',
         onlyCanonicalSelected
@@ -233,6 +236,18 @@ export function FlowsCanonicalBridgeButton({
           : 'border-divider bg-surface-primary! hover:bg-surface-secondary',
       )}
     >
+      <span
+        className={cn(
+          'flex size-4 shrink-0 items-center justify-center rounded border transition-colors',
+          onlyCanonicalSelected
+            ? 'border-brand bg-brand'
+            : 'border-2 border-surface-tertiary',
+        )}
+      >
+        {onlyCanonicalSelected && (
+          <CheckIcon className="size-3 stroke-[2px] stroke-surface-primary!" />
+        )}
+      </span>
       {canonicalProtocol.iconUrl && (
         <img
           src={canonicalProtocol.iconUrl}
@@ -240,7 +255,7 @@ export function FlowsCanonicalBridgeButton({
           className="size-5 rounded-full bg-white"
         />
       )}
-      Canonical bridge
+      Canonical bridge only
     </button>
   )
 }

--- a/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/FlowsProtocolsSelector.tsx
@@ -38,20 +38,7 @@ export function FlowsProtocolsSelector({
     toggleProtocolSelection,
     selectAllProtocols,
     deselectAllProtocols,
-    setSelectedProtocols,
   } = useInteropFlows()
-
-  const hasCanonical =
-    !!canonicalProtocolId &&
-    allProtocols.some((p) => p.id === canonicalProtocolId)
-  const onlyCanonicalSelected =
-    hasCanonical &&
-    selectedProtocols.length === 1 &&
-    selectedProtocols[0] === canonicalProtocolId
-
-  const canonicalProtocol = hasCanonical
-    ? allProtocols.find((p) => p.id === canonicalProtocolId)
-    : undefined
 
   const protocolsWithDetails = allProtocols
     .map(({ id, name, iconUrl, slug }) => ({
@@ -133,41 +120,7 @@ export function FlowsProtocolsSelector({
   )
 
   return (
-    <div className="flex items-start gap-1 max-md:w-full max-md:flex-col md:items-center md:gap-2">
-      {/* Direct "Canonical bridge" shortcut, sitting next to the selector. */}
-      {hasCanonical && canonicalProtocolId && (
-        <button
-          type="button"
-          onClick={() => {
-            if (onlyCanonicalSelected) {
-              selectAllProtocols()
-              return
-            }
-            setSelectedProtocols([canonicalProtocolId])
-            // Anchor the URL to the Volume & flows section (sets the hash and
-            // scrolls there) so the selected-bridge link is shareable.
-            if (typeof window !== 'undefined') {
-              window.location.hash = 'interop-flows'
-            }
-          }}
-          aria-pressed={onlyCanonicalSelected}
-          className={cn(
-            'flex h-9.5 shrink-0 items-center gap-2 rounded-lg border py-2 pr-4 pl-2 font-bold text-sm leading-none transition-colors max-md:w-full md:order-2',
-            onlyCanonicalSelected
-              ? 'border-brand text-brand'
-              : 'border-divider bg-surface-primary! hover:bg-surface-secondary',
-          )}
-        >
-          {canonicalProtocol?.iconUrl && (
-            <img
-              src={canonicalProtocol.iconUrl}
-              alt=""
-              className="size-5 rounded-full bg-white"
-            />
-          )}
-          Canonical bridge
-        </button>
-      )}
+    <div className="max-md:w-full">
       {/* Mobile */}
       <Drawer>
         <DrawerTrigger className="w-full md:hidden">{trigger}</DrawerTrigger>
@@ -228,6 +181,67 @@ export function FlowsProtocolsSelector({
         </DialogContent>
       </Dialog>
     </div>
+  )
+}
+
+/**
+ * Direct "Canonical bridge" shortcut. Rendered as a sibling of the chain and
+ * protocol selectors so it can sit inline on desktop but drop to its own full
+ * width row on mobile.
+ */
+export function FlowsCanonicalBridgeButton({
+  allProtocols,
+  canonicalProtocolId,
+}: {
+  allProtocols: (ProtocolDisplayable & {
+    id: string
+  })[]
+  canonicalProtocolId: string
+}) {
+  const { selectedProtocols, selectAllProtocols, setSelectedProtocols } =
+    useInteropFlows()
+
+  const canonicalProtocol = allProtocols.find(
+    (p) => p.id === canonicalProtocolId,
+  )
+  if (!canonicalProtocol) return null
+
+  const onlyCanonicalSelected =
+    selectedProtocols.length === 1 &&
+    selectedProtocols[0] === canonicalProtocolId
+
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        if (onlyCanonicalSelected) {
+          selectAllProtocols()
+          return
+        }
+        setSelectedProtocols([canonicalProtocolId])
+        // Anchor the URL to the Volume & flows section (sets the hash and
+        // scrolls there) so the selected-bridge link is shareable.
+        if (typeof window !== 'undefined') {
+          window.location.hash = 'interop-flows'
+        }
+      }}
+      aria-pressed={onlyCanonicalSelected}
+      className={cn(
+        'flex h-9.5 shrink-0 items-center gap-2 rounded-lg border py-2 pr-4 pl-2 font-bold text-sm leading-none transition-colors max-md:w-full max-md:justify-center',
+        onlyCanonicalSelected
+          ? 'border-brand text-brand'
+          : 'border-divider bg-surface-primary! hover:bg-surface-secondary',
+      )}
+    >
+      {canonicalProtocol.iconUrl && (
+        <img
+          src={canonicalProtocol.iconUrl}
+          alt=""
+          className="size-5 rounded-full bg-white"
+        />
+      )}
+      Canonical bridge
+    </button>
   )
 }
 

--- a/packages/frontend/src/pages/interop/components/flows/utils/InteropFlowsContext.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/utils/InteropFlowsContext.tsx
@@ -24,6 +24,7 @@ interface InteropFlowsContextType {
   toggleProtocolSelection: (protocolId: string) => void
   selectAllProtocols: () => void
   deselectAllProtocols: () => void
+  setSelectedProtocols: (protocolIds: string[]) => void
   highlightedChains: string[]
   toggleHighlightedChain: (chainId: string) => void
   setHighlightedChainPair: (chainIdA: string, chainIdB: string) => void
@@ -229,6 +230,7 @@ export function InteropFlowsProvider({
         toggleProtocolSelection,
         selectAllProtocols,
         deselectAllProtocols,
+        setSelectedProtocols,
         highlightedChains,
         toggleHighlightedChain,
         setHighlightedChainPair,

--- a/packages/frontend/src/pages/interop/protocol/components/InteropProtocolSummary.tsx
+++ b/packages/frontend/src/pages/interop/protocol/components/InteropProtocolSummary.tsx
@@ -99,7 +99,7 @@ export function InteropProtocolSummary({
         />
       </div>
       <HorizontalSeparator className="my-4" />
-      <InteropTransferSizeBreakdown protocolData={protocolData} />
+      <InteropTransferSizeBreakdown transferSize={protocolData.transferSize} />
       <HorizontalSeparator className="my-4" />
       <InteropTransferTypeBreakdown protocolData={protocolData} />
       {protocol.header.description && (

--- a/packages/frontend/src/pages/interop/protocol/components/InteropProtocolSummary.tsx
+++ b/packages/frontend/src/pages/interop/protocol/components/InteropProtocolSummary.tsx
@@ -1,30 +1,20 @@
-import type { CSSProperties, ReactNode } from 'react'
-import { Breakdown } from '~/components/breakdown/Breakdown'
 import { HorizontalSeparator } from '~/components/core/HorizontalSeparator'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '~/components/core/tooltip/Tooltip'
 import { AboutSection } from '~/components/projects/sections/AboutSection'
 import { EM_DASH } from '~/consts/characters'
 import type { InteropProtocolDashboardData } from '~/server/features/scaling/interop/getInteropProtocolData'
 import type { InteropProtocolEntry } from '~/server/features/scaling/interop/protocol/getInteropProtocolEntry'
-import type { TransferSizeDataPoint } from '~/server/features/scaling/interop/utils/getTransferSizeChartData'
 import { formatCurrency } from '~/utils/number-format/formatCurrency'
 import { formatInteger } from '~/utils/number-format/formatInteger'
 import { InteropNoDataBadge } from '../../components/InteropNoDataBadge'
 import { InteropTopPathValue } from '../../components/InteropTopPathValue'
 import { AvgDurationCell } from '../../components/table/AvgDurationCell'
 import { TopTokensCell } from '../../components/tokens/TopTokensCell'
-import {
-  INTEROP_TYPE_TO_BG_COLOR,
-  TRANSFER_TYPE_DISPLAY,
-} from '../../utils/display'
-import { transferSizeBuckets } from '../../utils/transferSizeBuckets'
 import type { InteropSelection } from '../../utils/types'
-
-type TransferType = keyof typeof TRANSFER_TYPE_DISPLAY
+import {
+  InteropSummaryStat,
+  InteropTransferSizeBreakdown,
+  InteropTransferTypeBreakdown,
+} from './InteropSummaryParts'
 
 export function InteropProtocolSummary({
   protocol,
@@ -35,48 +25,6 @@ export function InteropProtocolSummary({
   apiSelection: InteropSelection
   protocolData: InteropProtocolDashboardData
 }) {
-  const breakdownValues = [
-    {
-      value: protocolData?.transferSize?.countUnder100 ?? 0,
-      label: transferSizeBuckets.under100.label,
-      style: { backgroundColor: transferSizeBuckets.under100.color },
-    },
-    {
-      value: protocolData?.transferSize?.count100To1K ?? 0,
-      label: transferSizeBuckets.from100To1K.label,
-      style: { backgroundColor: transferSizeBuckets.from100To1K.color },
-    },
-    {
-      value: protocolData?.transferSize?.count1KTo10K ?? 0,
-      label: transferSizeBuckets.from1KTo10K.label,
-      style: { backgroundColor: transferSizeBuckets.from1KTo10K.color },
-    },
-    {
-      value: protocolData?.transferSize?.count10KTo100K ?? 0,
-      label: transferSizeBuckets.from10KTo100K.label,
-      style: { backgroundColor: transferSizeBuckets.from10KTo100K.color },
-    },
-    {
-      value: protocolData?.transferSize?.countOver100K ?? 0,
-      label: transferSizeBuckets.over100K.label,
-      style: { backgroundColor: transferSizeBuckets.over100K.color },
-    },
-  ]
-  const byBridgeType = protocolData?.entry?.byBridgeType
-  const transferTypeBreakdownValues = Object.keys(byBridgeType ?? {}).flatMap(
-    (type) => {
-      const transferType = type as TransferType
-      const stats = byBridgeType?.[transferType]
-      if (!stats) return []
-
-      return {
-        value: stats.volume,
-        label: TRANSFER_TYPE_DISPLAY[transferType].label,
-        className: INTEROP_TYPE_TO_BG_COLOR[transferType],
-      }
-    },
-  )
-
   return (
     <section
       id="summary"
@@ -84,7 +32,7 @@ export function InteropProtocolSummary({
       className="mt-4 flex w-full scroll-mt-[100vh] flex-col border-divider px-4 max-md:border-b max-md:pb-6 md:rounded-lg md:bg-surface-primary md:p-6"
     >
       <div className="grid grid-cols-1 gap-x-3 max-md:gap-y-3 md:grid-cols-3">
-        <StatsItem
+        <InteropSummaryStat
           title="Last 24h volume"
           value={
             protocolData?.entry?.volume
@@ -92,11 +40,11 @@ export function InteropProtocolSummary({
               : EM_DASH
           }
         />
-        <StatsItem
+        <InteropSummaryStat
           title="Last 24h transfer count"
           value={formatInteger(protocolData?.entry?.transferCount ?? 0)}
         />
-        <StatsItem
+        <InteropSummaryStat
           title="Last 24h top path"
           value={
             protocolData?.topPath ? (
@@ -107,7 +55,7 @@ export function InteropProtocolSummary({
           }
         />
         <HorizontalSeparator className="col-span-3 my-4 max-md:hidden" />
-        <StatsItem
+        <InteropSummaryStat
           title="Last 24h avg. transfer time"
           value={
             protocolData?.entry?.averageDuration ? (
@@ -121,7 +69,7 @@ export function InteropProtocolSummary({
             )
           }
         />
-        <StatsItem
+        <InteropSummaryStat
           title="Last 24 avg. transfer value"
           value={
             protocolData?.entry?.averageValue
@@ -129,7 +77,7 @@ export function InteropProtocolSummary({
               : EM_DASH
           }
         />
-        <StatsItem
+        <InteropSummaryStat
           title="Tokens by volume"
           value={
             <TopTokensCell
@@ -151,67 +99,9 @@ export function InteropProtocolSummary({
         />
       </div>
       <HorizontalSeparator className="my-4" />
-      <span className="font-medium text-paragraph-12 text-secondary">
-        Protocol transfer size
-      </span>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="cursor-pointer">
-            <Breakdown
-              values={breakdownValues}
-              className="mt-2! h-1.5 w-full"
-            />
-            <div className="mt-2 flex flex-wrap gap-2">
-              {breakdownValues.map((value) => (
-                <div key={value.label} className="flex items-center gap-[3px]">
-                  <div className="size-3.5 rounded-xs" style={value.style} />
-                  <span className="font-medium text-label-value-12 text-secondary leading-none">
-                    {value.label}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent fitContent>
-          <TransferSizeTooltipContent
-            breakdownValues={breakdownValues}
-            transferSize={protocolData?.transferSize}
-          />
-        </TooltipContent>
-      </Tooltip>
+      <InteropTransferSizeBreakdown protocolData={protocolData} />
       <HorizontalSeparator className="my-4" />
-      <span className="font-medium text-paragraph-12 text-secondary">
-        Transfer type distribution
-      </span>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <div className="cursor-pointer">
-            <Breakdown
-              values={transferTypeBreakdownValues}
-              className="mt-2! h-1.5 w-full"
-            />
-            <div className="mt-2 flex flex-wrap gap-2">
-              {transferTypeBreakdownValues
-                .filter((value) => value.value > 0)
-                .map((value) => (
-                  <div
-                    key={value.label}
-                    className="flex items-center gap-[3px]"
-                  >
-                    <div className={`size-3.5 rounded-xs ${value.className}`} />
-                    <span className="font-medium text-label-value-12 text-secondary leading-none">
-                      {value.label}
-                    </span>
-                  </div>
-                ))}
-            </div>
-          </div>
-        </TooltipTrigger>
-        <TooltipContent fitContent>
-          <TransferTypeTooltipContent values={transferTypeBreakdownValues} />
-        </TooltipContent>
-      </Tooltip>
+      <InteropTransferTypeBreakdown protocolData={protocolData} />
       {protocol.header.description && (
         <div className="max-md:hidden">
           <HorizontalSeparator className="my-4" />
@@ -219,121 +109,5 @@ export function InteropProtocolSummary({
         </div>
       )}
     </section>
-  )
-}
-
-function StatsItem({ title, value }: { title: string; value: ReactNode }) {
-  return (
-    <div className="flex gap-1.5 max-md:justify-between md:flex-col">
-      <span className="font-medium text-paragraph-12 text-secondary">
-        {title}
-      </span>
-      <div className="font-bold text-label-value-16 leading-none">{value}</div>
-    </div>
-  )
-}
-
-function TransferSizeTooltipContent({
-  breakdownValues,
-  transferSize,
-}: {
-  breakdownValues: { value: number; style: CSSProperties; label: string }[]
-  transferSize: TransferSizeDataPoint | undefined
-}) {
-  const totalTransfers = breakdownValues.reduce((sum, v) => sum + v.value, 0)
-
-  return (
-    <div className="flex flex-col">
-      <div className="flex flex-col gap-1.5">
-        <div className="flex items-center justify-between gap-x-6">
-          <span className="font-medium text-label-value-14">
-            Total identified transfers
-          </span>
-          <span className="font-medium text-label-value-15 text-primary tabular-nums">
-            {formatInteger(totalTransfers)} transfers
-          </span>
-        </div>
-        {breakdownValues.map((entry) => (
-          <div
-            key={entry.label}
-            className="flex items-center justify-between gap-x-6"
-          >
-            <div className="flex items-center gap-1">
-              <div className="size-3 rounded-xs" style={entry.style} />
-              <span className="font-medium text-label-value-14">
-                {entry.label}
-              </span>
-            </div>
-            <span className="font-medium text-label-value-15 text-primary tabular-nums">
-              {formatInteger(entry.value)} transfers
-            </span>
-          </div>
-        ))}
-      </div>
-      <HorizontalSeparator className="my-1.5" />
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between gap-x-6">
-          <span className="font-medium text-label-value-14">Min size</span>
-          <span className="font-medium text-label-value-15 text-primary tabular-nums">
-            {formatTransferSize(transferSize?.minTransferValueUsd)}
-          </span>
-        </div>
-        <div className="flex items-center justify-between gap-x-6">
-          <span className="font-medium text-label-value-14">Average size</span>
-          <span className="font-medium text-label-value-15 text-primary tabular-nums">
-            {formatTransferSize(transferSize?.averageTransferSizeUsd)}
-          </span>
-        </div>
-        <div className="flex items-center justify-between gap-x-6">
-          <span className="font-medium text-label-value-14">Max size</span>
-          <span className="font-medium text-label-value-15 text-primary tabular-nums">
-            {formatTransferSize(transferSize?.maxTransferValueUsd)}
-          </span>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function formatTransferSize(value: number | undefined) {
-  return value !== undefined ? formatCurrency(value, 'usd') : EM_DASH
-}
-
-function TransferTypeTooltipContent({
-  values,
-}: {
-  values: {
-    value: number
-    label: string
-    className: string
-  }[]
-}) {
-  const totalVolume = values.reduce((sum, v) => sum + v.value, 0)
-
-  return (
-    <div className="flex flex-col gap-0.5">
-      <div className="flex items-center justify-between gap-x-6">
-        <span className="font-medium text-label-value-14">Total volume</span>
-        <span className="font-medium text-label-value-15 text-primary tabular-nums">
-          {formatCurrency(totalVolume, 'usd')}
-        </span>
-      </div>
-      {values.map((entry) => (
-        <div
-          key={entry.label}
-          className="flex items-center justify-between gap-x-6"
-        >
-          <div className="flex items-center gap-1">
-            <div className={`size-3 rounded-xs ${entry.className}`} />
-            <span className="font-medium text-label-value-14">
-              {entry.label}
-            </span>
-          </div>
-          <span className="font-medium text-label-value-15 text-primary tabular-nums">
-            {formatCurrency(entry.value, 'usd')}
-          </span>
-        </div>
-      ))}
-    </div>
   )
 }

--- a/packages/frontend/src/pages/interop/protocol/components/InteropProtocolSummary.tsx
+++ b/packages/frontend/src/pages/interop/protocol/components/InteropProtocolSummary.tsx
@@ -101,7 +101,13 @@ export function InteropProtocolSummary({
       <HorizontalSeparator className="my-4" />
       <InteropTransferSizeBreakdown transferSize={protocolData.transferSize} />
       <HorizontalSeparator className="my-4" />
-      <InteropTransferTypeBreakdown protocolData={protocolData} />
+      <InteropTransferTypeBreakdown
+        byType={Object.fromEntries(
+          Object.entries(protocolData?.entry?.byBridgeType ?? {}).flatMap(
+            ([type, stats]) => (stats ? [[type, stats.volume] as const] : []),
+          ),
+        )}
+      />
       {protocol.header.description && (
         <div className="max-md:hidden">
           <HorizontalSeparator className="my-4" />

--- a/packages/frontend/src/pages/interop/protocol/components/InteropSummaryParts.tsx
+++ b/packages/frontend/src/pages/interop/protocol/components/InteropSummaryParts.tsx
@@ -7,7 +7,6 @@ import {
   TooltipTrigger,
 } from '~/components/core/tooltip/Tooltip'
 import { EM_DASH } from '~/consts/characters'
-import type { InteropProtocolDashboardData } from '~/server/features/scaling/interop/getInteropProtocolData'
 import type { TransferSizeDataPoint } from '~/server/features/scaling/interop/utils/getTransferSizeChartData'
 import { formatCurrency } from '~/utils/number-format/formatCurrency'
 import { formatInteger } from '~/utils/number-format/formatInteger'
@@ -105,23 +104,22 @@ export function InteropTransferSizeBreakdown({
 }
 
 export function InteropTransferTypeBreakdown({
-  protocolData,
+  byType,
 }: {
-  protocolData: InteropProtocolDashboardData
+  /** Volume per bridge type. */
+  byType: Partial<Record<TransferType, number>> | undefined
 }) {
-  const byBridgeType = protocolData?.entry?.byBridgeType
-  const transferTypeBreakdownValues = Object.keys(byBridgeType ?? {}).flatMap(
-    (type) => {
-      const transferType = type as TransferType
-      const stats = byBridgeType?.[transferType]
-      if (!stats) return []
-      return {
-        value: stats.volume,
-        label: TRANSFER_TYPE_DISPLAY[transferType].label,
-        className: INTEROP_TYPE_TO_BG_COLOR[transferType],
-      }
-    },
-  )
+  const transferTypeBreakdownValues = (
+    Object.keys(TRANSFER_TYPE_DISPLAY) as TransferType[]
+  ).flatMap((transferType) => {
+    const volume = byType?.[transferType]
+    if (volume === undefined) return []
+    return {
+      value: volume,
+      label: TRANSFER_TYPE_DISPLAY[transferType].label,
+      className: INTEROP_TYPE_TO_BG_COLOR[transferType],
+    }
+  })
 
   return (
     <div>

--- a/packages/frontend/src/pages/interop/protocol/components/InteropSummaryParts.tsx
+++ b/packages/frontend/src/pages/interop/protocol/components/InteropSummaryParts.tsx
@@ -1,0 +1,262 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Breakdown } from '~/components/breakdown/Breakdown'
+import { HorizontalSeparator } from '~/components/core/HorizontalSeparator'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '~/components/core/tooltip/Tooltip'
+import { EM_DASH } from '~/consts/characters'
+import type { InteropProtocolDashboardData } from '~/server/features/scaling/interop/getInteropProtocolData'
+import type { TransferSizeDataPoint } from '~/server/features/scaling/interop/utils/getTransferSizeChartData'
+import { formatCurrency } from '~/utils/number-format/formatCurrency'
+import { formatInteger } from '~/utils/number-format/formatInteger'
+import {
+  INTEROP_TYPE_TO_BG_COLOR,
+  TRANSFER_TYPE_DISPLAY,
+} from '../../utils/display'
+import { transferSizeBuckets } from '../../utils/transferSizeBuckets'
+
+type TransferType = keyof typeof TRANSFER_TYPE_DISPLAY
+
+export function InteropSummaryStat({
+  title,
+  value,
+}: {
+  title: string
+  value: ReactNode
+}) {
+  return (
+    <div className="flex gap-1.5 max-md:justify-between md:flex-col">
+      <span className="text-nowrap font-medium text-paragraph-12 text-secondary">
+        {title}
+      </span>
+      <div className="font-bold text-label-value-16 leading-none">{value}</div>
+    </div>
+  )
+}
+
+export function InteropTransferSizeBreakdown({
+  protocolData,
+}: {
+  protocolData: InteropProtocolDashboardData
+}) {
+  const breakdownValues = [
+    {
+      value: protocolData?.transferSize?.countUnder100 ?? 0,
+      label: transferSizeBuckets.under100.label,
+      style: { backgroundColor: transferSizeBuckets.under100.color },
+    },
+    {
+      value: protocolData?.transferSize?.count100To1K ?? 0,
+      label: transferSizeBuckets.from100To1K.label,
+      style: { backgroundColor: transferSizeBuckets.from100To1K.color },
+    },
+    {
+      value: protocolData?.transferSize?.count1KTo10K ?? 0,
+      label: transferSizeBuckets.from1KTo10K.label,
+      style: { backgroundColor: transferSizeBuckets.from1KTo10K.color },
+    },
+    {
+      value: protocolData?.transferSize?.count10KTo100K ?? 0,
+      label: transferSizeBuckets.from10KTo100K.label,
+      style: { backgroundColor: transferSizeBuckets.from10KTo100K.color },
+    },
+    {
+      value: protocolData?.transferSize?.countOver100K ?? 0,
+      label: transferSizeBuckets.over100K.label,
+      style: { backgroundColor: transferSizeBuckets.over100K.color },
+    },
+  ]
+
+  return (
+    <div>
+      <span className="font-medium text-paragraph-12 text-secondary">
+        Protocol transfer size
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="cursor-pointer">
+            <Breakdown
+              values={breakdownValues}
+              className="mt-2! h-1.5 w-full"
+            />
+            <div className="mt-2 flex flex-wrap gap-2">
+              {breakdownValues.map((value) => (
+                <div key={value.label} className="flex items-center gap-[3px]">
+                  <div className="size-3.5 rounded-xs" style={value.style} />
+                  <span className="font-medium text-label-value-12 text-secondary leading-none">
+                    {value.label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent fitContent>
+          <TransferSizeTooltipContent
+            breakdownValues={breakdownValues}
+            transferSize={protocolData?.transferSize}
+          />
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}
+
+export function InteropTransferTypeBreakdown({
+  protocolData,
+}: {
+  protocolData: InteropProtocolDashboardData
+}) {
+  const byBridgeType = protocolData?.entry?.byBridgeType
+  const transferTypeBreakdownValues = Object.keys(byBridgeType ?? {}).flatMap(
+    (type) => {
+      const transferType = type as TransferType
+      const stats = byBridgeType?.[transferType]
+      if (!stats) return []
+      return {
+        value: stats.volume,
+        label: TRANSFER_TYPE_DISPLAY[transferType].label,
+        className: INTEROP_TYPE_TO_BG_COLOR[transferType],
+      }
+    },
+  )
+
+  return (
+    <div>
+      <span className="font-medium text-paragraph-12 text-secondary">
+        Transfer type distribution
+      </span>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="cursor-pointer">
+            <Breakdown
+              values={transferTypeBreakdownValues}
+              className="mt-2! h-1.5 w-full"
+            />
+            <div className="mt-2 flex flex-wrap gap-2">
+              {transferTypeBreakdownValues
+                .filter((value) => value.value > 0)
+                .map((value) => (
+                  <div
+                    key={value.label}
+                    className="flex items-center gap-[3px]"
+                  >
+                    <div className={`size-3.5 rounded-xs ${value.className}`} />
+                    <span className="font-medium text-label-value-12 text-secondary leading-none">
+                      {value.label}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent fitContent>
+          <TransferTypeTooltipContent values={transferTypeBreakdownValues} />
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  )
+}
+
+function TransferSizeTooltipContent({
+  breakdownValues,
+  transferSize,
+}: {
+  breakdownValues: { value: number; style: CSSProperties; label: string }[]
+  transferSize: TransferSizeDataPoint | undefined
+}) {
+  const totalTransfers = breakdownValues.reduce((sum, v) => sum + v.value, 0)
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-col gap-1.5">
+        <div className="flex items-center justify-between gap-x-6">
+          <span className="font-medium text-label-value-14">
+            Total identified transfers
+          </span>
+          <span className="font-medium text-label-value-15 text-primary tabular-nums">
+            {formatInteger(totalTransfers)} transfers
+          </span>
+        </div>
+        {breakdownValues.map((entry) => (
+          <div
+            key={entry.label}
+            className="flex items-center justify-between gap-x-6"
+          >
+            <div className="flex items-center gap-1">
+              <div className="size-3 rounded-xs" style={entry.style} />
+              <span className="font-medium text-label-value-14">
+                {entry.label}
+              </span>
+            </div>
+            <span className="font-medium text-label-value-15 text-primary tabular-nums">
+              {formatInteger(entry.value)} transfers
+            </span>
+          </div>
+        ))}
+      </div>
+      <HorizontalSeparator className="my-1.5" />
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between gap-x-6">
+          <span className="font-medium text-label-value-14">Min size</span>
+          <span className="font-medium text-label-value-15 text-primary tabular-nums">
+            {formatTransferSize(transferSize?.minTransferValueUsd)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-x-6">
+          <span className="font-medium text-label-value-14">Average size</span>
+          <span className="font-medium text-label-value-15 text-primary tabular-nums">
+            {formatTransferSize(transferSize?.averageTransferSizeUsd)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between gap-x-6">
+          <span className="font-medium text-label-value-14">Max size</span>
+          <span className="font-medium text-label-value-15 text-primary tabular-nums">
+            {formatTransferSize(transferSize?.maxTransferValueUsd)}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function formatTransferSize(value: number | undefined) {
+  return value !== undefined ? formatCurrency(value, 'usd') : EM_DASH
+}
+
+function TransferTypeTooltipContent({
+  values,
+}: {
+  values: { value: number; label: string; className: string }[]
+}) {
+  const totalVolume = values.reduce((sum, v) => sum + v.value, 0)
+
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center justify-between gap-x-6">
+        <span className="font-medium text-label-value-14">Total volume</span>
+        <span className="font-medium text-label-value-15 text-primary tabular-nums">
+          {formatCurrency(totalVolume, 'usd')}
+        </span>
+      </div>
+      {values.map((entry) => (
+        <div
+          key={entry.label}
+          className="flex items-center justify-between gap-x-6"
+        >
+          <div className="flex items-center gap-1">
+            <div className={`size-3 rounded-xs ${entry.className}`} />
+            <span className="font-medium text-label-value-14">
+              {entry.label}
+            </span>
+          </div>
+          <span className="font-medium text-label-value-15 text-primary tabular-nums">
+            {formatCurrency(entry.value, 'usd')}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/frontend/src/pages/interop/protocol/components/InteropSummaryParts.tsx
+++ b/packages/frontend/src/pages/interop/protocol/components/InteropSummaryParts.tsx
@@ -37,33 +37,33 @@ export function InteropSummaryStat({
 }
 
 export function InteropTransferSizeBreakdown({
-  protocolData,
+  transferSize,
 }: {
-  protocolData: InteropProtocolDashboardData
+  transferSize: TransferSizeDataPoint | undefined
 }) {
   const breakdownValues = [
     {
-      value: protocolData?.transferSize?.countUnder100 ?? 0,
+      value: transferSize?.countUnder100 ?? 0,
       label: transferSizeBuckets.under100.label,
       style: { backgroundColor: transferSizeBuckets.under100.color },
     },
     {
-      value: protocolData?.transferSize?.count100To1K ?? 0,
+      value: transferSize?.count100To1K ?? 0,
       label: transferSizeBuckets.from100To1K.label,
       style: { backgroundColor: transferSizeBuckets.from100To1K.color },
     },
     {
-      value: protocolData?.transferSize?.count1KTo10K ?? 0,
+      value: transferSize?.count1KTo10K ?? 0,
       label: transferSizeBuckets.from1KTo10K.label,
       style: { backgroundColor: transferSizeBuckets.from1KTo10K.color },
     },
     {
-      value: protocolData?.transferSize?.count10KTo100K ?? 0,
+      value: transferSize?.count10KTo100K ?? 0,
       label: transferSizeBuckets.from10KTo100K.label,
       style: { backgroundColor: transferSizeBuckets.from10KTo100K.color },
     },
     {
-      value: protocolData?.transferSize?.countOver100K ?? 0,
+      value: transferSize?.countOver100K ?? 0,
       label: transferSizeBuckets.over100K.label,
       style: { backgroundColor: transferSizeBuckets.over100K.color },
     },
@@ -72,7 +72,7 @@ export function InteropTransferSizeBreakdown({
   return (
     <div>
       <span className="font-medium text-paragraph-12 text-secondary">
-        Protocol transfer size
+        Transfer size
       </span>
       <Tooltip>
         <TooltipTrigger asChild>
@@ -96,7 +96,7 @@ export function InteropTransferSizeBreakdown({
         <TooltipContent fitContent>
           <TransferSizeTooltipContent
             breakdownValues={breakdownValues}
-            transferSize={protocolData?.transferSize}
+            transferSize={transferSize}
           />
         </TooltipContent>
       </Tooltip>

--- a/packages/frontend/src/pages/interop/protocol/getInteropProtocolPageData.ts
+++ b/packages/frontend/src/pages/interop/protocol/getInteropProtocolPageData.ts
@@ -23,7 +23,7 @@ export async function getInteropProtocolPageData(
         ttl: 5 * 60,
         staleWhileRevalidate: 25 * 60,
       },
-      () => getCachedData(req.params.slug, manifest),
+      () => getInteropProtocolViewData(req.params.slug, manifest),
     ),
   ])
 
@@ -53,7 +53,10 @@ export async function getInteropProtocolPageData(
   }
 }
 
-async function getCachedData(slug: string, manifest: Manifest) {
+export async function getInteropProtocolViewData(
+  slug: string,
+  manifest: Manifest,
+) {
   const interopChains = getInteropChains()
   const liveChainIds = interopChains
     .filter((chain) => !chain.isUpcoming)

--- a/packages/frontend/src/pages/scaling/project/components/ScalingProjectSummary.tsx
+++ b/packages/frontend/src/pages/scaling/project/components/ScalingProjectSummary.tsx
@@ -279,6 +279,7 @@ function InteropMetrics({
           </span>
         </div>
       </div>
+      <HorizontalSeparator />
       <div className="grid gap-x-10 gap-y-4 md:grid-cols-2">
         <InteropMetric
           title="Interop protocols used"

--- a/packages/frontend/src/pages/scaling/project/components/ScalingProjectSummary.tsx
+++ b/packages/frontend/src/pages/scaling/project/components/ScalingProjectSummary.tsx
@@ -27,6 +27,8 @@ import { RoundedWarningIcon } from '~/icons/RoundedWarning'
 import { InteropTopItems } from '~/pages/interop/components/top-items/TopItems'
 import type { ProjectScalingEntry } from '~/server/features/scaling/project/getScalingProjectEntry'
 import { cn } from '~/utils/cn'
+import { formatActivityCount } from '~/utils/number-format/formatActivityCount'
+import { formatCurrency } from '~/utils/number-format/formatCurrency'
 import { ProjectScalingRosette } from './ScalingProjectRosette'
 import { ProjectScalingStats } from './ScalingProjectStats'
 
@@ -258,31 +260,51 @@ function InteropMetrics({
   interop: NonNullable<ProjectScalingEntry['header']['interop']>
 }) {
   return (
-    <div className="grid gap-x-10 gap-y-4 md:grid-cols-2">
-      <InteropMetric
-        title="Interop protocols used"
-        items={{
-          items: interop.protocols.items.map((protocol) => ({
-            id: protocol.id,
-            displayName: protocol.name,
-            iconUrl: protocol.iconUrl,
-            volume: protocol.volume,
-          })),
-          remainingCount: interop.protocols.remainingCount,
-        }}
-      />
-      <InteropMetric
-        title="Tokens transferred"
-        items={{
-          items: interop.tokens.items.map((token) => ({
-            id: token.id,
-            displayName: token.symbol,
-            iconUrl: token.iconUrl,
-            volume: token.volume,
-          })),
-          remainingCount: interop.tokens.remainingCount,
-        }}
-      />
+    <div className="flex flex-col gap-4">
+      <div className="grid gap-x-10 gap-y-4 md:grid-cols-2">
+        <div className="flex max-md:items-center max-md:justify-between md:flex-col md:gap-1.5">
+          <span className="font-medium text-label-value-12 text-secondary">
+            Last 24h volume
+          </span>
+          <span className="font-bold text-label-value-16">
+            {formatCurrency(interop.volume, 'usd')}
+          </span>
+        </div>
+        <div className="flex max-md:items-center max-md:justify-between md:flex-col md:gap-1.5">
+          <span className="font-medium text-label-value-12 text-secondary">
+            Last 24h transfer count
+          </span>
+          <span className="font-bold text-label-value-16">
+            {formatActivityCount(interop.transferCount)}
+          </span>
+        </div>
+      </div>
+      <div className="grid gap-x-10 gap-y-4 md:grid-cols-2">
+        <InteropMetric
+          title="Interop protocols used"
+          items={{
+            items: interop.protocols.items.map((protocol) => ({
+              id: protocol.id,
+              displayName: protocol.name,
+              iconUrl: protocol.iconUrl,
+              volume: protocol.volume,
+            })),
+            remainingCount: interop.protocols.remainingCount,
+          }}
+        />
+        <InteropMetric
+          title="Tokens by volume"
+          items={{
+            items: interop.tokens.items.map((token) => ({
+              id: token.id,
+              displayName: token.symbol,
+              iconUrl: token.iconUrl,
+              volume: token.volume,
+            })),
+            remainingCount: interop.tokens.remainingCount,
+          }}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/frontend/src/server/features/projects/search-bar/utils/getSearchBarProjectEntries.ts
+++ b/packages/frontend/src/server/features/projects/search-bar/utils/getSearchBarProjectEntries.ts
@@ -123,7 +123,11 @@ export function getSearchBarProjectEntries<
     })
   }
 
-  if (project.interopConfig) {
+  // Projects that also have a chain (scaling) page are served as a single
+  // unified page, so we only emit a standalone interop entry for pure interop
+  // projects (e.g. LayerZero). Chain+bridge projects (e.g. Arbitrum) appear
+  // once via their scaling entry and expose the bridge via an on-page toggle.
+  if (project.interopConfig && !project.scalingInfo) {
     results.push({
       ...common,
       name: project.interopConfig.name ?? project.name,

--- a/packages/frontend/src/server/features/scaling/interop/getInteropProtocolTransfers.ts
+++ b/packages/frontend/src/server/features/scaling/interop/getInteropProtocolTransfers.ts
@@ -24,6 +24,7 @@ const UNKNOWN_TOKEN_SYMBOL = 'Unknown'
 
 export async function getInteropProtocolTransfers({
   id,
+  protocolIds,
   from,
   to,
   type,
@@ -43,22 +44,28 @@ export async function getInteropProtocolTransfers({
     return getMockInteropTransfers({ from, to })
   }
 
-  const interopProject = await ps.getProject({
-    id,
-    select: ['interopConfig'],
-  })
-  if (!interopProject?.interopConfig) {
+  // Either a single protocol (`id`) or a set of protocols (`protocolIds`).
+  const ids = id ? [id] : (protocolIds ?? [])
+  if (ids.length === 0) {
+    return { items: [], nextCursor: undefined }
+  }
+  const idSet = new Set(ids.map((value) => value.toString()))
+  const interopProjects = (
+    await ps.getProjects({ select: ['interopConfig'] })
+  ).filter((project) => idSet.has(project.id.toString()))
+  if (interopProjects.length === 0) {
     return {
       items: [],
       nextCursor: undefined,
     }
   }
 
+  const allPlugins = interopProjects.flatMap(
+    (project) => project.interopConfig.plugins,
+  )
   const plugins = type
-    ? interopProject.interopConfig.plugins.filter(
-        (plugin) => plugin.bridgeType === type,
-      )
-    : interopProject.interopConfig.plugins
+    ? allPlugins.filter((plugin) => plugin.bridgeType === type)
+    : allPlugins
   if (plugins.length === 0) {
     return {
       items: [],

--- a/packages/frontend/src/server/features/scaling/interop/getInteropSelectionDetails.ts
+++ b/packages/frontend/src/server/features/scaling/interop/getInteropSelectionDetails.ts
@@ -4,11 +4,14 @@ import type { InteropSelectionDetailsParams } from './types'
 import { getLatestAggregatedInteropTransferWithTokens } from './utils/getLatestAggregatedInteropTransferWithTokens'
 import {
   aggregateTransferSize,
+  aggregateTransferType,
   type TransferSizeDataPoint,
+  type TransferTypeDataPoint,
 } from './utils/getTransferSizeChartData'
 
 export interface InteropSelectionDetails {
   transferSize: TransferSizeDataPoint | undefined
+  transferType: TransferTypeDataPoint | undefined
   snapshotTimestamp: UnixTime | undefined
 }
 
@@ -24,7 +27,11 @@ export async function getInteropSelectionDetails(
     params.to.length === 0 ||
     params.protocolIds.length === 0
   ) {
-    return { transferSize: undefined, snapshotTimestamp: undefined }
+    return {
+      transferSize: undefined,
+      transferType: undefined,
+      snapshotTimestamp: undefined,
+    }
   }
 
   const { records, snapshotTimestamp } =
@@ -36,6 +43,7 @@ export async function getInteropSelectionDetails(
 
   return {
     transferSize: aggregateTransferSize(records),
+    transferType: aggregateTransferType(records),
     snapshotTimestamp,
   }
 }

--- a/packages/frontend/src/server/features/scaling/interop/getInteropSelectionDetails.ts
+++ b/packages/frontend/src/server/features/scaling/interop/getInteropSelectionDetails.ts
@@ -1,0 +1,41 @@
+import type { UnixTime } from '@l2beat/shared-pure'
+import { env } from '~/env'
+import type { InteropSelectionDetailsParams } from './types'
+import { getLatestAggregatedInteropTransferWithTokens } from './utils/getLatestAggregatedInteropTransferWithTokens'
+import {
+  aggregateTransferSize,
+  type TransferSizeDataPoint,
+} from './utils/getTransferSizeChartData'
+
+export interface InteropSelectionDetails {
+  transferSize: TransferSizeDataPoint | undefined
+  snapshotTimestamp: UnixTime | undefined
+}
+
+/** Selection-aware details (across the chosen protocols + chains) powering the
+ * always-visible bridge subsections: the aggregate transfer-size distribution
+ * and the snapshot timestamp used by the transfers table. */
+export async function getInteropSelectionDetails(
+  params: InteropSelectionDetailsParams,
+): Promise<InteropSelectionDetails> {
+  if (
+    env.MOCK ||
+    params.from.length === 0 ||
+    params.to.length === 0 ||
+    params.protocolIds.length === 0
+  ) {
+    return { transferSize: undefined, snapshotTimestamp: undefined }
+  }
+
+  const { records, snapshotTimestamp } =
+    await getLatestAggregatedInteropTransferWithTokens(
+      { from: params.from, to: params.to },
+      undefined,
+      params.protocolIds,
+    )
+
+  return {
+    transferSize: aggregateTransferSize(records),
+    snapshotTimestamp,
+  }
+}

--- a/packages/frontend/src/server/features/scaling/interop/getProjectInteropData.ts
+++ b/packages/frontend/src/server/features/scaling/interop/getProjectInteropData.ts
@@ -10,6 +10,8 @@ import { getInteropChains } from './utils/getInteropChains'
 
 export interface ProjectInteropData {
   chainId: string
+  /** This chain's own canonical bridge protocol id (its interopConfig), if it has one. */
+  canonicalProtocolId: string | undefined
   interopChains: InteropChainWithIcon[]
   protocols: {
     id: string
@@ -19,6 +21,8 @@ export interface ProjectInteropData {
   }[]
   defaultSelectedChains: string[]
   summary: {
+    volume: number
+    transferCount: number
     protocols: {
       items: {
         id: string
@@ -79,13 +83,21 @@ export async function getProjectInteropData(
   const currentChainData = interopFlows.chainData.find(
     (chain) => chain.chainId === currentInteropChain.id,
   )
+  const canonicalProtocolId = interopProjects.find(
+    (protocol) => protocol.id === projectId,
+  )?.id
 
   return {
     chainId: currentInteropChain.id,
+    canonicalProtocolId,
     interopChains: orderedInteropChains,
     protocols,
     defaultSelectedChains,
     summary: {
+      volume: currentChainData?.totalVolume ?? 0,
+      transferCount:
+        (currentChainData?.transfersIn ?? 0) +
+        (currentChainData?.transfersOut ?? 0),
       protocols: {
         items: (currentChainData?.topProtocols ?? []).map((protocol) => ({
           id: protocol.id,

--- a/packages/frontend/src/server/features/scaling/interop/protocol/getInteropProtocolEntry.ts
+++ b/packages/frontend/src/server/features/scaling/interop/protocol/getInteropProtocolEntry.ts
@@ -103,7 +103,6 @@ export async function getInteropProtocolEntry(
         projectId: project.id,
         title: 'Top tokens by volume',
         apiSelection,
-        data,
       },
     })
 
@@ -114,7 +113,7 @@ export async function getInteropProtocolEntry(
         projectId: project.id,
         title: 'Transfers',
         apiSelection,
-        data,
+        snapshotTimestamp: data.entry?.snapshotTimestamp,
         interopChains: sortedChains,
       },
     })

--- a/packages/frontend/src/server/features/scaling/interop/types.ts
+++ b/packages/frontend/src/server/features/scaling/interop/types.ts
@@ -87,6 +87,14 @@ export const InteropProtocolParams = v.object({
   ...InteropSelectionInputShape,
 })
 
+export type InteropSelectionDetailsParams = v.infer<
+  typeof InteropSelectionDetailsParams
+>
+export const InteropSelectionDetailsParams = v.object({
+  ...InteropSelectionInputShape,
+  protocolIds: v.array(v.string()),
+})
+
 export type InteropTokenParams = v.infer<typeof InteropTokenParams>
 export const InteropTokenParams = v.object({
   tokenId: v.string(),
@@ -144,7 +152,11 @@ export const InteropProtocolTransfersCursor = v.object({
   transferId: v.string(),
 })
 export const InteropProtocolTransfersParams = v.object({
-  id: v.string().transform((value) => ProjectId(value)),
+  id: v
+    .string()
+    .transform((value) => ProjectId(value))
+    .optional(),
+  protocolIds: v.array(v.string()).optional(),
   ...InteropSelectionInputShape,
   type: KnownInteropBridgeType.optional(),
   tokenId: v.string().optional(),

--- a/packages/frontend/src/server/features/scaling/interop/utils/getTransferSizeChartData.ts
+++ b/packages/frontend/src/server/features/scaling/interop/utils/getTransferSizeChartData.ts
@@ -27,6 +27,69 @@ type TransferSizeDataPointAccumulated = TransferSizeDataPoint & {
   identifiedCount: number
 }
 
+/** Single transfer-size distribution aggregated across all given records
+ * (regardless of protocol), for a chain/protocol selection. */
+export function aggregateTransferSize(
+  records: AggregatedInteropTransferRecord[],
+): TransferSizeDataPoint | undefined {
+  if (records.length === 0) return undefined
+
+  let countUnder100 = 0
+  let count100To1K = 0
+  let count1KTo10K = 0
+  let count10KTo100K = 0
+  let countOver100K = 0
+  let minTransferValueUsd: number | undefined
+  let maxTransferValueUsd: number | undefined
+  let totalValueUsd = 0
+  let identifiedCount = 0
+
+  for (const record of records) {
+    countUnder100 += record.countUnder100
+    count100To1K += record.count100To1K
+    count1KTo10K += record.count1KTo10K
+    count10KTo100K += record.count10KTo100K
+    countOver100K += record.countOver100K
+    if (record.minTransferValueUsd !== undefined) {
+      minTransferValueUsd =
+        minTransferValueUsd !== undefined
+          ? Math.min(minTransferValueUsd, record.minTransferValueUsd)
+          : record.minTransferValueUsd
+    }
+    if (record.maxTransferValueUsd !== undefined) {
+      maxTransferValueUsd =
+        maxTransferValueUsd !== undefined
+          ? Math.max(maxTransferValueUsd, record.maxTransferValueUsd)
+          : record.maxTransferValueUsd
+    }
+    totalValueUsd += getInteropTransferValue(record) ?? 0
+    identifiedCount += record.identifiedCount
+  }
+
+  const total =
+    countUnder100 + count100To1K + count1KTo10K + count10KTo100K + countOver100K
+  if (total === 0) return undefined
+
+  return {
+    name: '',
+    iconUrl: '',
+    countUnder100,
+    percentageUnder100: round((countUnder100 / total) * 100, 2),
+    count100To1K,
+    percentage100To1K: round((count100To1K / total) * 100, 2),
+    count1KTo10K,
+    percentage1KTo10K: round((count1KTo10K / total) * 100, 2),
+    count10KTo100K,
+    percentage10KTo100K: round((count10KTo100K / total) * 100, 2),
+    countOver100K,
+    percentageOver100K: round((countOver100K / total) * 100, 2),
+    minTransferValueUsd,
+    maxTransferValueUsd,
+    averageTransferSizeUsd:
+      identifiedCount > 0 ? totalValueUsd / identifiedCount : undefined,
+  }
+}
+
 export function getTransferSizeChartData(
   records: AggregatedInteropTransferRecord[],
   interopProjects: Project<'interopConfig'>[],

--- a/packages/frontend/src/server/features/scaling/interop/utils/getTransferSizeChartData.ts
+++ b/packages/frontend/src/server/features/scaling/interop/utils/getTransferSizeChartData.ts
@@ -1,6 +1,10 @@
 import type { Project } from '@l2beat/config'
 import type { AggregatedInteropTransferRecord } from '@l2beat/database'
-import { assert, getInteropTransferValue } from '@l2beat/shared-pure'
+import {
+  assert,
+  getInteropTransferValue,
+  type InteropBridgeType,
+} from '@l2beat/shared-pure'
 import round from 'lodash/round'
 import { manifest } from '~/utils/Manifest'
 
@@ -88,6 +92,28 @@ export function aggregateTransferSize(
     averageTransferSizeUsd:
       identifiedCount > 0 ? totalValueUsd / identifiedCount : undefined,
   }
+}
+
+/** Volume per bridge type, keyed by the record's `bridgeType`. */
+export type TransferTypeDataPoint = Partial<Record<InteropBridgeType, number>>
+
+/** Single transfer-type (bridge type) volume distribution aggregated across all
+ * given records, for a chain/protocol selection. */
+export function aggregateTransferType(
+  records: AggregatedInteropTransferRecord[],
+): TransferTypeDataPoint | undefined {
+  if (records.length === 0) return undefined
+
+  const byType: TransferTypeDataPoint = {}
+  let total = 0
+  for (const record of records) {
+    const value = getInteropTransferValue(record) ?? 0
+    byType[record.bridgeType] = (byType[record.bridgeType] ?? 0) + value
+    total += value
+  }
+
+  if (total === 0) return undefined
+  return byType
 }
 
 export function getTransferSizeChartData(

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -407,6 +407,7 @@ export async function getScalingProjectEntry(
         protocols: interopData.protocols,
         defaultSelectedChains: interopData.defaultSelectedChains,
         defaultStatsChainId: interopData.chainId,
+        canonicalProtocolId: interopData.canonicalProtocolId,
       },
     })
   }

--- a/packages/frontend/src/server/trpc/routers/interop.ts
+++ b/packages/frontend/src/server/trpc/routers/interop.ts
@@ -2,6 +2,7 @@ import { getInteropDashboardData } from '~/server/features/scaling/interop/getIn
 import { getInteropFlows } from '~/server/features/scaling/interop/getInteropFlows'
 import { getInteropProtocolData } from '~/server/features/scaling/interop/getInteropProtocolData'
 import { getInteropProtocolTransfers } from '~/server/features/scaling/interop/getInteropProtocolTransfers'
+import { getInteropSelectionDetails } from '~/server/features/scaling/interop/getInteropSelectionDetails'
 import { getInteropTokenData } from '~/server/features/scaling/interop/getInteropTokenData'
 import { getInteropTokensInfinite } from '~/server/features/scaling/interop/getInteropTokens'
 import { getInteropTokensPairsInfinite } from '~/server/features/scaling/interop/getInteropTokensPairs'
@@ -12,6 +13,7 @@ import {
   InteropFlowsParams,
   InteropProtocolParams,
   InteropProtocolTransfersParams,
+  InteropSelectionDetailsParams,
   InteropSelectionInput,
   InteropTokenParams,
   InteropTokenTransfersParams,
@@ -26,6 +28,9 @@ export const interopRouter = router({
   protocol: procedure
     .input(InteropProtocolParams)
     .query(({ input }) => getInteropProtocolData(input)),
+  selectionDetails: procedure
+    .input(InteropSelectionDetailsParams)
+    .query(({ input }) => getInteropSelectionDetails(input)),
   tokenDashboard: procedure
     .input(InteropTokenParams)
     .query(({ input }) => getInteropTokenData(input)),

--- a/packages/frontend/src/server/trpc/routers/interop.ts
+++ b/packages/frontend/src/server/trpc/routers/interop.ts
@@ -1,5 +1,6 @@
 import { getInteropDashboardData } from '~/server/features/scaling/interop/getInteropDashboardData'
 import { getInteropFlows } from '~/server/features/scaling/interop/getInteropFlows'
+import { getInteropProtocolData } from '~/server/features/scaling/interop/getInteropProtocolData'
 import { getInteropProtocolTransfers } from '~/server/features/scaling/interop/getInteropProtocolTransfers'
 import { getInteropTokenData } from '~/server/features/scaling/interop/getInteropTokenData'
 import { getInteropTokensInfinite } from '~/server/features/scaling/interop/getInteropTokens'
@@ -9,6 +10,7 @@ import { getTokenFrameworksData } from '~/server/features/scaling/interop/getTok
 import {
   InteropDashboardParams,
   InteropFlowsParams,
+  InteropProtocolParams,
   InteropProtocolTransfersParams,
   InteropSelectionInput,
   InteropTokenParams,
@@ -21,6 +23,9 @@ export const interopRouter = router({
   dashboard: procedure
     .input(InteropDashboardParams)
     .query(({ input }) => getInteropDashboardData(input)),
+  protocol: procedure
+    .input(InteropProtocolParams)
+    .query(({ input }) => getInteropProtocolData(input)),
   tokenDashboard: procedure
     .input(InteropTokenParams)
     .query(({ input }) => getInteropTokenData(input)),


### PR DESCRIPTION
Chains that also have an interop configused to appear twice, including duplicate search results. These are now a single page.
  
  What changed:
  - The separate bridge page now redirects to the chain page, and only one entry shows in search.
  - Bridge data lives in the "Volume and flows" section. Added a protocols selector (like the Summary page) so you can filter which bridges are included.
  - Quick "Canonical bridge" shortcut; its URL is shareable
  - Bridge details under the flows: Top tokens, Transfers, and a transfer-size breakdown are shown for the current protocol + chain selection
  - Summary on top keeps the chain stats plus key interop stats (24h volume, transfers, tokens by volume).
  
  Part of L2B-14064