### PR TITLE
Public API: fix observability gaps in logging

### DIFF
--- a/packages/public-api/src/index.ts
+++ b/packages/public-api/src/index.ts
@@ -66,7 +66,7 @@ function main() {
     security: [{ apiKeyAuth: [] }],
   })
   const cache = new InMemoryCache({
-    logger,
+    logger: logger.for('Cache'),
     enabled: config.cacheEnabled,
   })
 
@@ -116,7 +116,7 @@ function main() {
   )
 
   if (config.auth) {
-    app.use(authMiddleware(config.auth))
+    app.use(authMiddleware(config.auth, logger))
   }
   app.use(loggerMiddleware(logger))
 
@@ -128,7 +128,7 @@ function main() {
   app.use(errorHandler(logger))
 
   app.listen(config.api.port, () => {
-    console.log(`Example app listening on port ${config.api.port}`)
+    logger.info('Started', { port: config.api.port })
   })
 }
 

--- a/packages/public-api/src/middleware/authMiddleware.ts
+++ b/packages/public-api/src/middleware/authMiddleware.ts
@@ -1,8 +1,11 @@
+import type { Logger } from '@l2beat/backend-tools'
 import type { NextFunction, Request, Response } from 'express'
 import type { AuthConfig } from '../config/Config'
 import { requestContext } from '../context/context'
+import { getParamsWithoutApiKey } from './loggerMiddleware'
 
-export function authMiddleware(config: AuthConfig) {
+export function authMiddleware(config: AuthConfig, logger: Logger) {
+  logger = logger.for('Auth')
   return (req: Request, res: Response, next: NextFunction) => {
     const apiKey = req.query.apiKey
 
@@ -11,6 +14,14 @@ export function authMiddleware(config: AuthConfig) {
     )?.[0]
 
     if (!user) {
+      const { url, queryParams } = getParamsWithoutApiKey(req.originalUrl)
+      logger.warn('Unauthorized request', {
+        method: req.method,
+        url,
+        queryParams,
+        referer: req.headers.referer ?? 'unknown',
+        userAgent: req.headers['user-agent'] ?? 'unknown',
+      })
       res.status(401).json({
         message: 'Unauthorized. Use apiKey query parameter with valid API key.',
       })

--- a/packages/public-api/src/middleware/errorHandler.ts
+++ b/packages/public-api/src/middleware/errorHandler.ts
@@ -13,7 +13,7 @@ export function errorHandler(logger: Logger) {
     res.status(500)
 
     const body = {
-      error: err instanceof Error ? err.message : String(err),
+      error: err instanceof Error ? err : new Error(String(err)),
       method: req.method,
       url: req.originalUrl,
       errorId,

--- a/packages/public-api/src/middleware/loggerMiddleware.ts
+++ b/packages/public-api/src/middleware/loggerMiddleware.ts
@@ -3,6 +3,7 @@ import type { NextFunction, Request, Response } from 'express'
 import { getContext } from '../context/context'
 
 export function loggerMiddleware(logger: Logger) {
+  logger = logger.for('Http')
   return (req: Request, res: Response, next: NextFunction) => {
     if (req.headers['user-agent']?.includes('Cloudflare-Healthchecks')) {
       return next()
@@ -43,7 +44,7 @@ export function loggerMiddleware(logger: Logger) {
 }
 
 const dummyUrl = 'https://api.l2beat.com'
-function getParamsWithoutApiKey(url: string) {
+export function getParamsWithoutApiKey(url: string) {
   const urlObj = new URL(`${dummyUrl}${url}`)
   urlObj.searchParams.delete('apiKey')
   const queryParams = Object.fromEntries(urlObj.searchParams.entries())


### PR DESCRIPTION
Fixes four observability gaps found while designing the Kibana dashboard for `@l2beat/public-api` (G1–G4 from the observability review).

## Changes

**G1 — 500 error messages were silently dropped from Elasticsearch** (`errorHandler.ts`)
The handler logged `error: err.message` (a string), but `formatEcsLog` destructures `error` out of parameters and only emits it when it's an object. Every 500 in ES had an `errorId` but no error text. Now the `Error` object itself is passed, so the ES document carries `error.message`, `error.type`, and `error.stack_trace`.

**G2 — 401 rejections produced zero logs** (`authMiddleware.ts`)
`authMiddleware` is registered before `loggerMiddleware`, so rejected requests never reached any logger — brute-force attempts and consumers with broken keys were invisible. The reject branch now emits `warn('Unauthorized request', …)` with the `apiKey` stripped from the logged URL (reuses `getParamsWithoutApiKey`).

**G3 — no `Started` log** (`index.ts`)
Startup was `console.log`, which never reaches ES — no restart/deploy audit. Replaced with `logger.info('Started', { port })`.

**G4 — most logs had no `service.name`** (`index.ts`, `loggerMiddleware.ts`)
The root logger was unscoped; only `errorHandler` called `.for()`. Request logs now use `Http`, cache logs `Cache`, auth logs `Auth`.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (46 passing) in `packages/public-api`
- Drove the real `errorHandler` + `Logger` + `formatEcsLog` pipeline with a thrown `Error` and confirmed the resulting ES document now contains `error.message` / `error.stack_trace` (it previously had neither)

## Noticed, not fixed (pre-existing)

`errorHandler` logs raw `req.originalUrl`, which includes the caller's `apiKey` query param — worth a follow-up to sanitize it the same way `loggerMiddleware` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)