### PR TITLE
Fixes around node layout in DiscoUI

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/controls/ClusterLayoutButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/controls/ClusterLayoutButton.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react'
 import { cn } from '../../../../utils/cn'
 import type { Node } from '../store/State'
 import { useStore } from '../store/store'
+import { centerLocationsInViewport } from '../store/utils/centerLocationsInViewport'
 import type { NodeLocations } from '../store/utils/storage'
 import { ControlButton } from './ControlButton'
 import { IconControlCluster } from './icons/IconControlCluster'
@@ -46,10 +47,13 @@ export function ClusterLayoutButton({ className }: { className?: string }) {
       selected.length === 0,
     )
 
+    // NaN tells d3 to assign its deterministic phyllotaxis seed. Seeding
+    // from current positions makes repeated presses non-idempotent:
+    // disconnected components repel each other further on every run.
     const simNodes: SimulationNode[] = simulationNodes.map((node) => ({
       id: node.id,
-      x: node.box.x / SIM_SCALE,
-      y: node.box.y / SIM_SCALE,
+      x: Number.NaN,
+      y: Number.NaN,
       node,
     }))
 
@@ -84,11 +88,23 @@ export function ClusterLayoutButton({ className }: { className?: string }) {
 
       simNodes.forEach((simNode) => {
         nodeLocations[simNode.id] = {
-          x: (simNode.x - minY) * SIM_SCALE + left,
-          y: (simNode.y - minX) * SIM_SCALE + top,
+          x: (simNode.x - minX) * SIM_SCALE + left,
+          y: (simNode.y - minY) * SIM_SCALE + top,
         }
       })
-      layout(nodeLocations)
+      if (selected.length === 0) {
+        const { transform, viewportContainer } = useStore.getState()
+        layout(
+          centerLocationsInViewport(
+            nodeLocations,
+            simulationNodes,
+            transform,
+            viewportContainer,
+          ),
+        )
+      } else {
+        layout(nodeLocations)
+      }
       simulation.stop()
       setUpdatingLayout(false)
     }

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/controls/StackLayoutButton.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/controls/StackLayoutButton.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import type { Node } from '../store/State'
 import { useStore } from '../store/store'
+import { centerLocationsInViewport } from '../store/utils/centerLocationsInViewport'
 import type { NodeLocations } from '../store/utils/storage'
 import { ControlButton } from './ControlButton'
 import { IconControlStack } from './icons/IconControlStack'
@@ -19,7 +20,19 @@ export function StackLayoutButton({ className }: { className?: string }) {
 
   return (
     <ControlButton
-      onClick={() => layout(stackAutoLayout(visibleNodes, considerAllNodes))}
+      onClick={() => {
+        let locations = stackAutoLayout(visibleNodes, considerAllNodes)
+        if (considerAllNodes) {
+          const { transform, viewportContainer } = useStore.getState()
+          locations = centerLocationsInViewport(
+            locations,
+            visibleNodes,
+            transform,
+            viewportContainer,
+          )
+        }
+        layout(locations)
+      }}
       className={clsx('px-3 py-2.5', className)}
     >
       <span className="flex items-center justify-center gap-2 text-center text-coffee-100">

--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/centerLocationsInViewport.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/store/utils/centerLocationsInViewport.ts
@@ -1,0 +1,49 @@
+import type { Node, State } from '../State'
+import type { NodeLocations } from './storage'
+
+// Translates a computed layout as a whole so its bounding box is centered
+// in the part of the canvas the user is currently looking at. World (0,0)
+// is only on screen until the user pans or zooms, so layouts anchored
+// there would land outside the viewport.
+export function centerLocationsInViewport(
+  locations: NodeLocations,
+  nodes: readonly Node[],
+  transform: State['transform'],
+  viewportContainer: HTMLElement | undefined,
+): NodeLocations {
+  if (!viewportContainer) {
+    return locations
+  }
+
+  let minX = Number.POSITIVE_INFINITY
+  let minY = Number.POSITIVE_INFINITY
+  let maxX = Number.NEGATIVE_INFINITY
+  let maxY = Number.NEGATIVE_INFINITY
+  for (const node of nodes) {
+    const location = locations[node.id]
+    if (!location) {
+      continue
+    }
+    minX = Math.min(minX, location.x)
+    minY = Math.min(minY, location.y)
+    maxX = Math.max(maxX, location.x + node.box.width)
+    maxY = Math.max(maxY, location.y + node.box.height)
+  }
+  if (minX > maxX) {
+    return locations
+  }
+
+  const rect = viewportContainer.getBoundingClientRect()
+  const { offsetX, offsetY, scale } = transform
+  const viewportCenterWorldX = (rect.width / 2 - offsetX) / scale
+  const viewportCenterWorldY = (rect.height / 2 - offsetY) / scale
+
+  const deltaX = viewportCenterWorldX - (minX + maxX) / 2
+  const deltaY = viewportCenterWorldY - (minY + maxY) / 2
+
+  const centered: NodeLocations = {}
+  for (const [id, location] of Object.entries(locations)) {
+    centered[id] = { x: location.x + deltaX, y: location.y + deltaY }
+  }
+  return centered
+}


### PR DESCRIPTION
- Cluster layout is now deterministic
- Typo fix in cluster layout
- Try to center the layout in the viewport. This helps with cases where after pressing the layout button the viewport becomes empty and most of the nodes are "somewhere"