### PR TITLE
Make root redirect temporary and non-cacheable

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -15,6 +15,10 @@
   <script>
     (function () { try { var e, t = window.__SSR_DATA__.props.recentChangelogEntriesIds, n = localStorage.getItem("last-read-changelog-entry-id"), r = n ? JSON.parse(n) : null; if (r) { var a = t.indexOf(r); e = -1 === a ? t.length : a } else e = t.length; if (e <= 0) return; for (var l = document.querySelectorAll('[data-role="changelog-unread-badge"]'), g = 0; g < l.length; g++)l[g].textContent = String(e), l[g].hidden = !1 } catch (e) { } })();
   </script>
+  <!-- One-time script to overwrite the stale cached 301 redirect for "/" (can be removed a few months after "/" stops redirecting) -->
+  <script>
+    (function () { try { if (window.location.pathname === "/" || localStorage.getItem("root-redirect-cache-purged")) return; fetch("/", { cache: "reload", redirect: "manual" }).then(function () { localStorage.setItem("root-redirect-cache-purged", "1") }).catch(function () { }) } catch (e) { } })();
+  </script>
   <script type="module" src="/src/ssr/ClientEntry.tsx"></script>
 </body>
 

--- a/packages/frontend/src/pages/ServerPageRouter.ts
+++ b/packages/frontend/src/pages/ServerPageRouter.ts
@@ -41,9 +41,11 @@ export function createServerPageRouter(
   })
 
   router.get('/', (_req, res) => {
-    // Temporary, non-cacheable redirect so browsers drop the previously
-    // cached 301 before "/" starts serving the home page.
-    res.set('Cache-Control', 'no-store')
+    // Temporary redirect so browsers drop the previously cached 301 before
+    // "/" starts serving the home page. no-cache (not no-store) so the
+    // response is stored and replaces the old 301 entry, but is revalidated
+    // (refetched, since 307 has no validators) on every use.
+    res.set('Cache-Control', 'no-cache')
     res.redirect(307, '/scaling/summary')
   })
 

--- a/packages/frontend/src/pages/ServerPageRouter.ts
+++ b/packages/frontend/src/pages/ServerPageRouter.ts
@@ -41,7 +41,10 @@ export function createServerPageRouter(
   })
 
   router.get('/', (_req, res) => {
-    res.redirect(301, '/scaling/summary')
+    // Temporary, non-cacheable redirect so browsers drop the previously
+    // cached 301 before "/" starts serving the home page.
+    res.set('Cache-Control', 'no-store')
+    res.redirect(307, '/scaling/summary')
   })
 
   const routers = [


### PR DESCRIPTION
## Why

`/` currently responds with a `301` to `/scaling/summary` and no `Cache-Control` header, so browsers cache the redirect indefinitely. Once the upcoming home page starts serving `/`, users holding the cached 301 would still be bounced to `/scaling/summary` without ever hitting the server. Shipping this ahead of the home page gives browser caches time to heal.

## What

1. Switch the redirect to `307` with `Cache-Control: no-cache`. Behavior is unchanged for users (they still land on `/scaling/summary`), but every visit to `/` from now on replaces the cached 301. `no-cache` rather than `no-store` (thanks @chatgpt-codex-connector for the catch): the 307 gets *stored*, which is the spec-guaranteed way to overwrite the old 301 entry, yet must be revalidated before every reuse — and since a 307 has no validators, that always means a full refetch, so nothing is ever served stale.
2. Add a one-time inline script to `index.html` that runs `fetch('/', { cache: 'reload', redirect: 'manual' })` from any page and remembers completion in `localStorage`. This heals users who never visit `/` directly — the forced refetch replaces their stale cached 301 entry. `redirect: 'manual'` keeps it cheap (the redirect response is enough; the target page is not downloaded).

The script can be removed a few months after `/` stops redirecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)