### PR TITLE
Add AggregatedInteropDeployedToken table and stats query (1/3)

### DIFF
--- a/packages/database/prisma/migrations/20260611083154_add_interop_deployed_token_aggregation/migration.sql
+++ b/packages/database/prisma/migrations/20260611083154_add_interop_deployed_token_aggregation/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "AggregatedInteropDeployedToken" (
+    "timestamp" TIMESTAMP(6) NOT NULL,
+    "id" VARCHAR(255) NOT NULL,
+    "srcChain" VARCHAR(255) NOT NULL,
+    "dstChain" VARCHAR(255) NOT NULL,
+    "bridgeType" VARCHAR(255) NOT NULL DEFAULT 'unknown',
+    "tokenChain" VARCHAR(255) NOT NULL,
+    "tokenAddress" VARCHAR(255) NOT NULL,
+    "transferTypeStats" JSONB,
+    "mintedValueUsd" REAL,
+    "burnedValueUsd" REAL,
+    "transferCount" INTEGER NOT NULL,
+    "transfersWithDurationCount" INTEGER NOT NULL DEFAULT 0,
+    "totalDurationSum" INTEGER NOT NULL,
+    "volume" REAL NOT NULL,
+    "minTransferValueUsd" REAL,
+    "maxTransferValueUsd" REAL,
+
+    CONSTRAINT "AggregatedInteropDeployedToken_pkey" PRIMARY KEY ("timestamp","srcChain","dstChain","bridgeType","id","tokenChain","tokenAddress")
+);
+
+-- CreateIndex
+CREATE INDEX "AggregatedInteropDeployedToken_timestamp_srcChain_dstChain_idx" ON "AggregatedInteropDeployedToken"("timestamp", "srcChain", "dstChain", "id", "bridgeType");

--- a/packages/database/prisma/migrations/20260611083154_add_interop_deployed_token_aggregation/migration.sql
+++ b/packages/database/prisma/migrations/20260611083154_add_interop_deployed_token_aggregation/migration.sql
@@ -21,4 +21,4 @@ CREATE TABLE "AggregatedInteropDeployedToken" (
 );
 
 -- CreateIndex
-CREATE INDEX "AggregatedInteropDeployedToken_timestamp_srcChain_dstChain_idx" ON "AggregatedInteropDeployedToken"("timestamp", "srcChain", "dstChain", "id", "bridgeType");
+CREATE INDEX "AggregatedInteropDeployedToken_timestamp_srcChain_dstChain__idx" ON "AggregatedInteropDeployedToken"("timestamp", "srcChain", "dstChain", "id", "bridgeType");

--- a/packages/database/prisma/migrations/20260611120000_add_deployed_token_aggregation_token_index/migration.sql
+++ b/packages/database/prisma/migrations/20260611120000_add_deployed_token_aggregation_token_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "AggregatedInteropDeployedToken_timestamp_tokenChain_tokenAd_idx" ON "AggregatedInteropDeployedToken"("timestamp", "tokenChain", "tokenAddress");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -662,6 +662,29 @@ model AggregatedInteropToken {
   @@index([timestamp, srcChain, dstChain, id, bridgeType])
 }
 
+model AggregatedInteropDeployedToken {
+  timestamp                  DateTime @db.Timestamp(6)
+  id                         String   @db.VarChar(255)
+  srcChain                   String   @db.VarChar(255)
+  dstChain                   String   @db.VarChar(255)
+  bridgeType                 String   @default("unknown") @db.VarChar(255)
+  tokenChain                 String   @db.VarChar(255)
+  tokenAddress               String   @db.VarChar(255)
+  transferTypeStats          Json?
+  mintedValueUsd             Float?   @db.Real
+  burnedValueUsd             Float?   @db.Real
+  transferCount              Int
+  transfersWithDurationCount Int      @default(0)
+  totalDurationSum           Int
+  volume                     Float    @db.Real
+  minTransferValueUsd        Float?   @db.Real
+  maxTransferValueUsd        Float?   @db.Real
+
+  @@id([timestamp, srcChain, dstChain, bridgeType, id, tokenChain, tokenAddress])
+  @@index([timestamp, srcChain, dstChain, id, bridgeType])
+  @@index([timestamp, tokenChain, tokenAddress])
+}
+
 model TokenFactInput {
   id        Int    @id @default(autoincrement())
   name      String @db.VarChar(255)

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -2,6 +2,7 @@ import type { LogConfig } from 'kysely'
 import type { PoolConfig } from 'pg'
 import { DatabaseClient } from './kysely'
 import { ActivityRepository } from './repositories/ActivityRepository'
+import { AggregatedInteropDeployedTokenRepository } from './repositories/AggregatedInteropDeployedTokenRepository'
 import { AggregatedInteropTokenRepository } from './repositories/AggregatedInteropTokenRepository'
 import { AggregatedInteropTokensPairRepository } from './repositories/AggregatedInteropTokensPairRepository'
 import { AggregatedInteropTransferRepository } from './repositories/AggregatedInteropTransferRepository'
@@ -70,6 +71,8 @@ export function createDatabase(
     interopTransfer: new InteropTransferRepository(db),
     aggregatedInteropTransfer: new AggregatedInteropTransferRepository(db),
     aggregatedInteropToken: new AggregatedInteropTokenRepository(db),
+    aggregatedInteropDeployedToken:
+      new AggregatedInteropDeployedTokenRepository(db),
     aggregatedInteropTokensPair: new AggregatedInteropTokensPairRepository(db),
     interopRecentPrices: new InteropRecentPricesRepository(db),
     interopPluginSyncState: new InteropPluginSyncStateRepository(db),

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -10,6 +10,10 @@ export type {
   AbstractTokenUpdateable,
 } from './repositories/AbstractTokenRepository'
 export type { ActivityRecord } from './repositories/ActivityRepository'
+export type {
+  AggregatedInteropDeployedTokenRecord,
+  AggregatedInteropDeployedTokenStats,
+} from './repositories/AggregatedInteropDeployedTokenRepository'
 export type { AggregatedInteropTokenRecord } from './repositories/AggregatedInteropTokenRepository'
 export type { AggregatedInteropTokensPairRecord } from './repositories/AggregatedInteropTokensPairRepository'
 export type {

--- a/packages/database/src/repositories/AggregatedInteropDeployedTokenRepository.test.ts
+++ b/packages/database/src/repositories/AggregatedInteropDeployedTokenRepository.test.ts
@@ -1,0 +1,176 @@
+import { type InteropBridgeType, UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { describeDatabase } from '../test/database'
+import {
+  type AggregatedInteropDeployedTokenRecord,
+  AggregatedInteropDeployedTokenRepository,
+} from './AggregatedInteropDeployedTokenRepository'
+
+describeDatabase(AggregatedInteropDeployedTokenRepository.name, (db) => {
+  const repository = db.aggregatedInteropDeployedToken
+
+  beforeEach(async () => {
+    await repository.deleteAll()
+  })
+
+  describe(
+    AggregatedInteropDeployedTokenRepository.prototype
+      .getSummedStatsByTimestampAndTokens.name,
+    () => {
+      it('returns empty array when no tokens are given', async () => {
+        await repository.insertMany([
+          record({
+            id: 'id1',
+            timestamp: UnixTime(100),
+            tokenChain: 'ethereum',
+            tokenAddress: '0x1',
+          }),
+        ])
+
+        const result = await repository.getSummedStatsByTimestampAndTokens(
+          UnixTime(100),
+          [],
+        )
+
+        expect(result).toEqual([])
+      })
+
+      it('sums stats per token across flows at the given timestamp', async () => {
+        await repository.insertMany([
+          record({
+            id: 'flow1',
+            timestamp: UnixTime(100),
+            srcChain: 'ethereum',
+            dstChain: 'arbitrum',
+            tokenChain: 'ethereum',
+            tokenAddress: '0x1',
+            transferCount: 2,
+            transfersWithDurationCount: 2,
+            totalDurationSum: 20,
+            volume: 1000,
+          }),
+          record({
+            id: 'flow2',
+            timestamp: UnixTime(100),
+            srcChain: 'base',
+            dstChain: 'ethereum',
+            tokenChain: 'ethereum',
+            tokenAddress: '0x1',
+            transferCount: 3,
+            transfersWithDurationCount: 1,
+            totalDurationSum: 40,
+            volume: 500,
+          }),
+          // different token - excluded from the first token's sums
+          record({
+            id: 'flow1',
+            timestamp: UnixTime(100),
+            srcChain: 'ethereum',
+            dstChain: 'arbitrum',
+            tokenChain: 'arbitrum',
+            tokenAddress: '0x2',
+            transferCount: 7,
+            transfersWithDurationCount: 7,
+            totalDurationSum: 70,
+            volume: 2000,
+          }),
+          // other timestamp - excluded
+          record({
+            id: 'flow1',
+            timestamp: UnixTime(200),
+            srcChain: 'ethereum',
+            dstChain: 'arbitrum',
+            tokenChain: 'ethereum',
+            tokenAddress: '0x1',
+            transferCount: 100,
+            volume: 9999,
+          }),
+          // token not in the query - excluded
+          record({
+            id: 'flow1',
+            timestamp: UnixTime(100),
+            srcChain: 'ethereum',
+            dstChain: 'arbitrum',
+            tokenChain: 'optimism',
+            tokenAddress: '0x3',
+            transferCount: 5,
+            volume: 300,
+          }),
+        ])
+
+        const result = await repository.getSummedStatsByTimestampAndTokens(
+          UnixTime(100),
+          [
+            { tokenChain: 'ethereum', tokenAddress: '0x1' },
+            { tokenChain: 'arbitrum', tokenAddress: '0x2' },
+          ],
+        )
+
+        result.sort((a, b) => a.tokenChain.localeCompare(b.tokenChain))
+        expect(result).toEqual([
+          {
+            tokenChain: 'arbitrum',
+            tokenAddress: '0x2',
+            transferCount: 7,
+            transfersWithDurationCount: 7,
+            totalDurationSum: 70,
+            volume: 2000,
+          },
+          {
+            tokenChain: 'ethereum',
+            tokenAddress: '0x1',
+            transferCount: 5,
+            transfersWithDurationCount: 3,
+            totalDurationSum: 60,
+            volume: 1500,
+          },
+        ])
+      })
+    },
+  )
+})
+
+function record({
+  id,
+  timestamp,
+  srcChain = 'ethereum',
+  dstChain = 'arbitrum',
+  bridgeType = 'unknown',
+  tokenChain,
+  tokenAddress,
+  transferCount = 1,
+  transfersWithDurationCount = transferCount,
+  totalDurationSum = 0,
+  volume = 1000,
+}: {
+  id: string
+  timestamp: UnixTime
+  srcChain?: string
+  dstChain?: string
+  bridgeType?: InteropBridgeType
+  tokenChain: string
+  tokenAddress: string
+  transferCount?: number
+  transfersWithDurationCount?: number
+  totalDurationSum?: number
+  volume?: number
+}): AggregatedInteropDeployedTokenRecord {
+  return {
+    id,
+    timestamp,
+    srcChain,
+    dstChain,
+    bridgeType,
+    tokenChain,
+    tokenAddress,
+    transferTypeStats: undefined,
+    transferCount,
+    transfersWithDurationCount,
+    totalDurationSum,
+    volume,
+    minTransferValueUsd: undefined,
+    maxTransferValueUsd: undefined,
+    mintedValueUsd: undefined,
+    burnedValueUsd: undefined,
+  }
+}

--- a/packages/database/src/repositories/AggregatedInteropDeployedTokenRepository.ts
+++ b/packages/database/src/repositories/AggregatedInteropDeployedTokenRepository.ts
@@ -1,0 +1,195 @@
+import { type InteropBridgeType, UnixTime } from '@l2beat/shared-pure'
+import { type Insertable, type Selectable, sql } from 'kysely'
+import { BaseRepository } from '../BaseRepository'
+import type { AggregatedInteropDeployedToken } from '../kysely/generated/types'
+import type { InteropTransferTypeStatsMap } from './InteropTransferTypeStats'
+
+export interface AggregatedInteropDeployedTokenRecord {
+  timestamp: UnixTime
+  id: string
+  bridgeType: InteropBridgeType
+  srcChain: string
+  dstChain: string
+  tokenChain: string
+  tokenAddress: string
+  transferTypeStats: InteropTransferTypeStatsMap | undefined
+  transferCount: number
+  transfersWithDurationCount: number
+  totalDurationSum: number
+  volume: number
+  minTransferValueUsd: number | undefined
+  maxTransferValueUsd: number | undefined
+  mintedValueUsd: number | undefined
+  burnedValueUsd: number | undefined
+}
+
+export function toRecord(
+  row: Selectable<AggregatedInteropDeployedToken>,
+): AggregatedInteropDeployedTokenRecord {
+  return {
+    timestamp: UnixTime.fromDate(row.timestamp),
+    id: row.id,
+    bridgeType: row.bridgeType as InteropBridgeType,
+    srcChain: row.srcChain,
+    dstChain: row.dstChain,
+    tokenChain: row.tokenChain,
+    tokenAddress: row.tokenAddress,
+    transferTypeStats:
+      (row.transferTypeStats as InteropTransferTypeStatsMap | null) ??
+      undefined,
+    transferCount: row.transferCount,
+    transfersWithDurationCount: row.transfersWithDurationCount,
+    totalDurationSum: row.totalDurationSum,
+    volume: row.volume,
+    minTransferValueUsd: row.minTransferValueUsd ?? undefined,
+    maxTransferValueUsd: row.maxTransferValueUsd ?? undefined,
+    mintedValueUsd: row.mintedValueUsd ?? undefined,
+    burnedValueUsd: row.burnedValueUsd ?? undefined,
+  }
+}
+
+export function toRow(
+  record: AggregatedInteropDeployedTokenRecord,
+): Insertable<AggregatedInteropDeployedToken> {
+  return {
+    timestamp: UnixTime.toDate(record.timestamp),
+    id: record.id,
+    bridgeType: record.bridgeType,
+    srcChain: record.srcChain,
+    dstChain: record.dstChain,
+    tokenChain: record.tokenChain,
+    tokenAddress: record.tokenAddress,
+    transferTypeStats: record.transferTypeStats,
+    transferCount: record.transferCount,
+    transfersWithDurationCount: record.transfersWithDurationCount,
+    totalDurationSum: record.totalDurationSum,
+    volume: record.volume,
+    minTransferValueUsd: record.minTransferValueUsd,
+    maxTransferValueUsd: record.maxTransferValueUsd,
+    mintedValueUsd: record.mintedValueUsd,
+    burnedValueUsd: record.burnedValueUsd,
+  }
+}
+
+export interface AggregatedInteropDeployedTokenStats {
+  tokenChain: string
+  tokenAddress: string
+  transferCount: number
+  transfersWithDurationCount: number
+  totalDurationSum: number
+  volume: number
+}
+
+export class AggregatedInteropDeployedTokenRepository extends BaseRepository {
+  async insertMany(
+    records: AggregatedInteropDeployedTokenRecord[],
+  ): Promise<number> {
+    if (records.length === 0) return 0
+
+    const rows = records.map(toRow)
+    await this.batch(rows, 1_000, async (batch) => {
+      await this.db
+        .insertInto('AggregatedInteropDeployedToken')
+        .values(batch)
+        .execute()
+    })
+    return rows.length
+  }
+
+  async getAll(): Promise<AggregatedInteropDeployedTokenRecord[]> {
+    const rows = await this.db
+      .selectFrom('AggregatedInteropDeployedToken')
+      .selectAll()
+      .execute()
+
+    return rows.map(toRecord)
+  }
+
+  async getByTimestamp(
+    timestamp: UnixTime,
+  ): Promise<AggregatedInteropDeployedTokenRecord[]> {
+    const rows = await this.db
+      .selectFrom('AggregatedInteropDeployedToken')
+      .selectAll()
+      .where('timestamp', '=', UnixTime.toDate(timestamp))
+      .execute()
+
+    return rows.map(toRecord)
+  }
+
+  async getSummedStatsByTimestampAndTokens(
+    timestamp: UnixTime,
+    tokens: { tokenChain: string; tokenAddress: string }[],
+  ): Promise<AggregatedInteropDeployedTokenStats[]> {
+    if (tokens.length === 0) return []
+
+    const rows = await this.db
+      .selectFrom('AggregatedInteropDeployedToken')
+      .select((eb) => [
+        'tokenChain',
+        'tokenAddress',
+        eb.fn.sum<number>('transferCount').as('transferCount'),
+        eb.fn
+          .sum<number>('transfersWithDurationCount')
+          .as('transfersWithDurationCount'),
+        eb.fn.sum<number>('totalDurationSum').as('totalDurationSum'),
+        eb.fn.sum<number>('volume').as('volume'),
+      ])
+      .where('timestamp', '=', UnixTime.toDate(timestamp))
+      .where((eb) =>
+        eb.or(
+          tokens.map((token) =>
+            eb.and([
+              eb('tokenChain', '=', token.tokenChain),
+              eb('tokenAddress', '=', token.tokenAddress),
+            ]),
+          ),
+        ),
+      )
+      .groupBy(['tokenChain', 'tokenAddress'])
+      .execute()
+
+    return rows.map((row) => ({
+      tokenChain: row.tokenChain,
+      tokenAddress: row.tokenAddress,
+      transferCount: Number(row.transferCount),
+      transfersWithDurationCount: Number(row.transfersWithDurationCount),
+      totalDurationSum: Number(row.totalDurationSum),
+      volume: Number(row.volume),
+    }))
+  }
+
+  async deleteAllButEarliestPerDayBefore(timestamp: UnixTime): Promise<number> {
+    const query = this.db
+      .with('earliest_timestamp_by_day', (eb) =>
+        eb
+          .selectFrom('AggregatedInteropDeployedToken')
+          .select((eb) => eb.fn.min('timestamp').as('min_timestamp'))
+          .groupBy(sql`date_trunc('day', timestamp)`),
+      )
+      .deleteFrom('AggregatedInteropDeployedToken')
+      .where('timestamp', '<', UnixTime.toDate(timestamp))
+      .where('timestamp', 'not in', (eb) =>
+        eb.selectFrom('earliest_timestamp_by_day').select('min_timestamp'),
+      )
+
+    const result = await query.executeTakeFirst()
+
+    return Number(result.numDeletedRows)
+  }
+
+  async deleteByTimestamp(timestamp: UnixTime): Promise<number> {
+    const result = await this.db
+      .deleteFrom('AggregatedInteropDeployedToken')
+      .where('timestamp', '=', UnixTime.toDate(timestamp))
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
+  async deleteAll(): Promise<number> {
+    const result = await this.db
+      .deleteFrom('AggregatedInteropDeployedToken')
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+}


### PR DESCRIPTION
Part 1/3 of the "Onchain deployments" token page section (split from #12072).

- Adds the `AggregatedInteropDeployedToken` table (per-deployed-token interop 24h aggregates) with its migration
- Adds a `(timestamp, tokenChain, tokenAddress)` index so per-deployment stat lookups are index scans (verified with `EXPLAIN ANALYZE` — BitmapOr over full index conditions)
- Adds `AggregatedInteropDeployedTokenRepository` with `getSummedStatsByTimestampAndTokens` (SQL-level `SUM` + `GROUP BY` per deployment) and repository tests

Followed by backend aggregation (2/3) and the frontend section (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)