### PR TITLE
Align ZK catalog milestones with the TVS bump they explain

### DIFF
--- a/packages/frontend/src/components/chart/tvs/stacked/zk-catalog/ZkCatalogProjectsTvsChart.tsx
+++ b/packages/frontend/src/components/chart/tvs/stacked/zk-catalog/ZkCatalogProjectsTvsChart.tsx
@@ -1,5 +1,5 @@
 import type { Milestone } from '@l2beat/config'
-import type { ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { Area, AreaChart } from 'recharts'
@@ -27,6 +27,7 @@ import { formatPercent } from '~/utils/calculatePercentageChange'
 import { formatTimestamp } from '~/utils/dates'
 import { generateAccessibleColors } from '~/utils/generateColors'
 import { formatCurrency } from '~/utils/number-format/formatCurrency'
+import { rangeToResolution } from '~/utils/range/range'
 
 interface ZkCatalogProjectsTvsChartProps {
   project: ChartProject
@@ -67,12 +68,20 @@ export function ZkCatalogProjectsTvsChart({
     )
   }, [projectsForTvs])
 
+  // Round to the active resolution so it matches the data gate in the query
+  // (which floors each project's `sinceTimestamp` to the resolution). Without
+  // this the tooltip would hide a project at its first datapoint, even though
+  // its area is already drawn there.
+  const resolution = rangeToResolution(range)
   const sinceByProjectId = useMemo(
     () =>
       new Map(
-        projectsForTvs.map((p) => [p.projectId.toString(), p.sinceTimestamp]),
+        projectsForTvs.map((p) => [
+          p.projectId.toString(),
+          UnixTime.toStartOf(p.sinceTimestamp, resolution),
+        ]),
       ),
-    [projectsForTvs],
+    [projectsForTvs, resolution],
   )
 
   const colors = useMemo(

--- a/packages/frontend/src/components/chart/tvs/stacked/zk-catalog/ZkCatalogProjectsTvsChart.tsx
+++ b/packages/frontend/src/components/chart/tvs/stacked/zk-catalog/ZkCatalogProjectsTvsChart.tsx
@@ -1,5 +1,5 @@
 import type { Milestone } from '@l2beat/config'
-import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
+import type { ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { Area, AreaChart } from 'recharts'
@@ -27,7 +27,6 @@ import { formatPercent } from '~/utils/calculatePercentageChange'
 import { formatTimestamp } from '~/utils/dates'
 import { generateAccessibleColors } from '~/utils/generateColors'
 import { formatCurrency } from '~/utils/number-format/formatCurrency'
-import { rangeToResolution } from '~/utils/range/range'
 
 interface ZkCatalogProjectsTvsChartProps {
   project: ChartProject
@@ -68,25 +67,23 @@ export function ZkCatalogProjectsTvsChart({
     )
   }, [projectsForTvs])
 
-  // Round to the active resolution so it matches the data gate in the query
-  // (which floors each project's `sinceTimestamp` to the resolution). Without
-  // this the tooltip would hide a project at its first datapoint, even though
-  // its area is already drawn there.
-  const resolution = rangeToResolution(range)
+  // `sinceTimestamp` comes from the server already floored to the active
+  // resolution, matching the chart's data gate. Building the tooltip gate from
+  // it (rather than re-rounding here) keeps the two from drifting apart.
   const sinceByProjectId = useMemo(
     () =>
       new Map(
-        projectsForTvs.map((p) => [
+        (data?.projects ?? []).map((p) => [
           p.projectId.toString(),
-          UnixTime.toStartOf(p.sinceTimestamp, resolution),
+          p.sinceTimestamp,
         ]),
       ),
-    [projectsForTvs, resolution],
+    [data?.projects],
   )
 
   const colors = useMemo(
-    () => generateAccessibleColors(data?.projectIds.length ?? 0),
-    [data?.projectIds.length],
+    () => generateAccessibleColors(data?.projects.length ?? 0),
+    [data?.projects.length],
   )
 
   const chartData = useMemo(() => {
@@ -99,7 +96,7 @@ export function ZkCatalogProjectsTvsChart({
         [key: string]: number | null
       } = { timestamp }
 
-      for (const projectId of data.projectIds) {
+      for (const { projectId } of data.projects) {
         const value = projects[projectId] ?? null
         if (value === null) {
           dataPoint[projectId] = null
@@ -119,20 +116,18 @@ export function ZkCatalogProjectsTvsChart({
   // Chart: oldest sinceTimestamp at the bottom, newest at the top
   const chartOrderedIds = useMemo(() => {
     if (!data) return []
-    return [...data.projectIds].sort(
-      (a, b) =>
-        (sinceByProjectId.get(a) ?? Number.POSITIVE_INFINITY) -
-        (sinceByProjectId.get(b) ?? Number.POSITIVE_INFINITY),
-    )
-  }, [data, sinceByProjectId])
+    return [...data.projects]
+      .sort((a, b) => a.sinceTimestamp - b.sinceTimestamp)
+      .map((p) => p.projectId)
+  }, [data])
 
   // Legend: biggest current value first
   const legendOrderedIds = useMemo(() => {
     if (!data) return []
     const lastPoint = chartData?.[chartData.length - 1]
-    return [...data.projectIds].sort(
-      (a, b) => (lastPoint?.[b] ?? 0) - (lastPoint?.[a] ?? 0),
-    )
+    return data.projects
+      .map((p) => p.projectId)
+      .sort((a, b) => (lastPoint?.[b] ?? 0) - (lastPoint?.[a] ?? 0))
   }, [data, chartData])
 
   const chartMeta = useMemo(() => {

--- a/packages/frontend/src/components/core/chart/ChartMilestones.test.ts
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.test.ts
@@ -63,6 +63,18 @@ describe('getTimestampedMilestones', () => {
     expect(result.every((p) => p.milestones.length === 0)).toEqual(true)
   })
 
+  it('drops milestones that fall after the last datapoint', () => {
+    const data = points([
+      ts('2024-05-26T00:00:00Z'),
+      ts('2024-05-27T00:00:00Z'),
+    ])
+    const result = getTimestampedMilestones(data, [
+      milestone('2024-05-28T06:00:00Z'),
+    ])
+
+    expect(result.every((p) => p.milestones.length === 0)).toEqual(true)
+  })
+
   it('groups same-day milestones on a daily grid', () => {
     const data = points([
       ts('2024-05-26T00:00:00Z'),

--- a/packages/frontend/src/components/core/chart/ChartMilestones.test.ts
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.test.ts
@@ -1,0 +1,100 @@
+import type { Milestone } from '@l2beat/config'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { getTimestampedMilestones } from './ChartMilestones'
+
+function ts(iso: string): number {
+  return UnixTime.fromDate(new Date(iso))
+}
+
+function milestone(date: string): Milestone {
+  return {
+    type: 'general',
+    title: date,
+    url: 'https://example.com',
+    date,
+  }
+}
+
+function points(timestamps: number[]) {
+  return timestamps.map((timestamp) => ({ timestamp }))
+}
+
+describe('getTimestampedMilestones', () => {
+  it('snaps a milestone to the start of its day on a daily grid', () => {
+    const data = points([
+      ts('2024-05-25T00:00:00Z'),
+      ts('2024-05-26T00:00:00Z'),
+      ts('2024-05-27T00:00:00Z'),
+    ])
+    const result = getTimestampedMilestones(data, [
+      milestone('2024-05-26T21:59:45Z'),
+    ])
+
+    const attached = result.filter((p) => p.milestones.length > 0)
+    expect(attached.length).toEqual(1)
+    expect(attached[0]?.timestamp).toEqual(ts('2024-05-26T00:00:00Z'))
+  })
+
+  it('snaps to the milestone hour on an hourly grid', () => {
+    const data = points([
+      ts('2024-05-26T20:00:00Z'),
+      ts('2024-05-26T21:00:00Z'),
+      ts('2024-05-26T22:00:00Z'),
+    ])
+    const result = getTimestampedMilestones(data, [
+      milestone('2024-05-26T21:59:45Z'),
+    ])
+
+    const attached = result.filter((p) => p.milestones.length > 0)
+    expect(attached.length).toEqual(1)
+    expect(attached[0]?.timestamp).toEqual(ts('2024-05-26T21:00:00Z'))
+  })
+
+  it('drops milestones that fall before the first datapoint', () => {
+    const data = points([
+      ts('2024-05-26T00:00:00Z'),
+      ts('2024-05-27T00:00:00Z'),
+    ])
+    const result = getTimestampedMilestones(data, [
+      milestone('2024-05-24T12:00:00Z'),
+    ])
+
+    expect(result.every((p) => p.milestones.length === 0)).toEqual(true)
+  })
+
+  it('groups same-day milestones on a daily grid', () => {
+    const data = points([
+      ts('2024-05-26T00:00:00Z'),
+      ts('2024-05-27T00:00:00Z'),
+    ])
+    const result = getTimestampedMilestones(data, [
+      milestone('2024-05-26T03:00:00Z'),
+      milestone('2024-05-26T21:00:00Z'),
+    ])
+
+    const attached = result.filter((p) => p.milestones.length > 0)
+    expect(attached.length).toEqual(1)
+    expect(attached[0]?.milestones.length).toEqual(2)
+  })
+
+  it('separates same-day milestones on an hourly grid', () => {
+    const data = points([
+      ts('2024-05-26T03:00:00Z'),
+      ts('2024-05-26T04:00:00Z'),
+      ts('2024-05-26T20:00:00Z'),
+      ts('2024-05-26T21:00:00Z'),
+    ])
+    const result = getTimestampedMilestones(data, [
+      milestone('2024-05-26T03:30:00Z'),
+      milestone('2024-05-26T21:00:00Z'),
+    ])
+
+    const attached = result.filter((p) => p.milestones.length > 0)
+    expect(attached.length).toEqual(2)
+    expect(attached.map((p) => p.timestamp)).toEqual([
+      ts('2024-05-26T03:00:00Z'),
+      ts('2024-05-26T21:00:00Z'),
+    ])
+  })
+})

--- a/packages/frontend/src/components/core/chart/ChartMilestones.test.ts
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.test.ts
@@ -63,7 +63,7 @@ describe('getTimestampedMilestones', () => {
     expect(result.every((p) => p.milestones.length === 0)).toEqual(true)
   })
 
-  it('drops milestones that fall after the last datapoint', () => {
+  it('drops milestones in a bucket after the last datapoint', () => {
     const data = points([
       ts('2024-05-26T00:00:00Z'),
       ts('2024-05-27T00:00:00Z'),
@@ -73,6 +73,20 @@ describe('getTimestampedMilestones', () => {
     ])
 
     expect(result.every((p) => p.milestones.length === 0)).toEqual(true)
+  })
+
+  it('keeps a milestone within the last bucket on the last datapoint', () => {
+    const data = points([
+      ts('2024-05-26T20:00:00Z'),
+      ts('2024-05-26T21:00:00Z'),
+    ])
+    const result = getTimestampedMilestones(data, [
+      milestone('2024-05-26T21:30:00Z'),
+    ])
+
+    const attached = result.filter((p) => p.milestones.length > 0)
+    expect(attached.length).toEqual(1)
+    expect(attached[0]?.timestamp).toEqual(ts('2024-05-26T21:00:00Z'))
   })
 
   it('groups same-day milestones on a daily grid', () => {

--- a/packages/frontend/src/components/core/chart/ChartMilestones.tsx
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.tsx
@@ -348,15 +348,28 @@ function mapMilestones<T extends { timestamp: number }>(
   // Snap each milestone to the largest datapoint at or before its timestamp.
   // The datapoint grid is resolution-aligned, so this floors the milestone to
   // the active resolution and keeps the marker on the same bucket as any data
-  // movement it explains, at every zoom level. Milestones outside the grid
-  // (before the first or after the last datapoint) are omitted.
+  // movement it explains, at every zoom level. Milestones outside the grid are
+  // omitted: those before the first datapoint, and those in a bucket after the
+  // last datapoint. A milestone within the last bucket still snaps to (and
+  // stays visible on) the last datapoint.
   const timestamps = data.map((point) => point.timestamp)
+  const firstTimestamp = timestamps[0]
+  const secondTimestamp = timestamps[1]
   const lastTimestamp = timestamps[timestamps.length - 1]
-  if (lastTimestamp === undefined) return []
+  if (
+    firstTimestamp === undefined ||
+    secondTimestamp === undefined ||
+    lastTimestamp === undefined
+  ) {
+    return result
+  }
+  // The first two datapoints are always regular grid points, so their spacing
+  // is the resolution period.
+  const period = secondTimestamp - firstTimestamp
 
   for (const milestone of milestones) {
     const milestoneTimestamp = UnixTime.fromDate(new Date(milestone.date))
-    if (milestoneTimestamp > lastTimestamp) continue
+    if (milestoneTimestamp >= lastTimestamp + period) continue
     let bucket: number | undefined
     for (const timestamp of timestamps) {
       if (timestamp > milestoneTimestamp) break

--- a/packages/frontend/src/components/core/chart/ChartMilestones.tsx
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.tsx
@@ -362,8 +362,8 @@ function mapMilestones<T extends { timestamp: number }>(
       bucket = timestamp
     }
     if (bucket === undefined) continue
-    result[bucket] ??= []
-    result[bucket].push(milestone)
+    const bucketMilestones = (result[bucket] ??= [])
+    bucketMilestones.push(milestone)
   }
 
   return result

--- a/packages/frontend/src/components/core/chart/ChartMilestones.tsx
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.tsx
@@ -326,29 +326,40 @@ function SingleMilestoneIcon({
   }
 }
 
-function getTimestampedMilestones<T extends { timestamp: number }>(
+export function getTimestampedMilestones<T extends { timestamp: number }>(
   data: T[] | undefined,
   milestones: Milestone[],
 ): TimestampedMilestone[] {
   if (!data || data.length < 2) return []
 
-  const mappedMilestones = mapMilestones(milestones)
+  const mappedMilestones = mapMilestones(milestones, data)
   return data.map((point) => ({
     timestamp: point.timestamp,
     milestones: mappedMilestones[point.timestamp] ?? [],
   }))
 }
 
-function mapMilestones(milestones: Milestone[]): Record<number, Milestone[]> {
+function mapMilestones<T extends { timestamp: number }>(
+  milestones: Milestone[],
+  data: T[],
+): Record<number, Milestone[]> {
   const result: Record<number, Milestone[]> = {}
 
+  // Snap each milestone to the largest datapoint at or before its timestamp.
+  // The datapoint grid is resolution-aligned, so this floors the milestone to
+  // the active resolution and keeps the marker on the same bucket as any data
+  // movement it explains, at every zoom level.
+  const timestamps = data.map((point) => point.timestamp)
   for (const milestone of milestones) {
-    const timestamp = UnixTime.toStartOf(
-      UnixTime.fromDate(new Date(milestone.date)),
-      'day',
-    )
-    result[timestamp] ??= []
-    result[timestamp].push(milestone)
+    const milestoneTimestamp = UnixTime.fromDate(new Date(milestone.date))
+    let bucket: number | undefined
+    for (const timestamp of timestamps) {
+      if (timestamp > milestoneTimestamp) break
+      bucket = timestamp
+    }
+    if (bucket === undefined) continue
+    result[bucket] ??= []
+    result[bucket].push(milestone)
   }
 
   return result

--- a/packages/frontend/src/components/core/chart/ChartMilestones.tsx
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.tsx
@@ -348,10 +348,14 @@ function mapMilestones<T extends { timestamp: number }>(
   // Snap each milestone to the largest datapoint at or before its timestamp.
   // The datapoint grid is resolution-aligned, so this floors the milestone to
   // the active resolution and keeps the marker on the same bucket as any data
-  // movement it explains, at every zoom level.
+  // movement it explains, at every zoom level. Milestones outside the grid
+  // (before the first or after the last datapoint) are omitted.
   const timestamps = data.map((point) => point.timestamp)
+  const lastTimestamp = timestamps[timestamps.length - 1]
   for (const milestone of milestones) {
     const milestoneTimestamp = UnixTime.fromDate(new Date(milestone.date))
+    if (lastTimestamp === undefined || milestoneTimestamp > lastTimestamp)
+      continue
     let bucket: number | undefined
     for (const timestamp of timestamps) {
       if (timestamp > milestoneTimestamp) break

--- a/packages/frontend/src/components/core/chart/ChartMilestones.tsx
+++ b/packages/frontend/src/components/core/chart/ChartMilestones.tsx
@@ -352,17 +352,23 @@ function mapMilestones<T extends { timestamp: number }>(
   // (before the first or after the last datapoint) are omitted.
   const timestamps = data.map((point) => point.timestamp)
   const lastTimestamp = timestamps[timestamps.length - 1]
+  if (lastTimestamp === undefined) return []
+
   for (const milestone of milestones) {
     const milestoneTimestamp = UnixTime.fromDate(new Date(milestone.date))
-    if (lastTimestamp === undefined || milestoneTimestamp > lastTimestamp)
-      continue
+    if (milestoneTimestamp > lastTimestamp) continue
     let bucket: number | undefined
     for (const timestamp of timestamps) {
       if (timestamp > milestoneTimestamp) break
       bucket = timestamp
     }
     if (bucket === undefined) continue
-    const bucketMilestones = (result[bucket] ??= [])
+
+    let bucketMilestones = result[bucket]
+    if (!bucketMilestones) {
+      bucketMilestones = []
+      result[bucket] = bucketMilestones
+    }
     bucketMilestones.push(milestone)
   }
 

--- a/packages/frontend/src/server/features/scaling/tvs/getDetailedTvsChartWithProjectsRanges.ts
+++ b/packages/frontend/src/server/features/scaling/tvs/getDetailedTvsChartWithProjectsRanges.ts
@@ -46,9 +46,15 @@ export type DetailedTvsChartWithProjectRangesDataPoint = [
   projects: Record<string, ProjectTvsChartDataPoint | null>,
 ]
 
+export type ChartProjectRange = {
+  projectId: ProjectId
+  /** Floored to the active resolution, matching the chart's data gate. */
+  sinceTimestamp: number
+}
+
 export type DetailedTvsChartWithProjectsRangesData = {
   chart: DetailedTvsChartWithProjectRangesDataPoint[]
-  projectIds: ProjectId[]
+  projects: ChartProjectRange[]
   syncedUntil: number
 }
 
@@ -72,21 +78,28 @@ export async function getDetailedTvsChartWithProjectsRanges({
   const db = getDb()
 
   if (projects.length === 0) {
-    return { chart: [], projectIds: [], syncedUntil: UnixTime.now() }
+    return { chart: [], projects: [], syncedUntil: UnixTime.now() }
   }
-
-  const groupedProjects = groupBy(projects, (p) => p.projectId)
-  const projectIds = Object.keys(groupedProjects) as ProjectId[]
 
   // Round each project's `sinceTimestamp` down to the active resolution so the
   // TVS bump it produces lands on the same datapoint as its milestone marker.
   // Without this the `>= sinceTimestamp` gate surfaces the value at the *next*
-  // datapoint, one bucket after the start-of-period milestone.
+  // datapoint, one bucket after the start-of-period milestone. The rounded
+  // values are returned to the client so its tooltip gate can't drift from the
+  // data gate computed here.
   const resolution = rangeToResolution(range)
   const roundedProjects = projects.map((p) => ({
     ...p,
     sinceTimestamp: UnixTime.toStartOf(p.sinceTimestamp, resolution),
   }))
+
+  const projectRanges: ChartProjectRange[] = Object.entries(
+    groupBy(roundedProjects, (p) => p.projectId),
+  ).map(([projectId, group]) => ({
+    projectId: projectId as ProjectId,
+    sinceTimestamp: Math.min(...group.map((p) => p.sinceTimestamp)),
+  }))
+  const projectIds = projectRanges.map((p) => p.projectId)
 
   const [ethPrices, values] = await Promise.all([
     getEthPrices(),
@@ -106,13 +119,15 @@ export async function getDetailedTvsChartWithProjectsRanges({
     ...roundedProjects.map((p) => p.sinceTimestamp),
   )
 
-  return getChartData(
+  const { chart, syncedUntil } = getChartData(
     values,
     ethPrices,
     projectIds,
     range,
     firstProjectTimestamp,
   )
+
+  return { chart, projects: projectRanges, syncedUntil }
 }
 
 function getChartData(
@@ -121,11 +136,10 @@ function getChartData(
   projectIds: ProjectId[],
   range: ChartRange,
   firstProjectTimestamp: number,
-): DetailedTvsChartWithProjectsRangesData {
+): Pick<DetailedTvsChartWithProjectsRangesData, 'chart' | 'syncedUntil'> {
   if (values.length === 0) {
     return {
       chart: [],
-      projectIds,
       syncedUntil: 0,
     }
   }
@@ -207,7 +221,6 @@ function getChartData(
 
   return {
     chart,
-    projectIds,
     syncedUntil,
   }
 }
@@ -221,8 +234,16 @@ function getMockDetailedTvsChartWithProjectsRangesData({
     [range[0] ?? 1573776000, range[1]],
     resolution,
   )
-  const groupedProjects = groupBy(projects, (p) => p.projectId)
-  const projectIds = Object.keys(groupedProjects) as ProjectId[]
+  const projectRanges: ChartProjectRange[] = Object.entries(
+    groupBy(projects, (p) => p.projectId),
+  ).map(([projectId, group]) => ({
+    projectId: projectId as ProjectId,
+    sinceTimestamp: UnixTime.toStartOf(
+      Math.min(...group.map((p) => p.sinceTimestamp)),
+      resolution,
+    ),
+  }))
+  const projectIds = projectRanges.map((p) => p.projectId)
 
   return {
     chart: timestamps.map((timestamp) => [
@@ -249,7 +270,7 @@ function getMockDetailedTvsChartWithProjectsRangesData({
         }),
       ),
     ]),
-    projectIds,
+    projects: projectRanges,
     syncedUntil: timestamps[timestamps.length - 1] ?? 0,
   }
 }

--- a/packages/frontend/src/server/features/scaling/tvs/getDetailedTvsChartWithProjectsRanges.ts
+++ b/packages/frontend/src/server/features/scaling/tvs/getDetailedTvsChartWithProjectsRanges.ts
@@ -78,10 +78,20 @@ export async function getDetailedTvsChartWithProjectsRanges({
   const groupedProjects = groupBy(projects, (p) => p.projectId)
   const projectIds = Object.keys(groupedProjects) as ProjectId[]
 
+  // Round each project's `sinceTimestamp` down to the active resolution so the
+  // TVS bump it produces lands on the same datapoint as its milestone marker.
+  // Without this the `>= sinceTimestamp` gate surfaces the value at the *next*
+  // datapoint, one bucket after the start-of-period milestone.
+  const resolution = rangeToResolution(range)
+  const roundedProjects = projects.map((p) => ({
+    ...p,
+    sinceTimestamp: UnixTime.toStartOf(p.sinceTimestamp, resolution),
+  }))
+
   const [ethPrices, values] = await Promise.all([
     getEthPrices(),
     db.tvsTokenValue.getSummedByTimestampWithProjectsRangesPerProject(
-      projects,
+      roundedProjects,
       range[0],
       range[1],
       {
@@ -93,7 +103,7 @@ export async function getDetailedTvsChartWithProjectsRanges({
   ])
 
   const firstProjectTimestamp = Math.min(
-    ...projects.map((p) => p.sinceTimestamp),
+    ...roundedProjects.map((p) => p.sinceTimestamp),
   )
 
   return getChartData(


### PR DESCRIPTION
Resolves L2B-14223

## Problem

On the ZK catalog TVS chart, a project's "joined" milestone marker sat one datapoint *before* the TVS bump it's meant to explain. The bump first appears at the datapoint satisfying the `>= sinceTimestamp` gate, while the milestone was rounded down to the **start of the day**. So on the daily chart the dot landed on the 26th while the bump showed on the 27th — and the mismatch grew worse at sub-day zoom (6h/hourly), where a start-of-day milestone could sit hours away from its bump.

## Fix

Round **both** sides down to the active resolution so the marker and the bump land on the same datapoint at every zoom level.

- **Query** (`getDetailedTvsChartWithProjectsRanges.ts`, ZK-catalog-only): floor each project's `sinceTimestamp` to the active resolution before the DB gate and `firstProjectTimestamp`, moving the bump onto the start-of-period datapoint. `untilTimestamp` is left untouched — no milestone aligns with a project *leaving* a system.
- **Milestones** (`ChartMilestones.tsx`, global): snap each milestone to the largest datapoint at or before its timestamp. The datapoint grid is resolution-aligned, so this floors to the active resolution with no new props. Tooltip/drawer dates are unaffected — they still read the true `milestone.date`.

## Tradeoff

This counts a project's TVS as ZK-secured up to one resolution-period before it actually joined — bounded by the granularity the user can perceive (≤1h on the hourly chart, ≤1 day only on the long daily chart). We chose this over moving just the marker, which would have shown the marker on the 27th while the tooltip said the 26th.

## Scope of the global change

Making milestone snapping resolution-aware affects every chart, but only at sub-day zoom and only as a correctness improvement: markers move from midnight to the event's true bucket, and same-day events stop merging when they're genuinely at different x-positions. Daily (long-range) charts are unchanged.

## Tests

New `ChartMilestones.test.ts` covers `getTimestampedMilestones`:
- daily-grid snap to start of day
- hourly-grid snap to the event's hour (not midnight)
- milestones before the first datapoint are dropped
- same-day grouping preserved on the daily grid
- same-day events separated on the hourly grid

## Manual check worth doing before merge

Verify on a live ZK catalog project with a recent join (so the 7-day hourly view shows the bump) that the dot and bump visually coincide — the unit tests cover the snapping logic but not the end-to-end render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)