### PR TITLE
Token UI graph improvements

### DIFF
--- a/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
@@ -248,35 +248,51 @@ read-time cost is the entire price paid for the foreign-key decision above.
 
 ## Relations graph
 
-The graph page in token-ui is a catalogue-level view of the relation
-observations. A node is a deployed token, identified by `(chain, address)`
-and labelled with the deployed token's symbol. A directed edge is an
-observed token relation; hovering it shows its endpoints, plugin, and
-bridge type. Node colors distinguish chains. Nodes can be dragged and the
-canvas can be panned or zoomed.
+The graph page in token-ui is a view of the relation observations resolved
+against the current token catalogue. Every observed `(chain, address)`
+endpoint is a node, including endpoints that do not yet have a
+`DeployedToken` row. Catalogued nodes are green and labelled with their
+deployed token symbol; uncatalogued nodes are orange and use a shortened
+address as their label. A directed edge is an observed token relation:
+burn-and-mint edges are blue and lock-and-mint edges are pink. Arrowheads
+preserve the observed `tokenFrom` to `tokenTo` direction for both bridge
+types. Nodes can be dragged and the canvas can be panned or zoomed.
 
 Before drawing, the UI treats every connected component as a cluster and
-sorts the clusters by deployed-token count (largest first, with a stable id
+sorts the clusters by endpoint count (largest first, with a stable id
 tie-break). Each cluster gets its own force simulation, which is run to
 completion in memory so clusters do not repel each other and users never see
 the graph settle. The finished clusters are placed left-to-right in a
 square-ish grid, starting at the top-left, then the whole grid is fitted into
-the viewport.
+the viewport. At low zoom levels each cluster is overlaid with its most common
+catalogued deployed-token symbol. The overlay stays a constant screen size as
+the graph scales, making cluster identities easier to scan when individual
+node labels are too small.
 
-Relations can exist before either endpoint is catalogued. The graph
-currently omits a relation unless both endpoints resolve to deployed
-tokens, and omits nodes left without a displayed relation. The observation
-stays in `TokenRelation` and can appear automatically once its missing
-endpoint is catalogued.
+Clicking a node keeps the node, its incoming/outgoing edges, and its neighbors
+prominent while dimming the rest of the graph. A non-modal details panel loads
+that one deployed token and its abstract token on demand; the initial graph
+payload does not contain full token records. The panel also lists the incoming
+and outgoing relations already present in the graph rather than issuing a
+second database query for the neighborhood. Uncatalogued nodes show their raw
+endpoint information instead of token details.
 
-An edge is red when both endpoints are assigned to abstract tokens and
-those abstract token IDs differ. This is a conflict between the observed
-non-swapping relation and the current catalogue assignments. An unassigned
-endpoint is not considered a conflict.
+Edges are independently hoverable and clickable. Clicking one highlights its
+two endpoints and loads only that relation's full transfer evidence, including
+source and destination transaction hashes used for explorer links. This keeps
+the evidence JSON out of the initial graph response.
 
-The graph query reads only relation identity fields. It deliberately
-excludes the full transfer evidence JSON used by deployed-token relation
-details, because the graph neither displays nor interprets that evidence.
+An edge is an assignment anomaly when both endpoints are assigned to abstract
+tokens and those abstract token IDs differ. An unassigned or uncatalogued
+endpoint is not considered an anomaly. The default view keeps the bridge-type
+colors and does not draw anomalies red. An anomaly switch changes conflicting
+edges to red and mutes other edges to gray, so anomaly inspection does not
+compete with the default bridge-mechanism view.
+
+The initial graph query reads only relation identity fields and the minimal
+endpoint display data. It deliberately excludes full deployed/abstract token
+records and the transfer evidence JSON; dedicated selection-time queries fetch
+one node or one relation detail record when requested.
 
 ## Human edits
 

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
@@ -449,6 +449,65 @@ describe('deployedTokensRouter', () => {
         ],
       })
     })
+
+    it('excludes bridge types the graph does not render', async () => {
+      const supported = tokenRelationRoute({
+        tokenFromChain: 'ethereum',
+        tokenFromAddress: '0xaaa',
+        tokenToChain: 'base',
+        tokenToAddress: '0xbbb',
+        plugin: 'supported',
+      })
+      const unsupported = {
+        ...tokenRelationRoute({
+          tokenFromChain: 'arbitrum',
+          tokenFromAddress: '0xccc',
+          tokenToChain: 'optimism',
+          tokenToAddress: '0xddd',
+          plugin: 'unsupported',
+        }),
+        bridgeType: 'nonMinting' as const,
+      }
+      const getTokens = mockFn().resolvesTo([])
+      const mockTokenDb = mockObject<TokenDatabase>({
+        tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
+          getAllRoutes: mockFn().resolvesTo([supported, unsupported]),
+        }),
+        deployedToken: mockObject<TokenDatabase['deployedToken']>({
+          getByPrimaryKeys: getTokens,
+        }),
+      })
+
+      const caller = createRouter(
+        mockTokenDb,
+        mockObject<Database>({}),
+        mockObject<CoingeckoClient>({}),
+      )
+
+      expect(await caller.getRelationsGraph()).toEqual({
+        nodes: [
+          {
+            id: 'ethereum:0xaaa',
+            chain: 'ethereum',
+            address: '0xaaa',
+            symbol: null,
+            isDeployed: false,
+          },
+          {
+            id: 'base:0xbbb',
+            chain: 'base',
+            address: '0xbbb',
+            symbol: null,
+            isDeployed: false,
+          },
+        ],
+        relations: [{ ...supported, isConflict: false }],
+      })
+      expect(getTokens).toHaveBeenCalledWith([
+        { chain: 'ethereum', address: '0xaaa' },
+        { chain: 'base', address: '0xbbb' },
+      ])
+    })
   })
 
   describe('checks', () => {

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
@@ -194,8 +194,112 @@ describe('deployedTokensRouter', () => {
     })
   })
 
+  describe('getRelationsGraphNodeDetails', () => {
+    it('returns one deployed token and its abstract token', async () => {
+      const token = deployedToken({
+        chain: 'ethereum',
+        address: '0xaaa',
+        symbol: 'USDC',
+        abstractTokenId: 'USDC',
+      })
+      const abstractToken = {
+        id: 'USDC',
+        symbol: 'USDC',
+        issuer: 'Circle',
+        category: 'stablecoin',
+        iconUrl: null,
+        coingeckoId: 'usd-coin',
+        coingeckoListingTimestamp: null,
+        additionalCoingeckoEntries: null,
+        comment: null,
+        reviewed: true,
+        isPriceUnreliable: false,
+      } satisfies AbstractTokenRecord
+      const findDeployedToken = mockFn().resolvesTo(token)
+      const findAbstractToken = mockFn().resolvesTo(abstractToken)
+      const mockTokenDb = mockObject<TokenDatabase>({
+        deployedToken: mockObject<TokenDatabase['deployedToken']>({
+          findByChainAndAddress: findDeployedToken,
+        }),
+        abstractToken: mockObject<TokenDatabase['abstractToken']>({
+          findById: findAbstractToken,
+        }),
+      })
+
+      const caller = createRouter(
+        mockTokenDb,
+        mockObject<Database>({}),
+        mockObject<CoingeckoClient>({}),
+      )
+
+      expect(
+        await caller.getRelationsGraphNodeDetails({
+          chain: token.chain,
+          address: token.address,
+        }),
+      ).toEqual({ deployedToken: token, abstractToken })
+      expect(findAbstractToken).toHaveBeenCalledWith('USDC')
+    })
+
+    it('returns null details for an uncatalogued endpoint', async () => {
+      const mockTokenDb = mockObject<TokenDatabase>({
+        deployedToken: mockObject<TokenDatabase['deployedToken']>({
+          findByChainAndAddress: mockFn().resolvesTo(undefined),
+        }),
+      })
+      const caller = createRouter(
+        mockTokenDb,
+        mockObject<Database>({}),
+        mockObject<CoingeckoClient>({}),
+      )
+
+      expect(
+        await caller.getRelationsGraphNodeDetails({
+          chain: 'optimism',
+          address: '0xccc',
+        }),
+      ).toEqual({ deployedToken: null, abstractToken: null })
+    })
+  })
+
+  describe('getRelationsGraphRelationDetails', () => {
+    it('loads transfer evidence only for the selected relation', async () => {
+      const route = tokenRelationRoute({
+        tokenFromChain: 'ethereum',
+        tokenFromAddress: '0xaaa',
+        tokenToChain: 'base',
+        tokenToAddress: '0xbbb',
+        plugin: 'test-plugin',
+      })
+      const relation = {
+        ...route,
+        transfer: {
+          transferId: 'transfer-1',
+          srcTxHash: '0xsrc',
+          dstTxHash: '0xdst',
+        },
+      } satisfies TokenRelationRecord
+      const findRelation = mockFn().resolvesTo(relation)
+      const mockTokenDb = mockObject<TokenDatabase>({
+        tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
+          findByPrimaryKey: findRelation,
+        }),
+      })
+      const caller = createRouter(
+        mockTokenDb,
+        mockObject<Database>({}),
+        mockObject<CoingeckoClient>({}),
+      )
+
+      expect(await caller.getRelationsGraphRelationDetails(route)).toEqual(
+        relation,
+      )
+      expect(findRelation).toHaveBeenCalledWith(route)
+    })
+  })
+
   describe('getRelationsGraph', () => {
-    it('returns resolved relation endpoints and lightweight edges', async () => {
+    it('returns deployed relation endpoints and lightweight edges', async () => {
       const relations = [
         tokenRelationRoute({
           tokenFromChain: 'base',
@@ -249,12 +353,14 @@ describe('deployedTokensRouter', () => {
             chain: 'base',
             address: '0xbbb',
             symbol: 'USDC',
+            isDeployed: true,
           },
           {
             id: 'ethereum:0xaaa',
             chain: 'ethereum',
             address: '0xaaa',
             symbol: 'USDC',
+            isDeployed: true,
           },
         ],
         relations: relations.map((relation) => ({
@@ -269,7 +375,7 @@ describe('deployedTokensRouter', () => {
       ])
     })
 
-    it('skips unresolved relations and marks different abstract tokens as conflicts', async () => {
+    it('includes missing endpoints and marks different abstract tokens as conflicts', async () => {
       const conflict = tokenRelationRoute({
         tokenFromChain: 'ethereum',
         tokenFromAddress: '0xaaa',
@@ -320,15 +426,27 @@ describe('deployedTokensRouter', () => {
             chain: 'ethereum',
             address: '0xaaa',
             symbol: 'USDC',
+            isDeployed: true,
           },
           {
             id: 'base:0xbbb',
             chain: 'base',
             address: '0xbbb',
             symbol: 'USDC',
+            isDeployed: true,
+          },
+          {
+            id: 'optimism:0xccc',
+            chain: 'optimism',
+            address: '0xccc',
+            symbol: null,
+            isDeployed: false,
           },
         ],
-        relations: [{ ...conflict, isConflict: true }],
+        relations: [
+          { ...conflict, isConflict: true },
+          { ...unresolved, isConflict: false },
+        ],
       })
     })
   })

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
@@ -1,4 +1,5 @@
 import { v } from '@l2beat/validate'
+import { TokenRelationPrimaryKey } from '../../../schemas/TokenRelation'
 import { readOnlyProcedure } from '../../procedures'
 import { router } from '../../trpc'
 import { checkDeployedToken } from './checkDeployedToken'
@@ -79,6 +80,41 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
         }
       }),
 
+    getRelationsGraphNodeDetails: readOnlyProcedure
+      .input(v.object({ chain: v.string(), address: v.string() }))
+      .query(async ({ ctx, input }) => {
+        const deployedToken =
+          await ctx.tokenDb.deployedToken.findByChainAndAddress(input)
+        if (deployedToken === undefined) {
+          return { deployedToken: null, abstractToken: null }
+        }
+        if (deployedToken.abstractTokenId === null) {
+          return { deployedToken, abstractToken: null }
+        }
+
+        const abstractToken = await ctx.tokenDb.abstractToken.findById(
+          deployedToken.abstractTokenId,
+        )
+        if (abstractToken === undefined) {
+          throw new Error(
+            `Missing abstract token ${deployedToken.abstractTokenId} assigned to ${deployedToken.chain}:${deployedToken.address}`,
+          )
+        }
+        return { deployedToken, abstractToken }
+      }),
+
+    getRelationsGraphRelationDetails: readOnlyProcedure
+      .input(TokenRelationPrimaryKey)
+      .query(async ({ ctx, input }) => {
+        const relation = await ctx.tokenDb.tokenRelation.findByPrimaryKey(input)
+        if (relation === undefined) {
+          throw new Error(
+            `Token relation ${formatTokenRelationPrimaryKey(input)} no longer exists`,
+          )
+        }
+        return relation
+      }),
+
     getRelationsGraph: readOnlyProcedure.query(async ({ ctx }) => {
       const relations = sortRelations(
         await ctx.tokenDb.tokenRelation.getAllRoutes(),
@@ -97,7 +133,7 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
       )
       const tokens = await ctx.tokenDb.deployedToken.getByPrimaryKeys(tokenKeys)
       const tokenMap = new Map(tokens.map((token) => [tokenKey(token), token]))
-      const renderableRelations = relations.flatMap((relation) => {
+      const graphRelations = relations.map((relation) => {
         const tokenFrom = tokenMap.get(
           tokenKey({
             chain: relation.tokenFromChain,
@@ -110,46 +146,28 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
             address: relation.tokenToAddress,
           }),
         )
-        if (!tokenFrom || !tokenTo) return []
 
-        return [
-          {
-            ...relation,
-            isConflict:
-              tokenFrom.abstractTokenId !== null &&
-              tokenTo.abstractTokenId !== null &&
-              tokenFrom.abstractTokenId !== tokenTo.abstractTokenId,
-          },
-        ]
+        return {
+          ...relation,
+          isConflict:
+            tokenFrom?.abstractTokenId != null &&
+            tokenTo?.abstractTokenId != null &&
+            tokenFrom.abstractTokenId !== tokenTo.abstractTokenId,
+        }
       })
-      const renderableTokenKeys = uniqueTokenKeys(
-        renderableRelations.flatMap((relation) => [
-          {
-            chain: relation.tokenFromChain,
-            address: relation.tokenFromAddress,
-          },
-          {
-            chain: relation.tokenToChain,
-            address: relation.tokenToAddress,
-          },
-        ]),
-      )
 
       return {
-        nodes: renderableTokenKeys.flatMap((key) => {
+        nodes: tokenKeys.map((key) => {
           const token = tokenMap.get(tokenKey(key))
-          return token
-            ? [
-                {
-                  id: tokenKey(token),
-                  chain: token.chain,
-                  address: token.address,
-                  symbol: token.symbol,
-                },
-              ]
-            : []
+          return {
+            id: tokenKey(key),
+            chain: key.chain,
+            address: key.address,
+            symbol: token?.symbol ?? null,
+            isDeployed: token !== undefined,
+          }
         }),
-        relations: renderableRelations,
+        relations: graphRelations,
       }
     }),
 
@@ -212,4 +230,10 @@ function uniqueTokenKeys(tokens: { chain: string; address: string }[]) {
 
 function tokenKey(token: { chain: string; address: string }) {
   return `${token.chain}:${token.address.toLowerCase()}`
+}
+
+function formatTokenRelationPrimaryKey(
+  relation: v.infer<typeof TokenRelationPrimaryKey>,
+) {
+  return `${relation.tokenFromChain}:${relation.tokenFromAddress} -> ${relation.tokenToChain}:${relation.tokenToAddress} via ${relation.plugin} (${relation.bridgeType})`
 }

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
@@ -117,7 +117,9 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
 
     getRelationsGraph: readOnlyProcedure.query(async ({ ctx }) => {
       const relations = sortRelations(
-        await ctx.tokenDb.tokenRelation.getAllRoutes(),
+        (await ctx.tokenDb.tokenRelation.getAllRoutes()).filter(
+          isGraphRelation,
+        ),
       )
       const tokenKeys = uniqueTokenKeys(
         relations.flatMap((relation) => [
@@ -219,6 +221,13 @@ function sortRelations<
           b.tokenToAddress,
         ].join(':'),
       ),
+  )
+}
+
+function isGraphRelation(relation: { bridgeType: string }): boolean {
+  return (
+    relation.bridgeType === 'burnAndMint' ||
+    relation.bridgeType === 'lockAndMint'
   )
 }
 

--- a/packages/token-ui/src/components/PlanConfirmationDialog.tsx
+++ b/packages/token-ui/src/components/PlanConfirmationDialog.tsx
@@ -59,6 +59,12 @@ export function PlanConfirmationDialog({
     queryClient.invalidateQueries(
       trpc.deployedTokens.getRelationsGraph.queryFilter(),
     )
+    queryClient.invalidateQueries(
+      trpc.deployedTokens.getRelationsGraphNodeDetails.queryFilter(),
+    )
+    queryClient.invalidateQueries(
+      trpc.deployedTokens.getRelationsGraphRelationDetails.queryFilter(),
+    )
     queryClient.invalidateQueries(trpc.deployedTokens.checks.queryFilter())
     queryClient.invalidateQueries(
       trpc.deployedTokens.getSuggestionsByCoingeckoId.queryFilter(),

--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
@@ -1,0 +1,539 @@
+import * as d3 from 'd3'
+import { type RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type LayoutLink,
+  type LayoutNode,
+  layoutRelationGraph,
+} from './relationGraphLayout'
+import {
+  getClusterLabelStyle,
+  getRelationGraphFocus,
+  mostCommonDeployedSymbol,
+  nodeColor,
+  nodeLabel,
+  RELATION_COLORS,
+  type RelationGraph,
+  type RelationGraphFocus,
+  type RelationGraphRelation,
+  type RelationGraphSelection,
+  relationColor,
+  relationId,
+  relationTypeLabel,
+  sourceId,
+  targetId,
+  unorderedPairKey,
+} from './relationGraphModel'
+
+type NodeDatum = RelationGraph['nodes'][number] & LayoutNode
+type VisualLink = LayoutLink<NodeDatum> & {
+  relation: RelationGraphRelation
+  curve: number
+}
+
+type HoveredItem = RelationGraphSelection | undefined
+
+interface GraphStyleState {
+  focus: RelationGraphFocus | undefined
+  highlightAnomalies: boolean
+  hovered: HoveredItem
+  selection: RelationGraphSelection | undefined
+}
+
+export function TokenRelationsGraph({
+  graph,
+  selection,
+  highlightAnomalies,
+  onSelectionChange,
+}: {
+  graph: RelationGraph
+  selection: RelationGraphSelection | undefined
+  highlightAnomalies: boolean
+  onSelectionChange: (selection: RelationGraphSelection | undefined) => void
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const svgRef = useRef<SVGSVGElement>(null)
+  const onSelectionChangeRef = useRef(onSelectionChange)
+  const [hovered, setHovered] = useState<HoveredItem>()
+  const size = useElementSize(containerRef)
+  // Hover styling touches every SVG node and edge. Build the selected
+  // neighborhood only when the selection changes so that pass stays linear.
+  const focus = useMemo(
+    () => getRelationGraphFocus(graph, selection),
+    [graph, selection],
+  )
+  const styleStateRef = useRef<GraphStyleState>({
+    focus,
+    highlightAnomalies,
+    hovered,
+    selection,
+  })
+  styleStateRef.current = {
+    focus,
+    highlightAnomalies,
+    hovered,
+    selection,
+  }
+
+  useEffect(() => {
+    onSelectionChangeRef.current = onSelectionChange
+  }, [onSelectionChange])
+
+  useEffect(() => {
+    const svgElement = svgRef.current
+    if (!svgElement || size.width === 0 || size.height === 0) return
+
+    const nodes = graph.nodes.map((node): NodeDatum => ({ ...node }))
+    const nodeById = new Map(nodes.map((node) => [node.id, node]))
+    const visualLinks = buildVisualLinks(graph.relations, nodeById)
+    const layout = layoutRelationGraph(nodes, buildSimulationLinks(visualLinks))
+    const clusterLabelData = layout.clusters.flatMap((cluster) => {
+      const text = mostCommonDeployedSymbol(cluster.nodes)
+      return text === undefined ? [] : [{ nodes: cluster.nodes, text }]
+    })
+
+    const svg = d3.select(svgElement)
+    svg.selectAll('*').remove()
+    svg.attr('viewBox', `0 0 ${size.width} ${size.height}`)
+
+    appendArrowMarkers(svg)
+
+    const background = svg
+      .append('rect')
+      .attr('width', size.width)
+      .attr('height', size.height)
+      .attr('fill', 'transparent')
+      .attr('cursor', 'grab')
+      .on('click', () => onSelectionChangeRef.current(undefined))
+
+    const layer = svg.append('g')
+    const linksLayer = layer.append('g')
+    const nodesLayer = layer.append('g')
+    const clusterLabelsLayer = layer.append('g')
+
+    const links = linksLayer
+      .selectAll<SVGPathElement, VisualLink>('path.relation-link')
+      .data(visualLinks, (link) => relationId(link.relation))
+      .join('path')
+      .attr('class', 'relation-link')
+      .attr('fill', 'none')
+      .attr('stroke', (link) => relationColor(link.relation))
+      .attr('stroke-linecap', 'round')
+      .attr('stroke-width', 1.4)
+      .attr('opacity', 0.55)
+      .attr('marker-end', (link) => markerUrl(link.relation, false))
+
+    links.append('title').text((link) => {
+      const relation = link.relation
+      return `${relation.tokenFromChain}:${relation.tokenFromAddress} -> ${relation.tokenToChain}:${relation.tokenToAddress}\n${relationTypeLabel(relation)} via ${relation.plugin}`
+    })
+
+    const linkHits = linksLayer
+      .selectAll<SVGPathElement, VisualLink>('path.relation-hit')
+      .data(visualLinks, (link) => relationId(link.relation))
+      .join('path')
+      .attr('class', 'relation-hit')
+      .attr('fill', 'none')
+      .attr('stroke', 'transparent')
+      .attr('stroke-width', 14)
+      .attr('pointer-events', 'stroke')
+      .attr('cursor', 'pointer')
+      .on('mouseenter', (_, link) =>
+        setHovered({ type: 'relation', id: relationId(link.relation) }),
+      )
+      .on('mouseleave', () => setHovered(undefined))
+      .on('click', (event, link) => {
+        event.stopPropagation()
+        onSelectionChangeRef.current({
+          type: 'relation',
+          id: relationId(link.relation),
+        })
+      })
+
+    const clusterLabels = clusterLabelsLayer
+      .selectAll<SVGTextElement, (typeof clusterLabelData)[number]>('text')
+      .data(clusterLabelData)
+      .join('text')
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'central')
+      .attr('paint-order', 'stroke')
+      .attr('stroke', 'var(--background)')
+      .attr('fill', 'var(--foreground)')
+      .attr('font-weight', 700)
+      .attr('letter-spacing', '0.08em')
+      .attr('pointer-events', 'none')
+      .text((label) => label.text)
+
+    const node = nodesLayer
+      .selectAll<SVGGElement, NodeDatum>('g.relation-node')
+      .data(nodes, (node) => node.id)
+      .join('g')
+      .attr('class', 'relation-node')
+      .attr('cursor', 'pointer')
+      .on('mouseenter', (_, node) => setHovered({ type: 'node', id: node.id }))
+      .on('mouseleave', () => setHovered(undefined))
+      .on('click', (event, node) => {
+        event.stopPropagation()
+        onSelectionChangeRef.current({ type: 'node', id: node.id })
+      })
+
+    node
+      .append('circle')
+      .attr('class', 'node-ring')
+      .attr('r', nodeRadius() + 5)
+      .attr('fill', 'none')
+      .attr('stroke', (node) => nodeColor(node))
+      .attr('stroke-width', 2.5)
+      .attr('opacity', 0)
+
+    node
+      .append('circle')
+      .attr('class', 'node-core')
+      .attr('r', nodeRadius())
+      .attr('fill', (node) => nodeColor(node))
+      .attr('stroke', 'var(--background)')
+      .attr('stroke-width', 2)
+
+    node
+      .append('text')
+      .attr('class', 'node-label')
+      .attr('x', 0)
+      .attr('y', -12)
+      .attr('text-anchor', 'middle')
+      .attr('paint-order', 'stroke')
+      .attr('stroke', 'var(--background)')
+      .attr('stroke-width', 3)
+      .attr('fill', 'var(--foreground)')
+      .attr('font-size', 11)
+      .attr('font-weight', 600)
+      .attr('pointer-events', 'none')
+      .text(nodeLabel)
+
+    node
+      .append('title')
+      .text(
+        (node) =>
+          `${nodeLabel(node)} on ${node.chain}\n${node.chain}:${node.address}\n${node.isDeployed ? 'Deployed token exists' : 'Missing deployed token'}`,
+      )
+
+    function redraw() {
+      links.attr('d', linkPath)
+      linkHits.attr('d', linkPath)
+      node.attr('transform', (node) => `translate(${node.x},${node.y})`)
+      clusterLabels
+        .attr('x', (label) => clusterCenter(label.nodes).x)
+        .attr('y', (label) => clusterCenter(label.nodes).y)
+    }
+    redraw()
+
+    const fitScale = Math.min(
+      (size.width - 32) / layout.width,
+      (size.height - 32) / layout.height,
+      1,
+    )
+    const zoom = d3
+      .zoom<SVGSVGElement, unknown>()
+      .scaleExtent([Math.min(fitScale / 2, 0.1), 8])
+      .on('start', () => background.attr('cursor', 'grabbing'))
+      .on('zoom', (event) => {
+        layer.attr('transform', event.transform.toString())
+        updateClusterLabelScale(clusterLabels, event.transform.k)
+      })
+      .on('end', () => background.attr('cursor', 'grab'))
+    svg.call(zoom)
+
+    const initialTransform = d3.zoomIdentity
+      .translate(
+        (size.width - layout.width * fitScale) / 2,
+        (size.height - layout.height * fitScale) / 2,
+      )
+      .scale(fitScale)
+    svg.call(zoom.transform, initialTransform)
+
+    node.call(
+      d3
+        .drag<SVGGElement, NodeDatum>()
+        .on('start', (event) => {
+          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'grabbing')
+        })
+        .on('drag', (event, node) => {
+          node.x = event.x
+          node.y = event.y
+          redraw()
+        })
+        .on('end', (event) => {
+          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'pointer')
+        }),
+    )
+    updateGraphStyles(svgElement, styleStateRef.current)
+  }, [graph, size.height, size.width])
+
+  useEffect(() => {
+    const svgElement = svgRef.current
+    if (!svgElement) return
+    updateGraphStyles(svgElement, {
+      focus,
+      highlightAnomalies,
+      hovered,
+      selection,
+    })
+  }, [focus, highlightAnomalies, hovered, selection])
+
+  return (
+    <div ref={containerRef} className="h-full w-full">
+      <svg ref={svgRef} className="h-full w-full" />
+    </div>
+  )
+}
+
+function updateGraphStyles(
+  svgElement: SVGSVGElement,
+  { focus, highlightAnomalies, hovered, selection }: GraphStyleState,
+) {
+  const svg = d3.select(svgElement)
+  const links = svg.selectAll<SVGPathElement, VisualLink>('.relation-link')
+  const nodes = svg.selectAll<SVGGElement, NodeDatum>('.relation-node')
+  const hasSelection = focus !== undefined
+
+  links
+    .attr('stroke', (link) =>
+      highlightAnomalies
+        ? link.relation.isConflict
+          ? RELATION_COLORS.conflict
+          : RELATION_COLORS.muted
+        : relationColor(link.relation),
+    )
+    .attr('marker-end', (link) => markerUrl(link.relation, highlightAnomalies))
+    .attr('opacity', (link) => {
+      const isHovered = isLinkActive(link, hovered)
+      const isSelected = focus?.relationIds.has(relationId(link.relation))
+      if (isHovered || isSelected) return 0.95
+      if (hasSelection) return 0.08
+      if (highlightAnomalies) {
+        return link.relation.isConflict ? 0.95 : 0.22
+      }
+      return 0.55
+    })
+    .attr('stroke-width', (link) => {
+      if (isLinkActive(link, hovered)) return 3
+      if (focus?.relationIds.has(relationId(link.relation))) return 2.8
+      if (highlightAnomalies && link.relation.isConflict) return 2.2
+      return 1.4
+    })
+
+  nodes
+    .attr('opacity', (node) =>
+      focus === undefined || focus.nodeIds.has(node.id) ? 1 : 0.12,
+    )
+    .select<SVGCircleElement>('.node-ring')
+    .attr('opacity', (node) => {
+      if (hovered?.type === 'node' && hovered.id === node.id) return 0.8
+      if (selection?.type === 'node' && selection.id === node.id) return 1
+      if (selection?.type === 'relation' && focus?.nodeIds.has(node.id)) {
+        return 0.7
+      }
+      return 0
+    })
+    .attr('stroke-width', (node) =>
+      selection?.type === 'node' && selection.id === node.id ? 3.5 : 2.5,
+    )
+
+  nodes
+    .select<SVGCircleElement>('.node-core')
+    .attr('r', (node) =>
+      hovered?.type === 'node' && hovered.id === node.id
+        ? nodeRadius() + 1.5
+        : nodeRadius(),
+    )
+}
+
+function appendArrowMarkers(
+  svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
+) {
+  const markers = [
+    { id: 'relation-arrow-burn-and-mint', color: RELATION_COLORS.burnAndMint },
+    { id: 'relation-arrow-lock-and-mint', color: RELATION_COLORS.lockAndMint },
+    { id: 'relation-arrow-conflict', color: RELATION_COLORS.conflict },
+    { id: 'relation-arrow-muted', color: RELATION_COLORS.muted },
+  ]
+
+  svg
+    .append('defs')
+    .selectAll('marker')
+    .data(markers)
+    .join('marker')
+    .attr('id', (marker) => marker.id)
+    .attr('viewBox', '0 0 10 10')
+    .attr('refX', 8)
+    .attr('refY', 5)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('d', 'M 0 0 L 10 5 L 0 10 z')
+    .attr('fill', (marker) => marker.color)
+}
+
+function markerUrl(
+  relation: RelationGraphRelation,
+  highlightAnomalies: boolean,
+) {
+  if (highlightAnomalies) {
+    return relation.isConflict
+      ? 'url(#relation-arrow-conflict)'
+      : 'url(#relation-arrow-muted)'
+  }
+  switch (relation.bridgeType) {
+    case 'burnAndMint':
+      return 'url(#relation-arrow-burn-and-mint)'
+    case 'lockAndMint':
+      return 'url(#relation-arrow-lock-and-mint)'
+    default:
+      throw new Error(
+        `Unexpected bridge type in relations graph: ${relation.bridgeType}`,
+      )
+  }
+}
+
+function updateClusterLabelScale(
+  labels: d3.Selection<
+    SVGTextElement,
+    { nodes: NodeDatum[]; text: string },
+    SVGGElement,
+    unknown
+  >,
+  scale: number,
+) {
+  const style = getClusterLabelStyle(scale)
+  labels
+    .attr('font-size', style.fontSize)
+    .attr('stroke-width', style.strokeWidth)
+    .attr('opacity', style.opacity)
+}
+
+function clusterCenter(nodes: NodeDatum[]) {
+  return {
+    x: d3.mean(nodes, (node) => node.x ?? 0) ?? 0,
+    y: d3.mean(nodes, (node) => node.y ?? 0) ?? 0,
+  }
+}
+
+function useElementSize<T extends HTMLElement>(ref: RefObject<T | null>) {
+  const [size, setSize] = useState({ width: 0, height: 0 })
+
+  useEffect(() => {
+    if (!ref.current) return
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+
+      setSize({
+        width: entry.contentRect.width,
+        height: entry.contentRect.height,
+      })
+    })
+    observer.observe(ref.current)
+
+    return () => observer.disconnect()
+  }, [ref])
+
+  return size
+}
+
+function buildVisualLinks(
+  relations: RelationGraphRelation[],
+  nodeById: Map<string, NodeDatum>,
+): VisualLink[] {
+  const relationGroups = new Map<string, RelationGraphRelation[]>()
+  for (const relation of relations) {
+    const key = unorderedPairKey(sourceId(relation), targetId(relation))
+    const group = relationGroups.get(key)
+    if (group === undefined) {
+      relationGroups.set(key, [relation])
+    } else {
+      group.push(relation)
+    }
+  }
+
+  return relations.map((relation) => {
+    const source = nodeById.get(sourceId(relation))
+    const target = nodeById.get(targetId(relation))
+    if (source === undefined || target === undefined) {
+      throw new Error('Relation graph contains an unknown endpoint')
+    }
+
+    const group = relationGroups.get(
+      unorderedPairKey(sourceId(relation), targetId(relation)),
+    )
+    if (group === undefined) {
+      throw new Error('Relation graph contains an ungrouped relation')
+    }
+    const index = group.findIndex(
+      (entry) => relationId(entry) === relationId(relation),
+    )
+    if (index === -1) {
+      throw new Error('Relation graph group does not contain relation')
+    }
+    const direction = source.id < target.id ? 1 : -1
+    const curve = (index - (group.length - 1) / 2) * 16 * direction
+
+    return { source, target, relation, curve }
+  })
+}
+
+function buildSimulationLinks(visualLinks: VisualLink[]) {
+  const links = new Map<string, LayoutLink<NodeDatum>>()
+  for (const link of visualLinks) {
+    links.set(unorderedPairKey(link.source.id, link.target.id), {
+      source: link.source,
+      target: link.target,
+    })
+  }
+  return [...links.values()]
+}
+
+function linkPath(link: VisualLink) {
+  const sourceX = link.source.x ?? 0
+  const sourceY = link.source.y ?? 0
+  const targetX = link.target.x ?? 0
+  const targetY = link.target.y ?? 0
+  const dx = targetX - sourceX
+  const dy = targetY - sourceY
+  const distance = Math.sqrt(dx * dx + dy * dy)
+  if (distance === 0) return `M${sourceX},${sourceY}`
+
+  const ux = dx / distance
+  const uy = dy / distance
+  const sx = sourceX + ux * (nodeRadius() + 2)
+  const sy = sourceY + uy * (nodeRadius() + 2)
+  const tx = targetX - ux * (nodeRadius() + 7)
+  const ty = targetY - uy * (nodeRadius() + 7)
+
+  if (link.curve === 0) {
+    return `M${sx},${sy} L${tx},${ty}`
+  }
+
+  const nx = -uy
+  const ny = ux
+  const mx = (sx + tx) / 2 + nx * link.curve
+  const my = (sy + ty) / 2 + ny * link.curve
+
+  return `M${sx},${sy} Q${mx},${my} ${tx},${ty}`
+}
+
+function nodeRadius() {
+  return 7
+}
+
+function isLinkActive(
+  link: VisualLink,
+  selection: RelationGraphSelection | undefined,
+) {
+  if (selection?.type === 'relation') {
+    return relationId(link.relation) === selection.id
+  }
+  if (selection?.type === 'node') {
+    return link.source.id === selection.id || link.target.id === selection.id
+  }
+  return false
+}

--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraphDetailsPanel.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraphDetailsPanel.tsx
@@ -1,0 +1,738 @@
+import type { RouterOutputs } from '@l2beat/token-backend'
+import { useQuery } from '@tanstack/react-query'
+import { ArrowRightIcon, ExternalLinkIcon, XIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { Badge } from '~/components/core/Badge'
+import { Button } from '~/components/core/Button'
+import { Separator } from '~/components/core/Separator'
+import { ExplorerLink } from '~/components/ExplorerLink'
+import { LoadingState } from '~/components/LoadingState'
+import { useTRPC } from '~/react-query/trpc'
+import {
+  nodeLabel,
+  RELATION_COLORS,
+  type RelationGraph,
+  type RelationGraphNode,
+  type RelationGraphRelation,
+  type RelationGraphSelection,
+  relationColor,
+  relationId,
+  relationPrimaryKey,
+  relationTypeLabel,
+  sourceId,
+  targetId,
+} from './relationGraphModel'
+
+type Chain = RouterOutputs['chains']['getAll'][number]
+type RelationDetails =
+  RouterOutputs['deployedTokens']['getRelationsGraphRelationDetails']
+
+export function TokenRelationsGraphDetailsPanel({
+  graph,
+  chains,
+  selection,
+  highlightAnomalies,
+  onSelectionChange,
+  onClose,
+}: {
+  graph: RelationGraph
+  chains: Chain[]
+  selection: RelationGraphSelection
+  highlightAnomalies: boolean
+  onSelectionChange: (selection: RelationGraphSelection) => void
+  onClose: () => void
+}) {
+  return (
+    <aside
+      role="dialog"
+      aria-modal="false"
+      aria-label="Graph selection details"
+      className="slide-in-from-right absolute inset-y-0 right-0 z-20 flex w-[min(92%,440px)] animate-in flex-col border-l bg-background shadow-xl duration-200"
+    >
+      <div className="flex items-start justify-between gap-4 border-b p-4">
+        <div>
+          <div className="font-semibold">
+            {selection.type === 'node' ? 'Token details' : 'Relation details'}
+          </div>
+          <div className="text-muted-foreground text-xs">
+            Click another node or connection to inspect it.
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="-mr-2 -mt-2"
+          aria-label="Close details"
+          onClick={onClose}
+        >
+          <XIcon />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {selection.type === 'node' ? (
+          <GraphNodeDetails
+            node={findNode(graph, selection.id)}
+            graph={graph}
+            chains={chains}
+            highlightAnomalies={highlightAnomalies}
+            onRelationClick={(relation) =>
+              onSelectionChange({
+                type: 'relation',
+                id: relationId(relation),
+              })
+            }
+          />
+        ) : (
+          <GraphRelationDetails
+            relation={findRelation(graph, selection.id)}
+            graph={graph}
+            chains={chains}
+            highlightAnomalies={highlightAnomalies}
+          />
+        )}
+      </div>
+    </aside>
+  )
+}
+
+function GraphNodeDetails({
+  node,
+  graph,
+  chains,
+  highlightAnomalies,
+  onRelationClick,
+}: {
+  node: RelationGraphNode
+  graph: RelationGraph
+  chains: Chain[]
+  highlightAnomalies: boolean
+  onRelationClick: (relation: RelationGraphRelation) => void
+}) {
+  const trpc = useTRPC()
+  const { data, isLoading, error } = useQuery(
+    trpc.deployedTokens.getRelationsGraphNodeDetails.queryOptions({
+      chain: node.chain,
+      address: node.address,
+    }),
+  )
+  const outgoing = graph.relations.filter(
+    (relation) => sourceId(relation) === node.id,
+  )
+  const incoming = graph.relations.filter(
+    (relation) => targetId(relation) === node.id,
+  )
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="break-all font-semibold text-lg">
+            {nodeLabel(node)} on {node.chain}
+          </h2>
+          <DeploymentBadge
+            deployed={
+              data === undefined ? node.isDeployed : data.deployedToken !== null
+            }
+          />
+        </div>
+        <div className="break-all text-muted-foreground text-xs">
+          {node.address}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <LoadingState className="h-32" />
+      ) : error ? (
+        <ErrorState message={error.message} />
+      ) : data?.deployedToken === null || data === undefined ? (
+        <MissingTokenDetails node={node} chains={chains} />
+      ) : (
+        <DeployedTokenDetails
+          token={data.deployedToken}
+          abstractToken={data.abstractToken}
+          chains={chains}
+        />
+      )}
+
+      <Separator />
+      <div className="space-y-4">
+        <h3 className="font-medium">Relations visible on this graph</h3>
+        <GraphRelationList
+          title="Outgoing"
+          emptyText="No outgoing relations."
+          relations={outgoing}
+          node={node}
+          graph={graph}
+          highlightAnomalies={highlightAnomalies}
+          onRelationClick={onRelationClick}
+        />
+        <GraphRelationList
+          title="Incoming"
+          emptyText="No incoming relations."
+          relations={incoming}
+          node={node}
+          graph={graph}
+          highlightAnomalies={highlightAnomalies}
+          onRelationClick={onRelationClick}
+        />
+      </div>
+    </div>
+  )
+}
+
+function MissingTokenDetails({
+  node,
+  chains,
+}: {
+  node: RelationGraphNode
+  chains: Chain[]
+}) {
+  const explorerUrl = findExplorerUrl(chains, node.chain)
+  return (
+    <DetailsSection title="Observed endpoint">
+      <p className="text-muted-foreground text-sm">
+        This address appears in an observed relation but is not currently in the
+        deployed token catalogue.
+      </p>
+      <DetailRows>
+        <DetailRow label="Chain">{node.chain}</DetailRow>
+        <DetailRow label="Address">
+          <AddressValue
+            chain={node.chain}
+            address={node.address}
+            explorerUrl={explorerUrl}
+          />
+        </DetailRow>
+      </DetailRows>
+    </DetailsSection>
+  )
+}
+
+function DeployedTokenDetails({
+  token,
+  abstractToken,
+  chains,
+}: {
+  token: NonNullable<
+    RouterOutputs['deployedTokens']['getRelationsGraphNodeDetails']['deployedToken']
+  >
+  abstractToken: RouterOutputs['deployedTokens']['getRelationsGraphNodeDetails']['abstractToken']
+  chains: Chain[]
+}) {
+  const explorerUrl = findExplorerUrl(chains, token.chain)
+
+  return (
+    <div className="space-y-5">
+      <DetailsSection title="Deployed token">
+        <div className="flex flex-wrap gap-3 text-sm">
+          <NewTabLink to={`/tokens/${token.chain}/${token.address}`}>
+            Open deployed token page
+          </NewTabLink>
+          {explorerUrl && token.address !== 'native' && (
+            <ExplorerLink
+              explorerUrl={explorerUrl}
+              value={token.address}
+              type="address"
+            >
+              Open in explorer
+            </ExplorerLink>
+          )}
+        </div>
+        <DetailRows>
+          <DetailRow label="Symbol">{token.symbol}</DetailRow>
+          <DetailRow label="Chain">{token.chain}</DetailRow>
+          <DetailRow label="Address">
+            <AddressValue
+              chain={token.chain}
+              address={token.address}
+              explorerUrl={explorerUrl}
+            />
+          </DetailRow>
+          <DetailRow label="Decimals">{token.decimals}</DetailRow>
+          <DetailRow label="Deployed">
+            {formatUnixTimestamp(token.deploymentTimestamp)}
+          </DetailRow>
+          {token.comment && (
+            <DetailRow label="Comment">{token.comment}</DetailRow>
+          )}
+        </DetailRows>
+        {token.metadata !== null && (
+          <JsonDetails label="Metadata" value={token.metadata} />
+        )}
+        {token.abstractTokenAssignmentProof != null && (
+          <JsonDetails
+            label="Abstract assignment proof"
+            value={token.abstractTokenAssignmentProof}
+          />
+        )}
+      </DetailsSection>
+
+      <DetailsSection title="Abstract token">
+        {abstractToken === null ? (
+          <div className="text-muted-foreground text-sm">
+            No abstract token assigned.
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-3">
+              {abstractToken.iconUrl && (
+                <img
+                  src={abstractToken.iconUrl}
+                  alt=""
+                  className="size-9 rounded-full bg-muted object-cover"
+                />
+              )}
+              <div>
+                <div className="font-medium">{abstractToken.symbol}</div>
+                <NewTabLink to={`/tokens/${abstractToken.id}`}>
+                  Open abstract token page
+                </NewTabLink>
+              </div>
+            </div>
+            <DetailRows>
+              <DetailRow label="ID">{abstractToken.id}</DetailRow>
+              <DetailRow label="Issuer">
+                {abstractToken.issuer ?? '—'}
+              </DetailRow>
+              <DetailRow label="Category">
+                {abstractToken.category ?? '—'}
+              </DetailRow>
+              <DetailRow label="Reviewed">
+                {abstractToken.reviewed ? 'Yes' : 'No'}
+              </DetailRow>
+              <DetailRow label="Price unreliable">
+                {abstractToken.isPriceUnreliable ? 'Yes' : 'No'}
+              </DetailRow>
+              {abstractToken.comment && (
+                <DetailRow label="Comment">{abstractToken.comment}</DetailRow>
+              )}
+            </DetailRows>
+          </>
+        )}
+      </DetailsSection>
+    </div>
+  )
+}
+
+function GraphRelationList({
+  title,
+  emptyText,
+  relations,
+  node,
+  graph,
+  highlightAnomalies,
+  onRelationClick,
+}: {
+  title: string
+  emptyText: string
+  relations: RelationGraphRelation[]
+  node: RelationGraphNode
+  graph: RelationGraph
+  highlightAnomalies: boolean
+  onRelationClick: (relation: RelationGraphRelation) => void
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        {title} ({relations.length})
+      </div>
+      {relations.length === 0 ? (
+        <div className="text-muted-foreground text-sm">{emptyText}</div>
+      ) : (
+        <div className="space-y-1.5">
+          {relations.map((relation) => {
+            const otherId =
+              sourceId(relation) === node.id
+                ? targetId(relation)
+                : sourceId(relation)
+            const otherNode = findNode(graph, otherId)
+            return (
+              <button
+                key={relationId(relation)}
+                type="button"
+                onClick={() => onRelationClick(relation)}
+                className="flex w-full cursor-pointer items-center gap-3 rounded-md border p-2 text-left text-sm hover:bg-muted"
+              >
+                <span
+                  className="h-0.5 w-7 shrink-0 rounded-full"
+                  style={{
+                    background: displayedRelationColor(
+                      relation,
+                      highlightAnomalies,
+                    ),
+                  }}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-medium">
+                    {nodeLabel(otherNode)} on {otherNode.chain}
+                  </span>
+                  <span className="block truncate text-muted-foreground text-xs">
+                    {relationTypeLabel(relation)} · {relation.plugin}
+                  </span>
+                </span>
+                <ArrowRightIcon className="size-4 shrink-0 text-muted-foreground" />
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function GraphRelationDetails({
+  relation,
+  graph,
+  chains,
+  highlightAnomalies,
+}: {
+  relation: RelationGraphRelation
+  graph: RelationGraph
+  chains: Chain[]
+  highlightAnomalies: boolean
+}) {
+  const trpc = useTRPC()
+  const { data, isLoading, error } = useQuery(
+    trpc.deployedTokens.getRelationsGraphRelationDetails.queryOptions(
+      relationPrimaryKey(relation),
+    ),
+  )
+  const source = findNode(graph, sourceId(relation))
+  const target = findNode(graph, targetId(relation))
+  const color = displayedRelationColor(relation, highlightAnomalies)
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant="outline" style={{ borderColor: color, color }}>
+            {relationTypeLabel(relation)}
+          </Badge>
+          {relation.isConflict && (
+            <Badge variant="destructive">Assignment anomaly</Badge>
+          )}
+        </div>
+        <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-2">
+          <EndpointCard node={source} chains={chains} />
+          <ArrowRightIcon className="size-5 text-muted-foreground" />
+          <EndpointCard node={target} chains={chains} />
+        </div>
+        <div className="text-center text-muted-foreground text-xs">
+          Observed direction
+        </div>
+      </div>
+
+      <DetailsSection title="Relation">
+        <DetailRows>
+          <DetailRow label="From">
+            {source.chain}:{source.address}
+          </DetailRow>
+          <DetailRow label="To">
+            {target.chain}:{target.address}
+          </DetailRow>
+          <DetailRow label="Bridge type">
+            {relationTypeLabel(relation)}
+          </DetailRow>
+          <DetailRow label="Plugin">{relation.plugin}</DetailRow>
+        </DetailRows>
+        {relation.isConflict && (
+          <p className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm">
+            Both deployed endpoints are assigned to different abstract tokens.
+          </p>
+        )}
+      </DetailsSection>
+
+      {isLoading ? (
+        <LoadingState className="h-32" />
+      ) : error ? (
+        <ErrorState message={error.message} />
+      ) : data ? (
+        <RelationEvidence relation={data} chains={chains} />
+      ) : null}
+    </div>
+  )
+}
+
+function EndpointCard({
+  node,
+  chains,
+}: {
+  node: RelationGraphNode
+  chains: Chain[]
+}) {
+  const explorerUrl = findExplorerUrl(chains, node.chain)
+  return (
+    <div className="min-w-0 rounded-md border p-2 text-center">
+      <div className="truncate font-medium text-sm">{nodeLabel(node)}</div>
+      <div className="truncate text-muted-foreground text-xs">{node.chain}</div>
+      <div className="mt-1 flex justify-center gap-2 text-xs">
+        {node.isDeployed && (
+          <NewTabLink to={`/tokens/${node.chain}/${node.address}`}>
+            Token
+          </NewTabLink>
+        )}
+        {explorerUrl && node.address !== 'native' && (
+          <ExplorerLink
+            explorerUrl={explorerUrl}
+            value={node.address}
+            type="address"
+          >
+            Explorer
+          </ExplorerLink>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function RelationEvidence({
+  relation,
+  chains,
+}: {
+  relation: RelationDetails
+  chains: Chain[]
+}) {
+  const evidence = readTransferEvidence(relation.transfer)
+
+  return (
+    <DetailsSection title="Sample transfer evidence">
+      <DetailRows>
+        {evidence.transferId && (
+          <DetailRow label="Transfer ID">{evidence.transferId}</DetailRow>
+        )}
+        {evidence.type && <DetailRow label="Type">{evidence.type}</DetailRow>}
+        {evidence.timestamp !== undefined && (
+          <DetailRow label="Timestamp">
+            {formatUnixTimestamp(evidence.timestamp)}
+          </DetailRow>
+        )}
+        <DetailRow label={`${relation.tokenFromChain} tx`}>
+          <TransactionValue
+            chain={relation.tokenFromChain}
+            txHash={evidence.srcTxHash}
+            chains={chains}
+          />
+        </DetailRow>
+        <DetailRow label={`${relation.tokenToChain} tx`}>
+          <TransactionValue
+            chain={relation.tokenToChain}
+            txHash={evidence.dstTxHash}
+            chains={chains}
+          />
+        </DetailRow>
+      </DetailRows>
+      <JsonDetails label="Raw transfer evidence" value={relation.transfer} />
+    </DetailsSection>
+  )
+}
+
+function TransactionValue({
+  chain,
+  txHash,
+  chains,
+}: {
+  chain: string
+  txHash: string | undefined
+  chains: Chain[]
+}) {
+  if (txHash === undefined) {
+    return <span className="text-muted-foreground">Not present</span>
+  }
+  const explorerUrl = findExplorerUrl(chains, chain)
+  if (explorerUrl === undefined) {
+    return <span className="break-all">{txHash}</span>
+  }
+  return (
+    <ExplorerLink explorerUrl={explorerUrl} value={txHash} type="tx">
+      <span className="break-all">{txHash}</span>
+    </ExplorerLink>
+  )
+}
+
+function AddressValue({
+  chain,
+  address,
+  explorerUrl,
+}: {
+  chain: string
+  address: string
+  explorerUrl: string | undefined
+}) {
+  if (explorerUrl === undefined || address === 'native') {
+    return <span className="break-all">{address}</span>
+  }
+  return (
+    <ExplorerLink explorerUrl={explorerUrl} value={address} type="address">
+      <span className="break-all">
+        {chain}:{address}
+      </span>
+    </ExplorerLink>
+  )
+}
+
+function DeploymentBadge({ deployed }: { deployed: boolean }) {
+  return (
+    <Badge
+      variant="outline"
+      className={
+        deployed
+          ? 'border-green-500/60 text-green-600 dark:text-green-400'
+          : 'border-orange-500/60 text-orange-600 dark:text-orange-400'
+      }
+    >
+      {deployed ? 'Deployed' : 'Missing'}
+    </Badge>
+  )
+}
+
+function DetailsSection({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-3">
+      <h3 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        {title}
+      </h3>
+      {children}
+    </section>
+  )
+}
+
+function DetailRows({ children }: { children: ReactNode }) {
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+      {children}
+    </dl>
+  )
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 break-words text-right">{children}</dd>
+    </>
+  )
+}
+
+function JsonDetails({ label, value }: { label: string; value: unknown }) {
+  const json = JSON.stringify(value, null, 2)
+  if (json === undefined) {
+    throw new Error(`Cannot serialize ${label}`)
+  }
+  return (
+    <details className="rounded-md border p-2">
+      <summary className="cursor-pointer text-muted-foreground text-xs">
+        {label}
+      </summary>
+      <pre className="mt-2 max-h-64 overflow-auto rounded bg-muted p-2 text-xs">
+        {json}
+      </pre>
+    </details>
+  )
+}
+
+function NewTabLink({ to, children }: { to: string; children: ReactNode }) {
+  return (
+    <Link
+      to={to}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-blue-500 underline hover:text-blue-600"
+    >
+      {children}
+      <ExternalLinkIcon className="size-3" />
+    </Link>
+  )
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="grid h-full min-h-24 place-items-center p-4 text-center text-destructive text-sm">
+      {message}
+    </div>
+  )
+}
+
+function findNode(graph: RelationGraph, id: string) {
+  const node = graph.nodes.find((node) => node.id === id)
+  if (node === undefined) {
+    throw new Error(`Graph node ${id} does not exist`)
+  }
+  return node
+}
+
+function findRelation(graph: RelationGraph, id: string) {
+  const relation = graph.relations.find(
+    (relation) => relationId(relation) === id,
+  )
+  if (relation === undefined) {
+    throw new Error(`Graph relation ${id} does not exist`)
+  }
+  return relation
+}
+
+function displayedRelationColor(
+  relation: RelationGraphRelation,
+  highlightAnomalies: boolean,
+) {
+  if (!highlightAnomalies) return relationColor(relation)
+  return relation.isConflict ? RELATION_COLORS.conflict : RELATION_COLORS.muted
+}
+
+function findExplorerUrl(chains: Chain[], chainName: string) {
+  return (
+    chains.find((chain) => chain.name === chainName)?.explorerUrl ?? undefined
+  )
+}
+
+function formatUnixTimestamp(timestamp: number) {
+  return new Date(timestamp * 1_000).toLocaleString()
+}
+
+function readTransferEvidence(transfer: RelationDetails['transfer']) {
+  if (
+    transfer === null ||
+    Array.isArray(transfer) ||
+    typeof transfer !== 'object'
+  ) {
+    throw new Error('Token relation transfer evidence must be an object')
+  }
+
+  return {
+    transferId: optionalString(transfer, 'transferId'),
+    type: optionalString(transfer, 'type'),
+    timestamp: optionalNumber(transfer, 'timestamp'),
+    srcTxHash: optionalString(transfer, 'srcTxHash'),
+    dstTxHash: optionalString(transfer, 'dstTxHash'),
+  }
+}
+
+function optionalString(value: Record<string, unknown>, key: string) {
+  const field = value[key]
+  if (field === undefined) return undefined
+  if (typeof field !== 'string') {
+    throw new Error(`Token relation transfer evidence ${key} must be a string`)
+  }
+  return field
+}
+
+function optionalNumber(value: Record<string, unknown>, key: string) {
+  const field = value[key]
+  if (field === undefined) return undefined
+  if (typeof field !== 'number') {
+    throw new Error(`Token relation transfer evidence ${key} must be a number`)
+  }
+  return field
+}

--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
@@ -1,52 +1,78 @@
-import type { RouterOutputs } from '@l2beat/token-backend'
 import { useQuery } from '@tanstack/react-query'
-import * as d3 from 'd3'
-import { type RefObject, useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { LoadingState } from '~/components/LoadingState'
 import { AppLayout } from '~/layouts/AppLayout'
 import { useTRPC } from '~/react-query/trpc'
+import { cn } from '~/utils/cn'
 import {
-  type LayoutLink,
-  type LayoutNode,
-  layoutRelationGraph,
-} from './relationGraphLayout'
-
-type Graph = RouterOutputs['deployedTokens']['getRelationsGraph']
-type Relation = Graph['relations'][number]
-type NodeDatum = Graph['nodes'][number] & LayoutNode
-type VisualLink = LayoutLink<NodeDatum> & {
-  relation: Relation
-  curve: number
-}
+  NODE_COLORS,
+  RELATION_COLORS,
+  type RelationGraph,
+  type RelationGraphSelection,
+} from './relationGraphModel'
+import { TokenRelationsGraph } from './TokenRelationsGraph'
+import { TokenRelationsGraphDetailsPanel } from './TokenRelationsGraphDetailsPanel'
 
 export function TokenRelationsGraphPage() {
   const trpc = useTRPC()
-  const { data, isLoading } = useQuery(
+  const [selection, setSelection] = useState<RelationGraphSelection>()
+  const [highlightAnomalies, setHighlightAnomalies] = useState(false)
+  const graphQuery = useQuery(
     trpc.deployedTokens.getRelationsGraph.queryOptions(),
   )
+  const chainsQuery = useQuery(trpc.chains.getAll.queryOptions())
+  const graph = graphQuery.data
 
   return (
     <AppLayout className="min-h-svh">
       <div className="flex h-[calc(100vh-1rem)] flex-col gap-3">
-        <div className="flex items-end justify-between gap-4">
+        <div className="flex flex-wrap items-end justify-between gap-4">
           <div>
             <h1 className="font-semibold text-xl">Token Relations Graph</h1>
             <div className="text-muted-foreground text-sm">
-              {data
-                ? `${data.nodes.length} deployed tokens, ${data.relations.length} relations`
-                : 'Loading graph data'}
+              {graph
+                ? graphSummary(graph)
+                : graphQuery.isError
+                  ? 'Graph unavailable'
+                  : 'Loading graph data'}
             </div>
           </div>
+          <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 text-xs">
+            <GraphLegend />
+            <AnomalySwitch
+              checked={highlightAnomalies}
+              onCheckedChange={setHighlightAnomalies}
+            />
+          </div>
         </div>
-        <div className="min-h-0 flex-1 overflow-hidden rounded-md border bg-background">
-          {isLoading || data === undefined ? (
+        <div className="relative min-h-0 flex-1 overflow-hidden rounded-md border bg-background">
+          {graphQuery.isError ? (
+            <div className="grid h-full place-items-center p-4 text-center text-destructive text-sm">
+              {graphQuery.error.message}
+            </div>
+          ) : graphQuery.isLoading || graph === undefined ? (
             <LoadingState className="h-full" />
-          ) : data.nodes.length === 0 ? (
+          ) : graph.nodes.length === 0 ? (
             <div className="grid h-full place-items-center text-muted-foreground text-sm">
               No token relations.
             </div>
           ) : (
-            <TokenRelationsGraph graph={data} />
+            <TokenRelationsGraph
+              graph={graph}
+              selection={selection}
+              highlightAnomalies={highlightAnomalies}
+              onSelectionChange={setSelection}
+            />
+          )}
+          {graph && selection && (
+            <TokenRelationsGraphDetailsPanel
+              graph={graph}
+              chains={chainsQuery.data ?? []}
+              selection={selection}
+              highlightAnomalies={highlightAnomalies}
+              onSelectionChange={setSelection}
+              onClose={() => setSelection(undefined)}
+            />
           )}
         </div>
       </div>
@@ -54,288 +80,70 @@ export function TokenRelationsGraphPage() {
   )
 }
 
-function TokenRelationsGraph({ graph }: { graph: Graph }) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const svgRef = useRef<SVGSVGElement>(null)
-  const size = useElementSize(containerRef)
-
-  useEffect(() => {
-    if (!svgRef.current || size.width === 0 || size.height === 0) return
-
-    const nodes = graph.nodes.map((node): NodeDatum => ({ ...node }))
-    const nodeById = new Map(nodes.map((node) => [node.id, node]))
-    const visualLinks = buildVisualLinks(graph.relations, nodeById)
-    const simulationLinks = buildSimulationLinks(visualLinks)
-    const layout = layoutRelationGraph(nodes, simulationLinks)
-    const chainColor = d3
-      .scaleOrdinal<string, string>(d3.schemeTableau10)
-      .domain([...new Set(nodes.map((node) => node.chain))].sort())
-
-    const svg = d3.select(svgRef.current)
-    svg.selectAll('*').remove()
-    svg.attr('viewBox', `0 0 ${size.width} ${size.height}`)
-
-    const layer = svg.append('g')
-    const linksLayer = layer.append('g')
-    const nodesLayer = layer.append('g')
-
-    svg
-      .append('defs')
-      .selectAll('marker')
-      .data([
-        { id: 'token-relation-arrow', color: 'var(--muted-foreground)' },
-        { id: 'token-relation-conflict-arrow', color: 'var(--destructive)' },
-      ])
-      .join('marker')
-      .attr('id', (marker) => marker.id)
-      .attr('viewBox', '0 0 10 10')
-      .attr('refX', 8)
-      .attr('refY', 5)
-      .attr('markerWidth', 6)
-      .attr('markerHeight', 6)
-      .attr('orient', 'auto')
-      .append('path')
-      .attr('d', 'M 0 0 L 10 5 L 0 10 z')
-      .attr('fill', (marker) => marker.color)
-
-    const fitScale = Math.min(
-      (size.width - 32) / layout.width,
-      (size.height - 32) / layout.height,
-      1,
-    )
-    const zoom = d3
-      .zoom<SVGSVGElement, unknown>()
-      .scaleExtent([Math.min(fitScale / 2, 0.1), 8])
-      .on('zoom', (event) => {
-        layer.attr('transform', event.transform.toString())
-      })
-    svg.call(zoom)
-
-    const links = linksLayer
-      .selectAll<SVGPathElement, VisualLink>('path')
-      .data(visualLinks, (link) => relationId(link.relation))
-      .join('path')
-      .attr('fill', 'none')
-      .attr('stroke', (link) =>
-        link.relation.isConflict
-          ? 'var(--destructive)'
-          : 'var(--muted-foreground)',
-      )
-      .attr('stroke-opacity', (link) => (link.relation.isConflict ? 0.9 : 0.45))
-      .attr('stroke-width', (link) => (link.relation.isConflict ? 2 : 1.2))
-      .attr('marker-end', (link) =>
-        link.relation.isConflict
-          ? 'url(#token-relation-conflict-arrow)'
-          : 'url(#token-relation-arrow)',
-      )
-
-    links.append('title').text((link) => {
-      const relation = link.relation
-      return `${formatEndpoint(relation.tokenFromChain, relation.tokenFromAddress)} -> ${formatEndpoint(relation.tokenToChain, relation.tokenToAddress)} via ${relation.plugin} (${relation.bridgeType})${relation.isConflict ? '\nConflict: endpoints belong to different abstract tokens' : ''}`
-    })
-
-    const node = nodesLayer
-      .selectAll<SVGGElement, NodeDatum>('g')
-      .data(nodes, (node) => node.id)
-      .join('g')
-      .attr('cursor', 'grab')
-
-    node
-      .append('circle')
-      .attr('r', nodeRadius())
-      .attr('fill', (node) => chainColor(node.chain))
-      .attr('stroke', 'var(--background)')
-      .attr('stroke-width', 2)
-
-    node
-      .append('text')
-      .attr('x', 0)
-      .attr('y', -12)
-      .attr('text-anchor', 'middle')
-      .attr('paint-order', 'stroke')
-      .attr('stroke', 'var(--background)')
-      .attr('stroke-width', 3)
-      .attr('fill', 'var(--foreground)')
-      .attr('font-size', 11)
-      .attr('font-weight', 600)
-      .text((node) => node.symbol)
-
-    node
-      .append('title')
-      .text(
-        (node) =>
-          `${node.symbol} on ${node.chain}\n${formatEndpoint(node.chain, node.address)}`,
-      )
-
-    function redraw() {
-      links.attr('d', linkPath)
-      node.attr('transform', (node) => `translate(${node.x},${node.y})`)
-    }
-    redraw()
-
-    const initialTransform = d3.zoomIdentity
-      .translate(
-        (size.width - layout.width * fitScale) / 2,
-        (size.height - layout.height * fitScale) / 2,
-      )
-      .scale(fitScale)
-    svg.call(zoom.transform, initialTransform)
-
-    node.call(
-      d3
-        .drag<SVGGElement, NodeDatum>()
-        .on('start', (event) => {
-          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'grabbing')
-        })
-        .on('drag', (event, node) => {
-          node.x = event.x
-          node.y = event.y
-          redraw()
-        })
-        .on('end', (event) => {
-          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'grab')
-        }),
-    )
-  }, [graph, size.height, size.width])
-
+function GraphLegend() {
   return (
-    <div ref={containerRef} className="h-full w-full">
-      <svg ref={svgRef} className="h-full w-full" />
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-muted-foreground">
+      <LegendDot color={NODE_COLORS.deployed} label="Deployed" />
+      <LegendDot color={NODE_COLORS.missing} label="Missing" />
+      <LegendLine color={RELATION_COLORS.burnAndMint} label="Burn & Mint" />
+      <LegendLine color={RELATION_COLORS.lockAndMint} label="Lock & Mint" />
     </div>
   )
 }
 
-function useElementSize<T extends HTMLElement>(ref: RefObject<T | null>) {
-  const [size, setSize] = useState({ width: 0, height: 0 })
-
-  useEffect(() => {
-    if (!ref.current) return
-
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0]
-      if (!entry) return
-
-      setSize({
-        width: entry.contentRect.width,
-        height: entry.contentRect.height,
-      })
-    })
-    observer.observe(ref.current)
-
-    return () => observer.disconnect()
-  }, [ref])
-
-  return size
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="size-2 rounded-full" style={{ background: color }} />
+      {label}
+    </span>
+  )
 }
 
-function buildVisualLinks(
-  relations: Relation[],
-  nodeById: Map<string, NodeDatum>,
-): VisualLink[] {
-  const relationGroups = new Map<string, Relation[]>()
-  for (const relation of relations) {
-    const key = unorderedPairKey(sourceId(relation), targetId(relation))
-    const group = relationGroups.get(key)
-    if (group === undefined) {
-      relationGroups.set(key, [relation])
-    } else {
-      group.push(relation)
-    }
-  }
-
-  return relations.map((relation) => {
-    const source = nodeById.get(sourceId(relation))
-    const target = nodeById.get(targetId(relation))
-    if (source === undefined || target === undefined) {
-      throw new Error('Relation graph contains an unknown endpoint')
-    }
-
-    const group = relationGroups.get(
-      unorderedPairKey(sourceId(relation), targetId(relation)),
-    )
-    if (group === undefined) {
-      throw new Error('Relation graph contains an ungrouped relation')
-    }
-    const index = group.findIndex(
-      (entry) => relationId(entry) === relationId(relation),
-    )
-    const curve = (index - (group.length - 1) / 2) * 16
-
-    return { source, target, relation, curve }
-  })
+function LegendLine({ color, label }: { color: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="h-0.5 w-5 rounded-full" style={{ background: color }} />
+      {label}
+    </span>
+  )
 }
 
-function buildSimulationLinks(visualLinks: VisualLink[]) {
-  const links = new Map<string, LayoutLink<NodeDatum>>()
-  for (const link of visualLinks) {
-    links.set(unorderedPairKey(link.source.id, link.target.id), {
-      source: link.source,
-      target: link.target,
-    })
-  }
-  return [...links.values()]
+function AnomalySwitch({
+  checked,
+  onCheckedChange,
+}: {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+      className="inline-flex cursor-pointer items-center gap-2 rounded-md border bg-background px-2.5 py-1.5 font-medium outline-none hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span
+        className={cn(
+          'relative inline-block h-5 w-9 shrink-0 rounded-full transition-colors',
+          checked ? 'bg-destructive' : 'bg-muted-foreground/35',
+        )}
+      >
+        <span
+          className={cn(
+            'absolute top-0.5 left-0.5 size-4 rounded-full bg-white shadow transition-transform',
+            checked ? 'translate-x-4' : 'translate-x-0',
+          )}
+        />
+      </span>
+      Highlight anomalies
+    </button>
+  )
 }
 
-function linkPath(link: VisualLink) {
-  const sourceX = link.source.x ?? 0
-  const sourceY = link.source.y ?? 0
-  const targetX = link.target.x ?? 0
-  const targetY = link.target.y ?? 0
-  const dx = targetX - sourceX
-  const dy = targetY - sourceY
-  const distance = Math.sqrt(dx * dx + dy * dy)
-  if (distance === 0) return `M${sourceX},${sourceY}`
-
-  const ux = dx / distance
-  const uy = dy / distance
-  const sx = sourceX + ux * (nodeRadius() + 2)
-  const sy = sourceY + uy * (nodeRadius() + 2)
-  const tx = targetX - ux * (nodeRadius() + 7)
-  const ty = targetY - uy * (nodeRadius() + 7)
-
-  if (link.curve === 0) {
-    return `M${sx},${sy} L${tx},${ty}`
-  }
-
-  const nx = -uy
-  const ny = ux
-  const mx = (sx + tx) / 2 + nx * link.curve
-  const my = (sy + ty) / 2 + ny * link.curve
-
-  return `M${sx},${sy} Q${mx},${my} ${tx},${ty}`
-}
-
-function nodeRadius() {
-  return 7
-}
-
-function relationId(relation: Relation) {
-  return [
-    relation.tokenFromChain,
-    relation.tokenFromAddress,
-    relation.tokenToChain,
-    relation.tokenToAddress,
-    relation.plugin,
-    relation.bridgeType,
-  ].join(':')
-}
-
-function sourceId(relation: Relation) {
-  return tokenId(relation.tokenFromChain, relation.tokenFromAddress)
-}
-
-function targetId(relation: Relation) {
-  return tokenId(relation.tokenToChain, relation.tokenToAddress)
-}
-
-function tokenId(chain: string, address: string) {
-  return `${chain}:${address.toLowerCase()}`
-}
-
-function unorderedPairKey(a: string, b: string) {
-  return a < b ? `${a}|${b}` : `${b}|${a}`
-}
-
-function formatEndpoint(chain: string, address: string) {
-  return `${chain}:${address}`
+function graphSummary(graph: RelationGraph) {
+  const deployed = graph.nodes.filter((node) => node.isDeployed).length
+  const missing = graph.nodes.length - deployed
+  return `${deployed} deployed tokens, ${missing} missing endpoints, ${graph.relations.length} relations`
 }

--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraphPage.tsx
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { LoadingState } from '~/components/LoadingState'
 import { AppLayout } from '~/layouts/AppLayout'
 import { useTRPC } from '~/react-query/trpc'
 import { cn } from '~/utils/cn'
 import {
+  getExistingRelationGraphSelection,
   NODE_COLORS,
   RELATION_COLORS,
   type RelationGraph,
@@ -22,6 +23,20 @@ export function TokenRelationsGraphPage() {
   )
   const chainsQuery = useQuery(trpc.chains.getAll.queryOptions())
   const graph = graphQuery.data
+  const graphSelection =
+    graph === undefined
+      ? undefined
+      : getExistingRelationGraphSelection(graph, selection)
+
+  useEffect(() => {
+    if (
+      graph !== undefined &&
+      selection !== undefined &&
+      graphSelection === undefined
+    ) {
+      setSelection(undefined)
+    }
+  }, [graph, graphSelection, selection])
 
   return (
     <AppLayout className="min-h-svh">
@@ -59,16 +74,16 @@ export function TokenRelationsGraphPage() {
           ) : (
             <TokenRelationsGraph
               graph={graph}
-              selection={selection}
+              selection={graphSelection}
               highlightAnomalies={highlightAnomalies}
               onSelectionChange={setSelection}
             />
           )}
-          {graph && selection && (
+          {graph && graphSelection && (
             <TokenRelationsGraphDetailsPanel
               graph={graph}
               chains={chainsQuery.data ?? []}
-              selection={selection}
+              selection={graphSelection}
               highlightAnomalies={highlightAnomalies}
               onSelectionChange={setSelection}
               onClose={() => setSelection(undefined)}

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'earl'
 import {
   getClusterLabelStyle,
+  getExistingRelationGraphSelection,
   getRelationGraphFocus,
   mostCommonDeployedSymbol,
   type RelationGraph,
@@ -61,23 +62,49 @@ describe(getClusterLabelStyle.name, () => {
   })
 })
 
-describe(getRelationGraphFocus.name, () => {
-  const relations = [
-    relation('ethereum', '0xaaa', 'base', '0xbbb', 'first'),
-    relation('ethereum', '0xaaa', 'optimism', '0xccc', 'second'),
-    relation('arbitrum', '0xddd', 'linea', '0xeee', 'unrelated'),
-  ]
-  const graph: RelationGraph = {
-    nodes: [
-      graphNode('ethereum', '0xaaa'),
-      graphNode('base', '0xbbb'),
-      graphNode('optimism', '0xccc'),
-      graphNode('arbitrum', '0xddd'),
-      graphNode('linea', '0xeee'),
-    ],
-    relations,
-  }
+const relations = [
+  relation('ethereum', '0xaaa', 'base', '0xbbb', 'first'),
+  relation('ethereum', '0xaaa', 'optimism', '0xccc', 'second'),
+  relation('arbitrum', '0xddd', 'linea', '0xeee', 'unrelated'),
+]
+const graph: RelationGraph = {
+  nodes: [
+    graphNode('ethereum', '0xaaa'),
+    graphNode('base', '0xbbb'),
+    graphNode('optimism', '0xccc'),
+    graphNode('arbitrum', '0xddd'),
+    graphNode('linea', '0xeee'),
+  ],
+  relations,
+}
 
+describe(getExistingRelationGraphSelection.name, () => {
+  it('keeps selections that exist in the graph', () => {
+    const selectedNode = graph.nodes[0]
+    if (selectedNode === undefined) throw new Error('Missing test node')
+    const selection = { type: 'node', id: selectedNode.id } as const
+    expect(getExistingRelationGraphSelection(graph, selection)).toEqual(
+      selection,
+    )
+  })
+
+  it('clears selections that no longer exist in the graph', () => {
+    expect(
+      getExistingRelationGraphSelection(graph, {
+        type: 'node',
+        id: 'missing:node',
+      }),
+    ).toEqual(undefined)
+    expect(
+      getExistingRelationGraphSelection(graph, {
+        type: 'relation',
+        id: 'missing:relation',
+      }),
+    ).toEqual(undefined)
+  })
+})
+
+describe(getRelationGraphFocus.name, () => {
   it('collects a selected node, its neighbors, and its incident relations', () => {
     const focus = requiredFocus(
       getRelationGraphFocus(graph, {

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
@@ -1,0 +1,179 @@
+import { expect } from 'earl'
+import {
+  getClusterLabelStyle,
+  getRelationGraphFocus,
+  mostCommonDeployedSymbol,
+  type RelationGraph,
+  type RelationGraphFocus,
+  type RelationGraphNode,
+  type RelationGraphRelation,
+  relationId,
+  tokenId,
+} from './relationGraphModel'
+
+describe(mostCommonDeployedSymbol.name, () => {
+  it('uses the most common deployed symbol and ignores missing endpoints', () => {
+    expect(
+      mostCommonDeployedSymbol([
+        node('ethereum:1', 'USDC'),
+        node('base:1', 'USDT'),
+        node('arbitrum:1', 'USDC'),
+        missingNode('optimism:1'),
+      ]),
+    ).toEqual('USDC')
+  })
+
+  it('uses symbol order as a stable tie-breaker', () => {
+    expect(
+      mostCommonDeployedSymbol([
+        node('ethereum:1', 'WETH'),
+        node('base:1', 'ETH'),
+      ]),
+    ).toEqual('ETH')
+  })
+
+  it('preserves the symbol casing', () => {
+    expect(mostCommonDeployedSymbol([node('ethereum:1', 'stETH')])).toEqual(
+      'stETH',
+    )
+  })
+})
+
+describe(getClusterLabelStyle.name, () => {
+  it('stops increasing labels below the minimum scale', () => {
+    expect(getClusterLabelStyle(0.25)).toEqual({
+      fontSize: 72,
+      strokeWidth: 16,
+      opacity: 0.8,
+    })
+    expect(getClusterLabelStyle(0.1).fontSize).toEqual(72)
+    expect(getClusterLabelStyle(0.1).strokeWidth).toEqual(16)
+  })
+
+  it('hides labels at extreme zoom-out', () => {
+    expect(getClusterLabelStyle(0.05).opacity).toEqual(0)
+  })
+
+  it('rejects invalid scales', () => {
+    expect(() => getClusterLabelStyle(0)).toThrow(
+      'Graph scale must be a positive finite number',
+    )
+  })
+})
+
+describe(getRelationGraphFocus.name, () => {
+  const relations = [
+    relation('ethereum', '0xaaa', 'base', '0xbbb', 'first'),
+    relation('ethereum', '0xaaa', 'optimism', '0xccc', 'second'),
+    relation('arbitrum', '0xddd', 'linea', '0xeee', 'unrelated'),
+  ]
+  const graph: RelationGraph = {
+    nodes: [
+      graphNode('ethereum', '0xaaa'),
+      graphNode('base', '0xbbb'),
+      graphNode('optimism', '0xccc'),
+      graphNode('arbitrum', '0xddd'),
+      graphNode('linea', '0xeee'),
+    ],
+    relations,
+  }
+
+  it('collects a selected node, its neighbors, and its incident relations', () => {
+    const focus = requiredFocus(
+      getRelationGraphFocus(graph, {
+        type: 'node',
+        id: tokenId('ethereum', '0xaaa'),
+      }),
+    )
+
+    expect([...focus.nodeIds].sort()).toEqual(
+      [
+        tokenId('ethereum', '0xaaa'),
+        tokenId('base', '0xbbb'),
+        tokenId('optimism', '0xccc'),
+      ].sort(),
+    )
+    expect([...focus.relationIds].sort()).toEqual(
+      relations.slice(0, 2).map(relationId).sort(),
+    )
+  })
+
+  it('collects only the endpoints of a selected relation', () => {
+    const selectedRelation = relations[1]
+    if (selectedRelation === undefined) {
+      throw new Error('Missing test relation')
+    }
+    const focus = requiredFocus(
+      getRelationGraphFocus(graph, {
+        type: 'relation',
+        id: relationId(selectedRelation),
+      }),
+    )
+
+    expect([...focus.nodeIds].sort()).toEqual(
+      [
+        tokenId(
+          selectedRelation.tokenFromChain,
+          selectedRelation.tokenFromAddress,
+        ),
+        tokenId(selectedRelation.tokenToChain, selectedRelation.tokenToAddress),
+      ].sort(),
+    )
+    expect([...focus.relationIds]).toEqual([relationId(selectedRelation)])
+  })
+})
+
+function node(id: string, symbol: string): RelationGraphNode {
+  return {
+    id,
+    symbol,
+    chain: id.split(':')[0] ?? '',
+    address: id,
+    isDeployed: true,
+  }
+}
+
+function missingNode(id: string): RelationGraphNode {
+  return {
+    id,
+    symbol: null,
+    chain: id.split(':')[0] ?? '',
+    address: id,
+    isDeployed: false,
+  }
+}
+
+function graphNode(chain: string, address: string): RelationGraphNode {
+  return {
+    id: tokenId(chain, address),
+    symbol: 'TOKEN',
+    chain,
+    address,
+    isDeployed: true,
+  }
+}
+
+function relation(
+  tokenFromChain: string,
+  tokenFromAddress: string,
+  tokenToChain: string,
+  tokenToAddress: string,
+  plugin: string,
+): RelationGraphRelation {
+  return {
+    tokenFromChain,
+    tokenFromAddress,
+    tokenToChain,
+    tokenToAddress,
+    plugin,
+    bridgeType: 'lockAndMint',
+    isConflict: false,
+  }
+}
+
+function requiredFocus(
+  focus: RelationGraphFocus | undefined,
+): RelationGraphFocus {
+  if (focus === undefined) throw new Error('Expected graph focus')
+  return focus
+}

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.ts
@@ -126,6 +126,21 @@ export function getClusterLabelStyle(scale: number) {
   }
 }
 
+export function getExistingRelationGraphSelection(
+  graph: RelationGraph,
+  selection: RelationGraphSelection | undefined,
+): RelationGraphSelection | undefined {
+  if (selection === undefined) return undefined
+
+  const exists =
+    selection.type === 'node'
+      ? graph.nodes.some((node) => node.id === selection.id)
+      : graph.relations.some(
+          (relation) => relationId(relation) === selection.id,
+        )
+  return exists ? selection : undefined
+}
+
 function clusterLabelOpacity(scale: number) {
   if (scale <= CLUSTER_LABEL_FADE_OUT_SCALE) return 0
   if (scale < CLUSTER_LABEL_FULL_OPACITY_SCALE) {

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.ts
@@ -1,0 +1,186 @@
+import type { RouterOutputs } from '@l2beat/token-backend'
+
+export type RelationGraph = RouterOutputs['deployedTokens']['getRelationsGraph']
+export type RelationGraphNode = RelationGraph['nodes'][number]
+export type RelationGraphRelation = RelationGraph['relations'][number]
+
+export type RelationGraphSelection =
+  | { type: 'node'; id: string }
+  | { type: 'relation'; id: string }
+
+export interface RelationGraphFocus {
+  nodeIds: Set<string>
+  relationIds: Set<string>
+}
+
+export const RELATION_COLORS = {
+  burnAndMint: '#3b82f6',
+  lockAndMint: '#ec4899',
+  conflict: '#ef4444',
+  muted: '#6b7280',
+} as const
+
+export const NODE_COLORS = {
+  deployed: '#22c55e',
+  missing: '#f97316',
+} as const
+
+const CLUSTER_LABEL_MIN_SCALE = 0.25
+const CLUSTER_LABEL_FADE_OUT_SCALE = 0.05
+const CLUSTER_LABEL_FULL_OPACITY_SCALE = 0.2
+const CLUSTER_LABEL_MAX_OPACITY = 0.8
+
+export function relationId(relation: RelationGraphRelation) {
+  return [
+    relation.tokenFromChain,
+    relation.tokenFromAddress,
+    relation.tokenToChain,
+    relation.tokenToAddress,
+    relation.plugin,
+    relation.bridgeType,
+  ].join(':')
+}
+
+export function relationPrimaryKey(relation: RelationGraphRelation) {
+  return {
+    tokenFromChain: relation.tokenFromChain,
+    tokenFromAddress: relation.tokenFromAddress,
+    tokenToChain: relation.tokenToChain,
+    tokenToAddress: relation.tokenToAddress,
+    plugin: relation.plugin,
+    bridgeType: relation.bridgeType,
+  }
+}
+
+export function sourceId(relation: RelationGraphRelation) {
+  return tokenId(relation.tokenFromChain, relation.tokenFromAddress)
+}
+
+export function targetId(relation: RelationGraphRelation) {
+  return tokenId(relation.tokenToChain, relation.tokenToAddress)
+}
+
+export function tokenId(chain: string, address: string) {
+  return `${chain}:${address.toLowerCase()}`
+}
+
+export function relationColor(relation: RelationGraphRelation) {
+  switch (relation.bridgeType) {
+    case 'burnAndMint':
+      return RELATION_COLORS.burnAndMint
+    case 'lockAndMint':
+      return RELATION_COLORS.lockAndMint
+    default:
+      throw new Error(
+        `Unexpected bridge type in relations graph: ${relation.bridgeType}`,
+      )
+  }
+}
+
+export function relationTypeLabel(relation: RelationGraphRelation) {
+  switch (relation.bridgeType) {
+    case 'burnAndMint':
+      return 'Burn & Mint'
+    case 'lockAndMint':
+      return 'Lock & Mint'
+    default:
+      throw new Error(
+        `Unexpected bridge type in relations graph: ${relation.bridgeType}`,
+      )
+  }
+}
+
+export function nodeColor(node: RelationGraphNode) {
+  return node.isDeployed ? NODE_COLORS.deployed : NODE_COLORS.missing
+}
+
+export function nodeLabel(node: RelationGraphNode) {
+  return node.symbol ?? shortAddress(node.address)
+}
+
+export function mostCommonDeployedSymbol(nodes: RelationGraphNode[]) {
+  const counts = new Map<string, number>()
+  for (const node of nodes) {
+    if (!node.isDeployed || node.symbol === null) continue
+    counts.set(node.symbol, (counts.get(node.symbol) ?? 0) + 1)
+  }
+
+  return [...counts]
+    .sort(
+      ([symbolA, countA], [symbolB, countB]) =>
+        countB - countA || symbolA.localeCompare(symbolB),
+    )
+    .at(0)?.[0]
+}
+
+export function getClusterLabelStyle(scale: number) {
+  if (!Number.isFinite(scale) || scale <= 0) {
+    throw new Error('Graph scale must be a positive finite number')
+  }
+
+  const clampedScale = Math.max(scale, CLUSTER_LABEL_MIN_SCALE)
+  return {
+    fontSize: 18 / clampedScale,
+    strokeWidth: 4 / clampedScale,
+    opacity: clusterLabelOpacity(scale),
+  }
+}
+
+function clusterLabelOpacity(scale: number) {
+  if (scale <= CLUSTER_LABEL_FADE_OUT_SCALE) return 0
+  if (scale < CLUSTER_LABEL_FULL_OPACITY_SCALE) {
+    const fadeRange =
+      CLUSTER_LABEL_FULL_OPACITY_SCALE - CLUSTER_LABEL_FADE_OUT_SCALE
+    return (
+      CLUSTER_LABEL_MAX_OPACITY *
+      ((scale - CLUSTER_LABEL_FADE_OUT_SCALE) / fadeRange)
+    )
+  }
+  if (scale <= 0.6) return CLUSTER_LABEL_MAX_OPACITY
+  if (scale >= 1) return 0
+  return CLUSTER_LABEL_MAX_OPACITY * ((1 - scale) / 0.4)
+}
+
+export function getRelationGraphFocus(
+  graph: RelationGraph,
+  selection: RelationGraphSelection | undefined,
+): RelationGraphFocus | undefined {
+  if (selection === undefined) return undefined
+
+  const nodeIds = new Set<string>()
+  const relationIds = new Set<string>()
+
+  if (selection.type === 'node') {
+    nodeIds.add(selection.id)
+    for (const relation of graph.relations) {
+      const source = sourceId(relation)
+      const target = targetId(relation)
+      if (source !== selection.id && target !== selection.id) continue
+
+      nodeIds.add(source)
+      nodeIds.add(target)
+      relationIds.add(relationId(relation))
+    }
+    return { nodeIds, relationIds }
+  }
+
+  const relation = graph.relations.find(
+    (relation) => relationId(relation) === selection.id,
+  )
+  if (relation === undefined) {
+    throw new Error(`Selected relation ${selection.id} is not in graph`)
+  }
+  nodeIds.add(sourceId(relation))
+  nodeIds.add(targetId(relation))
+  relationIds.add(selection.id)
+  return { nodeIds, relationIds }
+}
+
+export function shortAddress(address: string) {
+  if (address.length <= 14) return address
+  return `${address.slice(0, 8)}…${address.slice(-4)}`
+}
+
+export function unorderedPairKey(a: string, b: string) {
+  return a < b ? `${a}|${b}` : `${b}|${a}`
+}


### PR DESCRIPTION
Part of L2B-14472

- Add graph and lazy-loaded node/relation detail endpoints to token-backend.
- Show deployed and missing tokens in green and orange.
- Color Burn & Mint relations blue and Lock & Mint relations pink.
- Add anomaly highlighting toggle for conflicting relations.
- Add node/relation hover, selection, neighborhood dimming, and detail panels with external links.
- Add zoom-aware cluster labels using the most common deployed-token symbol.
- Optimize selected-graph rendering to keep interactions responsive.
- Add tests and update token-relations documentation.