### PR TITLE
Fix icons path in CONTRIBUTING (public → static)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ If you want to add a new project you can do that by opening a PR. To do this you
    `packages/config/src/processing/layer3s.ts`. The order of the projects
    should be kept alphabetical.
 4. Add a square PNG project icon with a minimum size of 128x128 pixels to
-   `packages/frontend/public/icons`. From the `packages/frontend` directory run
+   `packages/frontend/static/icons`. From the `packages/frontend` directory run
    `pnpm tinify-logos` afterwards to reduce its size.
 5. Run the website locally to check out your changes. (optional, see above)
 6. Make sure that things like linting, formatting and tests are all passing. To


### PR DESCRIPTION
Project icons live in `packages/frontend/static/icons`, not `public/icons` (which doesn't exist). Updated step 4 of the "Add your project to the website" instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)