### PR TITLE
Restart frontend dev server on .env changes

### DIFF
--- a/packages/frontend/scripts/dev.sh
+++ b/packages/frontend/scripts/dev.sh
@@ -40,7 +40,9 @@ while [ ! -f dist/server/index.js ]; do
   sleep 0.1
 done
 
-node --watch-path=dist/server dist/server/index.js
+watch_args=(--watch-path=dist/server)
+[ -f .env ] && watch_args+=(--watch-path=.env)
+node "${watch_args[@]}" dist/server/index.js
 pids+=($!)
 
 echo "All processes started. Press Ctrl+C to exit."


### PR DESCRIPTION
## Summary
- The frontend dev server (`scripts/dev.sh`) already restarts on rebuilds via `node --watch-path=dist/server`; this adds `.env` as a second watch path so editing it restarts the server and picks up new env values.
- Guarded with `[ -f .env ]` because node exits with an error when a watch path doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CQdc6rTsHS2vyDafsr3ozr