### PR TITLE
IA - promotion-aware FE

### DIFF
--- a/packages/frontend/src/server/features/scaling/interop/utils/getAggregatedInteropTimestamp.ts
+++ b/packages/frontend/src/server/features/scaling/interop/utils/getAggregatedInteropTimestamp.ts
@@ -16,5 +16,5 @@ export async function getAggregatedInteropSnapshotTimestamp(): Promise<
     )
   }
 
-  return db.aggregatedInteropTransfer.getLatestTimestamp()
+  return db.interopAggregateStatus.getLatestPromotedTimestamp()
 }

--- a/packages/public-api/src/routes/interop/getInteropData.ts
+++ b/packages/public-api/src/routes/interop/getInteropData.ts
@@ -30,7 +30,7 @@ export async function getInteropChainsData(
 
 async function getLatestAggregatedInteropTransfers(db: Database) {
   const latestTimestamp =
-    await db.aggregatedInteropTransfer.getLatestTimestamp()
+    await db.interopAggregateStatus.getLatestPromotedTimestamp()
   if (!latestTimestamp) {
     return []
   }


### PR DESCRIPTION
Resolves L2B-14237

The interop aggregation indexer produces an hourly aggregate snapshot (keyed by timestamp), and a promotion gate records a per-snapshot verdict (promoted / blocked) in the InteropAggregateStatus table — blocking snapshots whose data looks anomalous (e.g. a bad price inflating a lane past a ceiling). Until now the public read paths served the latest snapshot unconditionally, so a blocked snapshot would still reach production.

This PR flips the two public reads to serve the latest promoted snapshot. This is the step that actually activates display protection.

The frontend has a manual operator pin (interopAggregatesTimestampOverride in appState). It is checked first in the resolver and bypasses the promotion filter. Only the default path changed; the override branch is untouched. (Public API has no override.)