### PR TITLE
Add RWA categories to abstract token form

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -114,7 +114,11 @@ export type {
   TokenIngestionQueueRecord,
   TokenIngestionQueueState,
 } from './repositories/TokenIngestionQueueRepository'
-export type { TokenMetadataRecord } from './repositories/TokenMetadataRepository'
+export { TOKEN_CATEGORIES } from './repositories/TokenMetadataRepository'
+export type {
+  TokenCategory,
+  TokenMetadataRecord,
+} from './repositories/TokenMetadataRepository'
 export type {
   SummedByTimestampTokenValuePerProjectRecord,
   SummedByTimestampTokenValueRecord,

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -114,11 +114,11 @@ export type {
   TokenIngestionQueueRecord,
   TokenIngestionQueueState,
 } from './repositories/TokenIngestionQueueRepository'
-export { TOKEN_CATEGORIES } from './repositories/TokenMetadataRepository'
 export type {
   TokenCategory,
   TokenMetadataRecord,
 } from './repositories/TokenMetadataRepository'
+export { TOKEN_CATEGORIES } from './repositories/TokenMetadataRepository'
 export type {
   SummedByTimestampTokenValuePerProjectRecord,
   SummedByTimestampTokenValueRecord,

--- a/packages/database/src/repositories/AbstractTokenRepository.ts
+++ b/packages/database/src/repositories/AbstractTokenRepository.ts
@@ -3,12 +3,13 @@ import type { Insertable, Selectable, Updateable } from 'kysely'
 import { BaseRepository } from '../BaseRepository'
 import type { AbstractToken } from '../kysely/generated/types'
 import { fromTimestamp, toTimestamp } from '../utils/timestamp'
+import type { TokenCategory } from './TokenMetadataRepository'
 
 export type AbstractTokenRecord = {
   symbol: string
   id: string
   issuer: string | null
-  category: 'btc' | 'ether' | 'stablecoin' | 'other' | null
+  category: TokenCategory | null
   iconUrl: string | null
   coingeckoId: string | null
   coingeckoListingTimestamp: UnixTime | null
@@ -34,7 +35,7 @@ function toRecord(row: Selectable<AbstractToken>): AbstractTokenRecord {
     coingeckoId: row.coingeckoId,
 
     coingeckoListingTimestamp: toTimestamp(row.coingeckoListingTimestamp),
-    category: row.category as 'btc' | 'ether' | 'stablecoin' | 'other' | null,
+    category: row.category as TokenCategory | null,
   }
 }
 export { toRecord as toAbstractTokenRecord }

--- a/packages/database/src/repositories/TokenMetadataRepository.ts
+++ b/packages/database/src/repositories/TokenMetadataRepository.ts
@@ -2,13 +2,16 @@ import type { Insertable, Selectable } from 'kysely'
 import { BaseRepository } from '../BaseRepository'
 import type { TokenMetadata } from '../kysely/generated/types'
 
-export type TokenCategory =
-  | 'ether'
-  | 'stablecoin'
-  | 'btc'
-  | 'rwaRestricted'
-  | 'rwaPublic'
-  | 'other'
+export const TOKEN_CATEGORIES = [
+  'ether',
+  'stablecoin',
+  'btc',
+  'rwaRestricted',
+  'rwaPublic',
+  'other',
+] as const
+
+export type TokenCategory = (typeof TOKEN_CATEGORIES)[number]
 
 export type TokenSource =
   | 'canonical'

--- a/packages/token-backend/src/index.ts
+++ b/packages/token-backend/src/index.ts
@@ -1,5 +1,5 @@
-export { getTokenDbClient, type TokenDbClient } from './client'
 export type { TokenCategory } from '@l2beat/database'
+export { getTokenDbClient, type TokenDbClient } from './client'
 export type { Command } from './commands'
 export type {
   AbstractTokenRef,

--- a/packages/token-backend/src/index.ts
+++ b/packages/token-backend/src/index.ts
@@ -1,4 +1,4 @@
-export type { TokenCategory } from '@l2beat/database'
+export { TOKEN_CATEGORIES, type TokenCategory } from '@l2beat/database'
 export { getTokenDbClient, type TokenDbClient } from './client'
 export type { Command } from './commands'
 export type {

--- a/packages/token-backend/src/index.ts
+++ b/packages/token-backend/src/index.ts
@@ -1,4 +1,5 @@
 export { getTokenDbClient, type TokenDbClient } from './client'
+export type { TokenCategory } from '@l2beat/database'
 export type { Command } from './commands'
 export type {
   AbstractTokenRef,

--- a/packages/token-backend/src/schemas/AbstractToken.ts
+++ b/packages/token-backend/src/schemas/AbstractToken.ts
@@ -1,6 +1,7 @@
-import type {
-  AbstractTokenRecord as DbAbstractTokenRecord,
-  AbstractTokenUpdateable as DbAbstractTokenUpdateable,
+import {
+  type AbstractTokenRecord as DbAbstractTokenRecord,
+  type AbstractTokenUpdateable as DbAbstractTokenUpdateable,
+  TOKEN_CATEGORIES,
 } from '@l2beat/database'
 import { v } from '@l2beat/validate'
 import type { Equal, Expect } from '../utils/expectEqual'
@@ -11,10 +12,7 @@ export const AbstractTokenRecord = v.object({
   symbol: v.string(),
   id: v.string(),
   issuer: v.union([v.string(), v.null()]),
-  category: v.union([
-    v.enum(['btc', 'ether', 'stablecoin', 'other']),
-    v.null(),
-  ]),
+  category: v.union([v.enum(TOKEN_CATEGORIES), v.null()]),
   iconUrl: v.union([v.string(), v.null()]),
   coingeckoId: v.union([v.string(), v.null()]),
   coingeckoListingTimestamp: v.union([v.number(), v.null()]),
@@ -28,9 +26,7 @@ export type AbstractTokenUpdateable = v.infer<typeof AbstractTokenUpdateable>
 export const AbstractTokenUpdateable = v.object({
   symbol: v.string().optional(),
   issuer: v.union([v.string(), v.null()]).optional(),
-  category: v
-    .union([v.enum(['btc', 'ether', 'stablecoin', 'other']), v.null()])
-    .optional(),
+  category: v.union([v.enum(TOKEN_CATEGORIES), v.null()]).optional(),
   iconUrl: v.union([v.string(), v.null()]).optional(),
   coingeckoId: v.union([v.string(), v.null()]).optional(),
   coingeckoListingTimestamp: v.union([v.number(), v.null()]).optional(),

--- a/packages/token-ui/src/components/forms/AbstractTokenForm.tsx
+++ b/packages/token-ui/src/components/forms/AbstractTokenForm.tsx
@@ -27,7 +27,14 @@ import { parseDatePaste } from '~/utils/parseDate'
 import { Checkbox } from '../core/Checkbox'
 import { ExternalLink } from '../ExternalLink'
 
-const categoryValues = ['btc', 'ether', 'stablecoin', 'other'] as const
+const categoryValues = [
+  'btc',
+  'ether',
+  'stablecoin',
+  'rwaRestricted',
+  'rwaPublic',
+  'other',
+] as const
 const EMPTY_CATEGORY_VALUE = '__none__'
 
 export type AbstractTokenSchema = v.infer<typeof AbstractTokenSchema>

--- a/packages/token-ui/src/components/forms/AbstractTokenForm.tsx
+++ b/packages/token-ui/src/components/forms/AbstractTokenForm.tsx
@@ -1,3 +1,4 @@
+import type { TokenCategory } from '@l2beat/token-backend'
 import { v } from '@l2beat/validate'
 import { ArrowRightIcon, RefreshCwIcon } from 'lucide-react'
 import type { SubmitHandler, UseFormReturn } from 'react-hook-form'
@@ -34,7 +35,7 @@ const categoryValues = [
   'rwaRestricted',
   'rwaPublic',
   'other',
-] as const
+] as const satisfies readonly TokenCategory[]
 const EMPTY_CATEGORY_VALUE = '__none__'
 
 export type AbstractTokenSchema = v.infer<typeof AbstractTokenSchema>

--- a/packages/token-ui/src/components/forms/AbstractTokenForm.tsx
+++ b/packages/token-ui/src/components/forms/AbstractTokenForm.tsx
@@ -1,4 +1,4 @@
-import type { TokenCategory } from '@l2beat/token-backend'
+import { TOKEN_CATEGORIES } from '@l2beat/token-backend'
 import { v } from '@l2beat/validate'
 import { ArrowRightIcon, RefreshCwIcon } from 'lucide-react'
 import type { SubmitHandler, UseFormReturn } from 'react-hook-form'
@@ -28,14 +28,6 @@ import { parseDatePaste } from '~/utils/parseDate'
 import { Checkbox } from '../core/Checkbox'
 import { ExternalLink } from '../ExternalLink'
 
-const categoryValues = [
-  'btc',
-  'ether',
-  'stablecoin',
-  'rwaRestricted',
-  'rwaPublic',
-  'other',
-] as const satisfies readonly TokenCategory[]
 const EMPTY_CATEGORY_VALUE = '__none__'
 
 export type AbstractTokenSchema = v.infer<typeof AbstractTokenSchema>
@@ -43,7 +35,7 @@ export const AbstractTokenSchema = v.object({
   id: v.string(),
   issuer: v.string().optional(),
   symbol: v.string().check(minLengthCheck(1)),
-  category: v.union([v.enum(categoryValues), v.null()]),
+  category: v.union([v.enum(TOKEN_CATEGORIES), v.null()]),
   coingeckoId: v.string().optional(),
   coingeckoListingTimestamp: v.string().optional(),
   iconUrl: v
@@ -249,7 +241,7 @@ export function AbstractTokenForm({
                     <SelectItem value={EMPTY_CATEGORY_VALUE}>
                       No category
                     </SelectItem>
-                    {categoryValues.map((category) => (
+                    {TOKEN_CATEGORIES.map((category) => (
                       <SelectItem key={category} value={category}>
                         {category}
                       </SelectItem>


### PR DESCRIPTION
## What

Adds `rwaRestricted` and `rwaPublic` to the category selector in the abstract token form (`AbstractTokenForm.tsx`).

## Why

The `categoryValues` array was missing the two RWA categories that already exist in the canonical `TokenCategory` type (`ether | stablecoin | btc | rwaRestricted | rwaPublic | other`). This array drives both the validation schema (`v.enum(categoryValues)`) and the rendered dropdown options, so both now include the RWA categories.

Note: the category field lives on the abstract token form, not the deployed token form (which has no category field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)