### PR TITLE
Speed up config builds

### DIFF
--- a/packages/config/src/ProjectDatabase.test.ts
+++ b/packages/config/src/ProjectDatabase.test.ts
@@ -102,4 +102,29 @@ describe(ProjectDatabase.name, () => {
     expect(await db.getToken(token.id)).toEqual(token)
     expect(await db.getTokens()).toEqual([token])
   })
+
+  it('rolls back a failed transaction', async () => {
+    const project: BaseProject = {
+      id: ProjectId('rolled-back'),
+      slug: 'rolled-back',
+      name: 'Rolled back',
+      shortName: undefined,
+      addedAt: 0,
+    }
+
+    await expect(
+      db.transaction(async () => {
+        await db.saveProject(project)
+        throw new Error('test error')
+      }),
+    ).toBeRejectedWith('test error')
+
+    const result = await db.getProject({
+      id: project.id,
+      select: [],
+      whereNotNull: [],
+      whereNull: [],
+    })
+    expect(result).toEqual(undefined)
+  })
 })

--- a/packages/config/src/ProjectDatabase.ts
+++ b/packages/config/src/ProjectDatabase.ts
@@ -95,6 +95,18 @@ export class ProjectDatabase {
       )`)
   }
 
+  async transaction<T>(callback: () => Promise<T>): Promise<T> {
+    await this.query('BEGIN TRANSACTION')
+    try {
+      const result = await callback()
+      await this.query('COMMIT')
+      return result
+    } catch (error) {
+      await this.query('ROLLBACK')
+      throw error
+    }
+  }
+
   async saveProject(project: BaseProject) {
     const keys = Object.keys(schema) as (keyof BaseProject)[]
     const valueKeys = keys.map((_) => '?')

--- a/packages/config/src/build.ts
+++ b/packages/config/src/build.ts
@@ -8,16 +8,18 @@ async function main() {
   await db.init()
 
   const projects = getProjects()
-  for (const project of projects) {
-    await db.saveProject(project)
-  }
-
   const chains = projects
     .map((p) => p.chainConfig)
     .filter((c) => c !== undefined)
 
   const tokenList = getTokenList(chains)
-  for (const token of tokenList) {
-    await db.saveToken(token)
-  }
+  await db.transaction(async () => {
+    for (const project of projects) {
+      await db.saveProject(project)
+    }
+
+    for (const token of tokenList) {
+      await db.saveToken(token)
+    }
+  })
 }


### PR DESCRIPTION
## Summary

The config build inserted 261 projects and 1,063 tokens as 1,324 individually committed SQLite writes. This adds transaction support to `ProjectDatabase` and seeds all records in one atomic transaction, including rollback on failure.

## Performance

Alternating A/B runs against the same compiled output reduced the median `node build/build.js` time from approximately **3.02 s to 2.35 s**, a **~22% speedup**. Warm paired runs improved by roughly 26%.

The generated database remains row-for-row identical, with 261 projects and 1,063 tokens. Config typecheck, build, Biome, and the full test suite completed successfully.