### PR TITLE
IA - promotion foundation

### DIFF
--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
@@ -171,6 +171,13 @@ describe(InteropAggregatingIndexer.name, () => {
         insertMany: mockFn().resolvesTo(1),
       })
 
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
 
       const db = mockDatabase({
@@ -180,6 +187,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -253,6 +261,11 @@ describe(InteropAggregatingIndexer.name, () => {
       expect(
         aggregatedInteropTokensPair.deleteByTimestamp,
       ).toHaveBeenCalledWith(to)
+      expect(interopAggregateStatus.upsertAuto).toHaveBeenCalledWith({
+        timestamp: to,
+        status: 'promoted',
+      })
+      expect(interopAggregateStatus.deleteOrphaned).toHaveBeenCalledTimes(1)
     })
 
     it('handles empty transfers correctly', async () => {
@@ -298,6 +311,12 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
 
       const transaction = mockFn(async (fn: any) => await fn())
 
@@ -308,6 +327,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -455,6 +475,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
       const db = mockDatabase({
         transaction,
@@ -463,6 +490,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesToOnce(false).resolvesTo(true),
@@ -549,6 +577,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
 
       const db = mockDatabase({
@@ -558,6 +593,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -679,6 +715,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn) => await fn())
 
       const db = mockDatabase({
@@ -688,6 +731,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -782,6 +826,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
 
       const db = mockDatabase({
@@ -791,6 +842,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),

--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.ts
@@ -95,6 +95,15 @@ export class InteropAggregatingIndexer extends ManagedChildIndexer {
       await this.$.db.aggregatedInteropTokensPair.insertMany(
         aggregatedTokensPairs,
       )
+      // Mark this snapshot promoted by default. The promotion engine (a later
+      // stage) replaces this with a real verdict; the read path is unaffected
+      // until the cutover, so this is a no-op for what the frontend serves.
+      await this.$.db.interopAggregateStatus.upsertAuto({
+        timestamp: to,
+        status: 'promoted',
+      })
+      // Keep status rows in lockstep with the aggregates retention above.
+      await this.$.db.interopAggregateStatus.deleteOrphaned()
     })
 
     if (analysis && analysis.suspiciousGroups.length > 0) {


### PR DESCRIPTION
Makes the aggregating indexer record promotion status for every new snapshot it writes. **Still zero behaviour change for the frontend** — the read path is untouched, so this only populates status going forward (the display cutover is a later PR).

## What changed

- In `InteropAggregatingIndexer.update`, inside the **existing transaction** and after the aggregate inserts:
  - `interopAggregateStatus.upsertAuto({ timestamp: to, status: 'promoted' })`
  - `interopAggregateStatus.deleteOrphaned()`
- Atomic with the aggregate writes, so a snapshot can never exist without a status row. Runs only when aggregation runs — a skipped (stale-syncers) hour writes nothing.

## Notes for the reviewer

- The hard-coded `'promoted'` is intentional for this stage. The promotion engine (later PR) replaces it with a real verdict via the same `upsertAuto` call — no signature changes needed.
- `deleteOrphaned` is placed after the aggregate retention/overwrite so status stays in lockstep with what aggregate rows actually exist.