### PR TITLE
Organize clusters in TokenDB IU graph

### DIFF
--- a/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
@@ -252,8 +252,16 @@ The graph page in token-ui is a catalogue-level view of the relation
 observations. A node is a deployed token, identified by `(chain, address)`
 and labelled with the deployed token's symbol. A directed edge is an
 observed token relation; hovering it shows its endpoints, plugin, and
-bridge type. Node colors distinguish chains. The layout is force-directed;
-nodes can be dragged and the canvas can be panned or zoomed.
+bridge type. Node colors distinguish chains. Nodes can be dragged and the
+canvas can be panned or zoomed.
+
+Before drawing, the UI treats every connected component as a cluster and
+sorts the clusters by deployed-token count (largest first, with a stable id
+tie-break). Each cluster gets its own force simulation, which is run to
+completion in memory so clusters do not repel each other and users never see
+the graph settle. The finished clusters are placed left-to-right in a
+square-ish grid, starting at the top-left, then the whole grid is fitted into
+the viewport.
 
 Relations can exist before either endpoint is catalogued. The graph
 currently omits a relation unless both endpoints resolve to deployed

--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
@@ -192,8 +192,8 @@ function TokenRelationsGraph({ graph }: { graph: Graph }) {
           node.y = event.y
           redraw()
         })
-        .on('end', (event) => {
-          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'grab')
+        .on('end', function () {
+          d3.select(this).attr('cursor', 'grab')
         }),
     )
   }, [graph, size.height, size.width])

--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
@@ -5,13 +5,16 @@ import { type RefObject, useEffect, useRef, useState } from 'react'
 import { LoadingState } from '~/components/LoadingState'
 import { AppLayout } from '~/layouts/AppLayout'
 import { useTRPC } from '~/react-query/trpc'
+import {
+  type LayoutLink,
+  type LayoutNode,
+  layoutRelationGraph,
+} from './relationGraphLayout'
 
 type Graph = RouterOutputs['deployedTokens']['getRelationsGraph']
 type Relation = Graph['relations'][number]
-type NodeDatum = Graph['nodes'][number] & d3.SimulationNodeDatum
-type VisualLink = {
-  source: NodeDatum
-  target: NodeDatum
+type NodeDatum = Graph['nodes'][number] & LayoutNode
+type VisualLink = LayoutLink<NodeDatum> & {
   relation: Relation
   curve: number
 }
@@ -63,6 +66,7 @@ function TokenRelationsGraph({ graph }: { graph: Graph }) {
     const nodeById = new Map(nodes.map((node) => [node.id, node]))
     const visualLinks = buildVisualLinks(graph.relations, nodeById)
     const simulationLinks = buildSimulationLinks(visualLinks)
+    const layout = layoutRelationGraph(nodes, simulationLinks)
     const chainColor = d3
       .scaleOrdinal<string, string>(d3.schemeTableau10)
       .domain([...new Set(nodes.map((node) => node.chain))].sort())
@@ -94,9 +98,14 @@ function TokenRelationsGraph({ graph }: { graph: Graph }) {
       .attr('d', 'M 0 0 L 10 5 L 0 10 z')
       .attr('fill', (marker) => marker.color)
 
+    const fitScale = Math.min(
+      (size.width - 32) / layout.width,
+      (size.height - 32) / layout.height,
+      1,
+    )
     const zoom = d3
       .zoom<SVGSVGElement, unknown>()
-      .scaleExtent([0.1, 8])
+      .scaleExtent([Math.min(fitScale / 2, 0.1), 8])
       .on('zoom', (event) => {
         layer.attr('transform', event.transform.toString())
       })
@@ -158,48 +167,35 @@ function TokenRelationsGraph({ graph }: { graph: Graph }) {
           `${node.symbol} on ${node.chain}\n${formatEndpoint(node.chain, node.address)}`,
       )
 
-    const simulation = d3
-      .forceSimulation(nodes)
-      .force(
-        'link',
-        d3
-          .forceLink<NodeDatum, d3.SimulationLinkDatum<NodeDatum>>(
-            simulationLinks,
-          )
-          .id((node) => node.id)
-          .distance(100)
-          .strength(0.45),
+    function redraw() {
+      links.attr('d', linkPath)
+      node.attr('transform', (node) => `translate(${node.x},${node.y})`)
+    }
+    redraw()
+
+    const initialTransform = d3.zoomIdentity
+      .translate(
+        (size.width - layout.width * fitScale) / 2,
+        (size.height - layout.height * fitScale) / 2,
       )
-      .force('charge', d3.forceManyBody().strength(-130))
-      .force('center', d3.forceCenter(size.width / 2, size.height / 2))
-      .force('collision', d3.forceCollide<NodeDatum>().radius(26))
-      .on('tick', () => {
-        links.attr('d', linkPath)
-        node.attr('transform', (node) => `translate(${node.x},${node.y})`)
-      })
+      .scale(fitScale)
+    svg.call(zoom.transform, initialTransform)
 
     node.call(
       d3
         .drag<SVGGElement, NodeDatum>()
-        .on('start', (event, node) => {
-          if (!event.active) simulation.alphaTarget(0.3).restart()
-          node.fx = node.x
-          node.fy = node.y
+        .on('start', (event) => {
+          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'grabbing')
         })
         .on('drag', (event, node) => {
-          node.fx = event.x
-          node.fy = event.y
+          node.x = event.x
+          node.y = event.y
+          redraw()
         })
-        .on('end', (event, node) => {
-          if (!event.active) simulation.alphaTarget(0)
-          node.fx = null
-          node.fy = null
+        .on('end', (event) => {
+          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'grab')
         }),
     )
-
-    return () => {
-      simulation.stop()
-    }
   }, [graph, size.height, size.width])
 
   return (
@@ -239,29 +235,38 @@ function buildVisualLinks(
   const relationGroups = new Map<string, Relation[]>()
   for (const relation of relations) {
     const key = unorderedPairKey(sourceId(relation), targetId(relation))
-    relationGroups.set(key, [...(relationGroups.get(key) ?? []), relation])
+    const group = relationGroups.get(key)
+    if (group === undefined) {
+      relationGroups.set(key, [relation])
+    } else {
+      group.push(relation)
+    }
   }
 
-  return relations.flatMap((relation) => {
+  return relations.map((relation) => {
     const source = nodeById.get(sourceId(relation))
     const target = nodeById.get(targetId(relation))
-    if (!source || !target) return []
+    if (source === undefined || target === undefined) {
+      throw new Error('Relation graph contains an unknown endpoint')
+    }
 
-    const group =
-      relationGroups.get(
-        unorderedPairKey(sourceId(relation), targetId(relation)),
-      ) ?? []
+    const group = relationGroups.get(
+      unorderedPairKey(sourceId(relation), targetId(relation)),
+    )
+    if (group === undefined) {
+      throw new Error('Relation graph contains an ungrouped relation')
+    }
     const index = group.findIndex(
       (entry) => relationId(entry) === relationId(relation),
     )
     const curve = (index - (group.length - 1) / 2) * 16
 
-    return [{ source, target, relation, curve }]
+    return { source, target, relation, curve }
   })
 }
 
 function buildSimulationLinks(visualLinks: VisualLink[]) {
-  const links = new Map<string, d3.SimulationLinkDatum<NodeDatum>>()
+  const links = new Map<string, LayoutLink<NodeDatum>>()
   for (const link of visualLinks) {
     links.set(unorderedPairKey(link.source.id, link.target.id), {
       source: link.source,

--- a/packages/token-ui/src/pages/tokens/relationGraphLayout.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphLayout.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'earl'
+import {
+  type LayoutLink,
+  type LayoutNode,
+  layoutRelationGraph,
+} from './relationGraphLayout'
+
+describe(layoutRelationGraph.name, () => {
+  it('sorts connected clusters by size and places them in a grid', () => {
+    const nodes = ['b2', 'c3', 'a2', 'd1', 'c1', 'b1', 'a1', 'c2'].map(
+      (id): LayoutNode => ({ id }),
+    )
+    const nodeById = new Map(nodes.map((node) => [node.id, node]))
+    const links = [
+      link(nodeById, 'c1', 'c2'),
+      link(nodeById, 'c2', 'c3'),
+      link(nodeById, 'a1', 'a2'),
+      link(nodeById, 'b1', 'b2'),
+    ]
+
+    const layout = layoutRelationGraph(nodes, links)
+
+    expect(
+      layout.clusters.map((cluster) => cluster.nodes.map((node) => node.id)),
+    ).toEqual([['c1', 'c2', 'c3'], ['a1', 'a2'], ['b1', 'b2'], ['d1']])
+
+    const [first, second, third, fourth] = layout.clusters.map((cluster) =>
+      center(cluster.nodes),
+    )
+    if (
+      first === undefined ||
+      second === undefined ||
+      third === undefined ||
+      fourth === undefined
+    ) {
+      throw new Error('Expected four graph clusters')
+    }
+    expect(first.x < second.x).toEqual(true)
+    expect(first.y < third.y).toEqual(true)
+    expect(third.x < fourth.x).toEqual(true)
+  })
+})
+
+function link(
+  nodeById: Map<string, LayoutNode>,
+  sourceId: string,
+  targetId: string,
+): LayoutLink<LayoutNode> {
+  const source = nodeById.get(sourceId)
+  const target = nodeById.get(targetId)
+  if (source === undefined || target === undefined) {
+    throw new Error('Test link contains an unknown node')
+  }
+  return { source, target }
+}
+
+function center(nodes: LayoutNode[]) {
+  const x = nodes.map((node) => node.x ?? 0)
+  const y = nodes.map((node) => node.y ?? 0)
+  return {
+    x: (Math.min(...x) + Math.max(...x)) / 2,
+    y: (Math.min(...y) + Math.max(...y)) / 2,
+  }
+}

--- a/packages/token-ui/src/pages/tokens/relationGraphLayout.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphLayout.ts
@@ -1,0 +1,228 @@
+import * as d3 from 'd3'
+
+const CLUSTER_PADDING = 60
+const SIMULATION_TICKS = 300
+
+export interface LayoutNode extends d3.SimulationNodeDatum {
+  id: string
+}
+
+export interface LayoutLink<Node extends LayoutNode>
+  extends d3.SimulationLinkDatum<Node> {
+  source: Node
+  target: Node
+}
+
+interface Bounds {
+  minX: number
+  minY: number
+  maxX: number
+  maxY: number
+}
+
+export interface GraphCluster<
+  Node extends LayoutNode,
+  Link extends LayoutLink<Node>,
+> {
+  nodes: Node[]
+  links: Link[]
+}
+
+export interface GraphLayout<
+  Node extends LayoutNode,
+  Link extends LayoutLink<Node>,
+> {
+  clusters: GraphCluster<Node, Link>[]
+  width: number
+  height: number
+}
+
+export function layoutRelationGraph<
+  Node extends LayoutNode,
+  Link extends LayoutLink<Node>,
+>(nodes: Node[], links: Link[]): GraphLayout<Node, Link> {
+  const clusters = buildClusters(nodes, links)
+  for (const cluster of clusters) {
+    layoutCluster(cluster)
+  }
+
+  const columns = Math.ceil(Math.sqrt(clusters.length))
+  const rows = Math.ceil(clusters.length / columns)
+  const bounds = clusters.map((cluster) => getClusterBounds(cluster.nodes))
+  const columnWidths = Array.from({ length: columns }, () => 0)
+  const rowHeights = Array.from({ length: rows }, () => 0)
+
+  for (const [index, clusterBounds] of bounds.entries()) {
+    const column = index % columns
+    const row = Math.floor(index / columns)
+    columnWidths[column] = Math.max(
+      getItem(columnWidths, column),
+      width(clusterBounds),
+    )
+    rowHeights[row] = Math.max(getItem(rowHeights, row), height(clusterBounds))
+  }
+
+  const columnOffsets = cumulativeOffsets(columnWidths)
+  const rowOffsets = cumulativeOffsets(rowHeights)
+
+  for (const [index, cluster] of clusters.entries()) {
+    const column = index % columns
+    const row = Math.floor(index / columns)
+    const clusterBounds = getItem(bounds, index)
+    const targetX =
+      getItem(columnOffsets, column) + getItem(columnWidths, column) / 2
+    const targetY = getItem(rowOffsets, row) + getItem(rowHeights, row) / 2
+    const currentX = (clusterBounds.minX + clusterBounds.maxX) / 2
+    const currentY = (clusterBounds.minY + clusterBounds.maxY) / 2
+    translateCluster(cluster.nodes, targetX - currentX, targetY - currentY)
+  }
+
+  return {
+    clusters,
+    width: columnWidths.reduce((sum, value) => sum + value, 0),
+    height: rowHeights.reduce((sum, value) => sum + value, 0),
+  }
+}
+
+function buildClusters<Node extends LayoutNode, Link extends LayoutLink<Node>>(
+  nodes: Node[],
+  links: Link[],
+): GraphCluster<Node, Link>[] {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]))
+  const neighbors = new Map(
+    nodes.map((node) => [node.id, new Set<string>()] as const),
+  )
+
+  for (const link of links) {
+    getNeighbors(neighbors, link.source.id).add(link.target.id)
+    getNeighbors(neighbors, link.target.id).add(link.source.id)
+  }
+
+  const visited = new Set<string>()
+  const clusters: GraphCluster<Node, Link>[] = []
+  const clusterByNodeId = new Map<string, GraphCluster<Node, Link>>()
+  for (const root of [...nodes].sort(compareNodes)) {
+    if (visited.has(root.id)) continue
+
+    const component: Node[] = []
+    const pending = [root.id]
+    while (pending.length > 0) {
+      const id = pending.pop()
+      if (id === undefined || visited.has(id)) continue
+
+      const node = nodeById.get(id)
+      if (node === undefined) {
+        throw new Error(`Graph cluster contains unknown node ${id}`)
+      }
+      visited.add(id)
+      component.push(node)
+      for (const neighbor of getNeighbors(neighbors, id)) {
+        pending.push(neighbor)
+      }
+    }
+
+    const cluster: GraphCluster<Node, Link> = {
+      nodes: component.sort(compareNodes),
+      links: [],
+    }
+    clusters.push(cluster)
+    for (const node of component) {
+      clusterByNodeId.set(node.id, cluster)
+    }
+  }
+
+  for (const link of links) {
+    const sourceCluster = clusterByNodeId.get(link.source.id)
+    const targetCluster = clusterByNodeId.get(link.target.id)
+    if (sourceCluster === undefined || sourceCluster !== targetCluster) {
+      throw new Error('Graph link does not belong to a cluster')
+    }
+    sourceCluster.links.push(link)
+  }
+
+  return clusters.sort(
+    (a, b) =>
+      b.nodes.length - a.nodes.length ||
+      compareNodes(getItem(a.nodes, 0), getItem(b.nodes, 0)),
+  )
+}
+
+function layoutCluster<Node extends LayoutNode, Link extends LayoutLink<Node>>(
+  cluster: GraphCluster<Node, Link>,
+) {
+  const simulation = d3
+    .forceSimulation(cluster.nodes)
+    .force(
+      'link',
+      d3
+        .forceLink<Node, Link>(cluster.links)
+        .id((node) => node.id)
+        .distance(100)
+        .strength(0.45),
+    )
+    .force('charge', d3.forceManyBody().strength(-130))
+    .force('center', d3.forceCenter(0, 0))
+    .force('collision', d3.forceCollide<Node>().radius(26))
+    .stop()
+
+  simulation.tick(SIMULATION_TICKS)
+}
+
+function getClusterBounds(nodes: LayoutNode[]): Bounds {
+  const x = nodes.map((node) => node.x ?? 0)
+  const y = nodes.map((node) => node.y ?? 0)
+  return {
+    minX: Math.min(...x) - CLUSTER_PADDING,
+    minY: Math.min(...y) - CLUSTER_PADDING,
+    maxX: Math.max(...x) + CLUSTER_PADDING,
+    maxY: Math.max(...y) + CLUSTER_PADDING,
+  }
+}
+
+function getNeighbors(
+  neighbors: Map<string, Set<string>>,
+  id: string,
+): Set<string> {
+  const result = neighbors.get(id)
+  if (result === undefined) {
+    throw new Error(`Graph link contains unknown node ${id}`)
+  }
+  return result
+}
+
+function translateCluster(nodes: LayoutNode[], dx: number, dy: number) {
+  for (const node of nodes) {
+    node.x = (node.x ?? 0) + dx
+    node.y = (node.y ?? 0) + dy
+  }
+}
+
+function cumulativeOffsets(sizes: number[]) {
+  const offsets: number[] = []
+  let offset = 0
+  for (const size of sizes) {
+    offsets.push(offset)
+    offset += size
+  }
+  return offsets
+}
+
+function getItem<T>(items: T[], index: number): T {
+  const item = items[index]
+  if (item === undefined) {
+    throw new Error(`Missing graph layout item at index ${index}`)
+  }
+  return item
+}
+
+function width(bounds: Bounds) {
+  return bounds.maxX - bounds.minX
+}
+
+function height(bounds: Bounds) {
+  return bounds.maxY - bounds.minY
+}
+
+function compareNodes(a: LayoutNode, b: LayoutNode) {
+  return a.id.localeCompare(b.id)
+}


### PR DESCRIPTION
Part of L2B-14472

Before:

<img width="1305" height="1020" alt="image" src="https://github.com/user-attachments/assets/800ee9aa-b4cd-458e-911f-e7171e4eb021" />

After:

<img width="1709" height="1122" alt="image" src="https://github.com/user-attachments/assets/4b5daf43-5606-4860-901e-8370749f275c" />
