### PR TITLE
Model StarkEx programHash changes as upgrade permissions

### DIFF
--- a/packages/config/src/processing/getProjects.ts
+++ b/packages/config/src/processing/getProjects.ts
@@ -81,7 +81,7 @@ function layer2Or3ToProject(p: ScalingProject): BaseProject {
       ?.colors,
     statuses: {
       yellowWarning: p.display.headerWarning,
-      redWarning: getEoaUpgradeRedWarning(p.display.slug, p.display.redWarning),
+      redWarning: getEoaUpgradeRedWarning(p.id, p.display.redWarning),
       emergencyWarning: p.display.emergencyWarning,
       reviewStatus: p.reviewStatus,
       unverifiedContracts: getProjectUnverifiedContracts(p, daBridges),

--- a/packages/config/src/projects/_templates/starkex/FinalizableGpsFactAdapter/shapes.json
+++ b/packages/config/src/projects/_templates/starkex/FinalizableGpsFactAdapter/shapes.json
@@ -1,0 +1,7 @@
+{
+  "FinalizableGpsFactAdapter": {
+    "hash": "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0",
+    "address": "eth:0x40e1e5Ece49A878062fA9F87eA6dc81281098B22",
+    "blockNumber": 22188285
+  }
+}

--- a/packages/config/src/projects/_templates/starkex/FinalizableGpsFactAdapter/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/FinalizableGpsFactAdapter/template.jsonc
@@ -1,0 +1,30 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "FinalizableGpsFactAdapter",
+  "description": "Adapter between the core contract and the {{gpsContract}}. Stores the Cairo programHash (`{{programHash}}`), which can be changed until the adapter is finalized.",
+  "fields": {
+    "programHashMapped": {
+      "handler": {
+        "type": "call",
+        "method": "programHash",
+        "args": []
+      },
+      "edit": ["format", "StarknetProgramHash"]
+    },
+    "owner": {
+      "severity": "HIGH",
+      "handler": {
+        "type": "storage",
+        "slot": 2,
+        "returnType": "address"
+      },
+      "permissions": [
+        {
+          "type": "upgrade",
+          "description": "change the programHash, replacing the L2 execution logic whose proofs are accepted, directly or through appointed admins.",
+          "condition": "if the adapter is not finalized"
+        }
+      ]
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/starkex/GpsFactRegistryAdapter/shapes.json
+++ b/packages/config/src/projects/_templates/starkex/GpsFactRegistryAdapter/shapes.json
@@ -1,9 +1,4 @@
 {
-  "FinalizableGpsFactAdapterUSDC": {
-    "hash": "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0",
-    "address": "eth:0x40e1e5Ece49A878062fA9F87eA6dc81281098B22",
-    "blockNumber": 22188285
-  },
   "GpsFactRegistryAdapter": {
     "hash": "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd",
     "address": "eth:0x5339AB7557b3152b91A57D10B0Caf5da88Db5143",

--- a/packages/config/src/projects/_templates/starkex/StarkExchange/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkExchange/template.jsonc
@@ -33,7 +33,7 @@
         },
         {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
         },
         {
           "type": "interact",

--- a/packages/config/src/projects/_templates/starkex/StarkExchange/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkExchange/template.jsonc
@@ -33,7 +33,7 @@
         },
         {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
         },
         {
           "type": "interact",

--- a/packages/config/src/projects/_templates/starkex/StarkExchangeOld/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkExchangeOld/template.jsonc
@@ -36,7 +36,7 @@
         },
         {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
         },
         {
           "type": "interact",

--- a/packages/config/src/projects/_templates/starkex/StarkExchangeOld/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkExchangeOld/template.jsonc
@@ -36,7 +36,7 @@
         },
         {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
         },
         {
           "type": "interact",

--- a/packages/config/src/projects/_templates/starkex/StarkExchange_Frozen/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkExchange_Frozen/template.jsonc
@@ -35,7 +35,7 @@
         },
         {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
         },
         {
           "type": "interact",

--- a/packages/config/src/projects/_templates/starkex/StarkExchange_Frozen/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkExchange_Frozen/template.jsonc
@@ -35,7 +35,7 @@
         },
         {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
         },
         {
           "type": "interact",

--- a/packages/config/src/projects/_templates/starkex/StarkPerpetual/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkPerpetual/template.jsonc
@@ -34,11 +34,11 @@
         {
           "type": "upgrade",
           "delay": "{{configurationDelay}}",
-          "description": "change the global configuration hash committing to the L2 system parameters."
+          "description": "change the global and per-asset configuration hashes committing to the L2 system parameters."
         },
         {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set."
         },
         { "type": "interact", "description": "manage the token admin role." }
       ]

--- a/packages/config/src/projects/_templates/starkex/StarkPerpetual/template.jsonc
+++ b/packages/config/src/projects/_templates/starkex/StarkPerpetual/template.jsonc
@@ -32,8 +32,13 @@
       "permissions": [
         { "type": "upgrade", "delay": "{{getUpgradeActivationDelay}}" },
         {
+          "type": "upgrade",
+          "delay": "{{configurationDelay}}",
+          "description": "change the global configuration hash committing to the L2 system parameters."
+        },
+        {
           "type": "interact",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
         },
         { "type": "interact", "description": "manage the token admin role." }
       ]

--- a/packages/config/src/projects/apex/apex.ts
+++ b/packages/config/src/projects/apex/apex.ts
@@ -115,10 +115,6 @@ export const apex: ScalingProject = {
   },
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.LOW_DAC_THRESHOLD],
   display: {
-    redWarning: {
-      text: 'Critical contract references can be changed by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     architectureImage: 'starkex',
     headerWarning:
       'Apex Pro and the associated StarkEx instances [were sunset](https://www.apex.exchange/blog/detail/ApeX-Pro-Sunset-Delisting-Timeline-for-Trading-Pairs).',

--- a/packages/config/src/projects/apex/diffHistory.md
+++ b/packages/config/src/projects/apex/diffHistory.md
@@ -1,3 +1,176 @@
+Generated with discovered.json: 0xfdd80ece857d5d1aa0848e0dc7b15f0523ea76a0
+
+# Diff at Fri, 12 Jun 2026 11:53:38 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1767634866
+- current timestamp: 1767634866
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1767634866 (main branch discovery), not current.
+
+```diff
+    contract CommitteeUSDC (eth:0x23Cab3CF1aa7B929Df5e9f3712aCA3A6Fb9494E4) [starkex/Committee] {
+    +++ description: Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 3.
+      sourceHashes.0:
+-        "0x581fe96c5df565dd8524d044e5dcfdad1b613513021dce348f4c85f8c881a7b5"
++        "0x3cb57744ed0806e1e1604c1bbb564187321e4f492cadddae15c71324f33bfda2"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    contract FinalizableGpsFactAdapterUSDT (eth:0x40e1e5Ece49A878062fA9F87eA6dc81281098B22) [starkex/FinalizableGpsFactAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`770346231394331402493200980986217737662224545740427952627288191358999988146`), which can be changed until the adapter is finalized.
+      template:
+-        "starkex/GpsFactRegistryAdapter"
++        "starkex/FinalizableGpsFactAdapter"
+      sourceHashes.0:
+-        "0x395444e8f8af03cea56ff4137d997fc94a06817d06cea35a2b467a45c6ee136b"
++        "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0"
+      description:
+-        "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`770346231394331402493200980986217737662224545740427952627288191358999988146`)."
++        "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`770346231394331402493200980986217737662224545740427952627288191358999988146`), which can be changed until the adapter is finalized."
++++ severity: HIGH
+      values.owner:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+      fieldMeta:
++        {"owner":{"severity":"HIGH"}}
+    }
+```
+
+```diff
+    EOA  (eth:0x53c6Ec9640761c669B800088F097E01A8207Ac8b) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+      receivedPermissions.3:
++        {"permission":"upgrade","from":"eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b","description":"change the global configuration hash committing to the L2 system parameters.","role":".$admin"}
+    }
+```
+
+```diff
+    EOA  (eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A) {
+    +++ description: None
+      receivedPermissions.4:
++        {"permission":"upgrade","from":"eth:0x40e1e5Ece49A878062fA9F87eA6dc81281098B22","description":"change the programHash, replacing the L2 execution logic whose proofs are accepted, directly or through appointed admins.","role":".owner","condition":"if the adapter is not finalized"}
+      receivedPermissions.5:
++        {"permission":"upgrade","from":"eth:0xE741e26573782ae3C0ea9EC710FA99Fcd27fB953","description":"change the programHash, replacing the L2 execution logic whose proofs are accepted, directly or through appointed admins.","role":".owner","condition":"if the adapter is not finalized"}
+      eoaWithUpgradePermissions:
++        true
+    }
+```
+
+```diff
+    contract CommitteeUSDT (eth:0x7249082BfAFE9BCA502d38a686Ef3df37A0cf800) [starkex/Committee] {
+    +++ description: Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 3.
+      sourceHashes.0:
+-        "0xab5a8f616268fb3ec919ff2c4566b29938a53013be74e966348bf881eecd4c0a"
++        "0xa6c615cde1a1180a0bfa1c17038acb3ab6104b449aaed4d326f7a0d3baf0e5ce"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    contract StarkPerpetualUSDC (eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb) [starkex/StarkPerpetual] {
+    +++ description: Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.
+      sourceHashes.0:
+-        "0xb5e622bd6406dd3d2188cae22f160599ee0953d520795bb86831c4c266e45587"
++        "0x409415b9d5b1c07a1e521ad99a73a466d1a6a681df98a3f0241a82a9dcb861f1"
+      sourceHashes.1:
+-        "0xd2cfc40f85f0171f0b9b5a88fc7638bbb2af49fb1b87cf13a11d58f32403c598"
++        "0x7cd422f025b0fd3210c5dd5116401aea5673db49cd24c6a040b7b148d25dc7f4"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    contract PerpetualEscapeVerifier (eth:0xaadFdB9CAc145c65f2284fBe24600d07fb37F7BD) [edgex/PerpetualEscapeVerifier] {
+    +++ description: Special verifier for the escape() function.
+      sourceHashes.0:
+-        "0xb56ab8d20ca2ce7897c0448957f5ad2bb634a2019411b1cb0453afe5c86f4f5f"
++        "0x7b9a6fc1405ce527115c6c286c0e85ba27c6c9a0576b4ca39fe647103101c676"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    contract ApexAdminMultisig (eth:0xC532d2976209A56DdF4a99B844130f7c0daCa7B6) [GnosisSafe] {
+    +++ description: None
+      sourceHashes.1:
+-        "0xd42bbf9f7dcd3720a7fc6bdc6edfdfae8800a37d6dd4decfa0ef6ca4a2e88940"
++        "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+      receivedPermissions.3:
++        {"permission":"upgrade","from":"eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb","description":"change the global configuration hash committing to the L2 system parameters.","role":".$admin"}
+      deployerAddress:
++        "eth:0xB7B2d6d7a1ca768410B424bEd7f065F9756Cc299"
+    }
+```
+
+```diff
+    contract StarkPerpetualUSDT (eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b) [starkex/StarkPerpetual] {
+    +++ description: Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.
+      sourceHashes.0:
+-        "0xfd5ac94c5a362e7426efd613abbaca3b838cf7f6089b44d9c0d4f675ca4467b3"
++        "0x4c21fb0aff75ac1755959abe5aace71b3d70cd508a697c0a16ffbd2f81b5420a"
+      sourceHashes.1:
+-        "0xd44985473645ee33ac39b971c16c6b06bbada1d7c54ae7aa1e106e020fc3f4c1"
++        "0xcf0ce6605c3fb6262ab3bd6dcc022c17b07991a65c45c0a2a2d97ed59da1a36e"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    contract FinalizableGpsFactAdapterUSDC (eth:0xE741e26573782ae3C0ea9EC710FA99Fcd27fB953) [starkex/FinalizableGpsFactAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`), which can be changed until the adapter is finalized.
+      template:
+-        "starkex/GpsFactRegistryAdapter"
++        "starkex/FinalizableGpsFactAdapter"
+      sourceHashes.0:
+-        "0x395444e8f8af03cea56ff4137d997fc94a06817d06cea35a2b467a45c6ee136b"
++        "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0"
+      description:
+-        "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`)."
++        "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`), which can be changed until the adapter is finalized."
++++ severity: HIGH
+      values.owner:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+      fieldMeta:
++        {"owner":{"severity":"HIGH"}}
+    }
+```
+
+```diff
+    EOA  (eth:0xef75e1199B0599BA823b7770AcE8eb34864a1D55) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+      receivedPermissions.3:
++        {"permission":"upgrade","from":"eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb","description":"change the global configuration hash committing to the L2 system parameters.","role":".$admin"}
+    }
+```
+
 Generated with discovered.json: 0x92738990c4e0622cd398634a412ce1b760ef0850
 
 # Diff at Fri, 12 Jun 2026 10:18:39 GMT:

--- a/packages/config/src/projects/apex/diffHistory.md
+++ b/packages/config/src/projects/apex/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0xfdd80ece857d5d1aa0848e0dc7b15f0523ea76a0
+Generated with discovered.json: 0x99f4310550e32b4231cc95d543d356dad0f82ece
 
-# Diff at Fri, 12 Jun 2026 11:53:38 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:43 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1767634866
@@ -54,9 +54,9 @@ discovery. Values are for block 1767634866 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set."
       receivedPermissions.3:
-+        {"permission":"upgrade","from":"eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b","description":"change the global configuration hash committing to the L2 system parameters.","role":".$admin"}
++        {"permission":"upgrade","from":"eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b","description":"change the global and per-asset configuration hashes committing to the L2 system parameters.","role":".$admin"}
     }
 ```
 
@@ -116,9 +116,9 @@ discovery. Values are for block 1767634866 (main branch discovery), not current.
 +        "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set."
       receivedPermissions.3:
-+        {"permission":"upgrade","from":"eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb","description":"change the global configuration hash committing to the L2 system parameters.","role":".$admin"}
++        {"permission":"upgrade","from":"eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb","description":"change the global and per-asset configuration hashes committing to the L2 system parameters.","role":".$admin"}
       deployerAddress:
 +        "eth:0xB7B2d6d7a1ca768410B424bEd7f065F9756Cc299"
     }
@@ -165,9 +165,9 @@ discovery. Values are for block 1767634866 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set."
       receivedPermissions.3:
-+        {"permission":"upgrade","from":"eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb","description":"change the global configuration hash committing to the L2 system parameters.","role":".$admin"}
++        {"permission":"upgrade","from":"eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb","description":"change the global and per-asset configuration hashes committing to the L2 system parameters.","role":".$admin"}
     }
 ```
 

--- a/packages/config/src/projects/apex/discovered.json
+++ b/packages/config/src/projects/apex/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "apex",
   "timestamp": 1767634866,
-  "configHash": "0xe5caefe8207cf1906d47ac619fe52cde7187dc3d08214798fd6c869401dc1608",
+  "configHash": "0x948e9f121b346ff725b2faf7402bd03dbc0df5fdaca84abcaee5d9afd8d2275d",
   "entries": [
     {
       "address": "eth:0x0cbb676d12745948f75aF3A172cb7E4A4f8546e8",
@@ -24,10 +24,11 @@
       "type": "Contract",
       "template": "starkex/Committee",
       "sourceHashes": [
-        "0x581fe96c5df565dd8524d044e5dcfdad1b613513021dce348f4c85f8c881a7b5"
+        "0x3cb57744ed0806e1e1604c1bbb564187321e4f492cadddae15c71324f33bfda2"
       ],
       "proxyType": "immutable",
       "description": "Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 3.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1671630143,
       "sinceBlock": 16233442,
       "values": {
@@ -61,12 +62,13 @@
       "name": "FinalizableGpsFactAdapterUSDT",
       "address": "eth:0x40e1e5Ece49A878062fA9F87eA6dc81281098B22",
       "type": "Contract",
-      "template": "starkex/GpsFactRegistryAdapter",
+      "template": "starkex/FinalizableGpsFactAdapter",
       "sourceHashes": [
-        "0x395444e8f8af03cea56ff4137d997fc94a06817d06cea35a2b467a45c6ee136b"
+        "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0"
       ],
       "proxyType": "immutable",
-      "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`770346231394331402493200980986217737662224545740427952627288191358999988146`).",
+      "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`770346231394331402493200980986217737662224545740427952627288191358999988146`), which can be changed until the adapter is finalized.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1697631587,
       "sinceBlock": 18377195,
       "values": {
@@ -75,9 +77,11 @@
         "hasRegisteredFact": true,
         "identify": "StarkWare_FinalizableGpsFactAdapter_2022_1",
         "isFinalized": false,
+        "owner": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
         "programHash": "770346231394331402493200980986217737662224545740427952627288191358999988146",
         "programHashMapped": "ApeX-USDT"
       },
+      "fieldMeta": { "owner": { "severity": "HIGH" } },
       "implementationNames": {
         "eth:0x40e1e5Ece49A878062fA9F87eA6dc81281098B22": "FinalizableGpsFactAdapter"
       },
@@ -140,13 +144,19 @@
         {
           "permission": "interact",
           "from": "eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
           "permission": "upgrade",
           "from": "eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b",
           "delay": 1209600,
+          "role": ".$admin"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b",
+          "description": "change the global configuration hash committing to the L2 system parameters.",
           "role": ".$admin"
         }
       ]
@@ -168,6 +178,7 @@
       "address": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "type": "EOA",
       "proxyType": "EOA",
+      "eoaWithUpgradePermissions": true,
       "receivedPermissions": [
         {
           "permission": "interact",
@@ -192,6 +203,20 @@
           "from": "eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b",
           "description": "Permissioned to regularly update the state of the L2 on L1. Each state update must have been proven via the SHARP verifier and contains state diffs for data availability.",
           "role": ".operators"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x40e1e5Ece49A878062fA9F87eA6dc81281098B22",
+          "description": "change the programHash, replacing the L2 execution logic whose proofs are accepted, directly or through appointed admins.",
+          "role": ".owner",
+          "condition": "if the adapter is not finalized"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xE741e26573782ae3C0ea9EC710FA99Fcd27fB953",
+          "description": "change the programHash, replacing the L2 execution logic whose proofs are accepted, directly or through appointed admins.",
+          "role": ".owner",
+          "condition": "if the adapter is not finalized"
         }
       ]
     },
@@ -206,10 +231,11 @@
       "type": "Contract",
       "template": "starkex/Committee",
       "sourceHashes": [
-        "0xab5a8f616268fb3ec919ff2c4566b29938a53013be74e966348bf881eecd4c0a"
+        "0xa6c615cde1a1180a0bfa1c17038acb3ab6104b449aaed4d326f7a0d3baf0e5ce"
       ],
       "proxyType": "immutable",
       "description": "Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 3.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1697631587,
       "sinceBlock": 18377195,
       "values": {
@@ -267,8 +293,8 @@
       "type": "Contract",
       "template": "starkex/StarkPerpetual",
       "sourceHashes": [
-        "0xb5e622bd6406dd3d2188cae22f160599ee0953d520795bb86831c4c266e45587",
-        "0xd2cfc40f85f0171f0b9b5a88fc7638bbb2af49fb1b87cf13a11d58f32403c598"
+        "0x409415b9d5b1c07a1e521ad99a73a466d1a6a681df98a3f0241a82a9dcb861f1",
+        "0x7cd422f025b0fd3210c5dd5116401aea5673db49cd24c6a040b7b148d25dc7f4"
       ],
       "proxyType": "StarkWare diamond",
       "description": "Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.",
@@ -283,6 +309,7 @@
         "getValidiumTreeHeight",
         "getValidiumVaultRoot"
       ],
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1660252039,
       "sinceBlock": 15322967,
       "values": {
@@ -432,10 +459,11 @@
       "type": "Contract",
       "template": "edgex/PerpetualEscapeVerifier",
       "sourceHashes": [
-        "0xb56ab8d20ca2ce7897c0448957f5ad2bb634a2019411b1cb0453afe5c86f4f5f"
+        "0x7b9a6fc1405ce527115c6c286c0e85ba27c6c9a0576b4ca39fe647103101c676"
       ],
       "proxyType": "immutable",
       "description": "Special verifier for the escape() function.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1660252035,
       "sinceBlock": 15322966,
       "values": {
@@ -464,7 +492,7 @@
       "template": "GnosisSafe",
       "sourceHashes": [
         "0x81a7349eebb98ac33b0bc6842e3cb258034a8f2a4ba004570bb8e2e25947f9ff",
-        "0xd42bbf9f7dcd3720a7fc6bdc6edfdfae8800a37d6dd4decfa0ef6ca4a2e88940"
+        "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
       ],
       "proxyType": "gnosis safe",
       "receivedPermissions": [
@@ -477,7 +505,7 @@
         {
           "permission": "interact",
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -485,9 +513,16 @@
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
           "delay": 1209600,
           "role": ".$admin"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
+          "description": "change the global configuration hash committing to the L2 system parameters.",
+          "role": ".$admin"
         }
       ],
       "ignoreInWatchMode": ["nonce"],
+      "deployerAddress": "eth:0xB7B2d6d7a1ca768410B424bEd7f065F9756Cc299",
       "sinceTimestamp": 1672216439,
       "sinceBlock": 16282082,
       "values": {
@@ -516,8 +551,8 @@
       "type": "Contract",
       "template": "starkex/StarkPerpetual",
       "sourceHashes": [
-        "0xfd5ac94c5a362e7426efd613abbaca3b838cf7f6089b44d9c0d4f675ca4467b3",
-        "0xd44985473645ee33ac39b971c16c6b06bbada1d7c54ae7aa1e106e020fc3f4c1"
+        "0x4c21fb0aff75ac1755959abe5aace71b3d70cd508a697c0a16ffbd2f81b5420a",
+        "0xcf0ce6605c3fb6262ab3bd6dcc022c17b07991a65c45c0a2a2d97ed59da1a36e"
       ],
       "proxyType": "StarkWare diamond",
       "description": "Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.",
@@ -532,6 +567,7 @@
         "getValidiumTreeHeight",
         "getValidiumVaultRoot"
       ],
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1697631539,
       "sinceBlock": 18377191,
       "values": {
@@ -639,12 +675,13 @@
       "name": "FinalizableGpsFactAdapterUSDC",
       "address": "eth:0xE741e26573782ae3C0ea9EC710FA99Fcd27fB953",
       "type": "Contract",
-      "template": "starkex/GpsFactRegistryAdapter",
+      "template": "starkex/FinalizableGpsFactAdapter",
       "sourceHashes": [
-        "0x395444e8f8af03cea56ff4137d997fc94a06817d06cea35a2b467a45c6ee136b"
+        "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0"
       ],
       "proxyType": "immutable",
-      "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`).",
+      "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`), which can be changed until the adapter is finalized.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1661254231,
       "sinceBlock": 15396280,
       "values": {
@@ -653,9 +690,11 @@
         "hasRegisteredFact": true,
         "identify": "StarkWare_FinalizableGpsFactAdapter_2022_1",
         "isFinalized": false,
+        "owner": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
         "programHash": "2530337539466159944237001094809327283009177793361359619481044346150483328860",
         "programHashMapped": "ApeX-USDC 20250130"
       },
+      "fieldMeta": { "owner": { "severity": "HIGH" } },
       "implementationNames": {
         "eth:0xE741e26573782ae3C0ea9EC710FA99Fcd27fB953": "FinalizableGpsFactAdapter"
       },
@@ -706,13 +745,19 @@
         {
           "permission": "interact",
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
           "permission": "upgrade",
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
           "delay": 1209600,
+          "role": ".$admin"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
+          "description": "change the global configuration hash committing to the L2 system parameters.",
           "role": ".$admin"
         }
       ]
@@ -1371,9 +1416,9 @@
     "edgex/PerpetualEscapeVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
     "GnosisSafe": "0x12db59bec64fa8de67bbeb6a6e913f6c5ff1598c0a5fba90282afaf08e2a748c",
     "starkex/Committee": "0xea8d2e95c84337933f471b8c21505791bd94685784b7e5c407f5e7045403a683",
-    "starkex/GpsFactRegistryAdapter": "0x1ad87511dd3212f3837ce0d97076154480b4909b6970ad7fb66342c32f61b0bb",
+    "starkex/FinalizableGpsFactAdapter": "0x2c4115608421d0d7aabe41291500b1f02a4d2989db1976f2c05a07b91fe4ba47",
     "starkex/StarkPerpetual": "0x2c320b80005728ab66e5a80a93fb2a160ce7cd11e884bbe1e399562c8b0c52d6"
   },
   "usedBlockNumbers": { "ethereum": 24170019 },
-  "permissionsConfigHash": "0x62b2d4606178d73c21cf64c65a0a097f88bc3964c5914426822a4d037f5990fe"
+  "permissionsConfigHash": "0x3bfa56b1b0e1dfb901ada410023d521b701a38baa0f5135cf8ce910344255906"
 }

--- a/packages/config/src/projects/apex/discovered.json
+++ b/packages/config/src/projects/apex/discovered.json
@@ -144,7 +144,7 @@
         {
           "permission": "interact",
           "from": "eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -156,7 +156,7 @@
         {
           "permission": "upgrade",
           "from": "eth:0xe53A6eD882Eb3f90cCe0390DDB04c876C5482E6b",
-          "description": "change the global configuration hash committing to the L2 system parameters.",
+          "description": "change the global and per-asset configuration hashes committing to the L2 system parameters.",
           "role": ".$admin"
         }
       ]
@@ -505,7 +505,7 @@
         {
           "permission": "interact",
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -517,7 +517,7 @@
         {
           "permission": "upgrade",
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
-          "description": "change the global configuration hash committing to the L2 system parameters.",
+          "description": "change the global and per-asset configuration hashes committing to the L2 system parameters.",
           "role": ".$admin"
         }
       ],
@@ -745,7 +745,7 @@
         {
           "permission": "interact",
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -757,7 +757,7 @@
         {
           "permission": "upgrade",
           "from": "eth:0xA1D5443F2FB80A5A55ac804C948B45ce4C52DCbb",
-          "description": "change the global configuration hash committing to the L2 system parameters.",
+          "description": "change the global and per-asset configuration hashes committing to the L2 system parameters.",
           "role": ".$admin"
         }
       ]
@@ -1420,5 +1420,5 @@
     "starkex/StarkPerpetual": "0x2c320b80005728ab66e5a80a93fb2a160ce7cd11e884bbe1e399562c8b0c52d6"
   },
   "usedBlockNumbers": { "ethereum": 24170019 },
-  "permissionsConfigHash": "0x3bfa56b1b0e1dfb901ada410023d521b701a38baa0f5135cf8ce910344255906"
+  "permissionsConfigHash": "0xb2840e1d5e4a4c7e6ae951087dd3d87aac005d655a290cff70e3c01ce918e36e"
 }

--- a/packages/config/src/projects/brine/brine.ts
+++ b/packages/config/src/projects/brine/brine.ts
@@ -66,10 +66,6 @@ export const brine: ScalingProject = {
     BADGES.Infra.SHARP,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contract references can be changed by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     architectureImage: 'starkex',
     name: 'tanX',
     slug: 'tanx',

--- a/packages/config/src/projects/brine/diffHistory.md
+++ b/packages/config/src/projects/brine/diffHistory.md
@@ -1,3 +1,30 @@
+Generated with discovered.json: 0xea781d84cccb7157bdc97c3eed7b73bb592cc5b6
+
+# Diff at Fri, 12 Jun 2026 11:53:38 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1777891418
+- current timestamp: 1777891418
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1777891418 (main branch discovery), not current.
+
+```diff
+    EOA  (eth:0x303775491494a08b07365938787274F742a81F63) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+    }
+```
+
 Generated with discovered.json: 0x87d3a1e15d8b329e0032ae4fef49660f313eac2a
 
 # Diff at Fri, 12 Jun 2026 10:18:42 GMT:

--- a/packages/config/src/projects/brine/diffHistory.md
+++ b/packages/config/src/projects/brine/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0xea781d84cccb7157bdc97c3eed7b73bb592cc5b6
+Generated with discovered.json: 0xb3ca3b560b66681ea9ea8d5b39b7e35b7e35ecb4
 
-# Diff at Fri, 12 Jun 2026 11:53:38 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:44 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1777891418
@@ -21,7 +21,7 @@ discovery. Values are for block 1777891418 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
     }
 ```
 

--- a/packages/config/src/projects/brine/discovered.json
+++ b/packages/config/src/projects/brine/discovered.json
@@ -144,7 +144,7 @@
         {
           "permission": "interact",
           "from": "eth:0x1390f521A79BaBE99b69B37154D63D431da27A07",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -695,5 +695,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 25021111 },
-  "permissionsConfigHash": "0x392f01567cf26e1c90ecf490a96316addc13d2067555d3e4ecac0f20f5e89a83"
+  "permissionsConfigHash": "0xf6c0fcaf2bea7e6ba01698b25548bb09dd3ff19e56140cc1719643b2b3b7e7ec"
 }

--- a/packages/config/src/projects/brine/discovered.json
+++ b/packages/config/src/projects/brine/discovered.json
@@ -144,7 +144,7 @@
         {
           "permission": "interact",
           "from": "eth:0x1390f521A79BaBE99b69B37154D63D431da27A07",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -695,5 +695,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 25021111 },
-  "permissionsConfigHash": "0x3b8daf4be450e792dafade5a55ed1bc835b7fa2627def13a2e58ae21ee344071"
+  "permissionsConfigHash": "0x392f01567cf26e1c90ecf490a96316addc13d2067555d3e4ecac0f20f5e89a83"
 }

--- a/packages/config/src/projects/canvasconnect/diffHistory.md
+++ b/packages/config/src/projects/canvasconnect/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0x9dda6018a38c915b790f721b7f9feee7673a8961
+Generated with discovered.json: 0xd34805d132337a2efcc743c55fad53249173d34b
 
-# Diff at Fri, 12 Jun 2026 11:53:39 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:45 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1715171555
@@ -65,7 +65,7 @@ discovery. Values are for block 1715171555 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
     }
 ```
 

--- a/packages/config/src/projects/canvasconnect/diffHistory.md
+++ b/packages/config/src/projects/canvasconnect/diffHistory.md
@@ -1,3 +1,74 @@
+Generated with discovered.json: 0x9dda6018a38c915b790f721b7f9feee7673a8961
+
+# Diff at Fri, 12 Jun 2026 11:53:39 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1715171555
+- current timestamp: 1715171555
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1715171555 (main branch discovery), not current.
+
+```diff
+    contract GpsFactRegistryAdapter (eth:0x5339AB7557b3152b91A57D10B0Caf5da88Db5143) [starkex/GpsFactRegistryAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`16830627573509542901909952446321116535677491650708854009406762893086223513`).
+      sourceHashes.0:
+-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
++        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract StarkExchange (eth:0x7A7f9c8fe871cd50f6Ce935d7c7caD2e89987f9d) [starkex/StarkExchange] {
+    +++ description: Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.
+      sourceHashes.0:
+-        "0x2c95972415c771f5ef6d71449bae168597b6c35245fbe8769425e5c9c753e918"
++        "0xa2b51d5024b872eb502c2abfec88397c41c32d42494dd19905514a69d38abfec"
+      sourceHashes.1:
+-        "0xfb3c0545e8c9aeebaa6547f71087a1ad7d93e3344e0dfdb1051e1a18fd44a18b"
++        "0x9b28596a715350d61f719241f35d6ee159c111c93c05da1d4804157142ee790c"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    contract OrderRegistry (eth:0x806d435a82B0381bD884540c2235147c13B97fe6) [starkex/OrderRegistry] {
+    +++ description: Helper contract for registering limit orders from L1.
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract DACommittee (eth:0x8B3A6662809195453645e37C2005d655f57ca818) [starkex/Committee] {
+    +++ description: Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 1.
+      sourceHashes.0:
+-        "0x220ee35d4e83e9cca7e8fa42dcab4d9571ce3078b50bacbdb2fc75afa7f0290e"
++        "0x3b7f5470a746d06671f24e4231b09df04ea52e7555e4fb874e093867c094c437"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    EOA  (eth:0xc7C731AF62Cd43eB158ad3Ac0fC5d2dd32648C7A) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+    }
+```
+
 Generated with discovered.json: 0x5281d7e5694515a5caa0baba2169a0db95a1f1fa
 
 # Diff at Fri, 12 Jun 2026 10:18:42 GMT:

--- a/packages/config/src/projects/canvasconnect/discovered.json
+++ b/packages/config/src/projects/canvasconnect/discovered.json
@@ -313,7 +313,7 @@
         {
           "permission": "interact",
           "from": "eth:0x7A7f9c8fe871cd50f6Ce935d7c7caD2e89987f9d",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -699,5 +699,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 19825363 },
-  "permissionsConfigHash": "0x5017269aa86456e83179ca5ad5a3a2098e1299a245182909a202c512af3a9b09"
+  "permissionsConfigHash": "0x1737f87f1d9378511b5e153b9d36cd9fd285d41f9b2f9d5787491b8b080cb323"
 }

--- a/packages/config/src/projects/canvasconnect/discovered.json
+++ b/packages/config/src/projects/canvasconnect/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "canvasconnect",
   "timestamp": 1715171555,
-  "configHash": "0xc9117028a67f09c4a6757c13e8987cfefbeeb972be9b066e8e6619ef9e7d7a7a",
+  "configHash": "0x480f59b0885c0330df6bc66d485c7ce5e875f0da943763006cc75d8954d8a9e4",
   "entries": [
     {
       "address": "eth:0x107691bD4F590270B9793c807cB912DD278e8cB5",
@@ -42,10 +42,11 @@
       "type": "Contract",
       "template": "starkex/GpsFactRegistryAdapter",
       "sourceHashes": [
-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
+        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
       ],
       "proxyType": "immutable",
       "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`16830627573509542901909952446321116535677491650708854009406762893086223513`).",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1657453372,
       "sinceBlock": 15114702,
       "values": {
@@ -110,8 +111,8 @@
       "type": "Contract",
       "template": "starkex/StarkExchange",
       "sourceHashes": [
-        "0x2c95972415c771f5ef6d71449bae168597b6c35245fbe8769425e5c9c753e918",
-        "0xfb3c0545e8c9aeebaa6547f71087a1ad7d93e3344e0dfdb1051e1a18fd44a18b"
+        "0xa2b51d5024b872eb502c2abfec88397c41c32d42494dd19905514a69d38abfec",
+        "0x9b28596a715350d61f719241f35d6ee159c111c93c05da1d4804157142ee790c"
       ],
       "proxyType": "StarkWare diamond",
       "description": "Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.",
@@ -123,6 +124,7 @@
         "getVaultRoot",
         "getValidiumVaultRoot"
       ],
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1674388691,
       "sinceBlock": 16462191,
       "values": {
@@ -247,6 +249,7 @@
       ],
       "proxyType": "immutable",
       "description": "Helper contract for registering limit orders from L1.",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1657453372,
       "sinceBlock": 15114702,
       "values": {
@@ -264,10 +267,11 @@
       "type": "Contract",
       "template": "starkex/Committee",
       "sourceHashes": [
-        "0x220ee35d4e83e9cca7e8fa42dcab4d9571ce3078b50bacbdb2fc75afa7f0290e"
+        "0x3b7f5470a746d06671f24e4231b09df04ea52e7555e4fb874e093867c094c437"
       ],
       "proxyType": "immutable",
       "description": "Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 1.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1674737735,
       "sinceBlock": 16491125,
       "values": {
@@ -309,7 +313,7 @@
         {
           "permission": "interact",
           "from": "eth:0x7A7f9c8fe871cd50f6Ce935d7c7caD2e89987f9d",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -695,5 +699,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 19825363 },
-  "permissionsConfigHash": "0x4f479c44bd9e93ccd323094d2ab7de64405be9a38e19c0aa23255cbf31584aa0"
+  "permissionsConfigHash": "0x5017269aa86456e83179ca5ad5a3a2098e1299a245182909a202c512af3a9b09"
 }

--- a/packages/config/src/projects/deversifi/diffHistory.md
+++ b/packages/config/src/projects/deversifi/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0x9adb347fd5a4d6c38080a6c6ef7e90b543e2c030
+Generated with discovered.json: 0xd3e5c63955911dcb7044248b42a63e130886576d
 
-# Diff at Fri, 12 Jun 2026 11:52:43 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:45 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1741185503
@@ -68,7 +68,7 @@ discovery. Values are for block 1741185503 (main branch discovery), not current.
 +        "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
       deployerAddress:
 +        "eth:0x59232aC80E6d403b6381393e52f4665ECA328558"
     }

--- a/packages/config/src/projects/deversifi/diffHistory.md
+++ b/packages/config/src/projects/deversifi/diffHistory.md
@@ -1,3 +1,79 @@
+Generated with discovered.json: 0x9adb347fd5a4d6c38080a6c6ef7e90b543e2c030
+
+# Diff at Fri, 12 Jun 2026 11:52:43 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1741185503
+- current timestamp: 1741185503
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1741185503 (main branch discovery), not current.
+
+```diff
+    contract DACommittee (eth:0x28780349A33eEE56bb92241bAAB8095449e24306) [starkex/Committee] {
+    +++ description: Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 4.
+      sourceHashes.0:
+-        "0x83a4f7af4e5a371aadb57903aed1b1f96556a0b3eb4665044a65ad8f70a89edc"
++        "0x020c9c9c17945e048bf65721f9e88fb40a4337b59004006d8572b0280ba4bd9e"
+      deployerAddress:
++        "eth:0x325870CB1c06C3A619e461425712248FE269AFCa"
+    }
+```
+
+```diff
+    contract GpsFactRegistryAdapter (eth:0x3b1298395290Bb7924F0Fcc176DECF3B4879FE73) [starkex/GpsFactRegistryAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`3174901404014912024702042974619036870715605532092680335571201877913899936957`).
+      sourceHashes.0:
+-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
++        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
+      deployerAddress:
++        "eth:0xF689688640E88160c07C6FC5cc63039F29EDe86b"
+    }
+```
+
+```diff
+    contract OrderRegistry (eth:0x518c4A79a1102eEDc987005CA8cE6B87Ca14dDf8) [starkex/OrderRegistry] {
+    +++ description: Helper contract for registering limit orders from L1.
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract StarkExchange (eth:0x5d22045DAcEAB03B158031eCB7D9d06Fad24609b) [starkex/StarkExchangeOld] {
+    +++ description: Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.
+      sourceHashes.0:
+-        "0x46eae4f2e7b6b0f5096ba403f113ff3c86205368a36af081ab280441d64942fc"
++        "0xc66ba691d8b15208a55f7e85542f058e0e9ff48d81d4b3cc2bcbf63548155fa1"
+      sourceHashes.1:
+-        "0xbe79d78e7db305a3c7147712a7cca3e0f82bacad7f00a96fa6b07bc8abfe9974"
++        "0xa8cecfdb411346cb244897e1d9ab3a1c20a7661db141cc9288851db26d46e69b"
+      deployerAddress:
++        "eth:0x325870CB1c06C3A619e461425712248FE269AFCa"
+    }
+```
+
+```diff
+    contract RhinofiAdminMultisig (eth:0xCCa5De1e10c05c50C51ac551D9182cd31aca1889) [GnosisSafe] {
+    +++ description: None
+      sourceHashes.1:
+-        "0xd42bbf9f7dcd3720a7fc6bdc6edfdfae8800a37d6dd4decfa0ef6ca4a2e88940"
++        "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+      deployerAddress:
++        "eth:0x59232aC80E6d403b6381393e52f4665ECA328558"
+    }
+```
+
 Generated with discovered.json: 0xf3d141b25ac82cff4c29d46368f4ebeac1432474
 
 # Diff at Tue, 09 Jun 2026 12:43:32 GMT:

--- a/packages/config/src/projects/deversifi/discovered.json
+++ b/packages/config/src/projects/deversifi/discovered.json
@@ -548,7 +548,7 @@
         {
           "permission": "interact",
           "from": "eth:0x5d22045DAcEAB03B158031eCB7D9d06Fad24609b",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -1016,5 +1016,5 @@
     "starkex/StarkExchangeOld": "0x1349c13ead4263acc9bf71f1282c62684eebc9e54c3c2e0c9e4ce04e120b146e"
   },
   "usedBlockNumbers": { "ethereum": 21981331 },
-  "permissionsConfigHash": "0x8db3f94de187184c22df7a08b29f04105d3623c3e0d26022695a251bad898f2d"
+  "permissionsConfigHash": "0xa4bbbff7c4775b6a26c243c25c7ea6b32fbbb220828ed036b3c879f03212b343"
 }

--- a/packages/config/src/projects/deversifi/discovered.json
+++ b/packages/config/src/projects/deversifi/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "deversifi",
   "timestamp": 1741185503,
-  "configHash": "0xafe26a6f869f57433d1a7a0bab630c3b3f4ce5a6e26989c28f3e16e4bbbb4c1e",
+  "configHash": "0x6c480acf7a8cac6eeffbe44f61e11b5d67f1bc5a031ee0dc39233d911cc244bf",
   "entries": [
     {
       "address": "eth:0x0fa6bf3377Cfa276d9d7122c09C187e5e8ef1C59",
@@ -14,10 +14,11 @@
       "type": "Contract",
       "template": "starkex/Committee",
       "sourceHashes": [
-        "0x83a4f7af4e5a371aadb57903aed1b1f96556a0b3eb4665044a65ad8f70a89edc"
+        "0x020c9c9c17945e048bf65721f9e88fb40a4337b59004006d8572b0280ba4bd9e"
       ],
       "proxyType": "immutable",
       "description": "Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 4.",
+      "deployerAddress": "eth:0x325870CB1c06C3A619e461425712248FE269AFCa",
       "sinceTimestamp": 1603626845,
       "sinceBlock": 11125447,
       "values": {
@@ -59,10 +60,11 @@
       "type": "Contract",
       "template": "starkex/GpsFactRegistryAdapter",
       "sourceHashes": [
-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
+        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
       ],
       "proxyType": "immutable",
       "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`3174901404014912024702042974619036870715605532092680335571201877913899936957`).",
+      "deployerAddress": "eth:0xF689688640E88160c07C6FC5cc63039F29EDe86b",
       "sinceTimestamp": 1691481095,
       "sinceBlock": 17868827,
       "values": {
@@ -140,6 +142,7 @@
       ],
       "proxyType": "immutable",
       "description": "Helper contract for registering limit orders from L1.",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1626352379,
       "sinceBlock": 12831566,
       "values": {
@@ -162,8 +165,8 @@
       "type": "Contract",
       "template": "starkex/StarkExchangeOld",
       "sourceHashes": [
-        "0x46eae4f2e7b6b0f5096ba403f113ff3c86205368a36af081ab280441d64942fc",
-        "0xbe79d78e7db305a3c7147712a7cca3e0f82bacad7f00a96fa6b07bc8abfe9974"
+        "0xc66ba691d8b15208a55f7e85542f058e0e9ff48d81d4b3cc2bcbf63548155fa1",
+        "0xa8cecfdb411346cb244897e1d9ab3a1c20a7661db141cc9288851db26d46e69b"
       ],
       "proxyType": "StarkWare diamond",
       "description": "Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.",
@@ -175,6 +178,7 @@
         "getVaultRoot",
         "getValidiumVaultRoot"
       ],
+      "deployerAddress": "eth:0x325870CB1c06C3A619e461425712248FE269AFCa",
       "sinceTimestamp": 1590491810,
       "sinceBlock": 10141009,
       "values": {
@@ -531,7 +535,7 @@
       "template": "GnosisSafe",
       "sourceHashes": [
         "0x81a7349eebb98ac33b0bc6842e3cb258034a8f2a4ba004570bb8e2e25947f9ff",
-        "0xd42bbf9f7dcd3720a7fc6bdc6edfdfae8800a37d6dd4decfa0ef6ca4a2e88940"
+        "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
       ],
       "proxyType": "gnosis safe",
       "receivedPermissions": [
@@ -544,7 +548,7 @@
         {
           "permission": "interact",
           "from": "eth:0x5d22045DAcEAB03B158031eCB7D9d06Fad24609b",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -555,6 +559,7 @@
         }
       ],
       "ignoreInWatchMode": ["nonce"],
+      "deployerAddress": "eth:0x59232aC80E6d403b6381393e52f4665ECA328558",
       "sinceTimestamp": 1683214307,
       "sinceBlock": 17188210,
       "values": {
@@ -1011,5 +1016,5 @@
     "starkex/StarkExchangeOld": "0x1349c13ead4263acc9bf71f1282c62684eebc9e54c3c2e0c9e4ce04e120b146e"
   },
   "usedBlockNumbers": { "ethereum": 21981331 },
-  "permissionsConfigHash": "0x3ed9ab7a435598acdd353f88eea0ae38401fbf783c32a0247dcb3cf4db46f3f6"
+  "permissionsConfigHash": "0x8db3f94de187184c22df7a08b29f04105d3623c3e0d26022695a251bad898f2d"
 }

--- a/packages/config/src/projects/dydx/config.jsonc
+++ b/packages/config/src/projects/dydx/config.jsonc
@@ -35,6 +35,10 @@
     "eth:0xF23754231BC4cE8C8E92C3bADfB37d922d46053C": "FinalizableGpsFactAdapter"
   },
   "overrides": {
+    "eth:0xF23754231BC4cE8C8E92C3bADfB37d922d46053C": {
+      // the adapter is finalized, the programHash cannot be changed anymore
+      "category": "non-critical"
+    },
     "eth:0xD54f502e184B6B739d7D27a6410a67dc462D69c8": {
       "ignoreMethods": [
         "configurationHash",

--- a/packages/config/src/projects/dydx/diffHistory.md
+++ b/packages/config/src/projects/dydx/diffHistory.md
@@ -1,3 +1,422 @@
+Generated with discovered.json: 0xeb1ed541402d55f17cab344647508b4a43b0a7bb
+
+# Diff at Fri, 12 Jun 2026 11:52:43 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1733483111
+- current timestamp: 1733483111
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1733483111 (main branch discovery), not current.
+
+```diff
+    contract MerkleDistributor (eth:0x01d3348601968aB85b4bb028979006eac235a588) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda"
++        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980"
+      sourceHashes.1:
+-        "0x5eb26cee90dca2178b42fc264fc447af3272c9c84f97decb89285baa230ed77b"
++        "0x46df256871469d149a39c59c292ad8edef869b654c1776a8c303f170e660b4e0"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract CpuFrilessVerifier (eth:0x04D4E67F8B6c67D63219Cd088bC45E8e89fE6D73) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x4ed0a8fed2fb6b8cc5ecf363781107f0fea73b810fb2a78b6ff0e7565fac2f62"
++        "0xd90ba494c13eb50647848d3c0cbb13eda118ed2a2de43cb2a5361a16a46c194f"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract CpuOods (eth:0x0c6dEc0B366b1bb4C14597cf1Da8b4af2E7799b5) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xc9f95b23f16315cabf114838b357854b67aa18bffeb85f3e4763dd0b2ebdac5b"
++        "0xc864967dfaa57559f17b4d44fac4c9b4a942d3c744dddd26b36646a869ace30b"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract MerkleStatementContract (eth:0x0d62bac5c346c78DC1b27107CAbC5F4DE057a830) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xa671d6ba3e3803dbd31bbc7ade04cc66b5b41ef6553c5efe6b8645e4d2ea6030"
++        "0xff09c99e2b5180213c57497b300b4c69236daadf95c809aef260bb9cbbda1bc2"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract ClaimsProxy (eth:0x0fd829C3365A225FB9226e75c97c3A114bD3199e) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract PedersenHashPointsYColumn (eth:0x0fED12bD8B1B11c629001c436b90bcd99F4Fec92) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract CairoBootloaderProgram (eth:0x1dd8945200f5a09D6Fe0ed68494c2ac41cd02E2D) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract CpuConstraintPoly (eth:0x1F5459AA7857291112A8172ae1328248948d9d13) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract TreasuryProxyAdmin (eth:0x40D6992cbd03E0DC1c2DE9606D29Cb245E737a5d) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract WrappedEthereumDydxToken (eth:0x46b2DeAe6eFf3011008EA27EA36b7c27255ddFA9) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xece96853a5bdf87e554329700585a08c5c2cd492e0bd37f88d30bc44e530cc74"
++        "0xcc0780151a3848085cbe24f0b872869600778ba89b5a8eab80003c72f13c1b10"
+      deployerAddress:
++        "eth:0x10855066fc7823BA41eE5cF61C3fEdd8EEAd5FF9"
+    }
+```
+
+```diff
+    contract CpuFrilessVerifier (eth:0x4922f8750DFd040954b44F23980160342e308863) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x40ad0c189ae6d45546284ca7cfba8a4147e474ac91828f587c736afe8ef3a668"
++        "0xe9e4d574b6a31d9700c03e3c26a60f3f8c60d1a6662e97bd707c21d82628f4c9"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract EcdsaPointsXColumn (eth:0x52c4bb16FbA75f6EBD672568267BC334255Fb3c5) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract LiquidityStaking (eth:0x5Aa653A076c1dbB47cec8C1B4d152444CAD91941) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda"
++        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980"
+      sourceHashes.1:
+-        "0x0111ff9c30eb270b8df99390defd855542974eb8a6a6200212cee243a9ba9679"
++        "0x68826ff941ca67f46ef9f55ad212fa5e7418492ff27eeb938792a07951eb0eb9"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract PerpetualEscapeVerifier (eth:0x626211C1e9BC633f4D342Af99f4E8bc93f11F3DD) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x684921b3b4e6212f66865889daeb916ea5de2487eb8558ef4ef000b6fb159b35"
++        "0x17a50eeee4ef724aeacace03a95bfda8dc5e04fd39a88e579eb2f0ad4ba976ad"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract TreasuryBridge (eth:0x639192D54431F8c816368D3FB4107Bc168d0E871) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda"
++        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract ShortTimelockExecutor (eth:0x64c7d40c07EFAbec2AafdC243bF59eaF2195c6dc) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x2b69eb06923cd9704b99e54ed0d1294ea96da2ec719476b1f93b1d9176b6fe98"
++        "0x333128f42facd19bd1250ceaf07b48e383354aed5c9b2602e665b5c653cc77f0"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract SafetyModule (eth:0x65f7BA4Ec257AF7c55fd5854E5f6356bBd0fb8EC) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda"
++        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980"
+      sourceHashes.1:
+-        "0x57553f9e7638b7b9c78914908fedcfd695b2973d1860afc5395c8328e8a55a1d"
++        "0xd18171fd00e188cbe4f0b2d3e45c212c023ff24102e78e11bed179c6d5273885"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract SafetyModuleProxyAdmin (eth:0x6aaD0BCfbD91963Cf2c8FB042091fd411FB05b3C) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract MerkleDistributorProxyAdmin (eth:0x6C5cd3aD7A16Ae207D221908E6b997d9B0DcD7b0) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract DydxGovernor (eth:0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x2fe37952f2fff616157e00a7389810ee76f2ee19c2fd0449571e0c362f030aa1"
++        "0x7656211ec1b864e6cfeb49243a3cf6c9e48bd2c321c24be91e2758d1c83a9525"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract GpsStatementVerifier (eth:0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xfe731822f194cf686e57ab136911f5128f6262c4ecadef68cee6eba0751ca77b"
++        "0x28a0980438d6222829f7035602ed87662e61a8b0ec4a5911ffda35c37edcfb55"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract Committee (eth:0x8A8E80e0762243f0df39f2847808B7F6D62e2bb1) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xca16a90f8e3d769dcf7c193aade241726dd9cca439bdf131740e54b7725ee599"
++        "0x8cbb14b58dfef3e0ae420e37e2483d8dd8eb6733939754efee17eaad3e816bb4"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract DydxToken (eth:0x92D6C1e31e14520e676a687F0a93788B716BEff5) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xa1c6b779016519cd0e36109115853fdb48caef5ca257585e2ff61ca5a6e990c6"
++        "0x799fb1efc8d95575ed4a703acd617acbcf1f290aa178ba8a70a6571cc020c34e"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract ChainlinkAdapter (eth:0x99B0599952a4FD2d1A1561Fa4C010827EaD30354) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x3450d9fd6eeaee34343e727534e9aef6f035cc7b19eab0f5690268f9ddd379d6"
++        "0x7f73af3b3e5f33bb05fdb44ad5e2db02cde584258826e93f3c847d51a7082f67"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract PedersenHashPointsXColumn (eth:0x9Bcf13C6b68450B427bfa86698D61901A8a3456D) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract PriorityExecutor (eth:0xa306989BA6BcacdECCf3C0614FfF2B8C668e3CaE) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x5e7ffe4bf5cc430b1f4d7ee4515f29578b78793ea6192f9c9015849f1a25b493"
++        "0xa58ae3064418f58afccc55c9e3934f162836d3577ef427abb74c4056163e51d4"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract LiquidityStakingProxyAdmin (eth:0xAc5D8bCD13da463bea96c75f9085c4e40037F790) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract TreasuryVester (eth:0xb9431E19B29B952d9358025f680077C3Fd37292f) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract GovernanceStrategyV2 (eth:0xc2f5F3505910Da80F0592a3Cc023881C50b16505) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x10855066fc7823BA41eE5cF61C3fEdd8EEAd5FF9"
+    }
+```
+
+```diff
+    contract EcdsaPointsYColumn (eth:0xD14fd39630Ec941C3bA6C791E3af9E0027013A15) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract StarkPerpetual (eth:0xD54f502e184B6B739d7D27a6410a67dc462D69c8) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xcbc560d276343abe292d73f08cd9006d7faaf560c300a437744a6e8646c9baa6"
++        "0x04b744718ab1359591f09af5bd0c0128aa230df8320cd3e039e9e500537ea5d7"
+      sourceHashes.1:
+-        "0xbe20bbe6c3b6a691ea8198517ba23e844544647f6d12c96c2f69d20075251c3a"
++        "0x4d0d095ea175ac9b3355f36cdf5959bac2cf6de7a33823c06f2ab23747fb4c7e"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract MerklePauserExecutor (eth:0xd98e7A71BacB6F11438A8271dDB2EFd7f9361F52) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x2b69eb06923cd9704b99e54ed0d1294ea96da2ec719476b1f93b1d9176b6fe98"
++        "0x333128f42facd19bd1250ceaf07b48e383354aed5c9b2602e665b5c653cc77f0"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract CpuFrilessVerifier (eth:0xeCa5Da0287D407a23f7c0a13a9AAD87c7fBC10A3) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x0b61340aa73762dba13146142086ff4fbd1b253748bc6c19238d628db084e076"
++        "0xb29012481187f4f36fb71b178cc4774da85ce78ad3cdd9e9e29e311e9f889f06"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract LongTimelockExecutor (eth:0xEcaE9BF44A21d00E2350a42127A377Bf5856d84B) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x2b69eb06923cd9704b99e54ed0d1294ea96da2ec719476b1f93b1d9176b6fe98"
++        "0x333128f42facd19bd1250ceaf07b48e383354aed5c9b2602e665b5c653cc77f0"
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
+```diff
+    contract MemoryPageFactRegistry (eth:0xEfbCcE4659db72eC6897F46783303708cf9ACef8) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x1a064332cbf420353ceab684146a9c730873a5617ce302e26a88da05ea14b449"
++        "0x6f0dd1f218c7ba2b2808d07f8c6dee2bc265e3b69f579a2f357c07a6130a01fb"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract FinalizableGpsFactAdapter (eth:0xF23754231BC4cE8C8E92C3bADfB37d922d46053C) [starkex/FinalizableGpsFactAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3. Stores the Cairo programHash (`3022993219738828102988654230098311570191704199468817569337520096526584973032`), which can be changed until the adapter is finalized.
+      template:
+-        "starkex/GpsFactRegistryAdapter"
++        "starkex/FinalizableGpsFactAdapter"
+      sourceHashes.0:
+-        "0x395444e8f8af03cea56ff4137d997fc94a06817d06cea35a2b467a45c6ee136b"
++        "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0"
+      description:
+-        "Adapter between the core contract and the eth:0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3. Stores the Cairo programHash (`3022993219738828102988654230098311570191704199468817569337520096526584973032`)."
++        "Adapter between the core contract and the eth:0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3. Stores the Cairo programHash (`3022993219738828102988654230098311570191704199468817569337520096526584973032`), which can be changed until the adapter is finalized."
++++ severity: HIGH
+      values.owner:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+      fieldMeta:
++        {"owner":{"severity":"HIGH"}}
+      category:
++        {"name":"Non-Critical","priority":0}
+    }
+```
+
+```diff
+    contract FriStatementContract (eth:0xf6b83CcaDeee478FC372AF6ca7069b14FBc5E1B1) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0x193add6f23ec1dadc0f158bf31a76ebee58c7f4c229944b80585c7abf71b4d2d"
++        "0x81762cef9a7d773d7cf15480ebaf0f4bb51b6eb7babd0d74588c8e641879d2a7"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract StarkExRemoverGovernorV2 (eth:0xFCAac0F14deA11eDe11Afcb875f29130e1ad5ec0) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83"
+    }
+```
+
 Generated with discovered.json: 0x5ffa7fdca9dcb04978e72e8bf795e56da0eb5af3
 
 # Diff at Tue, 02 Sep 2025 14:30:02 GMT:

--- a/packages/config/src/projects/dydx/diffHistory.md
+++ b/packages/config/src/projects/dydx/diffHistory.md
@@ -1,6 +1,6 @@
 Generated with discovered.json: 0xeb1ed541402d55f17cab344647508b4a43b0a7bb
 
-# Diff at Fri, 12 Jun 2026 11:52:43 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:46 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1733483111

--- a/packages/config/src/projects/dydx/discovered.json
+++ b/packages/config/src/projects/dydx/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "dydx",
   "timestamp": 1733483111,
-  "configHash": "0x98fd5186d42b571696bd66d77a50c8315a91bd25f32c3fab40ac4eb42b318e08",
+  "configHash": "0x8875d703c7abc23b25c76fe48320020560de9f398af352b3495699f36fec03b2",
   "entries": [
     {
       "address": "eth:0x0000000000000000000000000000000000000001",
@@ -13,8 +13,8 @@
       "address": "eth:0x01d3348601968aB85b4bb028979006eac235a588",
       "type": "Contract",
       "sourceHashes": [
-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda",
-        "0x5eb26cee90dca2178b42fc264fc447af3272c9c84f97decb89285baa230ed77b"
+        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980",
+        "0x46df256871469d149a39c59c292ad8edef869b654c1776a8c303f170e660b4e0"
       ],
       "proxyType": "EIP1967 proxy",
       "ignoreInWatchMode": [
@@ -27,6 +27,7 @@
         "TRADER_SCORE_ALPHA_BASE",
         "WAITING_PERIOD"
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709502,
       "sinceBlock": 12931482,
       "values": {
@@ -91,9 +92,10 @@
       "address": "eth:0x04D4E67F8B6c67D63219Cd088bC45E8e89fE6D73",
       "type": "Contract",
       "sourceHashes": [
-        "0x4ed0a8fed2fb6b8cc5ecf363781107f0fea73b810fb2a78b6ff0e7565fac2f62"
+        "0xd90ba494c13eb50647848d3c0cbb13eda118ed2a2de43cb2a5361a16a46c194f"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752384,
       "sinceBlock": 11813202,
       "values": { "$immutable": true },
@@ -106,9 +108,10 @@
       "address": "eth:0x0c6dEc0B366b1bb4C14597cf1Da8b4af2E7799b5",
       "type": "Contract",
       "sourceHashes": [
-        "0xc9f95b23f16315cabf114838b357854b67aa18bffeb85f3e4763dd0b2ebdac5b"
+        "0xc864967dfaa57559f17b4d44fac4c9b4a942d3c744dddd26b36646a869ace30b"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752351,
       "sinceBlock": 11813198,
       "values": { "$immutable": true },
@@ -121,9 +124,10 @@
       "address": "eth:0x0d62bac5c346c78DC1b27107CAbC5F4DE057a830",
       "type": "Contract",
       "sourceHashes": [
-        "0xa671d6ba3e3803dbd31bbc7ade04cc66b5b41ef6553c5efe6b8645e4d2ea6030"
+        "0xff09c99e2b5180213c57497b300b4c69236daadf95c809aef260bb9cbbda1bc2"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752351,
       "sinceBlock": 11813198,
       "values": { "$immutable": true, "hasRegisteredFact": true },
@@ -139,6 +143,7 @@
         "0x14247f67293c931189c2f13126a402c94b2afb17f22e034e27562a726393e921"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709848,
       "sinceBlock": 12931509,
       "values": {
@@ -160,6 +165,7 @@
         "0x05c19e648542d62b4ddf24a4fa4c15a3a6e25cd850736e41c5544eb570a9f2a2"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752276,
       "sinceBlock": 11813192,
       "values": { "$immutable": true },
@@ -175,6 +181,7 @@
         "0x910ee17561c1bd968dbc0547bafcc9e8321d4ee336392525c0956ec59c94b799"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752200,
       "sinceBlock": 11813182,
       "values": {
@@ -418,6 +425,7 @@
         "0xeda6df888e68f267f04ff010db56b1a7b83756e14076d73718df7d33b1e2ae41"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752229,
       "sinceBlock": 11813186,
       "values": { "$immutable": true },
@@ -440,6 +448,7 @@
           "role": "admin"
         }
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627708831,
       "sinceBlock": 12931441,
       "values": {
@@ -455,10 +464,11 @@
       "address": "eth:0x46b2DeAe6eFf3011008EA27EA36b7c27255ddFA9",
       "type": "Contract",
       "sourceHashes": [
-        "0xece96853a5bdf87e554329700585a08c5c2cd492e0bd37f88d30bc44e530cc74"
+        "0xcc0780151a3848085cbe24f0b872869600778ba89b5a8eab80003c72f13c1b10"
       ],
       "proxyType": "immutable",
       "ignoreInWatchMode": ["_nextAvailableBridgeId", "totalSupply"],
+      "deployerAddress": "eth:0x10855066fc7823BA41eE5cF61C3fEdd8EEAd5FF9",
       "sinceTimestamp": 1694426279,
       "sinceBlock": 18112365,
       "values": {
@@ -490,9 +500,10 @@
       "address": "eth:0x4922f8750DFd040954b44F23980160342e308863",
       "type": "Contract",
       "sourceHashes": [
-        "0x40ad0c189ae6d45546284ca7cfba8a4147e474ac91828f587c736afe8ef3a668"
+        "0xe9e4d574b6a31d9700c03e3c26a60f3f8c60d1a6662e97bd707c21d82628f4c9"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752363,
       "sinceBlock": 11813200,
       "values": {
@@ -525,6 +536,7 @@
         "0x412fb414e7fea74325d60a077f704a49cf6d23a7a1d43c9fd09be7e9a4e5e76f"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752276,
       "sinceBlock": 11813192,
       "values": { "$immutable": true },
@@ -533,12 +545,26 @@
       }
     },
     {
+      "address": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "upgrade",
+          "from": "eth:0xF23754231BC4cE8C8E92C3bADfB37d922d46053C",
+          "description": "change the programHash, replacing the L2 execution logic whose proofs are accepted, directly or through appointed admins.",
+          "role": ".owner",
+          "condition": "if the adapter is not finalized"
+        }
+      ]
+    },
+    {
       "name": "LiquidityStaking",
       "address": "eth:0x5Aa653A076c1dbB47cec8C1B4d152444CAD91941",
       "type": "Contract",
       "sourceHashes": [
-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda",
-        "0x0111ff9c30eb270b8df99390defd855542974eb8a6a6200212cee243a9ba9679"
+        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980",
+        "0x68826ff941ca67f46ef9f55ad212fa5e7418492ff27eeb938792a07951eb0eb9"
       ],
       "proxyType": "EIP1967 proxy",
       "ignoreInWatchMode": [
@@ -565,6 +591,7 @@
         "totalSupply",
         "TOTAL_ALLOCATION"
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709656,
       "sinceBlock": 12931493,
       "values": {
@@ -655,9 +682,10 @@
       "address": "eth:0x626211C1e9BC633f4D342Af99f4E8bc93f11F3DD",
       "type": "Contract",
       "sourceHashes": [
-        "0x684921b3b4e6212f66865889daeb916ea5de2487eb8558ef4ef000b6fb159b35"
+        "0x17a50eeee4ef724aeacace03a95bfda8dc5e04fd39a88e579eb2f0ad4ba976ad"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1620888418,
       "sinceBlock": 12424523,
       "values": {
@@ -674,10 +702,11 @@
       "address": "eth:0x639192D54431F8c816368D3FB4107Bc168d0E871",
       "type": "Contract",
       "sourceHashes": [
-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda",
+        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980",
         "0xa1f45598b0f289ead20121783ac8f948cb7005845b5646ab5b8918e8252d2644"
       ],
       "proxyType": "EIP1967 proxy",
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627708861,
       "sinceBlock": 12931442,
       "values": {
@@ -707,9 +736,10 @@
       "address": "eth:0x64c7d40c07EFAbec2AafdC243bF59eaF2195c6dc",
       "type": "Contract",
       "sourceHashes": [
-        "0x2b69eb06923cd9704b99e54ed0d1294ea96da2ec719476b1f93b1d9176b6fe98"
+        "0x333128f42facd19bd1250ceaf07b48e383354aed5c9b2602e665b5c653cc77f0"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1626145373,
       "sinceBlock": 12816312,
       "values": {
@@ -735,11 +765,12 @@
       "address": "eth:0x65f7BA4Ec257AF7c55fd5854E5f6356bBd0fb8EC",
       "type": "Contract",
       "sourceHashes": [
-        "0x5e3d09f8089d63a7a6d8546086c617af3d5dd46af7590b5ef30cc4ca39754dda",
-        "0x57553f9e7638b7b9c78914908fedcfd695b2973d1860afc5395c8328e8a55a1d"
+        "0x5fc846f80d7760e9d7acbb0c4ad947b118b9ee40b5e53d7aa48135c2fcaf3980",
+        "0xd18171fd00e188cbe4f0b2d3e45c212c023ff24102e78e11bed179c6d5273885"
       ],
       "proxyType": "EIP1967 proxy",
       "ignoreInWatchMode": ["totalSupply", "inBlackoutWindow"],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709015,
       "sinceBlock": 12931454,
       "values": {
@@ -843,6 +874,7 @@
           "role": "admin"
         }
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627708955,
       "sinceBlock": 12931449,
       "values": {
@@ -868,6 +900,7 @@
           "role": "admin"
         }
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709450,
       "sinceBlock": 12931480,
       "values": {
@@ -883,10 +916,11 @@
       "address": "eth:0x7E9B1672616FF6D6629Ef2879419aaE79A9018D2",
       "type": "Contract",
       "sourceHashes": [
-        "0x2fe37952f2fff616157e00a7389810ee76f2ee19c2fd0449571e0c362f030aa1"
+        "0x7656211ec1b864e6cfeb49243a3cf6c9e48bd2c321c24be91e2758d1c83a9525"
       ],
       "proxyType": "immutable",
       "ignoreInWatchMode": ["getProposalsCount"],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1626145334,
       "sinceBlock": 12816310,
       "values": {
@@ -940,9 +974,10 @@
       "address": "eth:0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3",
       "type": "Contract",
       "sourceHashes": [
-        "0xfe731822f194cf686e57ab136911f5128f6262c4ecadef68cee6eba0751ca77b"
+        "0x28a0980438d6222829f7035602ed87662e61a8b0ec4a5911ffda35c37edcfb55"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1615417556,
       "sinceBlock": 12013702,
       "values": {
@@ -968,9 +1003,10 @@
       "address": "eth:0x8A8E80e0762243f0df39f2847808B7F6D62e2bb1",
       "type": "Contract",
       "sourceHashes": [
-        "0xca16a90f8e3d769dcf7c193aade241726dd9cca439bdf131740e54b7725ee599"
+        "0x8cbb14b58dfef3e0ae420e37e2483d8dd8eb6733939754efee17eaad3e816bb4"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1613033682,
       "sinceBlock": 11834295,
       "values": {
@@ -995,9 +1031,10 @@
       "address": "eth:0x92D6C1e31e14520e676a687F0a93788B716BEff5",
       "type": "Contract",
       "sourceHashes": [
-        "0xa1c6b779016519cd0e36109115853fdb48caef5ca257585e2ff61ca5a6e990c6"
+        "0x799fb1efc8d95575ed4a703acd617acbcf1f290aa178ba8a70a6571cc020c34e"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1626053832,
       "sinceBlock": 12809555,
       "values": {
@@ -1030,9 +1067,10 @@
       "address": "eth:0x99B0599952a4FD2d1A1561Fa4C010827EaD30354",
       "type": "Contract",
       "sourceHashes": [
-        "0x3450d9fd6eeaee34343e727534e9aef6f035cc7b19eab0f5690268f9ddd379d6"
+        "0x7f73af3b3e5f33bb05fdb44ad5e2db02cde584258826e93f3c847d51a7082f67"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709600,
       "sinceBlock": 12931491,
       "values": {
@@ -1055,6 +1093,7 @@
         "0x6eb94f42b6ee59326d27f5ec055a5872adf1df7825af5df411459832c72ba175"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752231,
       "sinceBlock": 11813187,
       "values": { "$immutable": true },
@@ -1067,7 +1106,7 @@
       "address": "eth:0xa306989BA6BcacdECCf3C0614FfF2B8C668e3CaE",
       "type": "Contract",
       "sourceHashes": [
-        "0x5e7ffe4bf5cc430b1f4d7ee4515f29578b78793ea6192f9c9015849f1a25b493"
+        "0xa58ae3064418f58afccc55c9e3934f162836d3577ef427abb74c4056163e51d4"
       ],
       "proxyType": "immutable",
       "receivedPermissions": [
@@ -1077,6 +1116,7 @@
           "role": "admin"
         }
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627710079,
       "sinceBlock": 12931528,
       "values": {
@@ -1121,6 +1161,7 @@
           "role": "admin"
         }
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709620,
       "sinceBlock": 12931492,
       "values": {
@@ -1140,6 +1181,7 @@
       ],
       "proxyType": "immutable",
       "ignoreInWatchMode": ["lastUpdate"],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627709382,
       "sinceBlock": 12931477,
       "values": {
@@ -1164,6 +1206,7 @@
         "0xee1844f59c7ff492ee5430d8673a00537a966cb0de1e21ec8c8ff1adf630e0af"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x10855066fc7823BA41eE5cF61C3fEdd8EEAd5FF9",
       "sinceTimestamp": 1694426291,
       "sinceBlock": 18112366,
       "values": {
@@ -1184,6 +1227,7 @@
         "0x16786b57094cb8c3157552703287a310748c4453d743f9f2fa22adc7a6bf991c"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752276,
       "sinceBlock": 11813192,
       "values": { "$immutable": true },
@@ -1196,11 +1240,12 @@
       "address": "eth:0xD54f502e184B6B739d7D27a6410a67dc462D69c8",
       "type": "Contract",
       "sourceHashes": [
-        "0xcbc560d276343abe292d73f08cd9006d7faaf560c300a437744a6e8646c9baa6",
-        "0xbe20bbe6c3b6a691ea8198517ba23e844544647f6d12c96c2f69d20075251c3a"
+        "0x04b744718ab1359591f09af5bd0c0128aa230df8320cd3e039e9e500537ea5d7",
+        "0x4d0d095ea175ac9b3355f36cdf5959bac2cf6de7a33823c06f2ab23747fb4c7e"
       ],
       "proxyType": "StarkWare diamond",
       "ignoreInWatchMode": ["getLastBatchId", "getSequenceNumber"],
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1613033682,
       "sinceBlock": 11834295,
       "values": {
@@ -1325,9 +1370,10 @@
       "address": "eth:0xd98e7A71BacB6F11438A8271dDB2EFd7f9361F52",
       "type": "Contract",
       "sourceHashes": [
-        "0x2b69eb06923cd9704b99e54ed0d1294ea96da2ec719476b1f93b1d9176b6fe98"
+        "0x333128f42facd19bd1250ceaf07b48e383354aed5c9b2602e665b5c653cc77f0"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1626145414,
       "sinceBlock": 12816315,
       "values": {
@@ -1358,9 +1404,10 @@
       "address": "eth:0xeCa5Da0287D407a23f7c0a13a9AAD87c7fBC10A3",
       "type": "Contract",
       "sourceHashes": [
-        "0x0b61340aa73762dba13146142086ff4fbd1b253748bc6c19238d628db084e076"
+        "0xb29012481187f4f36fb71b178cc4774da85ce78ad3cdd9e9e29e311e9f889f06"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1615417455,
       "sinceBlock": 12013692,
       "values": { "$immutable": true },
@@ -1373,9 +1420,10 @@
       "address": "eth:0xEcaE9BF44A21d00E2350a42127A377Bf5856d84B",
       "type": "Contract",
       "sourceHashes": [
-        "0x2b69eb06923cd9704b99e54ed0d1294ea96da2ec719476b1f93b1d9176b6fe98"
+        "0x333128f42facd19bd1250ceaf07b48e383354aed5c9b2602e665b5c653cc77f0"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1626145348,
       "sinceBlock": 12816311,
       "values": {
@@ -1401,9 +1449,10 @@
       "address": "eth:0xEfbCcE4659db72eC6897F46783303708cf9ACef8",
       "type": "Contract",
       "sourceHashes": [
-        "0x1a064332cbf420353ceab684146a9c730873a5617ce302e26a88da05ea14b449"
+        "0x6f0dd1f218c7ba2b2808d07f8c6dee2bc265e3b69f579a2f357c07a6130a01fb"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752200,
       "sinceBlock": 11813182,
       "values": { "$immutable": true, "hasRegisteredFact": true },
@@ -1415,12 +1464,13 @@
       "name": "FinalizableGpsFactAdapter",
       "address": "eth:0xF23754231BC4cE8C8E92C3bADfB37d922d46053C",
       "type": "Contract",
-      "template": "starkex/GpsFactRegistryAdapter",
+      "template": "starkex/FinalizableGpsFactAdapter",
       "sourceHashes": [
-        "0x395444e8f8af03cea56ff4137d997fc94a06817d06cea35a2b467a45c6ee136b"
+        "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0"
       ],
       "proxyType": "immutable",
-      "description": "Adapter between the core contract and the eth:0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3. Stores the Cairo programHash (`3022993219738828102988654230098311570191704199468817569337520096526584973032`).",
+      "description": "Adapter between the core contract and the eth:0x894c4a12548FB18EaA48cF34f9Cd874Fc08b7FC3. Stores the Cairo programHash (`3022993219738828102988654230098311570191704199468817569337520096526584973032`), which can be changed until the adapter is finalized.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1681722659,
       "sinceBlock": 17065528,
       "values": {
@@ -1429,9 +1479,11 @@
         "hasRegisteredFact": true,
         "identify": "StarkWare_FinalizableGpsFactAdapter_2022_1",
         "isFinalized": true,
+        "owner": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
         "programHash": "3022993219738828102988654230098311570191704199468817569337520096526584973032",
         "programHashMapped": "3022993219738828102988654230098311570191704199468817569337520096526584973032"
       },
+      "fieldMeta": { "owner": { "severity": "HIGH" } },
       "implementationNames": {
         "eth:0xF23754231BC4cE8C8E92C3bADfB37d922d46053C": "FinalizableGpsFactAdapter"
       },
@@ -1465,16 +1517,18 @@
             "109586309220455887239200613090920758778188956576212125550190099009305121410": "StarkNet (old)"
           }
         }
-      ]
+      ],
+      "category": { "name": "Non-Critical", "priority": 0 }
     },
     {
       "name": "FriStatementContract",
       "address": "eth:0xf6b83CcaDeee478FC372AF6ca7069b14FBc5E1B1",
       "type": "Contract",
       "sourceHashes": [
-        "0x193add6f23ec1dadc0f158bf31a76ebee58c7f4c229944b80585c7abf71b4d2d"
+        "0x81762cef9a7d773d7cf15480ebaf0f4bb51b6eb7babd0d74588c8e641879d2a7"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1612752351,
       "sinceBlock": 11813198,
       "values": { "$immutable": true, "hasRegisteredFact": true },
@@ -1497,6 +1551,7 @@
           "role": "admin"
         }
       ],
+      "deployerAddress": "eth:0x301DF37d653b281AF83a1DDf4464eF21A622eC83",
       "sinceTimestamp": 1627913849,
       "sinceBlock": 12946416,
       "values": {
@@ -2645,8 +2700,8 @@
     ]
   },
   "usedTemplates": {
-    "starkex/GpsFactRegistryAdapter": "0x1ad87511dd3212f3837ce0d97076154480b4909b6970ad7fb66342c32f61b0bb"
+    "starkex/FinalizableGpsFactAdapter": "0x2c4115608421d0d7aabe41291500b1f02a4d2989db1976f2c05a07b91fe4ba47"
   },
   "usedBlockNumbers": { "ethereum": 21343041 },
-  "permissionsConfigHash": "0x481b3728c4b52fe868305fcfe5718333fcc66d5450d25375e5417f5b40941587"
+  "permissionsConfigHash": "0x28028f4a468312ec5978cc440b78d4461d933bc30e6477be6ef3f0a14d862cb6"
 }

--- a/packages/config/src/projects/edgex/diffHistory.md
+++ b/packages/config/src/projects/edgex/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0x515808ad8b32e236aede73b20a7fd4cdb2d2fabf
+Generated with discovered.json: 0xb1703c9b23e30fcc16e61c3f884dd5abc84f19ce
 
-# Diff at Fri, 12 Jun 2026 11:52:44 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:47 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1777891423
@@ -40,10 +40,10 @@ discovery. Values are for block 1777891423 (main branch discovery), not current.
     contract Safe (eth:0x57814cC6e075f517781cB7c3B42897B3Bb2C54d8) [GnosisSafe] {
     +++ description: None
       receivedPermissions.1:
-+        {"permission":"interact","from":"eth:0xfAaE2946e846133af314d1Df13684c89fA7d83DD","description":"Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.","role":".$admin"}
++        {"permission":"interact","from":"eth:0xfAaE2946e846133af314d1Df13684c89fA7d83DD","description":"Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set.","role":".$admin"}
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "change the global configuration hash committing to the L2 system parameters."
++        "change the global and per-asset configuration hashes committing to the L2 system parameters."
       receivedPermissions.1.permission:
 -        "interact"
 +        "upgrade"

--- a/packages/config/src/projects/edgex/diffHistory.md
+++ b/packages/config/src/projects/edgex/diffHistory.md
@@ -1,3 +1,55 @@
+Generated with discovered.json: 0x515808ad8b32e236aede73b20a7fd4cdb2d2fabf
+
+# Diff at Fri, 12 Jun 2026 11:52:44 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1777891423
+- current timestamp: 1777891423
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1777891423 (main branch discovery), not current.
+
+```diff
+    contract FinalizableGpsFactAdapter (eth:0x4abBc1826389aC0FEaA49E70c30a041b665e8562) [starkex/FinalizableGpsFactAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`), which can be changed until the adapter is finalized.
+      name:
+-        "GpsFactRegistryAdapter"
++        "FinalizableGpsFactAdapter"
+      template:
+-        "starkex/GpsFactRegistryAdapter"
++        "starkex/FinalizableGpsFactAdapter"
+      description:
+-        "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`)."
++        "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`), which can be changed until the adapter is finalized."
++++ severity: HIGH
+      values.owner:
++        "eth:0x17b287122363a0a6dBA7F185347DFcfb9816dA6e"
+      fieldMeta:
++        {"owner":{"severity":"HIGH"}}
+    }
+```
+
+```diff
+    contract Safe (eth:0x57814cC6e075f517781cB7c3B42897B3Bb2C54d8) [GnosisSafe] {
+    +++ description: None
+      receivedPermissions.1:
++        {"permission":"interact","from":"eth:0xfAaE2946e846133af314d1Df13684c89fA7d83DD","description":"Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.","role":".$admin"}
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "change the global configuration hash committing to the L2 system parameters."
+      receivedPermissions.1.permission:
+-        "interact"
++        "upgrade"
+    }
+```
+
 Generated with discovered.json: 0xb833518de0c1ac00ef010b2c4e92b12768cf3218
 
 # Diff at Tue, 09 Jun 2026 12:43:33 GMT:

--- a/packages/config/src/projects/edgex/discovered.json
+++ b/packages/config/src/projects/edgex/discovered.json
@@ -35,6 +35,21 @@
       "proxyType": "EOA"
     },
     {
+      "address": "eth:0x17b287122363a0a6dBA7F185347DFcfb9816dA6e",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "eoaWithUpgradePermissions": true,
+      "receivedPermissions": [
+        {
+          "permission": "upgrade",
+          "from": "eth:0x4abBc1826389aC0FEaA49E70c30a041b665e8562",
+          "description": "change the programHash, replacing the L2 execution logic whose proofs are accepted, directly or through appointed admins.",
+          "role": ".owner",
+          "condition": "if the adapter is not finalized"
+        }
+      ]
+    },
+    {
       "address": "eth:0x223c0EF36fEe905a40175d92704b1d3624218EE7",
       "type": "EOA",
       "proxyType": "EOA"
@@ -113,15 +128,15 @@
       "targetProject": "shared-sharp-verifier"
     },
     {
-      "name": "GpsFactRegistryAdapter",
+      "name": "FinalizableGpsFactAdapter",
       "address": "eth:0x4abBc1826389aC0FEaA49E70c30a041b665e8562",
       "type": "Contract",
-      "template": "starkex/GpsFactRegistryAdapter",
+      "template": "starkex/FinalizableGpsFactAdapter",
       "sourceHashes": [
         "0xc8212559a530b4ba272dfc6c98851fa8aa4c1b36e2da1bdbe18091f2c59754f0"
       ],
       "proxyType": "immutable",
-      "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`).",
+      "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`2530337539466159944237001094809327283009177793361359619481044346150483328860`), which can be changed until the adapter is finalized.",
       "deployerAddress": "eth:0x17b287122363a0a6dBA7F185347DFcfb9816dA6e",
       "sinceTimestamp": 1720435919,
       "sinceBlock": 20261312,
@@ -131,9 +146,11 @@
         "hasRegisteredFact": true,
         "identify": "StarkWare_FinalizableGpsFactAdapter_2022_1",
         "isFinalized": false,
+        "owner": "eth:0x17b287122363a0a6dBA7F185347DFcfb9816dA6e",
         "programHash": "2530337539466159944237001094809327283009177793361359619481044346150483328860",
         "programHashMapped": "ApeX-USDC 20250130"
       },
+      "fieldMeta": { "owner": { "severity": "HIGH" } },
       "implementationNames": {
         "eth:0x4abBc1826389aC0FEaA49E70c30a041b665e8562": "FinalizableGpsFactAdapter"
       },
@@ -189,7 +206,13 @@
         {
           "permission": "interact",
           "from": "eth:0xfAaE2946e846133af314d1Df13684c89fA7d83DD",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "role": ".$admin"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xfAaE2946e846133af314d1Df13684c89fA7d83DD",
+          "description": "change the global configuration hash committing to the L2 system parameters.",
           "role": ".$admin"
         },
         {
@@ -1044,9 +1067,9 @@
     "edgex/MultiSigPoolV5": "0x404c9680db0038ee4a2fbbe47eed77cc3bfb5547b3232fc52e52b15a2fed25b8",
     "edgex/PerpetualEscapeVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
     "GnosisSafe": "0x12db59bec64fa8de67bbeb6a6e913f6c5ff1598c0a5fba90282afaf08e2a748c",
-    "starkex/GpsFactRegistryAdapter": "0x1ad87511dd3212f3837ce0d97076154480b4909b6970ad7fb66342c32f61b0bb",
+    "starkex/FinalizableGpsFactAdapter": "0x2c4115608421d0d7aabe41291500b1f02a4d2989db1976f2c05a07b91fe4ba47",
     "starkex/StarkPerpetual": "0x2c320b80005728ab66e5a80a93fb2a160ce7cd11e884bbe1e399562c8b0c52d6"
   },
   "usedBlockNumbers": { "ethereum": 25021111 },
-  "permissionsConfigHash": "0x0955109f74181271283bc4930702a9833e2498bd192856a9df5e842452e7ff68"
+  "permissionsConfigHash": "0x8c841d343fb62f5dc826d90d4e8ced0f26f7b92fa7c54e8eaaa318cccb588c07"
 }

--- a/packages/config/src/projects/edgex/discovered.json
+++ b/packages/config/src/projects/edgex/discovered.json
@@ -206,13 +206,13 @@
         {
           "permission": "interact",
           "from": "eth:0xfAaE2946e846133af314d1Df13684c89fA7d83DD",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
           "permission": "upgrade",
           "from": "eth:0xfAaE2946e846133af314d1Df13684c89fA7d83DD",
-          "description": "change the global configuration hash committing to the L2 system parameters.",
+          "description": "change the global and per-asset configuration hashes committing to the L2 system parameters.",
           "role": ".$admin"
         },
         {
@@ -1071,5 +1071,5 @@
     "starkex/StarkPerpetual": "0x2c320b80005728ab66e5a80a93fb2a160ce7cd11e884bbe1e399562c8b0c52d6"
   },
   "usedBlockNumbers": { "ethereum": 25021111 },
-  "permissionsConfigHash": "0x8c841d343fb62f5dc826d90d4e8ced0f26f7b92fa7c54e8eaaa318cccb588c07"
+  "permissionsConfigHash": "0xd69af937fe7c81018ac094dc6ca8d23ee0ff540efea7a1b6898e33de5f55e80f"
 }

--- a/packages/config/src/projects/edgex/edgex.ts
+++ b/packages/config/src/projects/edgex/edgex.ts
@@ -65,7 +65,10 @@ const includingSHARPUpgradeDelaySeconds = Math.min(
 
 const edgexProgramHashes = []
 edgexProgramHashes.push(
-  discovery.getContractValue<string>('GpsFactRegistryAdapter', 'programHash'),
+  discovery.getContractValue<string>(
+    'FinalizableGpsFactAdapter',
+    'programHash',
+  ),
 )
 edgexProgramHashes.push(...getSHARPBootloaderHashes())
 

--- a/packages/config/src/projects/layer2financezk/diffHistory.md
+++ b/packages/config/src/projects/layer2financezk/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0xde946d4cb72ade76364690dbb641deab6520d872
+Generated with discovered.json: 0x2c12b950a3cec6da9bb8791e7802c48e54a96c7b
 
-# Diff at Fri, 12 Jun 2026 11:53:40 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:47 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1761551414
@@ -21,7 +21,7 @@ discovery. Values are for block 1761551414 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
     }
 ```
 

--- a/packages/config/src/projects/layer2financezk/diffHistory.md
+++ b/packages/config/src/projects/layer2financezk/diffHistory.md
@@ -1,3 +1,101 @@
+Generated with discovered.json: 0xde946d4cb72ade76364690dbb641deab6520d872
+
+# Diff at Fri, 12 Jun 2026 11:53:40 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1761551414
+- current timestamp: 1761551414
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1761551414 (main branch discovery), not current.
+
+```diff
+    EOA  (eth:0x1E153596BceB29c6EAE88DDB290eBeCC3FE9735e) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+    }
+```
+
+```diff
+    contract OrderRegistry (eth:0x518c4A79a1102eEDc987005CA8cE6B87Ca14dDf8) [starkex/OrderRegistry] {
+    +++ description: Helper contract for registering limit orders from L1.
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract StrategyCompound (eth:0x5b000954F70B0410685193B0afd3074B744B5C97) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xd4db48e0b7efb71ded88f8c4a839b0175d98cfd365e8beaf4630e60dfb8ea404"
++        "0x5f8ab401ee2f38175e6f972f544fd64e926cb83e522dc35ddb91dc17c2061154"
+      deployerAddress:
++        "eth:0xe0b79Cf6311E72caF7D31a552BFec67841Dd5988"
+    }
+```
+
+```diff
+    contract GpsFactRegistryAdapter (eth:0x6e3AbCE72A3CD5edc05E59283c733Fd4bF8B3baE) [starkex/GpsFactRegistryAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`3485280386001712778192330279103973322645241679001461923469191557000342180556`).
+      sourceHashes.0:
+-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
++        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract StarkExchange (eth:0x82123571C8a5e0910280C066bc634c4945FFcbC8) [starkex/StarkExchange] {
+    +++ description: Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.
+      sourceHashes.0:
+-        "0x87045c081a3bd84c271153c36a9a503f84bc3035077d34144332c329d3fcb92d"
++        "0x8288c35b29d53f14d488adf0912b270210d6229d83219151b3f46d77c47dfc7b"
+      sourceHashes.1:
+-        "0xfaa0bf87cf9230ba5a3f5530b447f76606e0cd9fb9d1acd2f3b87d30884e63d1"
++        "0x5c9c7a970280b6bfdb50bdc2ee43b98a98e4d34b47aa0839b68e570d1af16c2a"
+      deployerAddress:
++        "eth:0x1E153596BceB29c6EAE88DDB290eBeCC3FE9735e"
+    }
+```
+
+```diff
+    contract Compound Token (eth:0xc00e94Cb662C3520282E6f5717214004A7f26888) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x1449e0687810BdDD356ae6Dd87789244A46d9AdB"
+    }
+```
+
+```diff
+    contract Broker (eth:0xe7c753895d492f8D4B06a2A1B16c1aEF2A7d16E5) [N/A] {
+    +++ description: None
+      sourceHashes.0:
+-        "0xd9040d82f39aa8ff258f35b318bdf0fc513f4d8844c61c34f6c8ce81eee40b55"
++        "0xecdf7fd26bcf3bcbd21e0a1d28dfb5a3bc99c67058d3a883002da12831a8ea45"
+      deployerAddress:
++        "eth:0xe0b79Cf6311E72caF7D31a552BFec67841Dd5988"
+    }
+```
+
+```diff
+    contract Committee (eth:0xF000A3B10e1920aDC6e7D829828e3357Fc5128A9) [N/A] {
+    +++ description: None
+      deployerAddress:
++        "eth:0x1E153596BceB29c6EAE88DDB290eBeCC3FE9735e"
+    }
+```
+
 Generated with discovered.json: 0x292c3d525c130a264dbf36e1235b3cf5f5e6aca8
 
 # Diff at Fri, 12 Jun 2026 10:18:53 GMT:

--- a/packages/config/src/projects/layer2financezk/discovered.json
+++ b/packages/config/src/projects/layer2financezk/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "layer2financezk",
   "timestamp": 1761551414,
-  "configHash": "0x410a3b16a8a78aea160d302a81f78d7a990e437be9807d38664dcd305b305ee1",
+  "configHash": "0x2b9807a6996be6a06e2c5afb842d38dec90d44998e70792add679a7c2348dbdf",
   "entries": [
     {
       "address": "eth:0x1E153596BceB29c6EAE88DDB290eBeCC3FE9735e",
@@ -18,7 +18,7 @@
         {
           "permission": "interact",
           "from": "eth:0x82123571C8a5e0910280C066bc634c4945FFcbC8",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -56,6 +56,7 @@
       ],
       "proxyType": "immutable",
       "description": "Helper contract for registering limit orders from L1.",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1626352379,
       "sinceBlock": 12831566,
       "values": {
@@ -72,9 +73,10 @@
       "address": "eth:0x5b000954F70B0410685193B0afd3074B744B5C97",
       "type": "Contract",
       "sourceHashes": [
-        "0xd4db48e0b7efb71ded88f8c4a839b0175d98cfd365e8beaf4630e60dfb8ea404"
+        "0x5f8ab401ee2f38175e6f972f544fd64e926cb83e522dc35ddb91dc17c2061154"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0xe0b79Cf6311E72caF7D31a552BFec67841Dd5988",
       "sinceTimestamp": 1648452775,
       "sinceBlock": 14473373,
       "values": {
@@ -95,10 +97,11 @@
       "type": "Contract",
       "template": "starkex/GpsFactRegistryAdapter",
       "sourceHashes": [
-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
+        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
       ],
       "proxyType": "immutable",
       "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`3485280386001712778192330279103973322645241679001461923469191557000342180556`).",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1640107463,
       "sinceBlock": 13849860,
       "values": {
@@ -150,8 +153,8 @@
       "type": "Contract",
       "template": "starkex/StarkExchange",
       "sourceHashes": [
-        "0x87045c081a3bd84c271153c36a9a503f84bc3035077d34144332c329d3fcb92d",
-        "0xfaa0bf87cf9230ba5a3f5530b447f76606e0cd9fb9d1acd2f3b87d30884e63d1"
+        "0x8288c35b29d53f14d488adf0912b270210d6229d83219151b3f46d77c47dfc7b",
+        "0x5c9c7a970280b6bfdb50bdc2ee43b98a98e4d34b47aa0839b68e570d1af16c2a"
       ],
       "proxyType": "StarkWare diamond",
       "description": "Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.",
@@ -163,6 +166,7 @@
         "getVaultRoot",
         "getValidiumVaultRoot"
       ],
+      "deployerAddress": "eth:0x1E153596BceB29c6EAE88DDB290eBeCC3FE9735e",
       "sinceTimestamp": 1645130774,
       "sinceBlock": 14225869,
       "values": {
@@ -299,6 +303,7 @@
         "0xface33f588d07cf7b8c64c6200efc11c45d45332a47c27e8c49859d6bc5c8001"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x1449e0687810BdDD356ae6Dd87789244A46d9AdB",
       "sinceTimestamp": 1583280535,
       "sinceBlock": 9601359,
       "values": {
@@ -345,9 +350,10 @@
       "address": "eth:0xe7c753895d492f8D4B06a2A1B16c1aEF2A7d16E5",
       "type": "Contract",
       "sourceHashes": [
-        "0xd9040d82f39aa8ff258f35b318bdf0fc513f4d8844c61c34f6c8ce81eee40b55"
+        "0xecdf7fd26bcf3bcbd21e0a1d28dfb5a3bc99c67058d3a883002da12831a8ea45"
       ],
       "proxyType": "immutable",
+      "deployerAddress": "eth:0xe0b79Cf6311E72caF7D31a552BFec67841Dd5988",
       "sinceTimestamp": 1648452641,
       "sinceBlock": 14473363,
       "values": {
@@ -369,6 +375,7 @@
       "type": "Contract",
       "unverified": true,
       "proxyType": "immutable",
+      "deployerAddress": "eth:0x1E153596BceB29c6EAE88DDB290eBeCC3FE9735e",
       "sinceTimestamp": 1650870230,
       "sinceBlock": 14652355,
       "values": { "$immutable": true },
@@ -770,5 +777,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 23667402 },
-  "permissionsConfigHash": "0x8d8988a05711b34e6afe9c324d6ffd3d065729fe81a3eabb0b0e40fc628f795e"
+  "permissionsConfigHash": "0x856d400f6e1dfa0ac07d1e012d8182f63e500000fc0fcef0e4fb9669d475677f"
 }

--- a/packages/config/src/projects/layer2financezk/discovered.json
+++ b/packages/config/src/projects/layer2financezk/discovered.json
@@ -18,7 +18,7 @@
         {
           "permission": "interact",
           "from": "eth:0x82123571C8a5e0910280C066bc634c4945FFcbC8",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -777,5 +777,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 23667402 },
-  "permissionsConfigHash": "0x856d400f6e1dfa0ac07d1e012d8182f63e500000fc0fcef0e4fb9669d475677f"
+  "permissionsConfigHash": "0x113747a7c028f1f174194085f1b84dab2e838f37bae13aa2a610c7b829c9f4bd"
 }

--- a/packages/config/src/projects/myria/diffHistory.md
+++ b/packages/config/src/projects/myria/diffHistory.md
@@ -1,3 +1,30 @@
+Generated with discovered.json: 0xeb7012e31da92b8e576a0c0e0a7afc2230f178a3
+
+# Diff at Fri, 12 Jun 2026 11:53:40 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1779099631
+- current timestamp: 1779099631
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1779099631 (main branch discovery), not current.
+
+```diff
+    EOA  (eth:0xc49Ec6Bb817E17a9Ca5B738ca330db403cc74245) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+    }
+```
+
 Generated with discovered.json: 0x487c1567228cc1e8e86f237fe279dcfd80e05c6e
 
 # Diff at Fri, 12 Jun 2026 10:18:56 GMT:

--- a/packages/config/src/projects/myria/diffHistory.md
+++ b/packages/config/src/projects/myria/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0xeb7012e31da92b8e576a0c0e0a7afc2230f178a3
+Generated with discovered.json: 0x13f90a320dedd6ff14ef89a61eb1fc894ceff7c0
 
-# Diff at Fri, 12 Jun 2026 11:53:40 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:48 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1779099631
@@ -21,7 +21,7 @@ discovery. Values are for block 1779099631 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
     }
 ```
 

--- a/packages/config/src/projects/myria/discovered.json
+++ b/packages/config/src/projects/myria/discovered.json
@@ -304,7 +304,7 @@
         {
           "permission": "interact",
           "from": "eth:0x3071BE11F9e92A9eb28F305e1Fa033cD102714e7",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -702,5 +702,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 25121451 },
-  "permissionsConfigHash": "0xad4f057fea11c359a90cff0578a3786c89051d9285b4c0366bc30c1d1acde81f"
+  "permissionsConfigHash": "0xf748d703490c8fa2c68311f0b52f831dd4d74036d33bf29f31a5257468c66e0f"
 }

--- a/packages/config/src/projects/myria/discovered.json
+++ b/packages/config/src/projects/myria/discovered.json
@@ -304,7 +304,7 @@
         {
           "permission": "interact",
           "from": "eth:0x3071BE11F9e92A9eb28F305e1Fa033cD102714e7",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -702,5 +702,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 25121451 },
-  "permissionsConfigHash": "0xf748d703490c8fa2c68311f0b52f831dd4d74036d33bf29f31a5257468c66e0f"
+  "permissionsConfigHash": "0x73a8d057089b01eb7b0d95a56329661442989d7927b00c7d2f09e3a57646e11a"
 }

--- a/packages/config/src/projects/myria/myria.ts
+++ b/packages/config/src/projects/myria/myria.ts
@@ -66,10 +66,6 @@ export const myria: ScalingProject = {
     BADGES.Infra.SHARP,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contract references can be changed by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     architectureImage: 'starkex',
     name: 'Myria',
     slug: 'myria',

--- a/packages/config/src/projects/reddioex/diffHistory.md
+++ b/packages/config/src/projects/reddioex/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0x5e89997909301ad2088405e87ced4d0fc7549847
+Generated with discovered.json: 0x1364513781fabd673495397b81d9227cfe5098f5
 
-# Diff at Fri, 12 Jun 2026 11:53:41 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:49 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1715171819
@@ -43,7 +43,7 @@ discovery. Values are for block 1715171819 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
     }
 ```
 

--- a/packages/config/src/projects/reddioex/diffHistory.md
+++ b/packages/config/src/projects/reddioex/diffHistory.md
@@ -1,3 +1,74 @@
+Generated with discovered.json: 0x5e89997909301ad2088405e87ced4d0fc7549847
+
+# Diff at Fri, 12 Jun 2026 11:53:41 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1715171819
+- current timestamp: 1715171819
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1715171819 (main branch discovery), not current.
+
+```diff
+    contract DACommittee (eth:0x4b2Bf1Cb06CB636e8A14540F76c477E61d8B6669) [starkex/Committee] {
+    +++ description: Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 3.
+      sourceHashes.0:
+-        "0x220ee35d4e83e9cca7e8fa42dcab4d9571ce3078b50bacbdb2fc75afa7f0290e"
++        "0x3b7f5470a746d06671f24e4231b09df04ea52e7555e4fb874e093867c094c437"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
+```diff
+    contract GpsFactRegistryAdapter (eth:0x5339AB7557b3152b91A57D10B0Caf5da88Db5143) [starkex/GpsFactRegistryAdapter] {
+    +++ description: Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`16830627573509542901909952446321116535677491650708854009406762893086223513`).
+      sourceHashes.0:
+-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
++        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    EOA  (eth:0x6b7763b749073e892c83E674c1EC4799D6f339Ef) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+    }
+```
+
+```diff
+    contract OrderRegistry (eth:0x806d435a82B0381bD884540c2235147c13B97fe6) [starkex/OrderRegistry] {
+    +++ description: Helper contract for registering limit orders from L1.
+      deployerAddress:
++        "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6"
+    }
+```
+
+```diff
+    contract StarkExchange (eth:0xB62BcD40A24985f560b5a9745d478791d8F1945C) [starkex/StarkExchange] {
+    +++ description: Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.
+      sourceHashes.0:
+-        "0x2c95972415c771f5ef6d71449bae168597b6c35245fbe8769425e5c9c753e918"
++        "0xa2b51d5024b872eb502c2abfec88397c41c32d42494dd19905514a69d38abfec"
+      sourceHashes.1:
+-        "0xfb3c0545e8c9aeebaa6547f71087a1ad7d93e3344e0dfdb1051e1a18fd44a18b"
++        "0x9b28596a715350d61f719241f35d6ee159c111c93c05da1d4804157142ee790c"
+      deployerAddress:
++        "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A"
+    }
+```
+
 Generated with discovered.json: 0xad5ab204a71a3005263eba9dafd8c3ea3d5f407d
 
 # Diff at Fri, 12 Jun 2026 10:19:00 GMT:

--- a/packages/config/src/projects/reddioex/discovered.json
+++ b/packages/config/src/projects/reddioex/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "reddioex",
   "timestamp": 1715171819,
-  "configHash": "0xf922fd92a5d95ec79f06c14b32e41435b3d1692609dbe5de1a87753d38af68ed",
+  "configHash": "0xc6d1bf971a918be70c2c0f34dbf91d7f66e0bb9a3e2d394166ad58fc1b9417d6",
   "entries": [
     {
       "address": "eth:0x2e1c08E457F0E0F462Ef99eC9271dc5BfAd88b2a",
@@ -29,10 +29,11 @@
       "type": "Contract",
       "template": "starkex/Committee",
       "sourceHashes": [
-        "0x220ee35d4e83e9cca7e8fa42dcab4d9571ce3078b50bacbdb2fc75afa7f0290e"
+        "0x3b7f5470a746d06671f24e4231b09df04ea52e7555e4fb874e093867c094c437"
       ],
       "proxyType": "immutable",
       "description": "Data Availability Committee (DAC) contract verifying and storing data availability claims from DAC Members (via a multisignature check). The threshold of valid signatures is 3.",
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1663498763,
       "sinceBlock": 15559994,
       "values": {
@@ -65,10 +66,11 @@
       "type": "Contract",
       "template": "starkex/GpsFactRegistryAdapter",
       "sourceHashes": [
-        "0x3c0fff412189244728e9be021e2c7a1084326cc80e71f930221094909caafec0"
+        "0x1bb1677263f0cad4764f3620f45cf353df37fb489e3404889126f7897afcdffd"
       ],
       "proxyType": "immutable",
       "description": "Adapter between the core contract and the eth:0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60. Stores the Cairo programHash (`16830627573509542901909952446321116535677491650708854009406762893086223513`).",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1657453372,
       "sinceBlock": 15114702,
       "values": {
@@ -142,7 +144,7 @@
         {
           "permission": "interact",
           "from": "eth:0xB62BcD40A24985f560b5a9745d478791d8F1945C",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -175,6 +177,7 @@
       ],
       "proxyType": "immutable",
       "description": "Helper contract for registering limit orders from L1.",
+      "deployerAddress": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
       "sinceTimestamp": 1657453372,
       "sinceBlock": 15114702,
       "values": {
@@ -202,8 +205,8 @@
       "type": "Contract",
       "template": "starkex/StarkExchange",
       "sourceHashes": [
-        "0x2c95972415c771f5ef6d71449bae168597b6c35245fbe8769425e5c9c753e918",
-        "0xfb3c0545e8c9aeebaa6547f71087a1ad7d93e3344e0dfdb1051e1a18fd44a18b"
+        "0xa2b51d5024b872eb502c2abfec88397c41c32d42494dd19905514a69d38abfec",
+        "0x9b28596a715350d61f719241f35d6ee159c111c93c05da1d4804157142ee790c"
       ],
       "proxyType": "StarkWare diamond",
       "description": "Central Validium contract. Receives (verified) state roots from the Operator, allows users to consume L2 -> L1 messages and send L1 -> L2 messages. Critical configuration values for the L2's logic are defined here by various governance roles.",
@@ -215,6 +218,7 @@
         "getRollupVaultRoot",
         "getValidiumVaultRoot"
       ],
+      "deployerAddress": "eth:0x5751a83170BeA11fE7CdA5D599B04153C021f21A",
       "sinceTimestamp": 1663498763,
       "sinceBlock": 15559994,
       "values": {
@@ -688,5 +692,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 19825385 },
-  "permissionsConfigHash": "0xf2acc1366a118bc2d97ad932df0b2f1bc7bcab6f67bbc088880495ebe4c3c770"
+  "permissionsConfigHash": "0x4fae9900e3cb391ff4e447702f5448637d1f9e6d0356e565b7428c4e06e63ca1"
 }

--- a/packages/config/src/projects/reddioex/discovered.json
+++ b/packages/config/src/projects/reddioex/discovered.json
@@ -144,7 +144,7 @@
         {
           "permission": "interact",
           "from": "eth:0xB62BcD40A24985f560b5a9745d478791d8F1945C",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -692,5 +692,5 @@
     "starkex/StarkExchange": "0x27c9aa7e5669180c5228a095027bfb8426029450cd708a9277ac4bee945f699c"
   },
   "usedBlockNumbers": { "ethereum": 19825385 },
-  "permissionsConfigHash": "0x4fae9900e3cb391ff4e447702f5448637d1f9e6d0356e565b7428c4e06e63ca1"
+  "permissionsConfigHash": "0x113e8f81b0377b10bca414c1dc0189fa3065394be4066f51bf1a2274fb005301"
 }

--- a/packages/config/src/projects/sorare/diffHistory.md
+++ b/packages/config/src/projects/sorare/diffHistory.md
@@ -1,3 +1,39 @@
+Generated with discovered.json: 0xb66f7ef319d749a6255ba7b3e82146df19cb5287
+
+# Diff at Fri, 12 Jun 2026 11:53:42 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1780646255
+- current timestamp: 1780646255
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1780646255 (main branch discovery), not current.
+
+```diff
+    EOA  (eth:0x5918481F777dBe437De249492B90AffB4e655de4) {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+    }
+```
+
+```diff
+    contract SorareAdminMultisig (eth:0xCc928977e4a75d25099e7DA7B6Fd79Dac2f9fD2B) [GnosisSafe] {
+    +++ description: None
+      receivedPermissions.1.description:
+-        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
++        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
+    }
+```
+
 Generated with discovered.json: 0xa4031c50e8ac1851ca25f997de0a0f5ca13673c2
 
 # Diff at Fri, 12 Jun 2026 10:19:04 GMT:

--- a/packages/config/src/projects/sorare/diffHistory.md
+++ b/packages/config/src/projects/sorare/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0xb66f7ef319d749a6255ba7b3e82146df19cb5287
+Generated with discovered.json: 0xc6d846c81d9db0374e0cd5811740ff7d039977ed
 
-# Diff at Fri, 12 Jun 2026 11:53:42 GMT:
+# Diff at Fri, 12 Jun 2026 12:07:50 GMT:
 
 - author: Luca Donno (<donnoh99@gmail.com>)
 - comparing to: main@77f62933d564f65f6ab803a9850a637ea4a77091 block: 1780646255
@@ -21,7 +21,7 @@ discovery. Values are for block 1780646255 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
     }
 ```
 
@@ -30,7 +30,7 @@ discovery. Values are for block 1780646255 (main branch discovery), not current.
     +++ description: None
       receivedPermissions.1.description:
 -        "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract."
-+        "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract."
++        "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set."
     }
 ```
 

--- a/packages/config/src/projects/sorare/discovered.json
+++ b/packages/config/src/projects/sorare/discovered.json
@@ -44,7 +44,7 @@
         {
           "permission": "interact",
           "from": "eth:0xF5C9F957705bea56a7e806943f98F7777B995826",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -207,7 +207,7 @@
         {
           "permission": "interact",
           "from": "eth:0xF5C9F957705bea56a7e806943f98F7777B995826",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters like the programHash, configHash, or message cancellation delay in the core contract.",
+          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
           "role": ".$admin"
         },
         {
@@ -907,5 +907,5 @@
     "starkex/StarkExchange_Frozen": "0x0136ed1863558a0fd0cd5283912fcd12ca49a1e78ee7595141def29b8e331ac1"
   },
   "usedBlockNumbers": { "ethereum": 25249836 },
-  "permissionsConfigHash": "0x0131831c94b2051722e15c2dff2f90be14ebc27ea122b9ac15fe7663a3e576ce"
+  "permissionsConfigHash": "0x57e4be827ed1bbe7708c0150936a3456c26700b1cce67cf80ac20e54285a4cbc"
 }

--- a/packages/config/src/projects/sorare/discovered.json
+++ b/packages/config/src/projects/sorare/discovered.json
@@ -44,7 +44,7 @@
         {
           "permission": "interact",
           "from": "eth:0xF5C9F957705bea56a7e806943f98F7777B995826",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -207,7 +207,7 @@
         {
           "permission": "interact",
           "from": "eth:0xF5C9F957705bea56a7e806943f98F7777B995826",
-          "description": "Permissioned to manage the Operator role, finalize state and change critical parameters in the core contract.",
+          "description": "Permissioned to appoint and remove the Operator, register additional verifier and availability verifier contracts (removals are delayed), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set.",
           "role": ".$admin"
         },
         {
@@ -907,5 +907,5 @@
     "starkex/StarkExchange_Frozen": "0x0136ed1863558a0fd0cd5283912fcd12ca49a1e78ee7595141def29b8e331ac1"
   },
   "usedBlockNumbers": { "ethereum": 25249836 },
-  "permissionsConfigHash": "0x57e4be827ed1bbe7708c0150936a3456c26700b1cce67cf80ac20e54285a4cbc"
+  "permissionsConfigHash": "0x854621f9dfca16025c1656672105e013cc7d495bc19f8c2cc24d9985d92a2ebd"
 }

--- a/packages/config/src/projects/sorare/sorare.ts
+++ b/packages/config/src/projects/sorare/sorare.ts
@@ -66,10 +66,6 @@ export const sorare: ScalingProject = {
     BADGES.Infra.SHARP,
   ],
   display: {
-    redWarning: {
-      text: 'Critical contract references can be changed by an EOA which could result in the loss of all funds.',
-      detailAnchor: 'permissions',
-    },
     architectureImage: 'starkex',
     headerWarning:
       'Sorare froze its StarkEx rollup on June 1st, 2026. The core rollup contract is currently frozen.',


### PR DESCRIPTION
Changing the programHash replaces the L2 execution logic, so it should be modelled as an upgrade even though no bytecode changes.

## Modelling

- Splits `FinalizableGpsFactAdapter` into its own template: the plain `GpsFactRegistryAdapter` is immutable, while the finalizable variant lets admins call `setProgramHash` until `finalize()`. Its owner (storage slot 2, `SimpleAdminable` has no getter and the admins mapping emits no events) gets an undelayed `upgrade` permission with the condition "if the adapter is not finalized".
- Models the StarkPerpetual global and per-asset configuration changes as an `upgrade` permission with `{{configurationDelay}}` (both share the same timelock, which is zero on apex, so effectively instant there).
- Rewrites the main contract `$admin` descriptions from the flat sources. The old text claimed governance can change the programHash, configHash, or message cancellation delay, and can finalize state: none of these functions exist there. Per the sources, spot governance can appoint the Operator, register verifier and availability verifier contracts (removals delayed by `FREEZE_GRACE_PERIOD + 21 days`), set the default vault withdrawal lock, unfreeze the exchange and manage the governor set; StarkPerpetual is the same minus the vault lock.
- dydx's adapter is finalized, so it is categorized non-critical (no flag).

## redWarning automation

- `getEoaUpgradeRedWarning` now keys discovery by project id instead of display slug. The slug lookup silently missed projects whose slug differs from the folder name, suppressing the automatic warning on tanx (brine), oev (oevnetwork) and redsonic (reddioex).
- Removes the manual "references" redWarnings from apex, myria, sorare and brine: all four keep the banner automatically, and the automatic wording is now the accurate one (spot governance swaps references through the delayed approval chain; their undelayed vector is the proxy upgrade, while apex's instant paths are modelled explicitly). bugbuster (no permission modelling on the Cartesi stack) and zkfair (incident record) keep manual warnings.

## New warnings

- edgex: its adapter owner is an EOA and the adapter is not finalized, so the EOA can instantly swap the execution logic while the main contract is otherwise multisig-governed.
- tanx, oev, redsonic: previously suppressed by the slug bug, their discoveries already carried the flag.