### PR TITLE
token-ui: add search to history page

### DIFF
--- a/packages/database/src/repositories/TokenDbHistoryRepository.test.ts
+++ b/packages/database/src/repositories/TokenDbHistoryRepository.test.ts
@@ -115,6 +115,50 @@ describeTokenDatabase(TokenDbHistoryRepository.name, (db) => {
       expect(page.totalCount).toEqual(3)
       expect(page.entries.map((e) => e.userEmail)).toEqual(['second@x.io'])
     })
+
+    it('filters entries by token data in the command via search', async () => {
+      await repository.insert(manualAddDeployed(UnixTime(1000), 'first@x.io'))
+      await repository.insert({
+        timestamp: UnixTime(2000),
+        source: 'manual',
+        userEmail: 'second@x.io',
+        commandType: 'AddDeployedTokenCommand',
+        command: {
+          type: 'AddDeployedTokenCommand',
+          record: {
+            chain: 'arbitrum',
+            address: '0x0000000000000000000000000000000000000bbb',
+            symbol: 'DAI',
+            abstractTokenId: 'DAI01',
+          },
+        },
+        ingestionLog: null,
+      })
+
+      const bySymbol = await repository.getPage({
+        offset: 0,
+        limit: 100,
+        search: 'dai',
+      })
+      expect(bySymbol.totalCount).toEqual(1)
+      expect(bySymbol.entries.map((e) => e.userEmail)).toEqual(['second@x.io'])
+
+      const byChain = await repository.getPage({
+        offset: 0,
+        limit: 100,
+        search: 'ethereum',
+      })
+      expect(byChain.totalCount).toEqual(1)
+      expect(byChain.entries.map((e) => e.userEmail)).toEqual(['first@x.io'])
+
+      const noMatch = await repository.getPage({
+        offset: 0,
+        limit: 100,
+        search: 'nonexistent',
+      })
+      expect(noMatch.totalCount).toEqual(0)
+      expect(noMatch.entries).toEqual([])
+    })
   })
 })
 

--- a/packages/database/src/repositories/TokenDbHistoryRepository.ts
+++ b/packages/database/src/repositories/TokenDbHistoryRepository.ts
@@ -2,6 +2,7 @@ import { UnixTime } from '@l2beat/shared-pure'
 import { type Insertable, type Selectable, sql } from 'kysely'
 import { BaseRepository } from '../BaseRepository'
 import type { TokenDbHistory } from '../kysely/generated/types'
+import { escapeLikePattern } from '../utils/escapeLikePattern'
 import { toJsonSafe } from '../utils/toJsonSafe'
 
 export type TokenDbHistorySource = 'manual' | 'ingestion'
@@ -69,9 +70,7 @@ export class TokenDbHistoryRepository extends BaseRepository {
     search?: string
   }): Promise<TokenDbHistoryPage> {
     const search = options.search?.trim()
-    const pattern = search
-      ? `%${search.replace(/[\\%_]/g, (char) => `\\${char}`)}%`
-      : undefined
+    const pattern = search ? `%${escapeLikePattern(search)}%` : undefined
 
     let rowsQuery = this.db
       .selectFrom('TokenDbHistory')

--- a/packages/database/src/repositories/TokenDbHistoryRepository.ts
+++ b/packages/database/src/repositories/TokenDbHistoryRepository.ts
@@ -1,5 +1,5 @@
 import { UnixTime } from '@l2beat/shared-pure'
-import type { Insertable, Selectable } from 'kysely'
+import { type Insertable, type Selectable, sql } from 'kysely'
 import { BaseRepository } from '../BaseRepository'
 import type { TokenDbHistory } from '../kysely/generated/types'
 import { toJsonSafe } from '../utils/toJsonSafe'
@@ -66,20 +66,36 @@ export class TokenDbHistoryRepository extends BaseRepository {
   async getPage(options: {
     offset: number
     limit: number
+    search?: string
   }): Promise<TokenDbHistoryPage> {
-    const rows = await this.db
+    const search = options.search?.trim()
+    const pattern = search
+      ? `%${search.replace(/[\\%_]/g, (char) => `\\${char}`)}%`
+      : undefined
+
+    let rowsQuery = this.db
       .selectFrom('TokenDbHistory')
       .selectAll()
       .orderBy('timestamp', 'desc')
       .orderBy('id', 'desc')
       .offset(options.offset)
       .limit(options.limit)
-      .execute()
 
-    const count = await this.db
+    let countQuery = this.db
       .selectFrom('TokenDbHistory')
       .select((eb) => eb.fn.countAll<number>().as('count'))
-      .executeTakeFirstOrThrow()
+
+    if (pattern) {
+      rowsQuery = rowsQuery.where(
+        sql<boolean>`"command"::text ILIKE ${pattern}`,
+      )
+      countQuery = countQuery.where(
+        sql<boolean>`"command"::text ILIKE ${pattern}`,
+      )
+    }
+
+    const rows = await rowsQuery.execute()
+    const count = await countQuery.executeTakeFirstOrThrow()
 
     return {
       entries: rows.map(toRecord),

--- a/packages/database/src/utils/escapeLikePattern.test.ts
+++ b/packages/database/src/utils/escapeLikePattern.test.ts
@@ -1,0 +1,14 @@
+import { expect } from 'earl'
+import { escapeLikePattern } from './escapeLikePattern'
+
+describe(escapeLikePattern.name, () => {
+  it('escapes LIKE wildcards and backslashes', () => {
+    expect(escapeLikePattern('100%_done\\now')).toEqual('100\\%\\_done\\\\now')
+  })
+
+  it('leaves plain text unchanged', () => {
+    expect(escapeLikePattern('USDC ethereum 0xabc')).toEqual(
+      'USDC ethereum 0xabc',
+    )
+  })
+})

--- a/packages/database/src/utils/escapeLikePattern.ts
+++ b/packages/database/src/utils/escapeLikePattern.ts
@@ -1,0 +1,3 @@
+export function escapeLikePattern(input: string): string {
+  return input.replace(/[\\%_]/g, (char) => `\\${char}`)
+}

--- a/packages/token-backend/src/trpc/routers/tokenDbHistory/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/tokenDbHistory/index.test.ts
@@ -42,7 +42,19 @@ describe('tokenDbHistoryRouter', () => {
       const result = await caller.getPage({ page: 2, pageSize: 5 })
 
       expect(result).toEqual(page)
-      expect(getPage).toHaveBeenCalledWith({ offset: 5, limit: 5 })
+      expect(getPage).toHaveBeenCalledWith({
+        offset: 5,
+        limit: 5,
+        search: undefined,
+      })
+
+      await caller.getPage({ page: 1, pageSize: 5, search: 'usdc' })
+
+      expect(getPage).toHaveBeenCalledWith({
+        offset: 0,
+        limit: 5,
+        search: 'usdc',
+      })
     })
   })
 })

--- a/packages/token-backend/src/trpc/routers/tokenDbHistory/index.ts
+++ b/packages/token-backend/src/trpc/routers/tokenDbHistory/index.ts
@@ -5,6 +5,7 @@ import { router } from '../../trpc'
 const HistoryPageInput = v.object({
   page: v.number(),
   pageSize: v.number(),
+  search: v.string().optional(),
 })
 
 export const tokenDbHistoryRouter = router({
@@ -15,6 +16,7 @@ export const tokenDbHistoryRouter = router({
     return ctx.tokenDb.tokenDbHistory.getPage({
       offset: (page - 1) * pageSize,
       limit: pageSize,
+      search: input.search,
     })
   }),
 })

--- a/packages/token-ui/src/pages/tokens/TokenHistoryPage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenHistoryPage.tsx
@@ -6,6 +6,7 @@ import {
   ChevronRightIcon,
   EyeIcon,
   HistoryIcon,
+  SearchIcon,
 } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
@@ -26,6 +27,7 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '~/components/core/Empty'
+import { Input } from '~/components/core/Input'
 import {
   Sheet,
   SheetContent,
@@ -44,6 +46,7 @@ import {
 import { Diff, ObjectDiff } from '~/components/Diff'
 import { IngestionLog } from '~/components/IngestionLog'
 import { LoadingState } from '~/components/LoadingState'
+import { useDebouncedValue } from '~/hooks/useDebouncedValue'
 import { AppLayout } from '~/layouts/AppLayout'
 import { useTRPC } from '~/react-query/trpc'
 import { diff } from '~/utils/getDiff'
@@ -68,10 +71,16 @@ interface AbstractTokenInfo {
 export function TokenHistoryPage() {
   const trpc = useTRPC()
   const [page, setPage] = useState(1)
+  const [search, setSearch] = useState('')
+  const debouncedSearch = useDebouncedValue(search.trim(), 300)
   const [selectedEntry, setSelectedEntry] = useState<HistoryEntry>()
   const { data: historyPage, isLoading } = useQuery(
     trpc.tokenDbHistory.getPage.queryOptions(
-      { page, pageSize: PAGE_SIZE },
+      {
+        page,
+        pageSize: PAGE_SIZE,
+        search: debouncedSearch || undefined,
+      },
       {
         refetchInterval: 10_000,
         refetchOnMount: 'always',
@@ -119,35 +128,49 @@ export function TokenHistoryPage() {
               {formatHistoryRange(page, totalCount)}
             </CardDescription>
           )}
-          {historyPage && totalCount > PAGE_SIZE && (
-            <CardAction>
-              <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={page <= 1}
-                  onClick={() => setPage((page) => Math.max(1, page - 1))}
-                >
-                  <ChevronLeftIcon />
-                  Previous
-                </Button>
-                <div className="whitespace-nowrap text-muted-foreground text-sm tabular-nums">
-                  Page {page} of {pageCount}
-                </div>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={page >= pageCount}
-                  onClick={() =>
-                    setPage((page) => Math.min(pageCount, page + 1))
-                  }
-                >
-                  Next
-                  <ChevronRightIcon />
-                </Button>
+          <CardAction>
+            <div className="flex flex-col items-end gap-2">
+              <div className="relative w-64">
+                <SearchIcon className="-translate-y-1/2 pointer-events-none absolute top-1/2 left-2.5 size-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search by token data..."
+                  className="h-8 pl-8"
+                  value={search}
+                  onChange={(e) => {
+                    setSearch(e.target.value)
+                    setPage(1)
+                  }}
+                />
               </div>
-            </CardAction>
-          )}
+              {historyPage && totalCount > PAGE_SIZE && (
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page <= 1}
+                    onClick={() => setPage((page) => Math.max(1, page - 1))}
+                  >
+                    <ChevronLeftIcon />
+                    Previous
+                  </Button>
+                  <div className="whitespace-nowrap text-muted-foreground text-sm tabular-nums">
+                    Page {page} of {pageCount}
+                  </div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled={page >= pageCount}
+                    onClick={() =>
+                      setPage((page) => Math.min(pageCount, page + 1))
+                    }
+                  >
+                    Next
+                    <ChevronRightIcon />
+                  </Button>
+                </div>
+              )}
+            </div>
+          </CardAction>
         </CardHeader>
         <CardContent className="min-h-0 flex-1 overflow-y-auto">
           {isLoading ? (
@@ -158,7 +181,11 @@ export function TokenHistoryPage() {
                 <EmptyMedia variant="icon">
                   <HistoryIcon />
                 </EmptyMedia>
-                <EmptyTitle>No history entries</EmptyTitle>
+                <EmptyTitle>
+                  {debouncedSearch
+                    ? 'No entries match your search'
+                    : 'No history entries'}
+                </EmptyTitle>
               </EmptyHeader>
             </Empty>
           ) : (


### PR DESCRIPTION
## What

Adds a search box to the token DB history page so entries can be filtered by token data.

## Details

- **Frontend** (`TokenHistoryPage`): search input in the card header, debounced (300ms) via the existing `useDebouncedValue` hook. Typing resets to page 1, and the empty state reads "No entries match your search" when a search is active.
- **tRPC router** (`tokenDbHistory.getPage`): added an optional `search` input field, passed through to the repository.
- **Repository** (`TokenDbHistoryRepository.getPage`): when `search` is present, both the rows and count queries get a `"command"::text ILIKE '%...%'` filter, so pagination and total count stay consistent with the filtered set. LIKE wildcards (`\`, `%`, `_`) in user input are escaped. Filtering is server-side over the command JSON, so search spans the full history, not just the current page.

Search matches anything inside the command JSON — symbol, chain, address, abstract token id, etc.

## Testing

- Added a repository test covering match-by-symbol, match-by-chain, and no-match cases.
- `pnpm typecheck` passes for database, token-backend, and token-ui; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)