### PR TITLE
Only add query params on token page when selection differs from default

### DIFF
--- a/packages/frontend/src/pages/interop/token/InteropTokenPage.tsx
+++ b/packages/frontend/src/pages/interop/token/InteropTokenPage.tsx
@@ -54,6 +54,7 @@ export function InteropTokenPage({
       <InteropSelectedChainsProvider
         interopChains={interopChains}
         initialSelection={initialSelection}
+        selectAllByDefault
       >
         <Content
           token={token}

--- a/packages/frontend/src/pages/interop/token/getInteropTokenPageData.ts
+++ b/packages/frontend/src/pages/interop/token/getInteropTokenPageData.ts
@@ -31,8 +31,12 @@ export async function getInteropTokenPageData(
     activeInteropChains,
   )
 
+  // On the token page all chains are selected by default
   const initialSelection = getInitialInteropSelection({
-    query: req.query,
+    query: {
+      from: req.query?.from ?? activeInteropChainIds,
+      to: req.query?.to ?? activeInteropChainIds,
+    },
     interopChainsIds: activeInteropChainIds,
   })
 

--- a/packages/frontend/src/pages/interop/utils/InteropSelectedChainsContext.tsx
+++ b/packages/frontend/src/pages/interop/utils/InteropSelectedChainsContext.tsx
@@ -14,6 +14,7 @@ import { useTracking } from '~/hooks/useTracking'
 import type { InteropChainWithIcon } from '../components/chain-selector/types'
 import { buildInteropUrl } from './buildInteropUrl'
 import { getValidInteropSelection } from './getValidInteropSelection'
+import { isSameInteropSelection } from './isSameInteropSelection'
 import { parseInteropSelectionFromSearchParams } from './parseInteropSelectionFromSearchParams'
 import type { InteropSelection } from './types'
 
@@ -37,16 +38,25 @@ interface InteropSelectedChainsProviderProps {
   children: ReactNode
   interopChains: InteropChainWithIcon[]
   initialSelection: InteropSelection
+  selectAllByDefault?: boolean
 }
 
 export function InteropSelectedChainsProvider({
   children,
   interopChains,
   initialSelection,
+  selectAllByDefault,
 }: InteropSelectedChainsProviderProps) {
   const allChainIds = useMemo(
     () => interopChains.map((c) => c.id),
     [interopChains],
+  )
+  const defaultSelection = useMemo<InteropSelection>(
+    () =>
+      selectAllByDefault
+        ? { from: allChainIds, to: allChainIds }
+        : { from: [], to: [] },
+    [selectAllByDefault, allChainIds],
   )
   const chainsById = useMemo(
     () => new Map(interopChains.map((chain) => [chain.id, chain])),
@@ -79,17 +89,33 @@ export function InteropSelectedChainsProvider({
       return
     }
 
+    const searchParams = new URLSearchParams(window.location.search)
     const currentSelection = parseInteropSelectionFromSearchParams({
-      searchParams: new URLSearchParams(window.location.search),
+      searchParams,
       interopChainsIds: allChainIds,
+      defaultSelection,
     })
-    if (isSameSelection(currentSelection, debouncedSelection)) {
+    if (isSameInteropSelection(currentSelection, debouncedSelection)) {
+      if (
+        isSameInteropSelection(debouncedSelection, defaultSelection) &&
+        (searchParams.has('from') || searchParams.has('to'))
+      ) {
+        searchParams.delete('from')
+        searchParams.delete('to')
+        const search = searchParams.toString()
+        window.history.replaceState(
+          {},
+          '',
+          window.location.pathname + (search ? `?${search}` : ''),
+        )
+      }
       return
     }
 
     const nextUrl = buildInteropUrl(
       window.location.pathname,
       debouncedSelection,
+      defaultSelection,
     )
 
     const currentUrl = window.location.pathname + window.location.search
@@ -108,7 +134,7 @@ export function InteropSelectedChainsProvider({
       chains,
       page: window.location.pathname,
     })
-  }, [debouncedSelection, allChainIds, track])
+  }, [debouncedSelection, allChainIds, defaultSelection, track])
 
   useEventListener('popstate', () => {
     skipNextUrlUpdate.current = true
@@ -116,6 +142,7 @@ export function InteropSelectedChainsProvider({
     const parsedSelection = parseInteropSelectionFromSearchParams({
       searchParams: new URLSearchParams(window.location.search),
       interopChainsIds: allChainIds,
+      defaultSelection,
     })
 
     setSelection(getValidInteropSelection(parsedSelection, allChainIds))
@@ -217,15 +244,6 @@ function toggleSelection(
   }
 
   return allChainIds.filter((id) => nextSet.has(id))
-}
-
-function isSameSelection(left: InteropSelection, right: InteropSelection) {
-  return (
-    left.from.length === right.from.length &&
-    left.to.length === right.to.length &&
-    left.from.every((value, index) => value === right.from[index]) &&
-    left.to.every((value, index) => value === right.to[index])
-  )
 }
 
 export function useInteropSelectedChains() {

--- a/packages/frontend/src/pages/interop/utils/buildInteropUrl.test.ts
+++ b/packages/frontend/src/pages/interop/utils/buildInteropUrl.test.ts
@@ -19,4 +19,36 @@ describe(buildInteropUrl.name, () => {
 
     expect(result).toEqual('/interop/summary')
   })
+
+  it('returns path without query when selection equals default selection', () => {
+    const result = buildInteropUrl(
+      '/interop/tokens/circle-usdc',
+      {
+        from: ['ethereum', 'arbitrum'],
+        to: ['ethereum', 'arbitrum'],
+      },
+      {
+        from: ['ethereum', 'arbitrum'],
+        to: ['ethereum', 'arbitrum'],
+      },
+    )
+
+    expect(result).toEqual('/interop/tokens/circle-usdc')
+  })
+
+  it('builds URL with empty params when selection is empty but default is not', () => {
+    const result = buildInteropUrl(
+      '/interop/tokens/circle-usdc',
+      {
+        from: [],
+        to: [],
+      },
+      {
+        from: ['ethereum', 'arbitrum'],
+        to: ['ethereum', 'arbitrum'],
+      },
+    )
+
+    expect(result).toEqual('/interop/tokens/circle-usdc?from=&to=')
+  })
 })

--- a/packages/frontend/src/pages/interop/utils/buildInteropUrl.ts
+++ b/packages/frontend/src/pages/interop/utils/buildInteropUrl.ts
@@ -1,10 +1,14 @@
+import { isSameInteropSelection } from './isSameInteropSelection'
 import type { InteropSelection } from './types'
+
+const EMPTY_SELECTION: InteropSelection = { from: [], to: [] }
 
 export function buildInteropUrl(
   path: string,
   selection: InteropSelection,
+  defaultSelection: InteropSelection = EMPTY_SELECTION,
 ): string {
-  if (selection.from.length === 0 && selection.to.length === 0) {
+  if (isSameInteropSelection(selection, defaultSelection)) {
     return path
   }
 

--- a/packages/frontend/src/pages/interop/utils/isSameInteropSelection.ts
+++ b/packages/frontend/src/pages/interop/utils/isSameInteropSelection.ts
@@ -1,0 +1,13 @@
+import type { InteropSelection } from './types'
+
+export function isSameInteropSelection(
+  left: InteropSelection,
+  right: InteropSelection,
+) {
+  return (
+    left.from.length === right.from.length &&
+    left.to.length === right.to.length &&
+    left.from.every((value, index) => value === right.from[index]) &&
+    left.to.every((value, index) => value === right.to[index])
+  )
+}

--- a/packages/frontend/src/pages/interop/utils/parseInteropSelectionFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/interop/utils/parseInteropSelectionFromSearchParams.test.ts
@@ -29,4 +29,30 @@ describe(parseInteropSelectionFromSearchParams.name, () => {
       to: [],
     })
   })
+
+  it('returns default selection when params are missing', () => {
+    const result = parseInteropSelectionFromSearchParams({
+      searchParams: new URLSearchParams(''),
+      interopChainsIds: CHAINS,
+      defaultSelection: { from: CHAINS, to: CHAINS },
+    })
+
+    expect(result).toEqual({
+      from: CHAINS,
+      to: CHAINS,
+    })
+  })
+
+  it('ignores default selection when params are present', () => {
+    const result = parseInteropSelectionFromSearchParams({
+      searchParams: new URLSearchParams('from=ethereum&to='),
+      interopChainsIds: CHAINS,
+      defaultSelection: { from: CHAINS, to: CHAINS },
+    })
+
+    expect(result).toEqual({
+      from: ['ethereum'],
+      to: [],
+    })
+  })
 })

--- a/packages/frontend/src/pages/interop/utils/parseInteropSelectionFromSearchParams.ts
+++ b/packages/frontend/src/pages/interop/utils/parseInteropSelectionFromSearchParams.ts
@@ -4,14 +4,16 @@ import type { InteropSelection } from './types'
 export function parseInteropSelectionFromSearchParams({
   searchParams,
   interopChainsIds,
+  defaultSelection,
 }: {
   searchParams: URLSearchParams
   interopChainsIds: string[]
+  defaultSelection?: InteropSelection
 }): InteropSelection {
   return getInitialInteropSelection({
     query: {
-      from: parseQueryArray(searchParams.get('from')),
-      to: parseQueryArray(searchParams.get('to')),
+      from: parseQueryArray(searchParams.get('from')) ?? defaultSelection?.from,
+      to: parseQueryArray(searchParams.get('to')) ?? defaultSelection?.to,
     },
     interopChainsIds,
   })


### PR DESCRIPTION
## Problem

Entering the interop token page always carried a huge query string listing every chain, e.g.

`/interop/tokens/circle-usdc?from=ethereum%2Carbitrum%2Csolana%2C...&to=ethereum%2Carbitrum%2C...`

even though "all chains" is the default selection. The params came from links on other interop pages (`getInteropTokenUrl` embeds the source page's full selection) and the token page kept them.

## Solution

The token page now treats the full chain set as its default selection, and `from`/`to` are only encoded in the URL when the selection differs from it:

- `getInteropTokenPageData` defaults missing query params to all active chains, so a bare URL renders with all chains selected (previously the section filters started empty and showed "Select at least one source and destination chain").
- `InteropSelectedChainsProvider` gets a `selectAllByDefault` prop (only set by the token page). On entry, params that just restate the default selection are stripped via `replaceState` (no extra history entry, unrelated query params are preserved).
- `buildInteropUrl` / `parseInteropSelectionFromSearchParams` accept an optional `defaultSelection`: building returns the bare path when the selection equals it, parsing resolves missing params to it. An explicitly empty selection still round-trips as `?from=&to=`.
- Extracted `isSameInteropSelection` from the context so `buildInteropUrl` can share it.

Other interop pages don't pass the new prop, so their "empty by default" semantics are unchanged.

## Verification

- Unit tests added for the new `defaultSelection` behavior in build/parse.
- Manually verified with Playwright against the mock dev server: the all-chains URL cleans itself to the bare path, partial selections are kept, extra params survive cleanup, and the summary page behaves exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)