### PR TITLE
archive Zk.Money v1 (Aztec v1) after escapeHatch exploit

### DIFF
--- a/packages/config/src/projects/aztec/aztec.ts
+++ b/packages/config/src/projects/aztec/aztec.ts
@@ -54,13 +54,14 @@ export const aztec: ScalingProject = {
   type: 'layer2',
   id: ProjectId('aztec'),
   addedAt: UnixTime(1623153328), // 2021-06-08T11:55:28Z
+  archivedAt: UnixTime.fromDate(new Date('2026-06-20')),
   capability: 'appchain',
   display: {
     name: 'Zk.Money v1 (Aztec v1)',
     shortName: 'Zk.Money v1',
     slug: 'aztecv1',
     warning:
-      'EOL: Ownership of the rollup contract is irrevocably renounced and Aztec is not running a rollup processor (operator). Users or third parties have to [run the rollup system by themselves](https://github.com/AztecProtocol/aztec-v2-ejector/) to withdraw or transact.',
+      'On 2026-06-17 the immutable rollup contract was [exploited for ~$2.16M](https://x.com/aztecFND/status/2067511967237939636) (1,158 ETH, ~150k DAI and renBTC) through its emergency escapeHatch() withdrawal function. Ownership of the rollup contract is irrevocably renounced, so it cannot be paused or patched, and Aztec is not running a rollup processor (operator). Aztec stated the affected product is deprecated and unrelated to the current Aztec Network or the AZTEC token.',
     description:
       'Zk.Money v1 (Aztec v1, or sometimes called Aztec 2.0) is an open source layer 2 network that aims to enable affordable, private crypto payments via zero-knowledge proofs.',
     purposes: ['Payments', 'Privacy'],

--- a/packages/config/src/projects/aztec/aztec.ts
+++ b/packages/config/src/projects/aztec/aztec.ts
@@ -348,6 +348,14 @@ export const aztec: ScalingProject = {
   },
   milestones: [
     {
+      title: 'Escape-hatch verifier exploit',
+      date: '2026-06-17T00:00:00Z',
+      url: 'https://www.aztec-labs.com/blog/aztec-2-incident.html',
+      description:
+        '$2.2M of assets are drained by exploiting an unsound verification key.',
+      type: 'incident',
+    },
+    {
       title: 'Aztec operator sunset',
       date: '2023-07-08T00:00:00Z',
       url: 'https://github.com/AztecProtocol/aztec-v2-ejector/',

--- a/packages/config/src/projects/aztecconnect/aztecconnect.ts
+++ b/packages/config/src/projects/aztecconnect/aztecconnect.ts
@@ -250,6 +250,14 @@ export const aztecconnect: ScalingProject = {
   },
   milestones: [
     {
+      title: 'Immutable smart contract exploit',
+      date: '2026-06-15T00:00:00Z',
+      url: 'https://www.aztec-labs.com/blog/aztec-connect-incident.html',
+      description:
+        '$~2.3M of assets are drained by exploiting a bug in a smart contract.',
+      type: 'incident',
+    },
+    {
       title: 'Aztec operator sunset',
       date: '2024-04-30T00:00:00Z',
       url: 'https://medium.com/aztec-protocol/sunsetting-aztec-connect-a786edce5cae',

--- a/packages/config/src/projects/aztecv1prover/aztecv1prover.ts
+++ b/packages/config/src/projects/aztecv1prover/aztecv1prover.ts
@@ -10,6 +10,7 @@ export const aztecv1prover: BaseProject = {
   name: 'Aztec v1',
   shortName: undefined,
   addedAt: UnixTime.fromDate(new Date('2025-08-15')),
+  archivedAt: UnixTime.fromDate(new Date('2026-06-20')),
   statuses: {
     yellowWarning: undefined,
     redWarning: undefined,


### PR DESCRIPTION
Archives Zk.Money v1 (Aztec v1) by setting `archivedAt` to 2026-06-20. Updates the yellow warning to explain the 2026-06-17 `escapeHatch()` exploit that drained ~$2.16M (1,158 ETH, ~150k DAI and renBTC) from the immutable rollup contract, linking the official Aztec Foundation statement. This is distinct from the June 14 Aztec Connect incident, which is a separate project.
