### PR TITLE
Add blob call metadata migration

### DIFF
--- a/packages/database/prisma/migrations/20260716120000_add_blob_call_metadata/migration.sql
+++ b/packages/database/prisma/migrations/20260716120000_add_blob_call_metadata/migration.sql
@@ -1,0 +1,11 @@
+-- The Blob table is a derived cache. Rebuild it so historical rows include
+-- call metadata required by calldata-based DA attribution.
+BEGIN;
+
+ALTER TABLE "Blob"
+ADD COLUMN "callSelector" VARCHAR(10),
+ADD COLUMN "callFirstParameter" VARCHAR(66);
+
+TRUNCATE TABLE "Blob" RESTART IDENTITY;
+
+COMMIT;

--- a/packages/database/prisma/migrations/20260716120000_add_blob_call_metadata/migration.sql
+++ b/packages/database/prisma/migrations/20260716120000_add_blob_call_metadata/migration.sql
@@ -1,11 +1,9 @@
--- The Blob table is a derived cache. Rebuild it so historical rows include
--- call metadata required by calldata-based DA attribution.
+-- These columns are nullable so the migration remains compatible with the
+-- currently deployed backend while blob_indexer_v2 replaces cached ranges.
 BEGIN;
 
 ALTER TABLE "Blob"
 ADD COLUMN "callSelector" VARCHAR(10),
 ADD COLUMN "callFirstParameter" VARCHAR(66);
-
-TRUNCATE TABLE "Blob" RESTART IDENTITY;
 
 COMMIT;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -334,14 +334,16 @@ model Notification {
 }
 
 model Blob {
-  id          Int      @id @default(autoincrement())
-  blockNumber Int
-  timestamp   DateTime @db.Timestamp(6)
-  daLayer     Int
-  from        String   @db.VarChar(255)
-  to          String?  @db.VarChar(255)
-  topics      String?
-  size        BigInt?
+  id                 Int      @id @default(autoincrement())
+  blockNumber        Int
+  timestamp          DateTime @db.Timestamp(6)
+  daLayer            Int
+  from               String   @db.VarChar(255)
+  to                 String?  @db.VarChar(255)
+  topics             String?
+  callSelector       String?  @db.VarChar(10)
+  callFirstParameter String?  @db.VarChar(66)
+  size               BigInt?
 
   @@index([blockNumber])
 }


### PR DESCRIPTION
## What changed

Adds nullable database columns and matching Prisma schema fields for Ethereum blob call selector and first-parameter metadata.

## Why

This is the database half of #12304. The migration remains backward compatible with the currently deployed backend. The dependent code PR introduces `blob_indexer_v2`, which backfills the cache by transactionally replacing each processed block range.

## Deployment order

Merge and deploy this database PR before the dependent code PR.

## Validation

- Contains only the SQL migration and matching `schema.prisma` change
- Does not truncate the live blob cache or reset UIF state
- Application code is intentionally excluded