### PR TITLE
Fix stack overflow in DeployedToken batch lookups

### DIFF
--- a/packages/database/src/repositories/DeployedTokenRepository.ts
+++ b/packages/database/src/repositories/DeployedTokenRepository.ts
@@ -71,6 +71,10 @@ function toUpdateRow(
   }
 }
 
+// Keeps each query's (chain, address) tuple list small enough to avoid
+// overflowing both the Kysely query compiler and the Postgres parser stack.
+const BATCH_SIZE = 1000
+
 export class DeployedTokenRepository extends BaseRepository {
   async insert(record: DeployedTokenRecord): Promise<void> {
     await this.db.insertInto('DeployedToken').values(toRow(record)).execute()
@@ -96,74 +100,78 @@ export class DeployedTokenRepository extends BaseRepository {
       abstractToken: AbstractTokenRecord | undefined
     }[]
   > {
-    if (pks.length === 0) {
-      return []
-    }
+    const result: {
+      deployedToken: DeployedTokenRecord
+      abstractToken: AbstractTokenRecord | undefined
+    }[] = []
 
-    const result = await this.db
-      .selectFrom('DeployedToken')
-      .leftJoin(
-        'AbstractToken',
-        'AbstractToken.id',
-        'DeployedToken.abstractTokenId',
-      )
-      .selectAll('DeployedToken')
-      .select([
-        'AbstractToken.id as AbstractToken_id',
-        'AbstractToken.issuer as AbstractToken_issuer',
-        'AbstractToken.category as AbstractToken_category',
-        'AbstractToken.iconUrl as AbstractToken_iconUrl',
-        'AbstractToken.coingeckoId as AbstractToken_coingeckoId',
-        'AbstractToken.coingeckoListingTimestamp as AbstractToken_coingeckoListingTimestamp',
-        'AbstractToken.symbol as AbstractToken_symbol',
-        'AbstractToken.comment as AbstractToken_comment',
-        'AbstractToken.reviewed as AbstractToken_reviewed',
-        'AbstractToken.isPriceUnreliable as AbstractToken_isPriceUnreliable',
-      ])
-      .where((eb) =>
-        eb.or(
-          pks.map((pk) =>
-            eb.and([
-              eb('chain', '=', pk.chain),
-              eb('address', '=', pk.address.toLowerCase()),
-            ]),
+    await this.batch(pks, BATCH_SIZE, async (batch) => {
+      const rows = await this.db
+        .selectFrom('DeployedToken')
+        .leftJoin(
+          'AbstractToken',
+          'AbstractToken.id',
+          'DeployedToken.abstractTokenId',
+        )
+        .selectAll('DeployedToken')
+        .select([
+          'AbstractToken.id as AbstractToken_id',
+          'AbstractToken.issuer as AbstractToken_issuer',
+          'AbstractToken.category as AbstractToken_category',
+          'AbstractToken.iconUrl as AbstractToken_iconUrl',
+          'AbstractToken.coingeckoId as AbstractToken_coingeckoId',
+          'AbstractToken.coingeckoListingTimestamp as AbstractToken_coingeckoListingTimestamp',
+          'AbstractToken.symbol as AbstractToken_symbol',
+          'AbstractToken.comment as AbstractToken_comment',
+          'AbstractToken.reviewed as AbstractToken_reviewed',
+          'AbstractToken.isPriceUnreliable as AbstractToken_isPriceUnreliable',
+        ])
+        .where((eb) =>
+          eb(
+            eb.refTuple('chain', 'address'),
+            'in',
+            batch.map((pk) => eb.tuple(pk.chain, pk.address.toLowerCase())),
           ),
-        ),
-      )
-      .execute()
+        )
+        .execute()
 
-    return result.map((row) => ({
-      deployedToken: toRecord({
-        symbol: row.symbol,
-        comment: row.comment,
-        chain: row.chain,
-        address: row.address,
-        abstractTokenId: row.abstractTokenId,
-        decimals: row.decimals,
-        deploymentTimestamp: row.deploymentTimestamp,
-        metadata: row.metadata as DeployedTokenMetadata,
-        abstractTokenAssignmentProof: row.abstractTokenAssignmentProof,
-      }),
-      abstractToken:
-        row.AbstractToken_id === null ||
-        row.AbstractToken_symbol === null ||
-        row.AbstractToken_reviewed === null ||
-        row.AbstractToken_isPriceUnreliable === null
-          ? undefined
-          : toAbstractTokenRecord({
-              id: row.AbstractToken_id,
-              issuer: row.AbstractToken_issuer,
-              symbol: row.AbstractToken_symbol,
-              category: row.AbstractToken_category,
-              iconUrl: row.AbstractToken_iconUrl,
-              coingeckoId: row.AbstractToken_coingeckoId,
-              coingeckoListingTimestamp:
-                row.AbstractToken_coingeckoListingTimestamp,
-              comment: row.AbstractToken_comment,
-              reviewed: row.AbstractToken_reviewed,
-              isPriceUnreliable: row.AbstractToken_isPriceUnreliable,
-            }),
-    }))
+      for (const row of rows) {
+        result.push({
+          deployedToken: toRecord({
+            symbol: row.symbol,
+            comment: row.comment,
+            chain: row.chain,
+            address: row.address,
+            abstractTokenId: row.abstractTokenId,
+            decimals: row.decimals,
+            deploymentTimestamp: row.deploymentTimestamp,
+            metadata: row.metadata as DeployedTokenMetadata,
+            abstractTokenAssignmentProof: row.abstractTokenAssignmentProof,
+          }),
+          abstractToken:
+            row.AbstractToken_id === null ||
+            row.AbstractToken_symbol === null ||
+            row.AbstractToken_reviewed === null ||
+            row.AbstractToken_isPriceUnreliable === null
+              ? undefined
+              : toAbstractTokenRecord({
+                  id: row.AbstractToken_id,
+                  issuer: row.AbstractToken_issuer,
+                  symbol: row.AbstractToken_symbol,
+                  category: row.AbstractToken_category,
+                  iconUrl: row.AbstractToken_iconUrl,
+                  coingeckoId: row.AbstractToken_coingeckoId,
+                  coingeckoListingTimestamp:
+                    row.AbstractToken_coingeckoListingTimestamp,
+                  comment: row.AbstractToken_comment,
+                  reviewed: row.AbstractToken_reviewed,
+                  isPriceUnreliable: row.AbstractToken_isPriceUnreliable,
+                }),
+        })
+      }
+    })
+
+    return result
   }
 
   async findByChainAndAddress(
@@ -181,24 +189,23 @@ export class DeployedTokenRepository extends BaseRepository {
   async getByChainsAndAddresses(
     pks: DeployedTokenPrimaryKey[],
   ): Promise<DeployedTokenRecord[]> {
-    if (pks.length === 0) {
-      return []
-    }
+    const rows: Selectable<DeployedToken>[] = []
 
-    const rows = await this.db
-      .selectFrom('DeployedToken')
-      .selectAll()
-      .where((eb) =>
-        eb.or(
-          pks.map((pk) =>
-            eb.and([
-              eb('chain', '=', pk.chain),
-              eb('address', '=', pk.address.toLowerCase()),
-            ]),
-          ),
-        ),
+    await this.batch(pks, BATCH_SIZE, async (batch) => {
+      rows.push(
+        ...(await this.db
+          .selectFrom('DeployedToken')
+          .selectAll()
+          .where((eb) =>
+            eb(
+              eb.refTuple('chain', 'address'),
+              'in',
+              batch.map((pk) => eb.tuple(pk.chain, pk.address.toLowerCase())),
+            ),
+          )
+          .execute()),
       )
-      .execute()
+    })
 
     return rows.map(toRecord)
   }
@@ -220,24 +227,25 @@ export class DeployedTokenRepository extends BaseRepository {
   async getByPrimaryKeys(
     keys: DeployedTokenPrimaryKey[],
   ): Promise<DeployedTokenRecord[]> {
-    if (keys.length === 0) {
-      return []
-    }
+    const rows: Selectable<DeployedToken>[] = []
 
-    const rows = await this.db
-      .selectFrom('DeployedToken')
-      .selectAll()
-      .where((eb) =>
-        eb.or(
-          keys.map((key) =>
-            eb.and([
-              eb('chain', '=', key.chain),
-              eb('address', '=', key.address.toLowerCase()),
-            ]),
-          ),
-        ),
+    await this.batch(keys, BATCH_SIZE, async (batch) => {
+      rows.push(
+        ...(await this.db
+          .selectFrom('DeployedToken')
+          .selectAll()
+          .where((eb) =>
+            eb(
+              eb.refTuple('chain', 'address'),
+              'in',
+              batch.map((key) =>
+                eb.tuple(key.chain, key.address.toLowerCase()),
+              ),
+            ),
+          )
+          .execute()),
       )
-      .execute()
+    })
     return rows.map(toRecord)
   }
 
@@ -252,25 +260,24 @@ export class DeployedTokenRepository extends BaseRepository {
   }
 
   async deleteByPrimaryKeys(keys: DeployedTokenPrimaryKey[]): Promise<number> {
-    if (keys.length === 0) {
-      return 0
-    }
+    let numDeletedRows = 0
 
-    const result = await this.db
-      .deleteFrom('DeployedToken')
-      .where((eb) =>
-        eb.or(
-          keys.map((key) =>
-            eb.and([
-              eb('chain', '=', key.chain),
-              eb('address', '=', key.address.toLowerCase()),
-            ]),
+    await this.batch(keys, BATCH_SIZE, async (batch) => {
+      const result = await this.db
+        .deleteFrom('DeployedToken')
+        .where((eb) =>
+          eb(
+            eb.refTuple('chain', 'address'),
+            'in',
+            batch.map((key) => eb.tuple(key.chain, key.address.toLowerCase())),
           ),
-        ),
-      )
-      .executeTakeFirst()
+        )
+        .executeTakeFirst()
 
-    return Number(result.numDeletedRows)
+      numDeletedRows += Number(result.numDeletedRows)
+    })
+
+    return numDeletedRows
   }
 
   async deleteAll(): Promise<bigint> {


### PR DESCRIPTION
## Problem

Production error:

```
ERROR TrpcRouter "Maximum call stack size exceeded"
path: deployedTokens.getByChainAndAddress
RangeError: Maximum call stack size exceeded
    at Array.push (<anonymous>)
    at PostgresQueryCompiler.visitNode
```

`DeployedTokenRepository.getByChainAndAddress` — and three sibling methods (`getByChainsAndAddresses`, `getByPrimaryKeys`, `deleteByPrimaryKeys`) — built their `WHERE` clause as:

```ts
.where((eb) =>
  eb.or(pks.map((pk) =>
    eb.and([eb('chain', '=', pk.chain), eb('address', '=', pk.address.toLowerCase())]),
  )),
)
```

Kysely reduces that array into a **left-deep tree of binary `OrNode`s** (depth ≈ N). The recursive `PostgresQueryCompiler.visitNode` then descends N frames deep and overflows the JS call stack once N reaches a few thousand. The bulk interop callers (`getTokenInfos`, `missingTokens`) pass the set of distinct tokens involved in unprocessed transfers, which can spike into the thousands during a backlog — triggering the crash.

## Fix

**1. `refTuple` rewrite.** Replace the nested `OR(AND(...))` with a tuple `IN`:

```ts
.where((eb) =>
  eb(eb.refTuple('chain', 'address'), 'in',
    batch.map((pk) => eb.tuple(pk.chain, pk.address.toLowerCase())),
  ),
)
```

This compiles to `("chain", "address") IN (($1,$2), ($3,$4), ...)` — a **flat** value list rather than a deep tree — so the Kysely compiler no longer recurses. Semantics are identical (case-insensitive address match via `.toLowerCase()`).

**2. Chunking.** A row-comparison `IN` is still expanded into a deep tree by the **Postgres parser**, so the rewrite alone only raises the ceiling — Postgres throws `stack depth limit exceeded` at ~10k tuples (verified empirically: 1k/3k/6k pass, 10k/20k fail). To stay safely under both limits, the input is batched through the existing `BaseRepository.batch` helper (`BATCH_SIZE = 1000`). The common small-input case still runs as a single query; only large inputs split into multiple batches (wrapped in a transaction by the helper).

Applied to all four methods that shared the identical pattern.

## Testing

- `cd packages/database && pnpm test` — 746 passing.
- `pnpm typecheck` — clean.
- Verified the failure/fix boundary with a throwaway probe: tuple-IN alone fails on Postgres at 10k+ tuples; chunked version handles 20k without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)