### PR TITLE
Extend chart time range display by one bucket for aggregated charts

### DIFF
--- a/packages/frontend/src/components/chart/activity/EthereumActivityChart.tsx
+++ b/packages/frontend/src/components/chart/activity/EthereumActivityChart.tsx
@@ -74,7 +74,7 @@ export function EthereumActivityChart({
     }))
   }, [chart?.data])
 
-  const timeRange = getChartTimeRangeFromData(chartData)
+  const timeRange = getChartTimeRangeFromData(chartData, { bucket: 'day' })
   const lastRatio = ratioData?.at(-1)?.ratio
   return (
     <div className="flex flex-col">

--- a/packages/frontend/src/components/chart/activity/ProjectActivityChart.tsx
+++ b/packages/frontend/src/components/chart/activity/ProjectActivityChart.tsx
@@ -83,7 +83,7 @@ export function ProjectActivityChart({
     }))
   }, [chart?.data])
 
-  const timeRange = getChartTimeRangeFromData(chartData)
+  const timeRange = getChartTimeRangeFromData(chartData, { bucket: 'day' })
   const lastRatio = ratioData?.at(-1)?.ratio
   return (
     <div className="flex flex-col">

--- a/packages/frontend/src/components/chart/activity/ScalingActivityChart.tsx
+++ b/packages/frontend/src/components/chart/activity/ScalingActivityChart.tsx
@@ -51,6 +51,7 @@ export function ScalingActivityChart({ milestones, entries }: Props) {
     () =>
       getChartTimeRangeFromData(
         data?.data.map(([timestamp, ..._]) => ({ timestamp })),
+        { bucket: 'day' },
       ),
     [data?.data],
   )

--- a/packages/frontend/src/components/chart/costs/ProjectCostsChart.tsx
+++ b/packages/frontend/src/components/chart/costs/ProjectCostsChart.tsx
@@ -9,7 +9,7 @@ import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
 import { Skeleton } from '~/components/core/Skeleton'
 import type { CostsUnit } from '~/server/features/scaling/costs/types'
 import { useTRPC } from '~/trpc/React'
-import type { ChartRange } from '~/utils/range/range'
+import { type ChartRange, rangeToResolution } from '~/utils/range/range'
 import { CostsChart } from './CostsChart'
 import { CostsChartRangeControls } from './CostsChartRangeControls'
 import { ProjectCostsChartStats } from './ProjectCostsChartStats'
@@ -93,8 +93,11 @@ export function ProjectCostsChart({
   }, [data, unit])
 
   const timeRange = useMemo(
-    () => getChartTimeRangeFromData(chartData),
-    [chartData],
+    () =>
+      getChartTimeRangeFromData(chartData, {
+        bucket: rangeToResolution(range),
+      }),
+    [chartData, range],
   )
 
   return (

--- a/packages/frontend/src/components/chart/costs/ScalingCostsChart.tsx
+++ b/packages/frontend/src/components/chart/costs/ScalingCostsChart.tsx
@@ -15,7 +15,7 @@ import type { ScalingCostsEntry } from '~/server/features/scaling/costs/getScali
 import type { CostsUnit } from '~/server/features/scaling/costs/types'
 import type { CostsProjectsFilter } from '~/server/features/scaling/costs/utils/getCostsProjects'
 import { useTRPC } from '~/trpc/React'
-import { optionToRange } from '~/utils/range/range'
+import { optionToRange, rangeToResolution } from '~/utils/range/range'
 import { rangeToDays } from '~/utils/range/rangeToDays'
 import { ChartControlsWrapper } from '../../core/chart/ChartControlsWrapper'
 import { ChartTimeRange } from '../../core/chart/ChartTimeRange'
@@ -113,8 +113,11 @@ export function ScalingCostsChart({ tab, milestones, entries }: Props) {
   }, [data, unit])
 
   const timeRange = useMemo(
-    () => getChartTimeRangeFromData(chartData),
-    [chartData],
+    () =>
+      getChartTimeRangeFromData(chartData, {
+        bucket: rangeToResolution(range),
+      }),
+    [chartData, range],
   )
 
   return (

--- a/packages/frontend/src/components/chart/data-availability/DaThroughputChart.tsx
+++ b/packages/frontend/src/components/chart/data-availability/DaThroughputChart.tsx
@@ -29,15 +29,15 @@ export function DaThroughputChart() {
     }),
   )
 
+  const resolution = rangeToResolution(range)
   const timeRange = useMemo(
     () =>
       getChartTimeRangeFromData(
         chartData?.data.map(([timestamp]) => ({ timestamp })),
+        { bucket: resolution },
       ),
-    [chartData],
+    [chartData, resolution],
   )
-
-  const resolution = rangeToResolution(range)
 
   return (
     <div>

--- a/packages/frontend/src/components/chart/data-availability/ThroughputSectionChart.tsx
+++ b/packages/frontend/src/components/chart/data-availability/ThroughputSectionChart.tsx
@@ -49,21 +49,22 @@ export function ThroughputSectionChart({
     }),
   )
 
+  const resolution = useMemo(() => rangeToResolution(range), [range])
+
   const dataWithConfiguredThroughputs = getDataWithConfiguredThroughputs(
     data?.totalChart.data,
     configuredThroughputs,
-    rangeToResolution(range),
+    resolution,
   )
 
   const timeRange = useMemo(
     () =>
       getChartTimeRangeFromData(
         data?.totalChart.data.map(([timestamp]) => ({ timestamp })),
+        { bucket: resolution },
       ),
-    [data],
+    [data, resolution],
   )
-
-  const resolution = useMemo(() => rangeToResolution(range), [range])
 
   return (
     <div>

--- a/packages/frontend/src/components/chart/data-posted/ProjectDataPostedChart.tsx
+++ b/packages/frontend/src/components/chart/data-posted/ProjectDataPostedChart.tsx
@@ -47,7 +47,8 @@ export function ProjectDataPostedChart({
     [data],
   )
 
-  const timeRange = getChartTimeRangeFromData(chartData)
+  const resolution = rangeToResolution(range)
+  const timeRange = getChartTimeRangeFromData(chartData, { bucket: resolution })
 
   return (
     <div className="flex flex-col">
@@ -58,7 +59,7 @@ export function ProjectDataPostedChart({
       <div className="mt-4">
         <DataPostedChart
           milestones={milestones}
-          resolution={rangeToResolution(range)}
+          resolution={resolution}
           data={chartData}
           syncedUntil={data?.syncedUntil}
           isLoading={isLoading}

--- a/packages/frontend/src/components/chart/liveness/ProjectLivenessChart.tsx
+++ b/packages/frontend/src/components/chart/liveness/ProjectLivenessChart.tsx
@@ -73,7 +73,8 @@ export function ProjectLivenessChart({
     return lastValidTimestamp
   }, [chart?.data])
 
-  const timeRange = getChartTimeRangeFromData(chartData)
+  const resolution = rangeToResolution(range)
+  const timeRange = getChartTimeRangeFromData(chartData, { bucket: resolution })
 
   return (
     <div className="flex flex-col">
@@ -104,7 +105,7 @@ export function ProjectLivenessChart({
           milestones={milestones}
           lastValidTimestamp={lastValidTimestamp}
           anyAnomalyLive={anyAnomalyLive}
-          resolution={rangeToResolution(range)}
+          resolution={resolution}
           tickCount={4}
         />
       </div>

--- a/packages/frontend/src/components/core/chart/utils/getChartTimeRangeFromData.ts
+++ b/packages/frontend/src/components/core/chart/utils/getChartTimeRangeFromData.ts
@@ -1,5 +1,17 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { ChartResolution } from '~/utils/range/range'
+
 export function getChartTimeRangeFromData<T extends { timestamp: number }>(
   data: T[] | undefined,
+  opts?: {
+    /**
+     * Set when the data timestamps are buckets/aggregates of this size. A
+     * bucket at timestamp `t` covers `[t, t + bucket)`, so the range end is
+     * extended by one bucket. Omit for point-in-time data (e.g. TVS) that must
+     * not be extended.
+     */
+    bucket?: ChartResolution
+  },
 ): [number, number] | undefined {
   if (!data) {
     return
@@ -12,5 +24,6 @@ export function getChartTimeRangeFromData<T extends { timestamp: number }>(
     return
   }
 
-  return [start, end]
+  const endOffset = opts?.bucket ? UnixTime.periodToSeconds(opts.bucket) : 0
+  return [start, end + endOffset]
 }

--- a/packages/frontend/src/components/projects/sections/privacy/PrivacyFlowsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/privacy/PrivacyFlowsSection.tsx
@@ -41,6 +41,9 @@ export function PrivacyFlowsSection({
     () =>
       getChartTimeRangeFromData(
         data?.chart.map(([timestamp]) => ({ timestamp })),
+        {
+          bucket: 'day',
+        },
       ),
     [data],
   )

--- a/packages/frontend/src/pages/ecosystems/project/components/charts/EcosystemsActivityChart.tsx
+++ b/packages/frontend/src/pages/ecosystems/project/components/charts/EcosystemsActivityChart.tsx
@@ -107,7 +107,7 @@ export function EcosystemsActivityChart({
   )
 
   const stats = getStats(chartData, allScalingProjectsUops)
-  const timeRange = getChartTimeRangeFromData(chartData)
+  const timeRange = getChartTimeRangeFromData(chartData, { bucket: 'day' })
 
   return (
     <EcosystemWidget className={className}>

--- a/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryChartsSection.tsx
+++ b/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryChartsSection.tsx
@@ -32,6 +32,7 @@ export function PrivacySummaryChartsSection({ projects, defaultRange }: Props) {
     () =>
       getChartTimeRangeFromData(
         flowsData?.chart.map(([timestamp]) => ({ timestamp })),
+        { bucket: 'day' },
       ),
     [flowsData],
   )

--- a/packages/frontend/src/pages/publications/monthly-updates/components/charts/MonthlyUpdateActivityChart.tsx
+++ b/packages/frontend/src/pages/publications/monthly-updates/components/charts/MonthlyUpdateActivityChart.tsx
@@ -76,7 +76,7 @@ export function MonthlyUpdateActivityChart({
   )
 
   const stats = getStats(chartData, allScalingProjectsUops)
-  const timeRange = getChartTimeRangeFromData(chartData)
+  const timeRange = getChartTimeRangeFromData(chartData, { bucket: 'day' })
 
   return (
     <PrimaryCard className="rounded-lg! border border-divider">

--- a/packages/frontend/src/pages/publications/monthly-updates/components/charts/MonthlyUpdateThroughputChart.tsx
+++ b/packages/frontend/src/pages/publications/monthly-updates/components/charts/MonthlyUpdateThroughputChart.tsx
@@ -73,7 +73,9 @@ export function MonthlyUpdateThroughputChart({
     })
   }, [data?.chart, denominator])
 
-  const timeRange = getChartTimeRangeFromData(chartData)
+  const timeRange = getChartTimeRangeFromData(chartData, {
+    bucket: rangeToResolution([from, to]),
+  })
 
   return (
     <PrimaryCard className="rounded-lg! border border-divider">


### PR DESCRIPTION
## What

`getChartTimeRangeFromData` now takes an optional `bucket` resolution. When set, the displayed range end is extended by one bucket, since a bucket at timestamp `t` covers `[t, t + bucket)` — e.g. a daily point at `Jun 7 00:00` covers all of Jun 7, so the header reads through `Jun 8`.

The `periodToSeconds` conversion now lives inside the util instead of being hardcoded at every call site.

## Behavior

- **Bucketed charts** pass their resolution: costs, data posted, throughput, liveness (`rangeToResolution(range)`); activity and privacy flows (`'day'`, since their backends always bucket daily).
- **Point-in-time snapshots** (TVS/TVL, ecosystem project counts) omit `bucket` and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)