### PR TITLE
Show initial bond for AggregateProof OP Stack chains (Base)

### DIFF
--- a/packages/config/src/templates/opStack.ts
+++ b/packages/config/src/templates/opStack.ts
@@ -1506,6 +1506,14 @@ function getRiskViewStateValidation(
         ...RISK_VIEW.STATE_FP_HYBRID_ZK,
         executionDelay: getExecutionDelay(templateVars),
         challengeDelay: getChallengePeriod(templateVars),
+        initialBond: {
+          value: formatEther(
+            templateVars.discovery.getContractValue<number>(
+              'DisputeGameFactory',
+              'initBondGame621',
+            ),
+          ),
+        },
         permissioned: false,
         defenderAdvantage: 'not-assessed',
       }


### PR DESCRIPTION
## Summary
The `AggregateProof` case in `getRiskViewStateValidation` [was missing](https://l2beat.com/scaling/risk/state-validation?tab=optimistic) the `initialBond` field, so Base (respectedGameType 621) rendered "N/A" in the State Validation table. Wired it up to `DisputeGameFactory.initBondGame621`, matching the pattern used by the neighboring `OpSuccinctFDP` and `Kailua` cases.

## Test plan
- [x] Verify the State Validation page shows the bond value (0.05 ETH) for Base