### PR TITLE
Log TimeLoop run failures with a message

### DIFF
--- a/packages/backend/src/tools/TimeLoop.test.ts
+++ b/packages/backend/src/tools/TimeLoop.test.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@l2beat/backend-tools'
 import { assert } from '@l2beat/shared-pure'
-import { expect, mockFn } from 'earl'
+import { expect, mockFn, mockObject } from 'earl'
 import { TimeLoop } from './TimeLoop'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -73,6 +73,21 @@ describe(TimeLoop.name, () => {
       await timeLoop.loopBody()
 
       expect(fn).toHaveBeenCalledTimes(2)
+    })
+
+    it('logs a named error when run throws', async () => {
+      const error = new Error('boom')
+      const errorFn = mockFn().returns(undefined)
+      const logger = mockObject<Logger>({
+        error: errorFn,
+        debug: mockFn().returns(undefined),
+      })
+
+      const timeLoop = new TestTimeLoop(mockFn().rejectsWith(error), logger)
+
+      await timeLoop.loopBody()
+
+      expect(errorFn).toHaveBeenCalledWith('Run failed', error)
     })
   })
 

--- a/packages/backend/src/tools/TimeLoop.ts
+++ b/packages/backend/src/tools/TimeLoop.ts
@@ -46,7 +46,7 @@ export abstract class TimeLoop {
     try {
       await this.run()
     } catch (e) {
-      this.logger.error(e)
+      this.logger.error('Run failed', e)
     }
     const durationMs = Date.now() - runStartTime
     this.logger.debug('Run ended', { durationMs })


### PR DESCRIPTION
## Why

`TimeLoop.loopBody` logs run errors as `logger.error(e)`, which ships Elasticsearch docs with an **empty `message` field**. All interop loop failures (matching, financials, compare, cleaner — 2k+ errors/week) group under `message: ""` in Kibana and can't be told apart without opening `error.message` on each doc.

## What

- `logger.error(e)` → `logger.error('Run failed', e)` in `TimeLoop.loopBody`
- Test pinning the message: a throwing `run()` logs `'Run failed'` with the error attached

This is one of the observability gaps found while designing the interop Kibana dashboard (error-stream panels group by `message.keyword` + `error.message.keyword`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)