### PR TITLE
Remove no-op JSON.stringify tRPC transformer

### DIFF
--- a/packages/backend/src/trpc/init.ts
+++ b/packages/backend/src/trpc/init.ts
@@ -2,10 +2,6 @@ import { initTRPC } from '@trpc/server'
 import type { BaseContext } from './context'
 
 const t = initTRPC.context<BaseContext>().create({
-  transformer: {
-    serialize: JSON.stringify,
-    deserialize: JSON.parse,
-  },
   errorFormatter({ shape, error }) {
     return {
       ...shape,

--- a/packages/backoffice/src/react-query/trpc.tsx
+++ b/packages/backoffice/src/react-query/trpc.tsx
@@ -110,10 +110,6 @@ function buildClient(url: string) {
           (op.direction === 'down' && op.result instanceof Error),
       }),
       httpBatchLink({
-        transformer: {
-          serialize: JSON.stringify,
-          deserialize: JSON.parse,
-        },
         url,
         headers: () => {
           const headers = new Headers()

--- a/packages/frontend/e2e/prefetch/trpcRequests.ts
+++ b/packages/frontend/e2e/prefetch/trpcRequests.ts
@@ -64,8 +64,8 @@ function stableHash(value: unknown): string {
 /**
  * Parses a batched tRPC request URL into its individual (procedure, input)
  * calls, e.g. /api/trpc/privacy.flowsChart,privacy.tvlChart?batch=1&input=...
- * The client uses a JSON.stringify transformer, so each input in the batch's
- * `input` map is itself a JSON string.
+ * With no data transformer configured, the batch's `input` map holds the raw
+ * input value for each index directly.
  */
 function parseCalls(rawUrl: string): TrpcCall[] {
   const url = new URL(rawUrl)
@@ -86,17 +86,7 @@ function parseCalls(rawUrl: string): TrpcCall[] {
     }
   }
 
-  return paths.map((path, index) => {
-    let input = inputMap[index]
-    if (typeof input === 'string') {
-      try {
-        input = JSON.parse(input)
-      } catch {
-        // leave as-is
-      }
-    }
-    return { path, input }
-  })
+  return paths.map((path, index) => ({ path, input: inputMap[index] }))
 }
 
 /**

--- a/packages/frontend/src/server/trpc/trpc.ts
+++ b/packages/frontend/src/server/trpc/trpc.ts
@@ -6,10 +6,6 @@ export const createTRPCContext = (opts: { headers: Headers }) => {
 }
 
 const t = initTRPC.context<typeof createTRPCContext>().create({
-  transformer: {
-    serialize: JSON.stringify,
-    deserialize: JSON.parse,
-  },
   errorFormatter({ shape, error }) {
     return {
       ...shape,

--- a/packages/frontend/src/trpc/React.tsx
+++ b/packages/frontend/src/trpc/React.tsx
@@ -1,11 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import {
-  createTRPCClient,
-  loggerLink,
-  unstable_httpBatchStreamLink,
-} from '@trpc/client'
+import { createTRPCClient, httpBatchStreamLink, loggerLink } from '@trpc/client'
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server'
 import { createTRPCContext } from '@trpc/tanstack-react-query'
 import type React from 'react'
@@ -53,11 +49,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
             env.NODE_ENV === 'development' ||
             (op.direction === 'down' && op.result instanceof Error),
         }),
-        unstable_httpBatchStreamLink({
-          transformer: {
-            serialize: JSON.stringify,
-            deserialize: JSON.parse,
-          },
+        httpBatchStreamLink({
           url: getBaseUrl() + '/api/trpc',
           headers: new Headers({ 'x-trpc-source': 'client' }),
         }),

--- a/packages/token-backend/src/client.ts
+++ b/packages/token-backend/src/client.ts
@@ -25,10 +25,6 @@ export function getTokenDbClient(config: TokenClientConfig) {
       httpBatchLink({
         url: config.apiUrl,
         methodOverride: 'POST', // Sometimes request body is too large to fit in GET's URL
-        transformer: {
-          serialize: JSON.stringify,
-          deserialize: JSON.parse,
-        },
         headers() {
           return headers
         },

--- a/packages/token-backend/src/trpc/trpc.ts
+++ b/packages/token-backend/src/trpc/trpc.ts
@@ -29,10 +29,6 @@ export const createTRPCContext = async (opts: {
 type Context = Awaited<ReturnType<typeof createTRPCContext>>
 
 export const trcpRoot = initTRPC.context<Context>().create({
-  transformer: {
-    serialize: JSON.stringify,
-    deserialize: JSON.parse,
-  },
   errorFormatter({ shape, error }) {
     return {
       ...shape,

--- a/packages/token-ui/src/react-query/trpc.tsx
+++ b/packages/token-ui/src/react-query/trpc.tsx
@@ -44,10 +44,6 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
             (op.direction === 'down' && op.result instanceof Error),
         }),
         httpBatchLink({
-          transformer: {
-            serialize: JSON.stringify,
-            deserialize: JSON.parse,
-          },
           url: '/trpc',
           headers: () => {
             const headers = new Headers()


### PR DESCRIPTION
## What

Removes the `{ serialize: JSON.stringify, deserialize: JSON.parse }` data transformer from every tRPC client and server in the repo.

## Why

A tRPC data transformer exists to preserve types JSON can't represent — `Date`, `BigInt`, `Map`, `Set`, `undefined` (what `superjson` does). The `JSON.stringify`/`JSON.parse` pair preserved **none** of those: tRPC already JSON-encodes the wire payload itself, so this transformer just **double-encoded** everything — extra encode/decode work per request with zero fidelity benefit. (A `Date` was already serialized to an ISO string regardless.)

## Changes

- Removed the transformer from every client/server pair so the wire formats stay in sync:
  - `frontend` (`src/server/trpc/trpc.ts`, `src/trpc/React.tsx`)
  - `backend` (`src/trpc/init.ts`)
  - `backoffice` (`src/react-query/trpc.tsx`)
  - `token-backend` (`src/trpc/trpc.ts`, `src/client.ts`)
  - `token-ui` (`src/react-query/trpc.tsx`)
- Dropped the now-stable `unstable_` prefix on `httpBatchStreamLink`.
- Fixed the prefetch e2e helper `parseCalls`, which decoded the old double-stringified wire format. With no transformer the batch `input` map holds raw values directly, so the per-index `JSON.parse` is removed — it would otherwise corrupt JSON-looking string inputs (e.g. `"123"` → `123`).

## Notes

`grep` confirms zero `serialize: JSON.stringify` transformers remain, so no client/server pair is left mismatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)