### PR TITLE
Aggregate interop transfers per deployed token (2/3)

### DIFF
--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
@@ -134,6 +134,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(1),
       })
+      const aggregatedInteropDeployedToken = mockObject<
+        Database['aggregatedInteropDeployedToken']
+      >({
+        deleteAllButEarliestPerDayBefore: mockFn().resolvesTo(0),
+        deleteByTimestamp: mockFn().resolvesTo(0),
+        insertMany: mockFn().resolvesTo(0),
+      })
       const aggregatedInteropTokensPair = mockObject<
         Database['aggregatedInteropTokensPair']
       >({
@@ -149,6 +156,7 @@ describe(InteropAggregatingIndexer.name, () => {
         interopTransfer,
         aggregatedInteropTransfer,
         aggregatedInteropToken,
+        aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
@@ -159,6 +167,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers,
           aggregatedTokens,
+          aggregatedDeployedTokens: [],
           aggregatedTokensPairs,
           warnings: [],
         }),
@@ -244,6 +253,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const aggregatedInteropDeployedToken = mockObject<
+        Database['aggregatedInteropDeployedToken']
+      >({
+        deleteAllButEarliestPerDayBefore: mockFn().resolvesTo(0),
+        deleteByTimestamp: mockFn().resolvesTo(0),
+        insertMany: mockFn().resolvesTo(0),
+      })
       const aggregatedInteropTokensPair = mockObject<
         Database['aggregatedInteropTokensPair']
       >({
@@ -259,6 +275,7 @@ describe(InteropAggregatingIndexer.name, () => {
         interopTransfer,
         aggregatedInteropTransfer,
         aggregatedInteropToken,
+        aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
@@ -269,6 +286,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers: [],
           aggregatedTokens: [],
+          aggregatedDeployedTokens: [],
           aggregatedTokensPairs: [],
           warnings: [],
         }),
@@ -318,12 +336,20 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const aggregatedInteropDeployedToken = mockObject<
+        Database['aggregatedInteropDeployedToken']
+      >({
+        deleteAllButEarliestPerDayBefore: mockFn().resolvesTo(0),
+        deleteByTimestamp: mockFn().resolvesTo(0),
+        insertMany: mockFn().resolvesTo(0),
+      })
       const transaction = mockFn(async (fn: any) => await fn())
       const db = mockDatabase({
         transaction,
         interopTransfer,
         aggregatedInteropTransfer,
         aggregatedInteropToken,
+        aggregatedInteropDeployedToken,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areAllSyncersFollowing: mockFn().returns(false),
@@ -333,6 +359,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers: [],
           aggregatedTokens: [],
+          aggregatedDeployedTokens: [],
           aggregatedTokensPairs: [],
           warnings: [],
         }),
@@ -382,6 +409,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const aggregatedInteropDeployedToken = mockObject<
+        Database['aggregatedInteropDeployedToken']
+      >({
+        deleteAllButEarliestPerDayBefore: mockFn().resolvesTo(0),
+        deleteByTimestamp: mockFn().resolvesTo(0),
+        insertMany: mockFn().resolvesTo(0),
+      })
       const aggregatedInteropTokensPair = mockObject<
         Database['aggregatedInteropTokensPair']
       >({
@@ -395,6 +429,7 @@ describe(InteropAggregatingIndexer.name, () => {
         interopTransfer,
         aggregatedInteropTransfer,
         aggregatedInteropToken,
+        aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
@@ -405,6 +440,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers: [],
           aggregatedTokens: [],
+          aggregatedDeployedTokens: [],
           aggregatedTokensPairs: [],
           warnings: [],
         }),
@@ -467,6 +503,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const aggregatedInteropDeployedToken = mockObject<
+        Database['aggregatedInteropDeployedToken']
+      >({
+        deleteAllButEarliestPerDayBefore: mockFn().resolvesTo(0),
+        deleteByTimestamp: mockFn().resolvesTo(0),
+        insertMany: mockFn().resolvesTo(0),
+      })
       const aggregatedInteropTokensPair = mockObject<
         Database['aggregatedInteropTokensPair']
       >({
@@ -481,6 +524,7 @@ describe(InteropAggregatingIndexer.name, () => {
         interopTransfer,
         aggregatedInteropTransfer,
         aggregatedInteropToken,
+        aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
@@ -490,6 +534,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers: [],
           aggregatedTokens: [],
+          aggregatedDeployedTokens: [],
           aggregatedTokensPairs: [],
           warnings: [],
         }),
@@ -588,6 +633,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const aggregatedInteropDeployedToken = mockObject<
+        Database['aggregatedInteropDeployedToken']
+      >({
+        deleteAllButEarliestPerDayBefore: mockFn().resolvesTo(0),
+        deleteByTimestamp: mockFn().resolvesTo(0),
+        insertMany: mockFn().resolvesTo(0),
+      })
       const aggregatedInteropTokensPair = mockObject<
         Database['aggregatedInteropTokensPair']
       >({
@@ -602,6 +654,7 @@ describe(InteropAggregatingIndexer.name, () => {
         interopTransfer,
         aggregatedInteropTransfer,
         aggregatedInteropToken,
+        aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
@@ -611,6 +664,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers: [],
           aggregatedTokens: [],
+          aggregatedDeployedTokens: [],
           aggregatedTokensPairs: [],
           warnings: [],
         }),
@@ -682,6 +736,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const aggregatedInteropDeployedToken = mockObject<
+        Database['aggregatedInteropDeployedToken']
+      >({
+        deleteAllButEarliestPerDayBefore: mockFn().resolvesTo(0),
+        deleteByTimestamp: mockFn().resolvesTo(0),
+        insertMany: mockFn().resolvesTo(0),
+      })
       const aggregatedInteropTokensPair = mockObject<
         Database['aggregatedInteropTokensPair']
       >({
@@ -696,6 +757,7 @@ describe(InteropAggregatingIndexer.name, () => {
         interopTransfer,
         aggregatedInteropTransfer,
         aggregatedInteropToken,
+        aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
@@ -705,6 +767,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers: [],
           aggregatedTokens: [],
+          aggregatedDeployedTokens: [],
           aggregatedTokensPairs: [],
           warnings: [],
         }),

--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
@@ -1,5 +1,6 @@
 import { Logger } from '@l2beat/backend-tools'
 import type {
+  AggregatedInteropDeployedTokenRecord,
   AggregatedInteropTokenRecord,
   AggregatedInteropTokensPairRecord,
   AggregatedInteropTransferRecord,
@@ -97,6 +98,27 @@ describe(InteropAggregatingIndexer.name, () => {
         },
       ]
 
+      const aggregatedDeployedTokens: AggregatedInteropDeployedTokenRecord[] = [
+        {
+          timestamp: to,
+          id: 'config1',
+          srcChain: 'ethereum',
+          dstChain: 'arbitrum',
+          tokenChain: 'arbitrum',
+          tokenAddress: '0xarb',
+          transferCount: 1,
+          transfersWithDurationCount: 1,
+          transferTypeStats: undefined,
+          totalDurationSum: 5000,
+          volume: 2000,
+          minTransferValueUsd: 2000,
+          maxTransferValueUsd: 2000,
+          bridgeType: 'lockAndMint',
+          mintedValueUsd: 2000,
+          burnedValueUsd: 0,
+        },
+      ]
+
       const aggregatedTokensPairs: AggregatedInteropTokensPairRecord[] = [
         {
           timestamp: to,
@@ -167,7 +189,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregate: mockFn().returns({
           aggregatedTransfers,
           aggregatedTokens,
-          aggregatedDeployedTokens: [],
+          aggregatedDeployedTokens,
           aggregatedTokensPairs,
           warnings: [],
         }),
@@ -213,6 +235,15 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken.deleteAllButEarliestPerDayBefore,
       ).toHaveBeenCalledWith(retentionCutoff)
       expect(aggregatedInteropToken.deleteByTimestamp).toHaveBeenCalledWith(to)
+      expect(aggregatedInteropDeployedToken.insertMany).toHaveBeenCalledWith(
+        aggregatedDeployedTokens,
+      )
+      expect(
+        aggregatedInteropDeployedToken.deleteAllButEarliestPerDayBefore,
+      ).toHaveBeenCalledWith(retentionCutoff)
+      expect(
+        aggregatedInteropDeployedToken.deleteByTimestamp,
+      ).toHaveBeenCalledWith(to)
       expect(aggregatedInteropTokensPair.insertMany).toHaveBeenCalledWith(
         aggregatedTokensPairs,
       )
@@ -315,6 +346,7 @@ describe(InteropAggregatingIndexer.name, () => {
       )
       expect(aggregatedInteropTransfer.insertMany).toHaveBeenCalledWith([])
       expect(aggregatedInteropToken.insertMany).toHaveBeenCalledWith([])
+      expect(aggregatedInteropDeployedToken.insertMany).toHaveBeenCalledWith([])
       expect(aggregatedInteropTokensPair.insertMany).toHaveBeenCalledWith([])
     })
 

--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.ts
@@ -50,8 +50,12 @@ export class InteropAggregatingIndexer extends ManagedChildIndexer {
 
     const transfers = await this.$.db.interopTransfer.getByRange(from, to)
 
-    const { aggregatedTransfers, aggregatedTokens, aggregatedTokensPairs } =
-      this.$.aggregationService.aggregate(transfers, this.$.configs, to)
+    const {
+      aggregatedTransfers,
+      aggregatedTokens,
+      aggregatedDeployedTokens,
+      aggregatedTokensPairs,
+    } = this.$.aggregationService.aggregate(transfers, this.$.configs, to)
     const analysis = await this.runAggregateAnalysis(to, aggregatedTransfers)
 
     await this.$.db.transaction(async () => {
@@ -61,14 +65,21 @@ export class InteropAggregatingIndexer extends ManagedChildIndexer {
       await this.$.db.aggregatedInteropToken.deleteAllButEarliestPerDayBefore(
         retentionCutoff,
       )
+      await this.$.db.aggregatedInteropDeployedToken.deleteAllButEarliestPerDayBefore(
+        retentionCutoff,
+      )
       await this.$.db.aggregatedInteropTokensPair.deleteAllButEarliestPerDayBefore(
         retentionCutoff,
       )
       await this.$.db.aggregatedInteropToken.deleteByTimestamp(to)
+      await this.$.db.aggregatedInteropDeployedToken.deleteByTimestamp(to)
       await this.$.db.aggregatedInteropTransfer.deleteByTimestamp(to)
       await this.$.db.aggregatedInteropTokensPair.deleteByTimestamp(to)
       await this.$.db.aggregatedInteropTransfer.insertMany(aggregatedTransfers)
       await this.$.db.aggregatedInteropToken.insertMany(aggregatedTokens)
+      await this.$.db.aggregatedInteropDeployedToken.insertMany(
+        aggregatedDeployedTokens,
+      )
       await this.$.db.aggregatedInteropTokensPair.insertMany(
         aggregatedTokensPairs,
       )
@@ -87,6 +98,7 @@ export class InteropAggregatingIndexer extends ManagedChildIndexer {
     this.logger.info('Aggregated interop transfers saved to db', {
       aggregatedRecords: aggregatedTransfers.length,
       aggregatedTokens: aggregatedTokens.length,
+      aggregatedDeployedTokens: aggregatedDeployedTokens.length,
       aggregatedTokenPairs: aggregatedTokensPairs.length,
       suspiciousGroups: analysis?.suspiciousGroups.length ?? 0,
     })

--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationService.test.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationService.test.ts
@@ -270,7 +270,74 @@ describe(InteropAggregationService.name, () => {
 
       expect(result.aggregatedTransfers).toEqual([])
       expect(result.aggregatedTokens).toEqual([])
+      expect(result.aggregatedDeployedTokens).toEqual([])
       expect(result.aggregatedTokensPairs).toEqual([])
+    })
+
+    it('aggregates deployed tokens per address with net minted', () => {
+      const transfers: InteropTransferRecord[] = [
+        createTransfer('across', 'msg1', 'deposit', to - UnixTime.HOUR, {
+          srcChain: 'ethereum',
+          dstChain: 'arbitrum',
+          srcAbstractTokenId: 'eth',
+          dstAbstractTokenId: 'eth',
+          srcTokenAddress: '0xeth',
+          dstTokenAddress: '0xarb',
+          duration: 5000,
+          srcValueUsd: 2000,
+          dstValueUsd: 2000,
+          srcWasBurned: false,
+          dstWasMinted: true,
+        }),
+      ]
+
+      const configs: InteropAggregationConfig[] = [
+        {
+          id: 'config1',
+          plugins: [{ plugin: 'across', bridgeType: 'lockAndMint' }],
+          type: 'other',
+        },
+      ]
+
+      const classifier = new InteropTransferClassifier()
+      const service = new InteropAggregationService(classifier)
+
+      const result = service.aggregate(transfers, configs, to)
+
+      expect(result.aggregatedDeployedTokens).toHaveLength(2)
+
+      const srcToken = result.aggregatedDeployedTokens.find(
+        (t) => t.tokenChain === 'ethereum' && t.tokenAddress === '0xeth',
+      )
+      const dstToken = result.aggregatedDeployedTokens.find(
+        (t) => t.tokenChain === 'arbitrum' && t.tokenAddress === '0xarb',
+      )
+
+      expect(srcToken).toEqual({
+        timestamp: to,
+        id: 'config1',
+        srcChain: 'ethereum',
+        dstChain: 'arbitrum',
+        tokenChain: 'ethereum',
+        tokenAddress: '0xeth',
+        transferTypeStats: {
+          deposit: { transferCount: 1, totalDurationSum: 5000 },
+        },
+        transferCount: 1,
+        transfersWithDurationCount: 1,
+        totalDurationSum: 5000,
+        volume: 2000,
+        minTransferValueUsd: 2000,
+        maxTransferValueUsd: 2000,
+        bridgeType: 'lockAndMint',
+        mintedValueUsd: 0,
+        burnedValueUsd: 0,
+      })
+
+      // The newly minted supply is attributed to the destination token.
+      expect(dstToken?.mintedValueUsd).toEqual(2000)
+      expect(dstToken?.burnedValueUsd).toEqual(0)
+      expect(dstToken?.volume).toEqual(2000)
     })
 
     it('aggregates one-sided transfers even when their bridge type cannot be inferred', () => {
@@ -361,6 +428,8 @@ function createTransfer(
     dstChain: string
     srcAbstractTokenId: string
     dstAbstractTokenId: string
+    srcTokenAddress?: string
+    dstTokenAddress?: string
     duration: number
     srcValueUsd?: number
     dstValueUsd?: number
@@ -384,7 +453,7 @@ function createTransfer(
     // transfer two-sided again.
     srcEventId:
       'srcEventId' in overrides ? overrides.srcEventId : 'random-event-id',
-    srcTokenAddress: undefined,
+    srcTokenAddress: overrides.srcTokenAddress,
     srcRawAmount: undefined,
     srcWasBurned: overrides.srcWasBurned,
     srcSymbol: undefined,
@@ -395,7 +464,7 @@ function createTransfer(
     dstLogIndex: 0,
     dstEventId:
       'dstEventId' in overrides ? overrides.dstEventId : 'random-event-id',
-    dstTokenAddress: undefined,
+    dstTokenAddress: overrides.dstTokenAddress,
     dstRawAmount: undefined,
     dstWasMinted: overrides.dstWasMinted,
     dstSymbol: undefined,

--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationService.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregationService.ts
@@ -1,4 +1,5 @@
 import type {
+  AggregatedInteropDeployedTokenRecord,
   AggregatedInteropTokenRecord,
   AggregatedInteropTokensPairRecord,
   AggregatedInteropTransferRecord,
@@ -9,6 +10,7 @@ import type { InteropBridgeType } from '@l2beat/shared-pure'
 import groupBy from 'lodash/groupBy'
 import type { InteropAggregationConfig } from '../../../../config/features/interop'
 import {
+  getAggregatedDeployedTokens,
   getAggregatedTokens,
   getAggregatedTokensPairs,
   getAggregatedTransfer,
@@ -17,6 +19,7 @@ import {
 export interface AggregationResult {
   aggregatedTransfers: AggregatedInteropTransferRecord[]
   aggregatedTokens: AggregatedInteropTokenRecord[]
+  aggregatedDeployedTokens: AggregatedInteropDeployedTokenRecord[]
   aggregatedTokensPairs: AggregatedInteropTokensPairRecord[]
 }
 
@@ -30,6 +33,7 @@ export class InteropAggregationService {
   ): AggregationResult {
     const aggregatedTransfers: AggregatedInteropTransferRecord[] = []
     const aggregatedTokens: AggregatedInteropTokenRecord[] = []
+    const aggregatedDeployedTokens: AggregatedInteropDeployedTokenRecord[] = []
     const aggregatedTokensPairs: AggregatedInteropTokensPairRecord[] = []
 
     for (const config of configs) {
@@ -65,6 +69,17 @@ export class InteropAggregationService {
             })),
           )
 
+          aggregatedDeployedTokens.push(
+            ...getAggregatedDeployedTokens(group, {
+              calculateNetMinted: bridgeType === 'lockAndMint',
+            }).map((token) => ({
+              timestamp,
+              id: config.id,
+              bridgeType,
+              ...token,
+            })),
+          )
+
           aggregatedTokensPairs.push(
             ...getAggregatedTokensPairs(group).map((pair) => ({
               timestamp,
@@ -80,6 +95,7 @@ export class InteropAggregationService {
     return {
       aggregatedTransfers,
       aggregatedTokens,
+      aggregatedDeployedTokens,
       aggregatedTokensPairs,
     }
   }

--- a/packages/backend/src/modules/interop/engine/aggregation/aggregation.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/aggregation.ts
@@ -1,4 +1,5 @@
 import type {
+  AggregatedInteropDeployedTokenRecord,
   AggregatedInteropTokenRecord,
   AggregatedInteropTokensPairRecord,
   AggregatedInteropTransferRecord,
@@ -345,6 +346,191 @@ export function getAggregatedTokens(
     srcChain: first.srcChain,
     dstChain: first.dstChain,
     abstractTokenId: abstractTokenId,
+    transferTypeStats: data.transferTypeStats,
+    transferCount: data.transferCount,
+    transfersWithDurationCount: data.transfersWithDurationCount,
+    totalDurationSum: data.totalDurationSum,
+    volume: data.volume,
+    minTransferValueUsd:
+      data.minTransferValueUsd !== undefined
+        ? Math.round(data.minTransferValueUsd * 100) / 100
+        : undefined,
+    maxTransferValueUsd:
+      data.maxTransferValueUsd !== undefined
+        ? Math.round(data.maxTransferValueUsd * 100) / 100
+        : undefined,
+    mintedValueUsd: data.mintedValueUsd,
+    burnedValueUsd: data.burnedValueUsd,
+  }))
+}
+
+export function getAggregatedDeployedTokens(
+  group: InteropTransferRecord[],
+  options?: {
+    calculateNetMinted?: boolean
+  },
+): Omit<
+  AggregatedInteropDeployedTokenRecord,
+  'id' | 'timestamp' | 'bridgeType'
+>[] {
+  const first = group[0]
+  assert(first, 'Group is empty')
+  const tokens: Record<
+    string,
+    {
+      tokenChain: string
+      tokenAddress: string
+      transferCount: number
+      totalDurationSum: number
+      transfersWithDurationCount: number
+      volume: number
+      minTransferValueUsd: number | undefined
+      maxTransferValueUsd: number | undefined
+      mintedValueUsd: number | undefined
+      burnedValueUsd: number | undefined
+      transferTypeStats: InteropTransferTypeStatsMap | undefined
+    }
+  > = {}
+
+  for (const transfer of group) {
+    const duration = transfer.duration
+    const isSameToken =
+      transfer.srcChain === transfer.dstChain &&
+      transfer.srcTokenAddress === transfer.dstTokenAddress
+
+    const isBurn =
+      transfer.srcWasBurned === true && transfer.dstWasMinted === false
+    const isMint =
+      transfer.srcWasBurned === false && transfer.dstWasMinted === true
+    const mintValue = transfer.dstValueUsd ?? transfer.srcValueUsd ?? 0
+    const burnValue = transfer.srcValueUsd ?? transfer.dstValueUsd ?? 0
+
+    if (transfer.srcTokenAddress) {
+      const srcTokenKey = `${transfer.srcChain}|${transfer.srcTokenAddress}`
+      const srcTokenTransferValueUsd =
+        transfer.srcValueUsd ?? transfer.dstValueUsd
+      const currentSrcToken = tokens[srcTokenKey]
+      tokens[srcTokenKey] = {
+        tokenChain: transfer.srcChain,
+        tokenAddress: transfer.srcTokenAddress,
+        transferCount: (currentSrcToken?.transferCount ?? 0) + 1,
+        totalDurationSum:
+          (currentSrcToken?.totalDurationSum ?? 0) + (duration ?? 0),
+        transfersWithDurationCount:
+          (currentSrcToken?.transfersWithDurationCount ?? 0) +
+          (duration !== undefined ? 1 : 0),
+        transferTypeStats:
+          duration !== undefined
+            ? addTransferTypeStats(
+                currentSrcToken?.transferTypeStats,
+                transfer.type,
+                duration,
+              )
+            : currentSrcToken?.transferTypeStats,
+        volume: (currentSrcToken?.volume ?? 0) + (transfer.srcValueUsd ?? 0),
+        minTransferValueUsd:
+          srcTokenTransferValueUsd !== undefined
+            ? Math.min(
+                currentSrcToken?.minTransferValueUsd ??
+                  Number.POSITIVE_INFINITY,
+                srcTokenTransferValueUsd,
+              )
+            : currentSrcToken?.minTransferValueUsd,
+        maxTransferValueUsd:
+          srcTokenTransferValueUsd !== undefined
+            ? Math.max(
+                currentSrcToken?.maxTransferValueUsd ??
+                  Number.NEGATIVE_INFINITY,
+                srcTokenTransferValueUsd,
+              )
+            : currentSrcToken?.maxTransferValueUsd,
+        mintedValueUsd: options?.calculateNetMinted
+          ? (currentSrcToken?.mintedValueUsd ?? 0)
+          : undefined,
+        burnedValueUsd: options?.calculateNetMinted
+          ? (currentSrcToken?.burnedValueUsd ?? 0)
+          : undefined,
+      }
+
+      if (options?.calculateNetMinted && isBurn) {
+        tokens[srcTokenKey].burnedValueUsd =
+          (tokens[srcTokenKey]?.burnedValueUsd ?? 0) + burnValue
+      }
+
+      if (
+        options?.calculateNetMinted &&
+        isMint &&
+        (isSameToken || !transfer.dstTokenAddress)
+      ) {
+        tokens[srcTokenKey].mintedValueUsd =
+          (tokens[srcTokenKey]?.mintedValueUsd ?? 0) + mintValue
+      }
+    }
+
+    if (transfer.dstTokenAddress && !isSameToken) {
+      const dstTokenKey = `${transfer.dstChain}|${transfer.dstTokenAddress}`
+      const dstTokenTransferValueUsd =
+        transfer.dstValueUsd ?? transfer.srcValueUsd
+      const currentDstToken = tokens[dstTokenKey]
+      tokens[dstTokenKey] = {
+        tokenChain: transfer.dstChain,
+        tokenAddress: transfer.dstTokenAddress,
+        transferCount: (currentDstToken?.transferCount ?? 0) + 1,
+        totalDurationSum:
+          (currentDstToken?.totalDurationSum ?? 0) + (duration ?? 0),
+        transfersWithDurationCount:
+          (currentDstToken?.transfersWithDurationCount ?? 0) +
+          (duration !== undefined ? 1 : 0),
+        transferTypeStats:
+          duration !== undefined
+            ? addTransferTypeStats(
+                currentDstToken?.transferTypeStats,
+                transfer.type,
+                duration,
+              )
+            : currentDstToken?.transferTypeStats,
+        volume: (currentDstToken?.volume ?? 0) + (transfer.dstValueUsd ?? 0),
+        minTransferValueUsd:
+          dstTokenTransferValueUsd !== undefined
+            ? Math.min(
+                currentDstToken?.minTransferValueUsd ??
+                  Number.POSITIVE_INFINITY,
+                dstTokenTransferValueUsd,
+              )
+            : currentDstToken?.minTransferValueUsd,
+        maxTransferValueUsd:
+          dstTokenTransferValueUsd !== undefined
+            ? Math.max(
+                currentDstToken?.maxTransferValueUsd ??
+                  Number.NEGATIVE_INFINITY,
+                dstTokenTransferValueUsd,
+              )
+            : currentDstToken?.maxTransferValueUsd,
+        mintedValueUsd: options?.calculateNetMinted
+          ? (currentDstToken?.mintedValueUsd ?? 0)
+          : undefined,
+        burnedValueUsd: options?.calculateNetMinted
+          ? (currentDstToken?.burnedValueUsd ?? 0)
+          : undefined,
+      }
+
+      if (options?.calculateNetMinted && isMint) {
+        tokens[dstTokenKey].mintedValueUsd =
+          (tokens[dstTokenKey]?.mintedValueUsd ?? 0) + mintValue
+      }
+
+      if (options?.calculateNetMinted && isBurn && !transfer.srcTokenAddress) {
+        tokens[dstTokenKey].burnedValueUsd =
+          (tokens[dstTokenKey]?.burnedValueUsd ?? 0) + burnValue
+      }
+    }
+  }
+
+  return Object.values(tokens).map((data) => ({
+    srcChain: first.srcChain,
+    dstChain: first.dstChain,
+    tokenChain: data.tokenChain,
+    tokenAddress: data.tokenAddress,
     transferTypeStats: data.transferTypeStats,
     transferCount: data.transferCount,
     transfersWithDurationCount: data.transfersWithDurationCount,


### PR DESCRIPTION
Part 2/3 of the "Onchain deployments" token page section (split from #12072). Stacked on #12079.

Extends the interop aggregation indexer to also produce per-deployed-token (chain + address) 24h aggregates alongside the existing per-abstract-token ones, written to `AggregatedInteropDeployedToken` in the same transaction and snapshot timestamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)