### PR TITLE
Reject unsafe numbers in Bytes.fromNumber

### DIFF
--- a/packages/shared-pure/src/types/Bytes.test.ts
+++ b/packages/shared-pure/src/types/Bytes.test.ts
@@ -37,6 +37,9 @@ describe(Bytes.name, () => {
     it('checks constructor arguments', () => {
       expect(() => Bytes.fromNumber(1.5)).toThrow(TypeError)
       expect(() => Bytes.fromNumber(-2)).toThrow(TypeError)
+      expect(() => Bytes.fromNumber(Number.MAX_SAFE_INTEGER + 1)).toThrow(
+        TypeError,
+      )
     })
 
     it('encodes 0 as empty', () => {

--- a/packages/shared-pure/src/types/Bytes.ts
+++ b/packages/shared-pure/src/types/Bytes.ts
@@ -114,7 +114,7 @@ function numberToString(value: number) {
 }
 
 function isNonNegativeInteger(value: unknown): value is number {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
 }
 
 function isByte(value: unknown): value is number {


### PR DESCRIPTION
## Summary

This updates `Bytes.fromNumber` to reject numbers that are outside JavaScript's safe integer range.

Previously, `Bytes.fromNumber` accepted any non-negative integer, including values greater than `Number.MAX_SAFE_INTEGER`. Such values may already be imprecise when represented as a JavaScript `number`, so encoding them into bytes can silently produce an unexpected value.

## Changes

- Use `Number.isSafeInteger` when validating numeric byte inputs
- Add regression coverage for rejecting unsafe integers in `Bytes.fromNumber`

## Testing

- `pnpm -C packages/shared-pure test`
- `pnpm -C packages/shared-pure lint`
- `pnpm -C packages/shared-pure typecheck`
- `pnpm -C packages/shared-pure format`
- `pnpm -C packages/shared-pure build`