### PR TITLE
Adjust deduplication logic for $pastUpgrades

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.test.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.test.ts
@@ -140,10 +140,11 @@ describe('buildPastUpgradeRows', () => {
     expect(rows[0]?.cells[2]?.diffUrl).toEqual(`/diff/${E}/${D}`)
   })
 
-  it('collapses entries that share a transaction hash', () => {
+  it('collapses entries that share a transaction hash and implementation set', () => {
     const value: FieldValue = {
       type: 'array',
-      // A diamond deployment emits the same tx several times.
+      // A diamond emits one DiamondCut event per cut; repeated events within a
+      // single tx resolve to the same cumulative facet set.
       values: [
         entry('2024-01-01T00:00:00.000Z', '0xdeploy', [F]),
         entry('2024-01-01T00:00:00.000Z', '0xdeploy', [F]),
@@ -158,5 +159,32 @@ describe('buildPastUpgradeRows', () => {
     expect(rows.map((r) => r.cells[0]?.address)).toEqual([A, F])
     expect(rows[0]?.cells[0]?.diffUrl).toEqual(`/diff/${F}/${A}`)
     expect(rows[1]?.cells[0]?.diffUrl).toEqual(undefined)
+  })
+
+  it('keeps distinct implementations changed within one transaction', () => {
+    // OP Stack upgrades go proxy -> StorageSetter (B) -> new impl (A) in a
+    // single tx, emitting two `Upgraded` events that share a hash and block
+    // timestamp. Both are real upgrades and must be shown, newest (A) first.
+    const value: FieldValue = {
+      type: 'array',
+      values: [
+        entry('2024-12-16T10:59:11.000Z', '0xfirst', [C]),
+        entry('2026-05-25T00:00:00.000Z', '0xsecond', [B]),
+        entry('2026-05-25T00:00:00.000Z', '0xsecond', [A]),
+      ],
+    }
+
+    const rows = buildPastUpgradeRows(value)
+
+    expect(rows.length).toEqual(3)
+    expect(rows.map((r) => r.cells[0]?.address)).toEqual([A, B, C])
+    expect(rows.map((r) => r.txHash)).toEqual([
+      '0xsecond',
+      '0xsecond',
+      '0xfirst',
+    ])
+    expect(rows[0]?.cells[0]?.diffUrl).toEqual(`/diff/${B}/${A}`)
+    expect(rows[1]?.cells[0]?.diffUrl).toEqual(`/diff/${C}/${B}`)
+    expect(rows[2]?.cells[0]?.diffUrl).toEqual(undefined)
   })
 })

--- a/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.test.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.test.ts
@@ -162,9 +162,7 @@ describe('buildPastUpgradeRows', () => {
   })
 
   it('keeps distinct implementations changed within one transaction', () => {
-    // OP Stack upgrades go proxy -> StorageSetter (B) -> new impl (A) in a
-    // single tx, emitting two `Upgraded` events that share a hash and block
-    // timestamp. Both are real upgrades and must be shown, newest (A) first.
+    // OP Stack: proxy -> StorageSetter (B) -> new impl (A) in one tx.
     const value: FieldValue = {
       type: 'array',
       values: [
@@ -186,5 +184,46 @@ describe('buildPastUpgradeRows', () => {
     expect(rows[0]?.cells[0]?.diffUrl).toEqual(`/diff/${B}/${A}`)
     expect(rows[1]?.cells[0]?.diffUrl).toEqual(`/diff/${C}/${B}`)
     expect(rows[2]?.cells[0]?.diffUrl).toEqual(undefined)
+  })
+
+  it('keeps a snapshot that recurs non-consecutively within one transaction', () => {
+    // A -> B -> A in one tx: the two A entries are not adjacent, so neither
+    // collapses and B still diffs against the intra-tx A, not pre-tx C.
+    const value: FieldValue = {
+      type: 'array',
+      values: [
+        entry('2024-01-01T00:00:00.000Z', '0xold', [C]),
+        entry('2026-05-25T00:00:00.000Z', '0xtx', [A]),
+        entry('2026-05-25T00:00:00.000Z', '0xtx', [B]),
+        entry('2026-05-25T00:00:00.000Z', '0xtx', [A]),
+      ],
+    }
+
+    const rows = buildPastUpgradeRows(value)
+
+    expect(rows.length).toEqual(4)
+    expect(rows.map((r) => r.cells[0]?.address)).toEqual([A, B, A, C])
+    expect(rows[0]?.cells[0]?.diffUrl).toEqual(`/diff/${B}/${A}`)
+    expect(rows[1]?.cells[0]?.diffUrl).toEqual(`/diff/${A}/${B}`)
+    expect(rows[2]?.cells[0]?.diffUrl).toEqual(`/diff/${C}/${A}`)
+    expect(rows[3]?.cells[0]?.diffUrl).toEqual(undefined)
+  })
+
+  it('still folds three consecutive identical diamond snapshots into one row', () => {
+    const value: FieldValue = {
+      type: 'array',
+      values: [
+        entry('2024-01-01T00:00:00.000Z', '0xdeploy', [F]),
+        entry('2024-01-01T00:00:00.000Z', '0xdeploy', [F]),
+        entry('2024-01-01T00:00:00.000Z', '0xdeploy', [F]),
+        entry('2024-03-01T00:00:00.000Z', '0xreset', [F]),
+      ],
+    }
+
+    const rows = buildPastUpgradeRows(value)
+
+    expect(rows.length).toEqual(2)
+    expect(rows.map((r) => r.txHash)).toEqual(['0xreset', '0xdeploy'])
+    expect(rows.map((r) => r.cells[0]?.address)).toEqual([F, F])
   })
 })

--- a/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.ts
@@ -84,30 +84,18 @@ export function buildPastUpgradeRows(value: FieldValue): PastUpgradeRow[] {
   })
 }
 
-/**
- * Collapses entries that are genuinely redundant: same transaction AND same
- * resulting implementation set. Diamonds emit one `$pastUpgrades` entry per
- * `DiamondCut` event and the repeated events within a single transaction
- * resolve to the same cumulative facet set, so they collapse to one row (the
- * last occurrence). Single-implementation proxies that change the
- * implementation more than once in a transaction - e.g. the OP Stack pattern of
- * `proxy -> StorageSetter -> new impl` emitting two `Upgraded` events - keep
- * every distinct implementation, so no real upgrade is hidden. Entries without
- * a transaction hash are always kept.
- */
+// Folds only consecutive identical snapshots (same tx + implementation set),
+// e.g. a diamond's repeated `DiamondCut` events. Distinct in-tx changes (OP
+// Stack `proxy -> StorageSetter -> impl`, or a recurring `A -> B -> A`) are
+// kept. Assumes `$pastUpgrades` is chronological, so same-tx events are adjacent.
 function collapseRedundantUpgrades(upgrades: PastUpgrade[]): PastUpgrade[] {
-  const lastIndexByKey = new Map<string, number>()
-  upgrades.forEach((upgrade, index) => {
-    if (upgrade.txHash !== undefined) {
-      lastIndexByKey.set(upgradeKey(upgrade), index)
+  return upgrades.filter((upgrade, index) => {
+    if (upgrade.txHash === undefined) {
+      return true
     }
+    const next = upgrades[index + 1]
+    return next === undefined || upgradeKey(next) !== upgradeKey(upgrade)
   })
-
-  return upgrades.filter(
-    (upgrade, index) =>
-      upgrade.txHash === undefined ||
-      lastIndexByKey.get(upgradeKey(upgrade)) === index,
-  )
 }
 
 function upgradeKey(upgrade: PastUpgrade): string {

--- a/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.ts
+++ b/packages/protocolbeat/src/apps/discovery/panel-values/pastUpgrades.ts
@@ -43,9 +43,13 @@ export interface PastUpgradeRow {
  * facets and the oldest entry get no diff.
  */
 export function buildPastUpgradeRows(value: FieldValue): PastUpgradeRow[] {
-  const sorted = [...dedupeByTransaction(parsePastUpgrades(value))].sort(
-    (a, b) => b.date.localeCompare(a.date),
-  )
+  const sorted = collapseRedundantUpgrades(parsePastUpgrades(value))
+    .map((upgrade, index) => ({ upgrade, index }))
+    .sort(
+      (a, b) =>
+        b.upgrade.date.localeCompare(a.upgrade.date) || b.index - a.index,
+    )
+    .map((entry) => entry.upgrade)
 
   return sorted.map((upgrade, entryIndex) => {
     const previous = sorted[entryIndex + 1]
@@ -81,24 +85,35 @@ export function buildPastUpgradeRows(value: FieldValue): PastUpgradeRow[] {
 }
 
 /**
- * Collapses entries that share a transaction hash. Diamonds emit one
- * `$pastUpgrades` entry per `DiamondCut` event, so a single upgrade transaction
- * can appear several times. We keep the last occurrence, which holds the final
- * cumulative facet set for that transaction. Entries without a hash are kept.
+ * Collapses entries that are genuinely redundant: same transaction AND same
+ * resulting implementation set. Diamonds emit one `$pastUpgrades` entry per
+ * `DiamondCut` event and the repeated events within a single transaction
+ * resolve to the same cumulative facet set, so they collapse to one row (the
+ * last occurrence). Single-implementation proxies that change the
+ * implementation more than once in a transaction - e.g. the OP Stack pattern of
+ * `proxy -> StorageSetter -> new impl` emitting two `Upgraded` events - keep
+ * every distinct implementation, so no real upgrade is hidden. Entries without
+ * a transaction hash are always kept.
  */
-function dedupeByTransaction(upgrades: PastUpgrade[]): PastUpgrade[] {
-  const lastIndexByTx = new Map<string, number>()
+function collapseRedundantUpgrades(upgrades: PastUpgrade[]): PastUpgrade[] {
+  const lastIndexByKey = new Map<string, number>()
   upgrades.forEach((upgrade, index) => {
     if (upgrade.txHash !== undefined) {
-      lastIndexByTx.set(upgrade.txHash, index)
+      lastIndexByKey.set(upgradeKey(upgrade), index)
     }
   })
 
   return upgrades.filter(
     (upgrade, index) =>
       upgrade.txHash === undefined ||
-      lastIndexByTx.get(upgrade.txHash) === index,
+      lastIndexByKey.get(upgradeKey(upgrade)) === index,
   )
+}
+
+function upgradeKey(upgrade: PastUpgrade): string {
+  return `${upgrade.txHash}:${upgrade.implementations
+    .map((implementation) => implementation.address)
+    .join(',')}`
 }
 
 function parsePastUpgrades(value: FieldValue): PastUpgrade[] {


### PR DESCRIPTION
In pastUpgrades.ts, dedupeByTransaction collapsed every $pastUpgrades entry that shared a transaction hash, keeping only the last one. That rule was written for diamonds (one DiamondCut event per cut, all resolving to the same cumulative facet set within a tx).

But OP Stack single-implementation proxies like the hashkey SuperchainConfig (0xfd12…B40A) upgrade in the pattern proxy → StorageSetter → new impl within one transaction, emitting two distinct Upgraded events.

Changed the dedupe key from txhash alone to txhash + implementation set:
Diamonds — duplicate-txhash entries are identical impl sets → still collapse to one row (verified: abstract/wonder/adi diamonds all have identical dups).
Single-impl proxies — entries with the same tx but different impls are kept → the StorageSetter step is no longer hidden, and the displayed row count matches $upgradeCount.