### PR TITLE
Ronin drop inactive game permissions 

### DIFF
--- a/packages/config/src/projects/roninnetwork/config.jsonc
+++ b/packages/config/src/projects/roninnetwork/config.jsonc
@@ -44,26 +44,6 @@
     "eth:0xF184a6Cd470Cac2CF5cD4fBa34e20D482D6A6062": {
       "description": "Immutable emergency-pause contract for the legacy MainchainGateway. Holders of the SENTRY_ROLE can flip MainchainGateway into a paused state to halt deposits and withdrawals in an emergency."
     },
-    "eth:0x45dA2CD511DA5FEAa535eBF166E628314a65843a": {
-      "fields": {
-        "proposerFromDGF": {
-          "permissions": [
-            {
-              "type": "interact",
-              "description": "Allowed to post new state roots of the current layer to the host chain."
-            }
-          ]
-        },
-        "challengerFromDGF": {
-          "permissions": [
-            {
-              "type": "interact",
-              "description": "Allowed to challenge or delete state roots proposed by a Proposer."
-            }
-          ]
-        }
-      }
-    },
     "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
       "ignoreInWatchMode": ["totalSupply"]
     },

--- a/packages/config/src/projects/roninnetwork/diffHistory.md
+++ b/packages/config/src/projects/roninnetwork/diffHistory.md
@@ -1,3 +1,37 @@
+Generated with discovered.json: 0x6f0658ee1bba4fce7b959c3bbf165c2f6c6a7c96
+
+# Diff at Thu, 09 Jul 2026 13:48:35 GMT:
+
+- author: vincfurc (<vincfurc@users.noreply.github.com>)
+- comparing to: main@1e8c379b8fe786381adcddb9c648173990ad4ea3 block: 1783327943
+- current timestamp: 1783604846
+
+## Description
+
+Drop the Ronin-local permission overrides on the DGF's `proposerFromDGF` and `challengerFromDGF` fields. Now that `respectedGameType` is 1337 (KailuaGame), these are the legacy proposer/challenger for the PermissionedDisputeGame (game type 1) — dormant unless the Guardian rolls back.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1783327943 (main branch discovery), not current.
+
+```diff
+    contract Conduit Multisig 1 (eth:0x4a4962275DF8C60a80d3a25faEc5AA7De116A746) [GnosisSafe] {
+    +++ description: None
+      receivedPermissions:
+-        [{"permission":"interact","from":"eth:0x45dA2CD511DA5FEAa535eBF166E628314a65843a","description":"Allowed to challenge or delete state roots proposed by a Proposer.","role":".challengerFromDGF"}]
+    }
+```
+
+```diff
+    EOA  (eth:0xD379de941E78Ab394d4D4917FcCE1CC45b6cd620) {
+    +++ description: None
+      receivedPermissions.0:
+-        {"permission":"interact","from":"eth:0x45dA2CD511DA5FEAa535eBF166E628314a65843a","description":"Allowed to post new state roots of the current layer to the host chain.","role":".proposerFromDGF"}
+    }
+```
+
 Generated with discovered.json: 0x3e6247f7c354f1b9671aaa3adfcf3fd24e665a9e
 
 # Diff at Mon, 06 Jul 2026 08:53:30 GMT:

--- a/packages/config/src/projects/roninnetwork/discovered.json
+++ b/packages/config/src/projects/roninnetwork/discovered.json
@@ -1,7 +1,7 @@
 {
   "name": "roninnetwork",
-  "timestamp": 1783327943,
-  "configHash": "0xd88cfdd0a17578feb5a040de29b13c55be76c5a500ac4408672eb02588fcb40e",
+  "timestamp": 1783604846,
+  "configHash": "0x15ab3abb01c25fa00bf289b7dc70528346b29b5aabdfea07384b5c0819521776",
   "entries": [
     {
       "address": "eth:0x000000000000000000000000000000000000dEaD",
@@ -771,7 +771,7 @@
         "game1337": "eth:0x296e7aD6D441b0627768bC0650179a4206479444",
         "game2000": "eth:0x0000000000000000000000000000000000000000",
         "game42": "eth:0x0000000000000000000000000000000000000000",
-        "gameCount": 110,
+        "gameCount": 116,
         "gameImpls": [
           "eth:0x0000000000000000000000000000000000000000",
           "eth:0x58bf355C5d4EdFc723eF89d99582ECCfd143266A",
@@ -835,14 +835,6 @@
         "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
       ],
       "proxyType": "gnosis safe",
-      "receivedPermissions": [
-        {
-          "permission": "interact",
-          "from": "eth:0x45dA2CD511DA5FEAa535eBF166E628314a65843a",
-          "description": "Allowed to challenge or delete state roots proposed by a Proposer.",
-          "role": ".challengerFromDGF"
-        }
-      ],
       "ignoreInWatchMode": ["nonce"],
       "deployerAddress": "eth:0x0954eC5B731501abf85766B5c6f5DE4C2B60BC44",
       "sinceTimestamp": 1680797639,
@@ -1873,7 +1865,7 @@
         "decimals": 18,
         "name": "Wrapped Ether",
         "symbol": "WETH",
-        "totalSupply": "2409386811941049161828731"
+        "totalSupply": "2465772783194992912944652"
       },
       "implementationNames": {
         "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "WETH9"
@@ -2041,7 +2033,7 @@
         "L2_BLOCK_NUMBER": 56278374,
         "l2BlockNumber": 0,
         "l2SequenceNumber": 0,
-        "lastResolved": "eth:0x9502579AF8570bBD08eAd1060Cc1ED6180BA39d6",
+        "lastResolved": "eth:0x31148E296790E417FE88bb065f367d4B06329dA6",
         "minCreationTime": 0,
         "opponentIndex": 0,
         "OPTIMISM_PORTAL": "eth:0x652CD53eCf9466E5Fb00D0E11d6CBf6469a56D77",
@@ -2091,12 +2083,6 @@
       "type": "EOA",
       "proxyType": "EOA",
       "receivedPermissions": [
-        {
-          "permission": "interact",
-          "from": "eth:0x45dA2CD511DA5FEAa535eBF166E628314a65843a",
-          "description": "Allowed to post new state roots of the current layer to the host chain.",
-          "role": ".proposerFromDGF"
-        },
         {
           "permission": "interact",
           "from": "eth:0xc7EaCDd1E755d2823463Abc4434CA445F752b336",
@@ -4205,6 +4191,6 @@
     "taiko/RiscZeroGroth16Verifier": "0x5a8e570685c41094b4b892489bb6a8f0f7509e1e71111612b374075e6bc5e562",
     "taiko/RiscZeroGroth16VerifierLegacy": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c"
   },
-  "usedBlockNumbers": { "ethereum": 25472415 },
-  "permissionsConfigHash": "0x2b18a1919801b8aa8af0f26884c37fe70a919998d1ee3b5176f99bf1c5b93672"
+  "usedBlockNumbers": { "ethereum": 25495416 },
+  "permissionsConfigHash": "0xcc0b1c6a2fc3d6bb3bc7a9be8cc395c230797656daf0b3fea23aa9c724fa1b84"
 }


### PR DESCRIPTION
The DGF still exposes gameArgs(1) — proposer + challenger addresses for the PermissionedDisputeGame (game type 1). Now that respectedGameType is 1337 (KailuaGame), these roles are dormant for withdrawals and only relevant if the Guardian flips respectedGameType back to 1.