### PR TITLE
IA - aggregate status table

### DIFF
--- a/packages/database/prisma/migrations/20260617145056_add_interop_aggregate_status/migration.sql
+++ b/packages/database/prisma/migrations/20260617145056_add_interop_aggregate_status/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "InteropAggregateStatus" (
+    "timestamp" TIMESTAMP(6) NOT NULL,
+    "status" VARCHAR(16) NOT NULL,
+    "promotedBy" VARCHAR(255),
+    "reasons" TEXT,
+    "checkedAt" TIMESTAMP(6) NOT NULL,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "InteropAggregateStatus_pkey" PRIMARY KEY ("timestamp")
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -714,6 +714,15 @@ model AggregatedInteropTokensPair {
   @@index([timestamp, srcChain, dstChain, id, bridgeType])
 }
 
+model InteropAggregateStatus {
+  timestamp  DateTime @id @db.Timestamp(6) // = aggregate snapshot `to`
+  status     String   @db.VarChar(16) // 'promoted' | 'blocked'
+  promotedBy String?  @db.VarChar(255) // 'auto' | operator email | 'backfill'
+  reasons    String?  @db.Text // RuleViolation[] as JSON text (blocked only)
+  checkedAt  DateTime @db.Timestamp(6)
+  updatedAt  DateTime @db.Timestamp(6)
+}
+
 model AppState {
   key       String   @id @db.VarChar(255)
   value     String   @db.Text

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -20,6 +20,7 @@ import { EcosystemTokenRepository } from './repositories/EcosystemTokenRepositor
 import { FlatSourcesRepository } from './repositories/FlatSourcesRepository'
 import { IndexerConfigurationRepository } from './repositories/IndexerConfigurationRepository'
 import { IndexerStateRepository } from './repositories/IndexerStateRepository'
+import { InteropAggregateStatusRepository } from './repositories/InteropAggregateStatusRepository'
 import { InteropConfigRepository } from './repositories/InteropConfigRepository'
 import { InteropEventRepository } from './repositories/InteropEventRepository'
 import { InteropMessageRepository } from './repositories/InteropMessageRepository'
@@ -70,6 +71,7 @@ export function createDatabase(
     interopMessage: new InteropMessageRepository(db),
     interopTransfer: new InteropTransferRepository(db),
     aggregatedInteropTransfer: new AggregatedInteropTransferRepository(db),
+    interopAggregateStatus: new InteropAggregateStatusRepository(db),
     aggregatedInteropToken: new AggregatedInteropTokenRepository(db),
     aggregatedInteropDeployedToken:
       new AggregatedInteropDeployedTokenRepository(db),

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -49,6 +49,10 @@ export type { DiscoveryCacheRecord } from './repositories/DiscoveryCacheReposito
 export type { FlatSourcesRecord } from './repositories/FlatSourcesRepository'
 export type { IndexerConfigurationRecord } from './repositories/IndexerConfigurationRepository'
 export type { IndexerStateRecord } from './repositories/IndexerStateRepository'
+export type {
+  InteropAggregateStatusRecord,
+  InteropAggregateStatusValue,
+} from './repositories/InteropAggregateStatusRepository'
 export type { InteropConfigRecord } from './repositories/InteropConfigRepository'
 export type {
   InteropEventContext,

--- a/packages/database/src/repositories/InteropAggregateStatusRepository.test.ts
+++ b/packages/database/src/repositories/InteropAggregateStatusRepository.test.ts
@@ -1,0 +1,207 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { describeDatabase } from '../test/database'
+import type { AggregatedInteropTransferRecord } from './AggregatedInteropTransferRepository'
+import { InteropAggregateStatusRepository } from './InteropAggregateStatusRepository'
+
+describeDatabase(InteropAggregateStatusRepository.name, (db) => {
+  const repository = db.interopAggregateStatus
+  const transfers = db.aggregatedInteropTransfer
+
+  beforeEach(async () => {
+    await repository.deleteAll()
+    await transfers.deleteAll()
+  })
+
+  describe(InteropAggregateStatusRepository.prototype.upsertAuto.name, () => {
+    it('inserts then updates an existing auto row', async () => {
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'promoted',
+      })
+      expect((await repository.getByTimestamp(UnixTime(100)))?.status).toEqual(
+        'promoted',
+      )
+
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'blocked',
+        reasons: [{ rule: 'maxLaneVolume' }],
+      })
+
+      const row = await repository.getByTimestamp(UnixTime(100))
+      expect(row?.status).toEqual('blocked')
+      expect(row?.promotedBy).toEqual('auto')
+      expect(row?.reasons).toEqual([{ rule: 'maxLaneVolume' }])
+    })
+
+    it('does NOT overwrite a manual (non-auto) verdict (sticky)', async () => {
+      await repository.upsert({
+        timestamp: UnixTime(100),
+        status: 'promoted',
+        promotedBy: 'ops@l2beat.com',
+      })
+
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'blocked',
+      })
+
+      const row = await repository.getByTimestamp(UnixTime(100))
+      expect(row?.status).toEqual('promoted')
+      expect(row?.promotedBy).toEqual('ops@l2beat.com')
+    })
+  })
+
+  describe(
+    InteropAggregateStatusRepository.prototype.getLatestPromotedTimestamp.name,
+    () => {
+      it('returns the max promoted timestamp, skipping a newer blocked one', async () => {
+        await repository.upsertAuto({
+          timestamp: UnixTime(100),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(200),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(300),
+          status: 'blocked',
+        })
+
+        expect(await repository.getLatestPromotedTimestamp()).toEqual(
+          UnixTime(200),
+        )
+      })
+
+      it('returns undefined when nothing is promoted', async () => {
+        await repository.upsertAuto({
+          timestamp: UnixTime(100),
+          status: 'blocked',
+        })
+
+        expect(await repository.getLatestPromotedTimestamp()).toEqual(undefined)
+      })
+    },
+  )
+
+  describe(
+    InteropAggregateStatusRepository.prototype
+      .getEarliestPromotedTimestampForDay.name,
+    () => {
+      it('returns the earliest promoted timestamp of the day, skipping blocked', async () => {
+        const dayEarly = UnixTime(UnixTime.DAY + 100)
+        const dayMid = UnixTime(UnixTime.DAY + 200)
+        const dayLate = UnixTime(UnixTime.DAY + 300)
+        const nextDay = UnixTime(2 * UnixTime.DAY + 100)
+
+        // earliest of the day is blocked → must be skipped
+        await repository.upsertAuto({ timestamp: dayEarly, status: 'blocked' })
+        await repository.upsertAuto({ timestamp: dayMid, status: 'promoted' })
+        await repository.upsertAuto({ timestamp: dayLate, status: 'promoted' })
+        await repository.upsertAuto({ timestamp: nextDay, status: 'promoted' })
+
+        expect(
+          await repository.getEarliestPromotedTimestampForDay(dayLate),
+        ).toEqual(dayMid)
+      })
+
+      it('returns undefined for a day with no promoted snapshot', async () => {
+        const day = UnixTime(UnixTime.DAY + 100)
+        await repository.upsertAuto({ timestamp: day, status: 'blocked' })
+
+        expect(
+          await repository.getEarliestPromotedTimestampForDay(day),
+        ).toEqual(undefined)
+      })
+    },
+  )
+
+  describe(
+    InteropAggregateStatusRepository.prototype.deleteOrphaned.name,
+    () => {
+      it('removes status rows whose snapshot no longer exists', async () => {
+        await transfers.insertMany([
+          transfer(UnixTime(100)),
+          transfer(UnixTime(300)),
+        ])
+        await repository.upsertAuto({
+          timestamp: UnixTime(100),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(200),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(300),
+          status: 'blocked',
+        })
+
+        const deleted = await repository.deleteOrphaned()
+
+        expect(deleted).toEqual(1)
+        expect(await repository.getByTimestamp(UnixTime(100))).not.toEqual(
+          undefined,
+        )
+        expect(await repository.getByTimestamp(UnixTime(200))).toEqual(
+          undefined,
+        )
+        expect(await repository.getByTimestamp(UnixTime(300))).not.toEqual(
+          undefined,
+        )
+      })
+    },
+  )
+
+  describe(InteropAggregateStatusRepository.prototype.getRecent.name, () => {
+    it('returns the most recent rows, newest first', async () => {
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'promoted',
+      })
+      await repository.upsertAuto({
+        timestamp: UnixTime(200),
+        status: 'blocked',
+      })
+      await repository.upsertAuto({
+        timestamp: UnixTime(300),
+        status: 'promoted',
+      })
+
+      const recent = await repository.getRecent(2)
+      expect(recent.map((r) => r.timestamp)).toEqual([
+        UnixTime(300),
+        UnixTime(200),
+      ])
+    })
+  })
+})
+
+function transfer(timestamp: UnixTime): AggregatedInteropTransferRecord {
+  return {
+    timestamp,
+    id: 'p',
+    bridgeType: 'unknown',
+    srcChain: 'ethereum',
+    dstChain: 'arbitrum',
+    transferTypeStats: undefined,
+    transferCount: 1,
+    transfersWithDurationCount: 1,
+    identifiedCount: 1,
+    totalDurationSum: 0,
+    srcValueUsd: undefined,
+    dstValueUsd: undefined,
+    minTransferValueUsd: undefined,
+    maxTransferValueUsd: undefined,
+    avgValueInFlight: undefined,
+    mintedValueUsd: undefined,
+    burnedValueUsd: undefined,
+    countUnder100: 0,
+    count100To1K: 0,
+    count1KTo10K: 0,
+    count10KTo100K: 0,
+    countOver100K: 0,
+  }
+}

--- a/packages/database/src/repositories/InteropAggregateStatusRepository.ts
+++ b/packages/database/src/repositories/InteropAggregateStatusRepository.ts
@@ -1,0 +1,186 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { type Insertable, type Selectable, sql } from 'kysely'
+import { BaseRepository } from '../BaseRepository'
+import type { InteropAggregateStatus } from '../kysely/generated/types'
+
+export type InteropAggregateStatusValue = 'promoted' | 'blocked'
+
+export interface InteropAggregateStatusRecord {
+  /** Identifies the aggregate snapshot (the aggregation `to` timestamp). */
+  timestamp: UnixTime
+  status: InteropAggregateStatusValue
+  /** 'auto' for engine verdicts, operator email for manual flips. */
+  promotedBy: string | undefined
+  /** Decision payload (RuleViolation[]) when blocked; opaque to the DB layer. */
+  reasons: unknown | undefined
+  checkedAt: UnixTime
+  updatedAt: UnixTime
+}
+
+export function toRecord(
+  row: Selectable<InteropAggregateStatus>,
+): InteropAggregateStatusRecord {
+  return {
+    timestamp: UnixTime.fromDate(row.timestamp),
+    status: row.status as InteropAggregateStatusValue,
+    promotedBy: row.promotedBy ?? undefined,
+    reasons: row.reasons != null ? JSON.parse(row.reasons) : undefined,
+    checkedAt: UnixTime.fromDate(row.checkedAt),
+    updatedAt: UnixTime.fromDate(row.updatedAt),
+  }
+}
+
+export function toRow(
+  record: InteropAggregateStatusRecord,
+): Insertable<InteropAggregateStatus> {
+  return {
+    timestamp: UnixTime.toDate(record.timestamp),
+    status: record.status,
+    promotedBy: record.promotedBy ?? null,
+    // stored as JSON text (the column is `String`); parsed back in `toRecord`
+    reasons:
+      record.reasons === undefined ? null : JSON.stringify(record.reasons),
+    checkedAt: UnixTime.toDate(record.checkedAt),
+    updatedAt: UnixTime.toDate(record.updatedAt),
+  }
+}
+
+export class InteropAggregateStatusRepository extends BaseRepository {
+  /**
+   * Engine write. Sticky: inserts a new row, or updates an existing one ONLY when
+   * its `promotedBy` is still `'auto'`. A human verdict (non-`auto`) is never
+   * downgraded by the engine.
+   */
+  async upsertAuto(record: {
+    timestamp: UnixTime
+    status: InteropAggregateStatusValue
+    reasons?: unknown
+  }): Promise<void> {
+    const now = UnixTime.now()
+    const row = toRow({
+      timestamp: record.timestamp,
+      status: record.status,
+      promotedBy: 'auto',
+      reasons: record.reasons,
+      checkedAt: now,
+      updatedAt: now,
+    })
+    await this.db
+      .insertInto('InteropAggregateStatus')
+      .values(row)
+      .onConflict((oc) =>
+        oc
+          .column('timestamp')
+          .doUpdateSet({
+            status: row.status,
+            promotedBy: row.promotedBy,
+            reasons: row.reasons,
+            checkedAt: row.checkedAt,
+            updatedAt: row.updatedAt,
+          })
+          // existing row only (table-qualified to disambiguate from `excluded`) —
+          // never overwrite a manual (non-`auto`) verdict
+          .where('InteropAggregateStatus.promotedBy', '=', 'auto'),
+      )
+      .execute()
+  }
+
+  /** Manual (operator) write — unconditional; takes precedence over the engine. */
+  async upsert(record: {
+    timestamp: UnixTime
+    status: InteropAggregateStatusValue
+    promotedBy: string
+    reasons?: unknown
+  }): Promise<void> {
+    const now = UnixTime.now()
+    const row = toRow({
+      timestamp: record.timestamp,
+      status: record.status,
+      promotedBy: record.promotedBy,
+      reasons: record.reasons,
+      checkedAt: now,
+      updatedAt: now,
+    })
+    await this.db
+      .insertInto('InteropAggregateStatus')
+      .values(row)
+      .onConflict((oc) =>
+        oc.column('timestamp').doUpdateSet({
+          status: row.status,
+          promotedBy: row.promotedBy,
+          reasons: row.reasons,
+          checkedAt: row.checkedAt,
+          updatedAt: row.updatedAt,
+        }),
+      )
+      .execute()
+  }
+
+  async getLatestPromotedTimestamp(): Promise<UnixTime | undefined> {
+    const result = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .select((eb) => eb.fn.max('timestamp').as('max_timestamp'))
+      .where('status', '=', 'promoted')
+      .executeTakeFirst()
+    return result?.max_timestamp
+      ? UnixTime.fromDate(result.max_timestamp)
+      : undefined
+  }
+
+  async getEarliestPromotedTimestampForDay(
+    timestamp: UnixTime,
+  ): Promise<UnixTime | undefined> {
+    const result = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .select((eb) => eb.fn.min('timestamp').as('min_timestamp'))
+      .where('status', '=', 'promoted')
+      .where(
+        sql`date_trunc('day', timestamp)`,
+        '=',
+        sql`date_trunc('day', ${UnixTime.toDate(timestamp)}::timestamp)`,
+      )
+      .executeTakeFirst()
+    return result?.min_timestamp
+      ? UnixTime.fromDate(result.min_timestamp)
+      : undefined
+  }
+
+  async getByTimestamp(
+    timestamp: UnixTime,
+  ): Promise<InteropAggregateStatusRecord | undefined> {
+    const row = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .selectAll()
+      .where('timestamp', '=', UnixTime.toDate(timestamp))
+      .executeTakeFirst()
+    return row ? toRecord(row) : undefined
+  }
+
+  async getRecent(limit: number): Promise<InteropAggregateStatusRecord[]> {
+    const rows = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .selectAll()
+      .orderBy('timestamp', 'desc')
+      .limit(limit)
+      .execute()
+    return rows.map(toRecord)
+  }
+
+  /** Drops status rows whose snapshot no longer exists (kept in lockstep with retention). */
+  async deleteOrphaned(): Promise<number> {
+    const result = await this.db
+      .deleteFrom('InteropAggregateStatus')
+      .where('timestamp', 'not in', (eb) =>
+        eb.selectFrom('AggregatedInteropTransfer').select('timestamp'),
+      )
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
+  async deleteAll(): Promise<number> {
+    const result = await this.db
+      .deleteFrom('InteropAggregateStatus')
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+}


### PR DESCRIPTION
First slice of the Interop aggregate **promotion gate**. Adds the storage + access layer that later PRs build on. **No behaviour change** — nothing reads this table yet.

## What changed

- **New `InteropAggregateStatus` table** — one row per aggregate snapshot `timestamp`:
  - `status` — `promoted` | `blocked`
  - `promotedBy` — `auto` (engine) or operator email (manual flip)
  - `reasons` — JSON text, populated only when `blocked`
  - `checkedAt` / `updatedAt`
  - Migration is **`CREATE TABLE` only — no backfill** (backfill is a separate, later migration).
- **`InteropAggregateStatusRepository`**
  - `upsertAuto` — engine write, **sticky**: `ON CONFLICT … WHERE promotedBy = 'auto'` (table-qualified to disambiguate from `excluded`), so it never overwrites a manual verdict.
  - `upsert` — manual (operator) write, unconditional.
  - reads used by the eventual cutover: `getLatestPromotedTimestamp`, `getEarliestPromotedTimestampForDay`, `getByTimestamp`, `getRecent`.
  - `deleteOrphaned` — drops status rows whose snapshot no longer exists (keeps the table in lockstep with aggregate retention).
- Registered in the `Database` factory and the record types exported from the package index.

## Notes for the reviewer

- `reasons` is `JSON.stringify`'d on write and parsed on read. The `pg` driver serializes JS **arrays** as Postgres array literals (which `jsonb` rejects), so the column is `Text` and we control the JSON ourselves.
- The sticky `upsertAuto` is the mechanism that lets a later promotion engine re-evaluate the current hour without ever clobbering a human's manual flip.