### PR TITLE
derive anomaly visibility from status not end timestamp

### DIFF
--- a/packages/frontend/src/components/chart/liveness/ProjectLivenessChart.tsx
+++ b/packages/frontend/src/components/chart/liveness/ProjectLivenessChart.tsx
@@ -10,6 +10,7 @@ import { LivenessChartSubtypeControls } from '~/pages/scaling/liveness/component
 import type { LivenessAnomaly } from '~/server/features/scaling/liveness/types'
 import { useTRPC } from '~/trpc/React'
 import { cn } from '~/utils/cn'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import { type ChartRange, rangeToResolution } from '~/utils/range/range'
 import { ChartControlsWrapper } from '../../core/chart/ChartControlsWrapper'
 import { getDefaultSubtype } from './getDefaultSubtype'
@@ -50,7 +51,7 @@ export function ProjectLivenessChart({
   )
 
   const anyAnomalyLive = anomalies.some(
-    (anomaly) => anomaly.subtype === subtype && anomaly.end === undefined,
+    (anomaly) => anomaly.subtype === subtype && isAnomalyOngoing(anomaly),
   )
   const chartData = useMemo(() => {
     return chart?.data?.map(([timestamp, min, avg, max]) => {

--- a/packages/frontend/src/components/projects/sections/liveness/LivenessSection.tsx
+++ b/packages/frontend/src/components/projects/sections/liveness/LivenessSection.tsx
@@ -12,6 +12,7 @@ import { RoundedWarningIcon } from '~/icons/RoundedWarning'
 import { AnomalyText } from '~/pages/scaling/liveness/components/AnomalyText'
 import { NoAnomaliesState } from '~/pages/scaling/liveness/components/NoRecentAnomaliesState'
 import type { LivenessAnomaly } from '~/server/features/scaling/liveness/types'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import type { TrackedTransactionsByType } from '~/utils/project/tracked-txs/getTrackedTransactions'
 import type { ChartRange } from '~/utils/range/range'
 import { TrackedTransactions } from '../costs/TrackedTransactions'
@@ -45,7 +46,7 @@ export function LivenessSection({
   isForDaBridge,
   ...sectionProps
 }: LivenessSectionProps) {
-  const ongoingAnomalies = anomalies.filter((a) => a.end === undefined)
+  const ongoingAnomalies = anomalies.filter(isAnomalyOngoing)
   return (
     <ProjectSection {...sectionProps}>
       <p className="mb-4 text-paragraph-15 md:text-paragraph-16">

--- a/packages/frontend/src/pages/scaling/liveness/components/AnomalyIndicator.tsx
+++ b/packages/frontend/src/pages/scaling/liveness/components/AnomalyIndicator.tsx
@@ -7,6 +7,7 @@ import {
 } from '~/components/core/tooltip/Tooltip'
 import type { LivenessAnomaly } from '~/server/features/scaling/liveness/types'
 import { cn } from '~/utils/cn'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 
 interface Props {
   anomalies: LivenessAnomaly[]
@@ -19,7 +20,7 @@ export function AnomalyIndicator({ anomalies, href }: Props) {
     anomalies,
     indicators.length,
   )
-  const hasOngoing = anomalies.some((a) => a.end === undefined)
+  const hasOngoing = anomalies.some(isAnomalyOngoing)
 
   const content = (
     <div className="flex flex-col items-center gap-0.5">
@@ -92,7 +93,7 @@ function calculateUptimePercentage(anomalies: LivenessAnomaly[], days: number) {
   const intervals = anomalies
     .map((a) => ({
       start: Math.max(a.start, windowStart),
-      end: a.end ? Math.min(a.end, now) : now,
+      end: isAnomalyOngoing(a) ? now : Math.min(a.end ?? a.start, now),
     }))
     .filter((i) => i.end > i.start)
     .sort((a, b) => a.start - b.start)
@@ -123,14 +124,15 @@ function toAnomalyIndicatorEntries(anomalies: LivenessAnomaly[]) {
     const anomaliesInGivenDay = anomalies.filter((a) => {
       return (
         dayInLoop >= UnixTime.toStartOf(a.start, 'day') &&
-        (!a.end || dayInLoop <= UnixTime.toEndOf(a.end, 'day'))
+        (isAnomalyOngoing(a) ||
+          dayInLoop <= UnixTime.toEndOf(a.end ?? a.start, 'day'))
       )
     })
 
     if (anomaliesInGivenDay.length === 0) {
       result.push('none')
     } else {
-      const isAnyOngoing = anomaliesInGivenDay.some((a) => a.end === undefined)
+      const isAnyOngoing = anomaliesInGivenDay.some(isAnomalyOngoing)
       result.push(isAnyOngoing ? 'ongoing' : 'recovered')
     }
 

--- a/packages/frontend/src/pages/scaling/liveness/components/AnomalyIndicator.tsx
+++ b/packages/frontend/src/pages/scaling/liveness/components/AnomalyIndicator.tsx
@@ -91,10 +91,17 @@ function calculateUptimePercentage(anomalies: LivenessAnomaly[], days: number) {
 
   // clamp intervals to the window
   const intervals = anomalies
-    .map((a) => ({
-      start: Math.max(a.start, windowStart),
-      end: isAnomalyOngoing(a) ? now : Math.min(a.end ?? a.start, now),
-    }))
+    .flatMap((a) => {
+      const end = isAnomalyOngoing(a) ? now : a.end
+      if (end === undefined) {
+        return []
+      }
+
+      return {
+        start: Math.max(a.start, windowStart),
+        end: Math.min(end, now),
+      }
+    })
     .filter((i) => i.end > i.start)
     .sort((a, b) => a.start - b.start)
 

--- a/packages/frontend/src/pages/scaling/liveness/components/AnomalyText.tsx
+++ b/packages/frontend/src/pages/scaling/liveness/components/AnomalyText.tsx
@@ -2,6 +2,7 @@ import { formatDuration } from '~/components/chart/liveness/LivenessChart'
 import type { LivenessAnomaly } from '~/server/features/scaling/liveness/types'
 import { cn } from '~/utils/cn'
 import { formatTimestamp } from '~/utils/dates'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import { anomalySubtypeToLabel } from './AnomalyIndicator'
 import { getDurationColorClassName } from './LivenessDurationCell'
 
@@ -12,7 +13,7 @@ export function AnomalyText({
   anomaly: LivenessAnomaly
   className?: string
 }) {
-  if (anomaly.end === undefined) {
+  if (isAnomalyOngoing(anomaly)) {
     return (
       <p className={cn('text-paragraph-13', className)}>
         No{' '}
@@ -65,10 +66,15 @@ export function AnomalyText({
       <span className="font-medium">
         {formatTimestamp(anomaly.start, { mode: 'datetime' })}
       </span>{' '}
-      until{' '}
-      <span className="font-medium">
-        {formatTimestamp(anomaly.end, { mode: 'datetime' })}
-      </span>
+      {anomaly.end && (
+        <>
+          {' '}
+          until{' '}
+          <span className="font-medium">
+            {formatTimestamp(anomaly.end, { mode: 'datetime' })}
+          </span>
+        </>
+      )}
       {')'}. These typically occur every{' '}
       <span
         className={cn(

--- a/packages/frontend/src/pages/scaling/liveness/components/RecentAnomalies.tsx
+++ b/packages/frontend/src/pages/scaling/liveness/components/RecentAnomalies.tsx
@@ -10,6 +10,7 @@ import { PrimaryCard } from '~/components/primary-card/PrimaryCard'
 import { ChevronIcon } from '~/icons/Chevron'
 import type { LivenessAnomaly } from '~/server/features/scaling/liveness/types'
 import { cn } from '~/utils/cn'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import { AnomalyText } from './AnomalyText'
 import { NoAnomaliesState } from './NoRecentAnomaliesState'
 
@@ -82,8 +83,8 @@ function AnomalyCollapsible({
 }: {
   projectWithAnomalies: ProjectWithAnomaly
 }) {
-  const isAnyOngoing = projectWithAnomalies.recentAnomalies.some(
-    (anomaly) => anomaly.end === undefined,
+  const isAnyOngoing = projectWithAnomalies.recentAnomalies.some((anomaly) =>
+    isAnomalyOngoing(anomaly),
   )
   return (
     <Collapsible
@@ -112,7 +113,7 @@ function AnomalyCollapsible({
             return (
               <div key={anomaly.start} className="text-xs">
                 <HorizontalSeparator className="my-3 first:mt-0" />
-                {anomaly.end === undefined ? (
+                {isAnomalyOngoing(anomaly) ? (
                   <div className="mb-1 flex items-center gap-1">
                     <LiveIndicator />
                     <span className="subtitle-12 text-negative uppercase leading-none">

--- a/packages/frontend/src/pages/scaling/liveness/getScalingLivenessData.ts
+++ b/packages/frontend/src/pages/scaling/liveness/getScalingLivenessData.ts
@@ -9,6 +9,7 @@ import { getMetadata } from '~/ssr/head/getMetadata'
 import type { RenderData } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { manifest } from '~/utils/Manifest'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import type { TabbedScalingEntries } from '../utils/groupByScalingTabs'
 
 export async function getScalingLivenessData(
@@ -61,8 +62,8 @@ function getProjectsWithAnomalies(
       const recentAnomalies = entry.anomalies.filter(
         (anomaly) =>
           anomaly.isApproved &&
-          (anomaly.end === undefined ||
-            anomaly.end >
+          (isAnomalyOngoing(anomaly) ||
+            (anomaly.end ?? anomaly.start) >
               UnixTime.toStartOf(UnixTime.now(), 'day') - 2 * UnixTime.DAY),
       )
 
@@ -78,11 +79,11 @@ function getProjectsWithAnomalies(
       }
     })
     .sort((a, b) => {
-      const aOngoing = a?.recentAnomalies.some(
-        (anomaly) => anomaly.end === undefined,
+      const aOngoing = a?.recentAnomalies.some((anomaly) =>
+        isAnomalyOngoing(anomaly),
       )
-      const bOngoing = b?.recentAnomalies.some(
-        (anomaly) => anomaly.end === undefined,
+      const bOngoing = b?.recentAnomalies.some((anomaly) =>
+        isAnomalyOngoing(anomaly),
       )
 
       if (aOngoing && !bOngoing) {

--- a/packages/frontend/src/server/features/data-availability/liveness/getDaLivenessEntries.ts
+++ b/packages/frontend/src/server/features/data-availability/liveness/getDaLivenessEntries.ts
@@ -3,6 +3,7 @@ import { assert, ProjectId } from '@l2beat/shared-pure'
 import type { TabbedDaEntries } from '~/pages/data-availability/utils/groupByDaTabs'
 import { groupByDaTabs } from '~/pages/data-availability/utils/groupByDaTabs'
 import { ps } from '~/server/projects'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import {
   getProjectsChangeReport,
   type ProjectsChangeReport,
@@ -119,9 +120,7 @@ function getDaLivenessEntry(
                 ? 'impactful-change'
                 : undefined,
           syncWarning,
-          ongoingAnomaly: bridgeLiveness.anomalies.some(
-            (a) => a.end === undefined,
-          ),
+          ongoingAnomaly: bridgeLiveness.anomalies.some(isAnomalyOngoing),
         },
         relayerType: b.daBridge.relayerType,
         validationType: b.daBridge.validationType,

--- a/packages/frontend/src/server/features/data-availability/project/getDaProjectEntry.ts
+++ b/packages/frontend/src/server/features/data-availability/project/getDaProjectEntry.ts
@@ -15,6 +15,7 @@ import { ps } from '~/server/projects'
 import type { SsrHelpers } from '~/trpc/server'
 import { manifest } from '~/utils/Manifest'
 import { getProjectLinks } from '~/utils/project/getProjectLinks'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import { getProjectsChangeReport } from '../../projects-change-report/getProjectsChangeReport'
 import { getProjectInteropData } from '../../scaling/interop/getProjectInteropData'
 import { getLiveness } from '../../scaling/liveness/getLiveness'
@@ -146,9 +147,7 @@ export async function getDaProjectEntry(
 
   const projectLiveness =
     selected && liveness ? liveness[selected.id] : undefined
-  const ongoingAnomalies = projectLiveness?.anomalies.filter(
-    (a) => a.end === undefined,
-  )
+  const ongoingAnomalies = projectLiveness?.anomalies.filter(isAnomalyOngoing)
 
   const layerTvs = tvsPerProject.reduce((acc, value) => acc + value.tvs, 0)
 

--- a/packages/frontend/src/server/features/data-availability/summary/getDaSummaryEntries.ts
+++ b/packages/frontend/src/server/features/data-availability/summary/getDaSummaryEntries.ts
@@ -15,6 +15,7 @@ import {
 } from '~/pages/data-availability/utils/MapRisksToRosetteValues'
 import { ps } from '~/server/projects'
 import { manifest } from '~/utils/Manifest'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import {
   getProjectsChangeReport,
   type ProjectsChangeReport,
@@ -144,9 +145,7 @@ function getDaSummaryEntry(
             : projectsChangeReport.getChanges(b.id).impactfulChange
               ? 'impactful-change'
               : undefined,
-        ongoingAnomaly: bridgeLiveness?.anomalies.some(
-          (a) => a.end === undefined,
-        ),
+        ongoingAnomaly: bridgeLiveness?.anomalies.some(isAnomalyOngoing),
       },
       tvs: getTvs(b.daBridge.usedIn.map((project) => project.id)),
       risks: mapBridgeRisksToRosetteValues(b.daBridge.risks),

--- a/packages/frontend/src/server/features/scaling/liveness/getLiveness.ts
+++ b/packages/frontend/src/server/features/scaling/liveness/getLiveness.ts
@@ -277,7 +277,7 @@ function getAnomalies(
   })
 
   return [
-    ...filteredAnomalies.map((a) => {
+    ...filteredAnomalies.map((a): LivenessAnomaly => {
       const avgInterval = project30Days.find(
         (r) => r.subtype === a.subtype,
       )?.avg
@@ -293,12 +293,13 @@ function getAnomalies(
           ? UnixTime.now() - a.timestamp
           : a.duration,
         end: isOngoing ? undefined : computedEnd,
+        status: isOngoing ? 'ongoing' : 'recovered',
         subtype: a.subtype,
         avgInterval,
         isApproved: false,
       }
     }),
-    ...realTimeAnomalies.map((a) => {
+    ...realTimeAnomalies.map((a): LivenessAnomaly => {
       const avgInterval = project30Days.find(
         (r) => r.subtype === a.subtype,
       )?.avg
@@ -308,6 +309,7 @@ function getAnomalies(
         start: a.start,
         end: a.end,
         durationInSeconds: a.end ? a.end - a.start : UnixTime.now() - a.start,
+        status: a.status,
         subtype: a.subtype,
         avgInterval,
         isApproved: true,
@@ -317,16 +319,16 @@ function getAnomalies(
 }
 
 function sortAnomalies(a: LivenessAnomaly, b: LivenessAnomaly) {
-  if (a.end === undefined && b.end === undefined) {
+  if (a.status === 'ongoing' && b.status === 'ongoing') {
     return b.start - a.start
   }
-  if (a.end === undefined) {
+  if (a.status === 'ongoing') {
     return -1
   }
-  if (b.end === undefined) {
+  if (b.status === 'ongoing') {
     return 1
   }
-  return b.end - a.end
+  return (b.end ?? b.start) - (a.end ?? a.start)
 }
 
 function getMockLivenessData(): LivenessResponse {
@@ -465,6 +467,7 @@ function generateAnomalies(): LivenessAnomaly[] {
           subtype: Math.random() > 0.5 ? 'batchSubmissions' : 'stateUpdates',
           start,
           end: isOngoing ? undefined : end,
+          status: isOngoing ? 'ongoing' : 'recovered',
           durationInSeconds: isOngoing ? UnixTime.now() - start : end - start,
           avgInterval: generateRandomTime(),
           isApproved: isOngoing,

--- a/packages/frontend/src/server/features/scaling/liveness/types.ts
+++ b/packages/frontend/src/server/features/scaling/liveness/types.ts
@@ -1,6 +1,7 @@
 import type { TrackedTxsConfigSubtype, UnixTime } from '@l2beat/shared-pure'
 
 export type LivenessTimeRange = '30d' | '90d' | 'max'
+export type LivenessAnomalyStatus = 'ongoing' | 'recovered'
 
 export interface LivenessDataPoint {
   averageInSeconds: number
@@ -11,6 +12,7 @@ export interface LivenessDataPoint {
 export interface LivenessAnomaly {
   start: UnixTime
   end: UnixTime | undefined
+  status: LivenessAnomalyStatus
   durationInSeconds: number
   subtype: TrackedTxsConfigSubtype
   avgInterval: number

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -41,6 +41,7 @@ import { getBadgeWithParamsAndLink } from '~/utils/project/getBadgeWithParams'
 import { getDiagramParams } from '~/utils/project/getDiagramParams'
 import { getProjectLinks } from '~/utils/project/getProjectLinks'
 import { getLivenessSection } from '~/utils/project/liveness/getLivenessSection'
+import { isAnomalyOngoing } from '~/utils/project/liveness/isAnomalyOngoing'
 import { getScalingRiskSummarySection } from '~/utils/project/risk-summary/getScalingRiskSummary'
 import { getDataAvailabilitySection } from '~/utils/project/technology/getDataAvailabilitySection'
 import { getOperatorSection } from '~/utils/project/technology/getOperatorSection'
@@ -216,9 +217,7 @@ export async function getScalingProjectEntry(
     ? getDiscoveryUpdates(project.id)
     : []
 
-  const ongoingAnomalies = projectLiveness?.anomalies.filter(
-    (a) => a.end === undefined,
-  )
+  const ongoingAnomalies = projectLiveness?.anomalies.filter(isAnomalyOngoing)
 
   const tvsProjectStats = tvsStats.projects[project.id]
   const interopData = await getProjectInteropData(

--- a/packages/frontend/src/utils/project/liveness/isAnomalyOngoing.ts
+++ b/packages/frontend/src/utils/project/liveness/isAnomalyOngoing.ts
@@ -1,0 +1,5 @@
+import type { LivenessAnomaly } from '~/server/features/scaling/liveness/types'
+
+export function isAnomalyOngoing(anomaly: LivenessAnomaly) {
+  return anomaly.status === 'ongoing'
+}


### PR DESCRIPTION
Automatically resolved anomalies do not have end timestamp and we cannot accurately compute it