### PR TITLE
Fix OP Mainnet canonical bridge interop transfer time split

### DIFF
--- a/packages/config/src/projects/optimism/optimism.ts
+++ b/packages/config/src/projects/optimism/optimism.ts
@@ -69,6 +69,7 @@ export const optimism: ScalingProject = opStackL2({
             'maker-bridge.L1ToL2Transfer',
             'sorare-base.L1ToL2Transfer',
             'lido-wsteth.L1ToL2Transfer',
+            'synthetix-bridge.L1ToL2Transfer',
           ],
         },
         {
@@ -78,6 +79,31 @@ export const optimism: ScalingProject = opStackL2({
             'opstack-standardbridge.L2ToL1Transfer',
             'maker-bridge.L2ToL1Transfer',
             'lido-wsteth.L2ToL1Transfer',
+            'synthetix-bridge.L2ToL1Transfer',
+          ],
+        },
+      ],
+      burnAndMint: [
+        {
+          label: 'L1 -> L2',
+          transferTypes: [
+            'opstack.L1ToL2Transfer',
+            'opstack-standardbridge.L1ToL2Transfer',
+            'beefy-bridge.L1ToL2Transfer',
+            'maker-bridge.L1ToL2Transfer',
+            'sorare-base.L1ToL2Transfer',
+            'lido-wsteth.L1ToL2Transfer',
+            'synthetix-bridge.L1ToL2Transfer',
+          ],
+        },
+        {
+          label: 'L2 -> L1',
+          transferTypes: [
+            'opstack.L2ToL1Transfer',
+            'opstack-standardbridge.L2ToL1Transfer',
+            'maker-bridge.L2ToL1Transfer',
+            'lido-wsteth.L2ToL1Transfer',
+            'synthetix-bridge.L2ToL1Transfer',
           ],
         },
       ],


### PR DESCRIPTION
OP Mainnet's interop page showed a single average transfer time instead of the `L1 -> L2` / `L2 -> L1` split that Base shows. The cause: OP's `interopConfig` has a `burnAndMint` plugin (synthetix-bridge) on top of its `lockAndMint` plugins, but `durationSplit` only defined a `lockAndMint` entry, so `getDurationSplit` bailed out (it requires every relevant bridge type to have a matching split) and fell back to a meaningless single average. This adds a `burnAndMint` entry mirroring `lockAndMint` and includes the synthetix-bridge transfer types in both, so the protocol page renders the directional split correctly.