### PR TITLE
Don't hide member fields when triming large arrays

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-nodes/NodesPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-nodes/NodesPanel.tsx
@@ -244,6 +244,7 @@ const LARGE_ARRAY_THRESHOLD = 10
 function getKeysToHideOnLoad(fields: ApiField[]): string[] {
   const largeArrays = fields.filter(
     (field) =>
+      field.name !== '$members' &&
       field.value.type === 'array' &&
       field.value.values.length > LARGE_ARRAY_THRESHOLD,
   )


### PR DESCRIPTION
Resolves L2B-14280