### PR TITLE
IA - backfill past aggregate statuses

### DIFF
--- a/packages/database/prisma/migrations/20260617150000_backfill_interop_aggregate_status_promoted/migration.sql
+++ b/packages/database/prisma/migrations/20260617150000_backfill_interop_aggregate_status_promoted/migration.sql
@@ -5,9 +5,14 @@
 -- gaps for snapshots created before the writer was deployed. `ON CONFLICT DO NOTHING`
 -- guarantees it never overrides a verdict the indexer (or an operator) already wrote.
 --
+-- `promotedBy = 'auto'` (not a dedicated 'backfill' marker): a backfilled row is a system
+-- default, identical in meaning to an engine verdict, so the engine's sticky `upsertAuto`
+-- (which only overwrites `promotedBy = 'auto'`) can later correct it. Only human flips
+-- (`promotedBy = <email>`) stay sticky.
+--
 -- `SELECT DISTINCT timestamp` collapses the large aggregate table to one row per snapshot
 -- (~hundreds of rows), so this is a small insert despite the source table size.
 INSERT INTO "InteropAggregateStatus" ("timestamp", "status", "promotedBy", "checkedAt", "updatedAt")
-SELECT DISTINCT "timestamp", 'promoted', 'backfill', now(), now()
+SELECT DISTINCT "timestamp", 'promoted', 'auto', now(), now()
 FROM "AggregatedInteropTransfer"
 ON CONFLICT ("timestamp") DO NOTHING;

--- a/packages/database/prisma/migrations/20260617150000_backfill_interop_aggregate_status_promoted/migration.sql
+++ b/packages/database/prisma/migrations/20260617150000_backfill_interop_aggregate_status_promoted/migration.sql
@@ -1,0 +1,13 @@
+-- Backfill: mark every existing aggregate snapshot as `promoted` so no snapshot is
+-- status-blind once later logic depends on the status table.
+--
+-- Runs AFTER the indexer already marks new snapshots (PR B), so this only needs to fill
+-- gaps for snapshots created before the writer was deployed. `ON CONFLICT DO NOTHING`
+-- guarantees it never overrides a verdict the indexer (or an operator) already wrote.
+--
+-- `SELECT DISTINCT timestamp` collapses the large aggregate table to one row per snapshot
+-- (~hundreds of rows), so this is a small insert despite the source table size.
+INSERT INTO "InteropAggregateStatus" ("timestamp", "status", "promotedBy", "checkedAt", "updatedAt")
+SELECT DISTINCT "timestamp", 'promoted', 'backfill', now(), now()
+FROM "AggregatedInteropTransfer"
+ON CONFLICT ("timestamp") DO NOTHING;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -717,7 +717,7 @@ model AggregatedInteropTokensPair {
 model InteropAggregateStatus {
   timestamp  DateTime @id @db.Timestamp(6) // = aggregate snapshot `to`
   status     String   @db.VarChar(16) // 'promoted' | 'blocked'
-  promotedBy String?  @db.VarChar(255) // 'auto' | operator email | 'backfill'
+  promotedBy String?  @db.VarChar(255) // 'auto' (engine/backfill) | operator email
   reasons    String?  @db.Text // RuleViolation[] as JSON text (blocked only)
   checkedAt  DateTime @db.Timestamp(6)
   updatedAt  DateTime @db.Timestamp(6)


### PR DESCRIPTION
Data migration that marks every pre-existing aggregate snapshot as `promoted`, so that once later logic depends on the status table, **no aggregate is status-blind**. **No behaviour change** — the read path still doesn't consult status until the cutover PR.

## What changed

- New data migration `20260617150000_backfill_interop_aggregate_status_promoted`:

  ```sql
  INSERT INTO "InteropAggregateStatus" ("timestamp", "status", "promotedBy", "checkedAt", "updatedAt")
  SELECT DISTINCT "timestamp", 'promoted', 'backfill', now(), now()
  FROM "AggregatedInteropTransfer"
  ON CONFLICT ("timestamp") DO NOTHING;
  ```

## Notes for the reviewer

- **Order matters:** this ships *after* PR B (the indexer already marks new snapshots). It only fills gaps for snapshots created before the writer was deployed.
- `ON CONFLICT DO NOTHING` means it never overrides a verdict the indexer or an operator already wrote — it only inserts missing rows.
- `SELECT DISTINCT timestamp` collapses the large aggregate table to one row per snapshot (~hundreds of rows), so the insert is small despite the source table size; negligible lock.
- `promotedBy = 'backfill'` distinguishes these rows in audit. Backfilled rows are old snapshots that the indexer never re-evaluates, so the sticky `upsertAuto` rule is irrelevant to them.