### PR TITLE
Remove manual EOA upgrade redWarnings

### DIFF
--- a/packages/config/src/projects/edgechain/edgechain.ts
+++ b/packages/config/src/projects/edgechain/edgechain.ts
@@ -19,10 +19,6 @@ export const edgechain: ScalingProject = orbitStackL3({
     REASON_FOR_BEING_OTHER.SMALL_DAC,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     name: 'Edge Chain',
     slug: 'edgechain',
     description:

--- a/packages/config/src/projects/funki/funki.ts
+++ b/packages/config/src/projects/funki/funki.ts
@@ -62,10 +62,6 @@ export const funki: ScalingProject = opStackL2({
     architectureImage: 'opstack-rollup-superchain-opfp-preu16',
     description:
       'Funki chain is an OP Stack Optimium on Ethereum reimagining the blockchain experience as an interconnected world brimming with wonder, adventure, and fun.',
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     stacks: ['OP Stack'],
     links: {
       websites: ['https://funkichain.com'],

--- a/packages/config/src/projects/geist/geist.ts
+++ b/packages/config/src/projects/geist/geist.ts
@@ -19,10 +19,6 @@ export const geist: ScalingProject = orbitStackL3({
     REASON_FOR_BEING_OTHER.SMALL_DAC,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     name: 'Geist',
     slug: 'geist',
     description:

--- a/packages/config/src/projects/l3x/l3x.ts
+++ b/packages/config/src/projects/l3x/l3x.ts
@@ -24,10 +24,6 @@ export const l3x: ScalingProject = orbitStackL3({
     REASON_FOR_BEING_OTHER.SMALL_DAC,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     name: 'L3X',
     slug: 'l3x',
     description:

--- a/packages/config/src/projects/lambda/lambda.ts
+++ b/packages/config/src/projects/lambda/lambda.ts
@@ -16,10 +16,6 @@ export const lambda: ScalingProject = opStackL2({
   display: {
     name: 'Lambda Chain',
     slug: 'lambda',
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     description:
       'Lambda Chain is an OP Stack Rollup on Ethereum, focusing on long-term data storage and -availability.',
     links: {

--- a/packages/config/src/projects/molten/molten.ts
+++ b/packages/config/src/projects/molten/molten.ts
@@ -18,10 +18,6 @@ export const molten: ScalingProject = orbitStackL3({
   additionalBadges: [BADGES.L3ParentChain.Arbitrum, BADGES.RaaS.Caldera],
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
   display: {
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     name: 'Molten Network',
     shortName: 'Molten',
     slug: 'molten',

--- a/packages/config/src/projects/muster/muster.ts
+++ b/packages/config/src/projects/muster/muster.ts
@@ -20,10 +20,6 @@ export const muster: ScalingProject = orbitStackL3({
   display: {
     name: 'Muster',
     slug: 'muster',
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     description:
       'Muster Network is an Arbitrum Orbit L3 gaming chain aiming to transform digital ownership for brands and games while managing blockchain infrastructure and security.',
     links: {

--- a/packages/config/src/projects/parallel/parallel.ts
+++ b/packages/config/src/projects/parallel/parallel.ts
@@ -24,10 +24,6 @@ export const parallel: ScalingProject = orbitStackL2({
   display: {
     name: 'Parallel',
     slug: 'parallel',
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     headerWarning:
       'Parallel is [deprecating their Orbit stack Layer 2](https://medium.com/@ParallelFi/the-withdrawal-on-parallel-l2-is-now-available-c3b4b572864e).',
     description:

--- a/packages/config/src/projects/playblock/playblock.ts
+++ b/packages/config/src/projects/playblock/playblock.ts
@@ -19,10 +19,6 @@ export const playblock: ScalingProject = orbitStackL3({
     REASON_FOR_BEING_OTHER.SMALL_DAC,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     name: 'PlayBlock',
     slug: 'playblock',
     description:

--- a/packages/config/src/projects/r0ar/r0ar.ts
+++ b/packages/config/src/projects/r0ar/r0ar.ts
@@ -19,10 +19,6 @@ export const r0ar: ScalingProject = opStackL2({
     slug: 'r0ar',
     description:
       'R0ar is an Optimistic Rollup utilizing the OP Stack focusing on DeFi.',
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     stacks: ['OP Stack'],
     links: {
       websites: ['https://r0ar.io/'],

--- a/packages/config/src/projects/shibarium/shibarium.ts
+++ b/packages/config/src/projects/shibarium/shibarium.ts
@@ -32,10 +32,6 @@ export const shibarium: ScalingProject = {
   display: {
     name: 'Shibarium',
     slug: 'shibarium',
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     description:
       'Shibarium is an EVM-compatible, proof of stake sidechain for Ethereum. It is built by developers behind the Shiba Inu token ecosystem. The main bridge to Ethereum is currently validated by Shibarium validators and allows for asset as well as data movement between Shibarium and Ethereum.',
     purposes: ['Universal'],

--- a/packages/config/src/projects/thebinaryholdings/thebinaryholdings.ts
+++ b/packages/config/src/projects/thebinaryholdings/thebinaryholdings.ts
@@ -22,10 +22,6 @@ export const thebinaryholdings: ScalingProject = opStackL2({
     name: 'The Binary Holdings',
     slug: 'thebinaryholdings',
     shortName: 'Binary',
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     description:
       'The Binary Holdings is a web3 infrastructure that integrates into telecommunication and banking apps to increase user engagement, retention, and ARPU (Average Revenue Per User) - while rewarding users for their engagement. It uses its own token (BNRY) for gas.',
     links: {

--- a/packages/config/src/projects/xchain/xchain.ts
+++ b/packages/config/src/projects/xchain/xchain.ts
@@ -17,10 +17,6 @@ export const xchain: ScalingProject = orbitStackL2({
     REASON_FOR_BEING_OTHER.SMALL_DAC,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contracts can be upgraded by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     name: 'XCHAIN',
     slug: 'xchain',
     description:


### PR DESCRIPTION
Follow-up to #11395. Removes the 13 manual `redWarning` assignments that used the exact text the automation now derives from `eoaWithUpgradePermissions`.

- 10 projects (geist, l3x, lambda, molten, muster, parallel, r0ar, shibarium, thebinaryholdings, xchain) are corroborated by discovery and keep the warning automatically, with no visible change.
- 3 warnings were stale: edgechain, funki and playblock have since moved upgrade permissions from EOAs to multisigs (5/8, 3/4 and 4/12 Safes respectively), so they lose the red warning.

The remaining manual redWarnings (apex, myria, sorare, brine, bugbuster, zkfair, etc.) describe risks the automation does not detect yet (critical reference changes by EOA, unverified implementations) and are untouched.