### PR TITLE
Add Ethplorer and Worldplorer explorer links

### DIFF
--- a/packages/config/src/projects/ethereum/ethereum.ts
+++ b/packages/config/src/projects/ethereum/ethereum.ts
@@ -37,6 +37,7 @@ export const ethereum: BaseProject = {
       ],
       explorers: [
         'https://etherscan.io/',
+        'https://ethplorer.io/',
         'https://eth.blockscout.com/',
         'https://beaconcha.in/',
       ],

--- a/packages/config/src/projects/worldchain/worldchain.ts
+++ b/packages/config/src/projects/worldchain/worldchain.ts
@@ -34,6 +34,7 @@ export const worldchain = opStackL2({
       explorers: [
         'https://worldscan.org',
         'https://worldchain-mainnet.explorer.alchemy.com/',
+        'https://worldplorer.com/',
       ],
       repositories: ['https://github.com/worldcoin'],
       socialMedia: [


### PR DESCRIPTION
Description:
This PR adds two blockchain explorer links to existing L2BEAT project configurations:

Ethereum DA project: adds Ethplorer - https://ethplorer.io/
World Chain scaling project: adds Worldplorer - https://worldplorer.com/
Both links are added to the existing display.links.explorers arrays, following the same pattern already used for Blastplorer on Blast and Lineaplorer on Linea.

No project metadata, risk parameters, tokens, milestones, or research sections are changed