### PR TITLE
fix: left-align privacy attributes on project page

### DIFF
--- a/packages/frontend/src/components/projects/ProjectSummaryStat.tsx
+++ b/packages/frontend/src/components/projects/ProjectSummaryStat.tsx
@@ -29,7 +29,7 @@ export function ProjectSummaryStat(props: ProjectSummaryStatProps) {
   return (
     <li
       className={cn(
-        'flex max-md:items-center max-md:justify-between md:flex-col md:gap-3',
+        'flex gap-4 max-md:items-center max-md:justify-between md:flex-col md:gap-3',
         props.className,
       )}
     >

--- a/packages/frontend/src/pages/privacy/project/PrivacyProjectPage.tsx
+++ b/packages/frontend/src/pages/privacy/project/PrivacyProjectPage.tsx
@@ -108,7 +108,7 @@ export function PrivacyProjectPage({ entry, queryState, ...props }: Props) {
                           className="mt-6 md:mt-4"
                           title="Attributes"
                           tooltip="Protocol attributes and capabilities."
-                          valueClassName="flex flex-wrap justify-end gap-1 md:justify-start"
+                          valueClassName="flex flex-wrap justify-start gap-1"
                           value={entry.attributes.map((attribute) => (
                             <PrivacyAttributeTag
                               key={attribute.id}


### PR DESCRIPTION
## Summary
- Attribute tags on privacy project pages (e.g. https://l2beat.com/privacy/projects/railgun) were right-aligned on mobile widths (`justify-end`), which looked broken when the tags wrapped to multiple lines.
- Changed to `justify-start` so they are always left-aligned, as reported in [L2B-14347](https://linear.app/l2beat/issue/L2B-14347/attributes-go-to-the-right).
- The attributes layout in the privacy summary table is untouched — it only shares the `PrivacyAttributeTag` chip component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)