### PR TITLE
Website observability gap

### DIFF
--- a/packages/frontend/src/server/routers/TrpcRouter.ts
+++ b/packages/frontend/src/server/routers/TrpcRouter.ts
@@ -1,3 +1,5 @@
+import { assertUnreachable } from '@l2beat/shared-pure'
+import type { TRPCError } from '@trpc/server'
 import * as trpcExpress from '@trpc/server/adapters/express'
 import express from 'express'
 import { appRouter } from '~/server/trpc/root'
@@ -20,7 +22,8 @@ export function createTrpcRouter() {
       router: appRouter,
       createContext,
       onError: (opts) => {
-        logger.warn(opts.error.message, {
+        const logFn = getLogFn(opts.error)
+        logFn(opts.error.message, opts.error, {
           requestId: getRequestId(opts.req),
           ip: getRequestIp(opts.req),
           method: opts.req.method,
@@ -28,7 +31,6 @@ export function createTrpcRouter() {
           referer: opts.req.headers.referer ?? 'unknown',
           userAgent: opts.req.headers['user-agent'] ?? 'unknown',
           path: opts.path,
-          stack: opts.error.stack,
           code: opts.error.code,
           type: opts.type,
           input: opts.input,
@@ -38,4 +40,34 @@ export function createTrpcRouter() {
   )
 
   return router
+}
+
+function getLogFn(error: TRPCError) {
+  switch (error.code) {
+    case 'UNAUTHORIZED':
+    case 'BAD_REQUEST':
+      return logger.warn
+    case 'PARSE_ERROR':
+    case 'INTERNAL_SERVER_ERROR':
+    case 'NOT_IMPLEMENTED':
+    case 'BAD_GATEWAY':
+    case 'SERVICE_UNAVAILABLE':
+    case 'GATEWAY_TIMEOUT':
+    case 'PAYMENT_REQUIRED':
+    case 'FORBIDDEN':
+    case 'NOT_FOUND':
+    case 'METHOD_NOT_SUPPORTED':
+    case 'TIMEOUT':
+    case 'CONFLICT':
+    case 'PRECONDITION_FAILED':
+    case 'PAYLOAD_TOO_LARGE':
+    case 'UNSUPPORTED_MEDIA_TYPE':
+    case 'UNPROCESSABLE_CONTENT':
+    case 'PRECONDITION_REQUIRED':
+    case 'TOO_MANY_REQUESTS':
+    case 'CLIENT_CLOSED_REQUEST':
+      return logger.error
+    default:
+      assertUnreachable(error.code)
+  }
 }

--- a/packages/frontend/src/server/routers/TrpcRouter.ts
+++ b/packages/frontend/src/server/routers/TrpcRouter.ts
@@ -8,6 +8,7 @@ import { getRequestIp } from '../utils/getRequestIp'
 import { getLogger } from '../utils/logger'
 
 const logger = getLogger().for('TrpcRouter')
+const MAX_LOGGED_INPUT_LENGTH = 1000
 
 const createContext = ({ req }: trpcExpress.CreateExpressContextOptions) => ({
   headers: new Headers(req.headers as Record<string, string>),
@@ -33,13 +34,55 @@ export function createTrpcRouter() {
           path: opts.path,
           code: opts.error.code,
           type: opts.type,
-          input: opts.input,
+          input: stringifyInputForLogging(opts.input),
+          inputType: getInputType(opts.input),
         })
       },
     }),
   )
 
   return router
+}
+
+function stringifyInputForLogging(input: unknown): string | undefined {
+  if (input === undefined) {
+    return undefined
+  }
+
+  try {
+    const stringified =
+      typeof input === 'string'
+        ? input
+        : JSON.stringify(input, (_key, value: unknown) =>
+            typeof value === 'bigint' ? value.toString() : value,
+          )
+
+    if (stringified === undefined) {
+      return undefined
+    }
+
+    return stringified.length > MAX_LOGGED_INPUT_LENGTH
+      ? `${stringified.slice(0, MAX_LOGGED_INPUT_LENGTH)}...`
+      : stringified
+  } catch {
+    return '[unserializable input]'
+  }
+}
+
+function getInputType(input: unknown): string | undefined {
+  if (input === undefined) {
+    return undefined
+  }
+
+  if (input === null) {
+    return 'null'
+  }
+
+  if (Array.isArray(input)) {
+    return 'array'
+  }
+
+  return typeof input
 }
 
 function getLogFn(error: TRPCError) {

--- a/packages/shared-pure/src/tools/InMemoryCache.test.ts
+++ b/packages/shared-pure/src/tools/InMemoryCache.test.ts
@@ -205,7 +205,12 @@ describe(InMemoryCache.name, () => {
         const initialCache = new Map([
           ['key', { result: 'stale', timestamp: now - 2000 }],
         ])
-        const cache = new InMemoryCache({ initialCache })
+        const logger = {
+          info: mockFn(),
+          warn: mockFn(),
+          for: () => undefined as never,
+        }
+        const cache = new InMemoryCache({ initialCache, logger })
         const fallback = mockFn().rejectsWith(new Error('Revalidation failed'))
 
         // First call should return stale data and trigger revalidation
@@ -219,6 +224,15 @@ describe(InMemoryCache.name, () => {
 
         // Wait for background revalidation to fail
         await new Promise((resolve) => setTimeout(resolve, 10))
+
+        expect(logger.warn).toHaveBeenCalledTimes(1)
+
+        const [message, parameters] = logger.warn.calls[0]?.args ?? []
+        expect(message).toEqual('Cache revalidation failed')
+        expect((parameters as { key: string }).key).toEqual('key')
+        expect((parameters as { error: Error }).error.message).toEqual(
+          'Revalidation failed',
+        )
 
         // Next request should still get stale data since revalidation failed
         const result2 = await cache.get(

--- a/packages/shared-pure/src/tools/InMemoryCache.test.ts
+++ b/packages/shared-pure/src/tools/InMemoryCache.test.ts
@@ -208,6 +208,7 @@ describe(InMemoryCache.name, () => {
         const logger = {
           info: mockFn(),
           warn: mockFn(),
+          debug: mockFn(),
           for: () => undefined as never,
         }
         const cache = new InMemoryCache({ initialCache, logger })

--- a/packages/shared-pure/src/tools/InMemoryCache.test.ts
+++ b/packages/shared-pure/src/tools/InMemoryCache.test.ts
@@ -206,9 +206,9 @@ describe(InMemoryCache.name, () => {
           ['key', { result: 'stale', timestamp: now - 2000 }],
         ])
         const logger = {
-          info: mockFn(),
-          warn: mockFn(),
-          debug: mockFn(),
+          info: mockFn().returns(undefined),
+          warn: mockFn().returns(undefined),
+          debug: mockFn().returns(undefined),
           for: () => undefined as never,
         }
         const cache = new InMemoryCache({ initialCache, logger })

--- a/packages/shared-pure/src/tools/InMemoryCache.ts
+++ b/packages/shared-pure/src/tools/InMemoryCache.ts
@@ -4,6 +4,7 @@ const PROMISE_TIMEOUT = 30
 
 type Logger = {
   info: (...args: unknown[]) => void
+  warn: (...args: unknown[]) => void
   for: (object: object) => Logger
 }
 
@@ -130,8 +131,12 @@ export class InMemoryCache {
         timestamp: UnixTime.now(),
         maxLifetime,
       })
-    } catch {
+    } catch (error) {
       // If revalidation fails, we keep the stale data
+      this.logger?.warn('Cache revalidation failed', {
+        key,
+        error,
+      })
     }
   }
 

--- a/packages/shared-pure/src/tools/InMemoryCache.ts
+++ b/packages/shared-pure/src/tools/InMemoryCache.ts
@@ -5,6 +5,7 @@ const PROMISE_TIMEOUT = 30
 type Logger = {
   info: (...args: unknown[]) => void
   warn: (...args: unknown[]) => void
+  debug: (...args: unknown[]) => void
   for: (object: object) => Logger
 }
 
@@ -49,7 +50,7 @@ export class InMemoryCache {
       return fallback()
     }
 
-    this.logger?.info('Getting cache key', { key: options.key })
+    this.logger?.debug('Getting cache key', { key: options.key })
     const key = this.getKey(options.key.filter(Boolean) as string[])
     const now = UnixTime.now()
     const maxLifetime = options.ttl + (options.staleWhileRevalidate ?? 0)


### PR DESCRIPTION
## Summary
- Fix issue where input type wouldn't be accepted by ElasticSearch when BAD_REQUEST by serializing input
- Log expected client-side tRPC errors as warnings and unexpected/server-side tRPC errors as errors.
- Make `InMemoryCache` observability less noisy by moving cache-key lookup logs to debug and warning when stale background revalidation fails.
- Add test coverage for failed cache revalidation logging.
