### PR TITLE
IA - engine + simple rule

### DIFF
--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.test.ts
@@ -171,6 +171,13 @@ describe(InteropAggregatingIndexer.name, () => {
         insertMany: mockFn().resolvesTo(1),
       })
 
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
 
       const db = mockDatabase({
@@ -180,6 +187,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -253,6 +261,11 @@ describe(InteropAggregatingIndexer.name, () => {
       expect(
         aggregatedInteropTokensPair.deleteByTimestamp,
       ).toHaveBeenCalledWith(to)
+      expect(interopAggregateStatus.upsertAuto).toHaveBeenCalledWith({
+        timestamp: to,
+        status: 'promoted',
+      })
+      expect(interopAggregateStatus.deleteOrphaned).toHaveBeenCalledTimes(1)
     })
 
     it('handles empty transfers correctly', async () => {
@@ -298,6 +311,12 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
 
       const transaction = mockFn(async (fn: any) => await fn())
 
@@ -308,6 +327,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -455,6 +475,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
       const db = mockDatabase({
         transaction,
@@ -463,6 +490,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesToOnce(false).resolvesTo(true),
@@ -549,6 +577,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
 
       const db = mockDatabase({
@@ -558,6 +593,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -679,6 +715,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn) => await fn())
 
       const db = mockDatabase({
@@ -688,6 +731,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),
@@ -782,6 +826,13 @@ describe(InteropAggregatingIndexer.name, () => {
         deleteByTimestamp: mockFn().resolvesTo(0),
         insertMany: mockFn().resolvesTo(0),
       })
+      const interopAggregateStatus = mockObject<
+        Database['interopAggregateStatus']
+      >({
+        upsertAuto: mockFn().resolvesTo(undefined),
+        deleteOrphaned: mockFn().resolvesTo(0),
+      })
+
       const transaction = mockFn(async (fn: any) => await fn())
 
       const db = mockDatabase({
@@ -791,6 +842,7 @@ describe(InteropAggregatingIndexer.name, () => {
         aggregatedInteropToken,
         aggregatedInteropDeployedToken,
         aggregatedInteropTokensPair,
+        interopAggregateStatus,
       })
       const syncersManager = mockObject<InteropSyncersManager>({
         areSyncersFreshEnough: mockFn().resolvesTo(true),

--- a/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.ts
+++ b/packages/backend/src/modules/interop/engine/aggregation/InteropAggregatingIndexer.ts
@@ -95,6 +95,15 @@ export class InteropAggregatingIndexer extends ManagedChildIndexer {
       await this.$.db.aggregatedInteropTokensPair.insertMany(
         aggregatedTokensPairs,
       )
+      // Mark this snapshot promoted by default. The promotion engine (a later
+      // stage) replaces this with a real verdict; the read path is unaffected
+      // until the cutover, so this is a no-op for what the frontend serves.
+      await this.$.db.interopAggregateStatus.upsertAuto({
+        timestamp: to,
+        status: 'promoted',
+      })
+      // Keep status rows in lockstep with the aggregates retention above.
+      await this.$.db.interopAggregateStatus.deleteOrphaned()
     })
 
     if (analysis && analysis.suspiciousGroups.length > 0) {

--- a/packages/database/prisma/migrations/20260617145056_add_interop_aggregate_status/migration.sql
+++ b/packages/database/prisma/migrations/20260617145056_add_interop_aggregate_status/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "InteropAggregateStatus" (
+    "timestamp" TIMESTAMP(6) NOT NULL,
+    "status" VARCHAR(16) NOT NULL,
+    "promotedBy" VARCHAR(255),
+    "reasons" TEXT,
+    "checkedAt" TIMESTAMP(6) NOT NULL,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "InteropAggregateStatus_pkey" PRIMARY KEY ("timestamp")
+);

--- a/packages/database/prisma/migrations/20260617150000_backfill_interop_aggregate_status_promoted/migration.sql
+++ b/packages/database/prisma/migrations/20260617150000_backfill_interop_aggregate_status_promoted/migration.sql
@@ -1,0 +1,13 @@
+-- Backfill: mark every existing aggregate snapshot as `promoted` so no snapshot is
+-- status-blind once later logic depends on the status table.
+--
+-- Runs AFTER the indexer already marks new snapshots (PR B), so this only needs to fill
+-- gaps for snapshots created before the writer was deployed. `ON CONFLICT DO NOTHING`
+-- guarantees it never overrides a verdict the indexer (or an operator) already wrote.
+--
+-- `SELECT DISTINCT timestamp` collapses the large aggregate table to one row per snapshot
+-- (~hundreds of rows), so this is a small insert despite the source table size.
+INSERT INTO "InteropAggregateStatus" ("timestamp", "status", "promotedBy", "checkedAt", "updatedAt")
+SELECT DISTINCT "timestamp", 'promoted', 'backfill', now(), now()
+FROM "AggregatedInteropTransfer"
+ON CONFLICT ("timestamp") DO NOTHING;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -714,6 +714,15 @@ model AggregatedInteropTokensPair {
   @@index([timestamp, srcChain, dstChain, id, bridgeType])
 }
 
+model InteropAggregateStatus {
+  timestamp  DateTime @id @db.Timestamp(6) // = aggregate snapshot `to`
+  status     String   @db.VarChar(16) // 'promoted' | 'blocked'
+  promotedBy String?  @db.VarChar(255) // 'auto' | operator email | 'backfill'
+  reasons    String?  @db.Text // RuleViolation[] as JSON text (blocked only)
+  checkedAt  DateTime @db.Timestamp(6)
+  updatedAt  DateTime @db.Timestamp(6)
+}
+
 model AppState {
   key       String   @id @db.VarChar(255)
   value     String   @db.Text

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -20,6 +20,7 @@ import { EcosystemTokenRepository } from './repositories/EcosystemTokenRepositor
 import { FlatSourcesRepository } from './repositories/FlatSourcesRepository'
 import { IndexerConfigurationRepository } from './repositories/IndexerConfigurationRepository'
 import { IndexerStateRepository } from './repositories/IndexerStateRepository'
+import { InteropAggregateStatusRepository } from './repositories/InteropAggregateStatusRepository'
 import { InteropConfigRepository } from './repositories/InteropConfigRepository'
 import { InteropEventRepository } from './repositories/InteropEventRepository'
 import { InteropMessageRepository } from './repositories/InteropMessageRepository'
@@ -70,6 +71,7 @@ export function createDatabase(
     interopMessage: new InteropMessageRepository(db),
     interopTransfer: new InteropTransferRepository(db),
     aggregatedInteropTransfer: new AggregatedInteropTransferRepository(db),
+    interopAggregateStatus: new InteropAggregateStatusRepository(db),
     aggregatedInteropToken: new AggregatedInteropTokenRepository(db),
     aggregatedInteropDeployedToken:
       new AggregatedInteropDeployedTokenRepository(db),

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -49,6 +49,10 @@ export type { DiscoveryCacheRecord } from './repositories/DiscoveryCacheReposito
 export type { FlatSourcesRecord } from './repositories/FlatSourcesRepository'
 export type { IndexerConfigurationRecord } from './repositories/IndexerConfigurationRepository'
 export type { IndexerStateRecord } from './repositories/IndexerStateRepository'
+export type {
+  InteropAggregateStatusRecord,
+  InteropAggregateStatusValue,
+} from './repositories/InteropAggregateStatusRepository'
 export type { InteropConfigRecord } from './repositories/InteropConfigRepository'
 export type {
   InteropEventContext,

--- a/packages/database/src/repositories/InteropAggregateStatusRepository.test.ts
+++ b/packages/database/src/repositories/InteropAggregateStatusRepository.test.ts
@@ -1,0 +1,207 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { describeDatabase } from '../test/database'
+import type { AggregatedInteropTransferRecord } from './AggregatedInteropTransferRepository'
+import { InteropAggregateStatusRepository } from './InteropAggregateStatusRepository'
+
+describeDatabase(InteropAggregateStatusRepository.name, (db) => {
+  const repository = db.interopAggregateStatus
+  const transfers = db.aggregatedInteropTransfer
+
+  beforeEach(async () => {
+    await repository.deleteAll()
+    await transfers.deleteAll()
+  })
+
+  describe(InteropAggregateStatusRepository.prototype.upsertAuto.name, () => {
+    it('inserts then updates an existing auto row', async () => {
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'promoted',
+      })
+      expect((await repository.getByTimestamp(UnixTime(100)))?.status).toEqual(
+        'promoted',
+      )
+
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'blocked',
+        reasons: [{ rule: 'maxLaneVolume' }],
+      })
+
+      const row = await repository.getByTimestamp(UnixTime(100))
+      expect(row?.status).toEqual('blocked')
+      expect(row?.promotedBy).toEqual('auto')
+      expect(row?.reasons).toEqual([{ rule: 'maxLaneVolume' }])
+    })
+
+    it('does NOT overwrite a manual (non-auto) verdict (sticky)', async () => {
+      await repository.upsert({
+        timestamp: UnixTime(100),
+        status: 'promoted',
+        promotedBy: 'ops@l2beat.com',
+      })
+
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'blocked',
+      })
+
+      const row = await repository.getByTimestamp(UnixTime(100))
+      expect(row?.status).toEqual('promoted')
+      expect(row?.promotedBy).toEqual('ops@l2beat.com')
+    })
+  })
+
+  describe(
+    InteropAggregateStatusRepository.prototype.getLatestPromotedTimestamp.name,
+    () => {
+      it('returns the max promoted timestamp, skipping a newer blocked one', async () => {
+        await repository.upsertAuto({
+          timestamp: UnixTime(100),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(200),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(300),
+          status: 'blocked',
+        })
+
+        expect(await repository.getLatestPromotedTimestamp()).toEqual(
+          UnixTime(200),
+        )
+      })
+
+      it('returns undefined when nothing is promoted', async () => {
+        await repository.upsertAuto({
+          timestamp: UnixTime(100),
+          status: 'blocked',
+        })
+
+        expect(await repository.getLatestPromotedTimestamp()).toEqual(undefined)
+      })
+    },
+  )
+
+  describe(
+    InteropAggregateStatusRepository.prototype
+      .getEarliestPromotedTimestampForDay.name,
+    () => {
+      it('returns the earliest promoted timestamp of the day, skipping blocked', async () => {
+        const dayEarly = UnixTime(UnixTime.DAY + 100)
+        const dayMid = UnixTime(UnixTime.DAY + 200)
+        const dayLate = UnixTime(UnixTime.DAY + 300)
+        const nextDay = UnixTime(2 * UnixTime.DAY + 100)
+
+        // earliest of the day is blocked → must be skipped
+        await repository.upsertAuto({ timestamp: dayEarly, status: 'blocked' })
+        await repository.upsertAuto({ timestamp: dayMid, status: 'promoted' })
+        await repository.upsertAuto({ timestamp: dayLate, status: 'promoted' })
+        await repository.upsertAuto({ timestamp: nextDay, status: 'promoted' })
+
+        expect(
+          await repository.getEarliestPromotedTimestampForDay(dayLate),
+        ).toEqual(dayMid)
+      })
+
+      it('returns undefined for a day with no promoted snapshot', async () => {
+        const day = UnixTime(UnixTime.DAY + 100)
+        await repository.upsertAuto({ timestamp: day, status: 'blocked' })
+
+        expect(
+          await repository.getEarliestPromotedTimestampForDay(day),
+        ).toEqual(undefined)
+      })
+    },
+  )
+
+  describe(
+    InteropAggregateStatusRepository.prototype.deleteOrphaned.name,
+    () => {
+      it('removes status rows whose snapshot no longer exists', async () => {
+        await transfers.insertMany([
+          transfer(UnixTime(100)),
+          transfer(UnixTime(300)),
+        ])
+        await repository.upsertAuto({
+          timestamp: UnixTime(100),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(200),
+          status: 'promoted',
+        })
+        await repository.upsertAuto({
+          timestamp: UnixTime(300),
+          status: 'blocked',
+        })
+
+        const deleted = await repository.deleteOrphaned()
+
+        expect(deleted).toEqual(1)
+        expect(await repository.getByTimestamp(UnixTime(100))).not.toEqual(
+          undefined,
+        )
+        expect(await repository.getByTimestamp(UnixTime(200))).toEqual(
+          undefined,
+        )
+        expect(await repository.getByTimestamp(UnixTime(300))).not.toEqual(
+          undefined,
+        )
+      })
+    },
+  )
+
+  describe(InteropAggregateStatusRepository.prototype.getRecent.name, () => {
+    it('returns the most recent rows, newest first', async () => {
+      await repository.upsertAuto({
+        timestamp: UnixTime(100),
+        status: 'promoted',
+      })
+      await repository.upsertAuto({
+        timestamp: UnixTime(200),
+        status: 'blocked',
+      })
+      await repository.upsertAuto({
+        timestamp: UnixTime(300),
+        status: 'promoted',
+      })
+
+      const recent = await repository.getRecent(2)
+      expect(recent.map((r) => r.timestamp)).toEqual([
+        UnixTime(300),
+        UnixTime(200),
+      ])
+    })
+  })
+})
+
+function transfer(timestamp: UnixTime): AggregatedInteropTransferRecord {
+  return {
+    timestamp,
+    id: 'p',
+    bridgeType: 'unknown',
+    srcChain: 'ethereum',
+    dstChain: 'arbitrum',
+    transferTypeStats: undefined,
+    transferCount: 1,
+    transfersWithDurationCount: 1,
+    identifiedCount: 1,
+    totalDurationSum: 0,
+    srcValueUsd: undefined,
+    dstValueUsd: undefined,
+    minTransferValueUsd: undefined,
+    maxTransferValueUsd: undefined,
+    avgValueInFlight: undefined,
+    mintedValueUsd: undefined,
+    burnedValueUsd: undefined,
+    countUnder100: 0,
+    count100To1K: 0,
+    count1KTo10K: 0,
+    count10KTo100K: 0,
+    countOver100K: 0,
+  }
+}

--- a/packages/database/src/repositories/InteropAggregateStatusRepository.ts
+++ b/packages/database/src/repositories/InteropAggregateStatusRepository.ts
@@ -1,0 +1,186 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { type Insertable, type Selectable, sql } from 'kysely'
+import { BaseRepository } from '../BaseRepository'
+import type { InteropAggregateStatus } from '../kysely/generated/types'
+
+export type InteropAggregateStatusValue = 'promoted' | 'blocked'
+
+export interface InteropAggregateStatusRecord {
+  /** Identifies the aggregate snapshot (the aggregation `to` timestamp). */
+  timestamp: UnixTime
+  status: InteropAggregateStatusValue
+  /** 'auto' for engine verdicts, operator email for manual flips. */
+  promotedBy: string | undefined
+  /** Decision payload (RuleViolation[]) when blocked; opaque to the DB layer. */
+  reasons: unknown | undefined
+  checkedAt: UnixTime
+  updatedAt: UnixTime
+}
+
+export function toRecord(
+  row: Selectable<InteropAggregateStatus>,
+): InteropAggregateStatusRecord {
+  return {
+    timestamp: UnixTime.fromDate(row.timestamp),
+    status: row.status as InteropAggregateStatusValue,
+    promotedBy: row.promotedBy ?? undefined,
+    reasons: row.reasons != null ? JSON.parse(row.reasons) : undefined,
+    checkedAt: UnixTime.fromDate(row.checkedAt),
+    updatedAt: UnixTime.fromDate(row.updatedAt),
+  }
+}
+
+export function toRow(
+  record: InteropAggregateStatusRecord,
+): Insertable<InteropAggregateStatus> {
+  return {
+    timestamp: UnixTime.toDate(record.timestamp),
+    status: record.status,
+    promotedBy: record.promotedBy ?? null,
+    // stored as JSON text (the column is `String`); parsed back in `toRecord`
+    reasons:
+      record.reasons === undefined ? null : JSON.stringify(record.reasons),
+    checkedAt: UnixTime.toDate(record.checkedAt),
+    updatedAt: UnixTime.toDate(record.updatedAt),
+  }
+}
+
+export class InteropAggregateStatusRepository extends BaseRepository {
+  /**
+   * Engine write. Sticky: inserts a new row, or updates an existing one ONLY when
+   * its `promotedBy` is still `'auto'`. A human verdict (non-`auto`) is never
+   * downgraded by the engine.
+   */
+  async upsertAuto(record: {
+    timestamp: UnixTime
+    status: InteropAggregateStatusValue
+    reasons?: unknown
+  }): Promise<void> {
+    const now = UnixTime.now()
+    const row = toRow({
+      timestamp: record.timestamp,
+      status: record.status,
+      promotedBy: 'auto',
+      reasons: record.reasons,
+      checkedAt: now,
+      updatedAt: now,
+    })
+    await this.db
+      .insertInto('InteropAggregateStatus')
+      .values(row)
+      .onConflict((oc) =>
+        oc
+          .column('timestamp')
+          .doUpdateSet({
+            status: row.status,
+            promotedBy: row.promotedBy,
+            reasons: row.reasons,
+            checkedAt: row.checkedAt,
+            updatedAt: row.updatedAt,
+          })
+          // existing row only (table-qualified to disambiguate from `excluded`) —
+          // never overwrite a manual (non-`auto`) verdict
+          .where('InteropAggregateStatus.promotedBy', '=', 'auto'),
+      )
+      .execute()
+  }
+
+  /** Manual (operator) write — unconditional; takes precedence over the engine. */
+  async upsert(record: {
+    timestamp: UnixTime
+    status: InteropAggregateStatusValue
+    promotedBy: string
+    reasons?: unknown
+  }): Promise<void> {
+    const now = UnixTime.now()
+    const row = toRow({
+      timestamp: record.timestamp,
+      status: record.status,
+      promotedBy: record.promotedBy,
+      reasons: record.reasons,
+      checkedAt: now,
+      updatedAt: now,
+    })
+    await this.db
+      .insertInto('InteropAggregateStatus')
+      .values(row)
+      .onConflict((oc) =>
+        oc.column('timestamp').doUpdateSet({
+          status: row.status,
+          promotedBy: row.promotedBy,
+          reasons: row.reasons,
+          checkedAt: row.checkedAt,
+          updatedAt: row.updatedAt,
+        }),
+      )
+      .execute()
+  }
+
+  async getLatestPromotedTimestamp(): Promise<UnixTime | undefined> {
+    const result = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .select((eb) => eb.fn.max('timestamp').as('max_timestamp'))
+      .where('status', '=', 'promoted')
+      .executeTakeFirst()
+    return result?.max_timestamp
+      ? UnixTime.fromDate(result.max_timestamp)
+      : undefined
+  }
+
+  async getEarliestPromotedTimestampForDay(
+    timestamp: UnixTime,
+  ): Promise<UnixTime | undefined> {
+    const result = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .select((eb) => eb.fn.min('timestamp').as('min_timestamp'))
+      .where('status', '=', 'promoted')
+      .where(
+        sql`date_trunc('day', timestamp)`,
+        '=',
+        sql`date_trunc('day', ${UnixTime.toDate(timestamp)}::timestamp)`,
+      )
+      .executeTakeFirst()
+    return result?.min_timestamp
+      ? UnixTime.fromDate(result.min_timestamp)
+      : undefined
+  }
+
+  async getByTimestamp(
+    timestamp: UnixTime,
+  ): Promise<InteropAggregateStatusRecord | undefined> {
+    const row = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .selectAll()
+      .where('timestamp', '=', UnixTime.toDate(timestamp))
+      .executeTakeFirst()
+    return row ? toRecord(row) : undefined
+  }
+
+  async getRecent(limit: number): Promise<InteropAggregateStatusRecord[]> {
+    const rows = await this.db
+      .selectFrom('InteropAggregateStatus')
+      .selectAll()
+      .orderBy('timestamp', 'desc')
+      .limit(limit)
+      .execute()
+    return rows.map(toRecord)
+  }
+
+  /** Drops status rows whose snapshot no longer exists (kept in lockstep with retention). */
+  async deleteOrphaned(): Promise<number> {
+    const result = await this.db
+      .deleteFrom('InteropAggregateStatus')
+      .where('timestamp', 'not in', (eb) =>
+        eb.selectFrom('AggregatedInteropTransfer').select('timestamp'),
+      )
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
+  async deleteAll(): Promise<number> {
+    const result = await this.db
+      .deleteFrom('InteropAggregateStatus')
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+}


### PR DESCRIPTION
Adds the pluggable promotion engine and wires it into the aggregating indexer. It evaluates each snapshot, records a `promoted`/`blocked` verdict, and (in `enforce`) sends a Discord alert on a block. **The read path is untouched — display is still ungated until the cutover PR**, so this stage records + alerts only (an observe window to calibrate on real data).

## What changed

- **Engine** (`engine/promotion/`):
  - `types.ts` — `PromotionContext` (a snapshot's transfers + tokens), `RuleViolation`, `PromotionRule`.
  - `rules.ts` — kick-off rule **`maxLaneVolume`**: blocks when **any single lane's** volume (`max(srcValueUsd, dstValueUsd)`, matching the displayed `getInteropTransferValue`) exceeds the ceiling. Per-lane `scope = id|bridgeType|srcChain|dstChain`.
  - `evaluatePromotion.ts` — runs every rule under its **own try/catch** (one broken rule is isolated into `ruleErrors`, never blanket-fails the eval).
  - `InteropPromotionService.reconcile(ctx)` — owns the decision + status write (`upsertAuto`), returns `{ status, reasons, notify }`. Modes: `off` (always promote), `shadow` (evaluate + log, always promote, never alert), `enforce` (block + alert on violations). Engine-level error → `failClosed` decides block vs promote.
- **Notifier** — `InteropNotifier.notifyBlockedSnapshot(timestamp, reasons)` (reuses the existing interop Discord webhook + queue).
- **Indexer** — calls `promotionService.reconcile(...)` inside the existing transaction (replacing PR B's hard-coded promote), keeps `deleteOrphaned()`, and post-commit calls `notifyBlockedSnapshot` when `reconcile` says so.
- **Config** — `InteropPromotionConfig { mode, failClosed, maxLaneVolumeUsd }` under `interop.aggregation.promotion`, env-tunable:
  - `INTEROP_PROMOTION_MODE` (default `shadow`), `INTEROP_PROMOTION_FAIL_CLOSED` (default `true`), `INTEROP_PROMOTION_MAX_LANE_VOLUME_USD` (default **$1,000,000,000**).

## Notes for the reviewer

- **Per-lane, not a global sum, on purpose.** A per-lane ceiling needs no subgroup/aggregate de-duplication (summing all rows double-counts subgroup volume that's already inside a parent aggregate like USDT0 ⊂ LayerZero) and directly targets the failure mode of one bad price inflating a single lane.
- **Single rule on purpose** (start simple). The engine takes a `rules: PromotionRule[]`, so adding more rules later is one array entry — no engine/service/indexer changes.
- `reconcile` must run inside the indexer transaction (status atomic with aggregates); notification fires after commit.
- `mode` defaults to `shadow`: on deploy it evaluates + logs would-be blocks without blocking or alerting. Flip to `enforce` via env after calibration. `off` is the kill switch.
