### PR TITLE
Collapse SideNavLayout mode flags into a single variant prop

### DIFF
--- a/packages/frontend/src/layouts/SideNavLayout.tsx
+++ b/packages/frontend/src/layouts/SideNavLayout.tsx
@@ -11,29 +11,61 @@ import { cn } from '~/utils/cn'
 
 const LOGO_LINK = '/'
 
+export type SideNavLayoutVariant = 'default' | 'wide' | 'home'
+
+/**
+ * Per-surface classes for each layout variant. 'home' is the full-width
+ * homepage treatment: the content area owns its padding and the footer
+ * spans the whole page.
+ */
+const VARIANT_CLASSES: Record<
+  SideNavLayoutVariant,
+  {
+    topBanner?: string
+    bannerWrapper: string
+    contentArea: string
+    footer: string
+    footerInner: string
+  }
+> = {
+  default: {
+    bannerWrapper: 'lg:mr-3',
+    contentArea: 'md:px-5 lg:pl-0 max-w-(--breakpoint-lg)',
+    footer: 'md:px-12 md:pt-8 lg:pr-9 lg:pl-6',
+    footerInner: 'max-w-[1142px]',
+  },
+  wide: {
+    bannerWrapper: 'lg:mr-3',
+    contentArea: 'md:px-5 lg:pl-0 max-w-412',
+    footer: 'md:px-12 md:pt-8 lg:pr-9 lg:pl-6',
+    footerInner: 'max-w-[1142px]',
+  },
+  home: {
+    topBanner: 'lg:mr-0',
+    bannerWrapper: 'lg:mr-0',
+    contentArea:
+      'max-w-none px-4 pb-6 max-md:px-0 md:px-6 lg:px-8 xl:px-10 2xl:max-w-[1840px]',
+    footer: 'md:px-8 md:pt-10 lg:px-16 lg:pt-12 lg:pb-6',
+    footerInner: 'max-w-none',
+  },
+}
+
 export interface SideNavLayoutProps {
   children: React.ReactNode
   childrenWrapperClassName?: string
-  contentAreaClassName?: string
-  maxWidth?: 'default' | 'wide'
-  /** Full-width content, top bar on mobile. */
-  homepageLayout?: boolean
+  variant?: SideNavLayoutVariant
 }
 
 export function SideNavLayout({
   children,
   childrenWrapperClassName,
-  contentAreaClassName,
-  maxWidth = 'default',
-  homepageLayout = false,
+  variant = 'default',
 }: SideNavLayoutProps) {
   const whatsNew = useWhatsNewContext()
+  const classes = VARIANT_CLASSES[variant]
   const topChildren = (
     <TopBanner
-      className={cn(
-        'lg:rounded-b-xl 2xl:rounded-br-none',
-        homepageLayout && 'lg:mr-0',
-      )}
+      className={cn('lg:rounded-b-xl 2xl:rounded-br-none', classes.topBanner)}
     />
   )
 
@@ -58,37 +90,22 @@ export function SideNavLayout({
           )}
         >
           <div
-            className={cn(
-              'hidden lg:block 2xl:mr-0',
-              homepageLayout ? 'lg:mr-0' : 'lg:mr-3',
-            )}
+            className={cn('hidden lg:block 2xl:mr-0', classes.bannerWrapper)}
           >
             {topChildren}
           </div>
           <div
             className={cn(
               'mx-auto flex w-full min-w-0 grow flex-col',
-              homepageLayout
-                ? 'max-w-none px-4 pb-6 md:px-6 lg:px-8 xl:px-10'
-                : 'md:px-5 lg:pl-0',
-              !homepageLayout &&
-                maxWidth === 'default' &&
-                'max-w-(--breakpoint-lg)',
-              !homepageLayout && maxWidth === 'wide' && 'max-w-412',
-              contentAreaClassName,
+              classes.contentArea,
             )}
           >
             {children}
             {whatsNew && <WhatsNewWidgetCloseable whatsNew={whatsNew} />}
           </div>
           <Footer
-            className={cn(
-              homepageLayout && 'md:px-8 md:pt-10 lg:px-16 lg:pt-12 lg:pb-6',
-              !homepageLayout && 'md:px-12 md:pt-8 lg:pr-9 lg:pl-6',
-            )}
-            innerContainerClassName={
-              homepageLayout ? 'max-w-none' : 'max-w-[1142px]'
-            }
+            className={classes.footer}
+            innerContainerClassName={classes.footerInner}
           />
         </div>
       </div>

--- a/packages/frontend/src/pages/dev/icons/IconPreviewPage.tsx
+++ b/packages/frontend/src/pages/dev/icons/IconPreviewPage.tsx
@@ -13,7 +13,7 @@ export function IconPreviewPage(props: AppLayoutProps) {
 
   return (
     <AppLayout {...props}>
-      <SideNavLayout maxWidth="wide">
+      <SideNavLayout variant="wide">
         <MainPageHeader>Icon Preview</MainPageHeader>
         {entries.length === 0 ? (
           <PrimaryCard className="mt-6">

--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -65,9 +65,8 @@ export function HomePage({
     <AppLayout {...props}>
       <HydrationBoundary state={queryState}>
         <SideNavLayout
-          homepageLayout
+          variant="home"
           childrenWrapperClassName="max-md:bg-surface-primary"
-          contentAreaClassName="max-md:px-0 2xl:max-w-[1840px]"
         >
           <header className="flex items-center gap-4 pt-[18px] pb-5 max-lg:hidden">
             <h1 className="font-bold text-[26px]">Home</h1>

--- a/packages/frontend/src/pages/interop/burn-and-mint/InteropBurnAndMintPage.tsx
+++ b/packages/frontend/src/pages/interop/burn-and-mint/InteropBurnAndMintPage.tsx
@@ -50,7 +50,7 @@ export function InteropBurnAndMintPage({
           interopChains={interopChains}
           initialSelection={initialSelection}
         >
-          <SideNavLayout maxWidth="wide">
+          <SideNavLayout variant="wide">
             <Content
               interopChains={interopChains}
               onboardingInteropChains={onboardingInteropChains}

--- a/packages/frontend/src/pages/interop/lock-and-mint/InteropLockAndMintPage.tsx
+++ b/packages/frontend/src/pages/interop/lock-and-mint/InteropLockAndMintPage.tsx
@@ -50,7 +50,7 @@ export function InteropLockAndMintPage({
           interopChains={interopChains}
           initialSelection={initialSelection}
         >
-          <SideNavLayout maxWidth="wide">
+          <SideNavLayout variant="wide">
             <Content
               interopChains={interopChains}
               onboardingInteropChains={onboardingInteropChains}

--- a/packages/frontend/src/pages/interop/non-minting/InteropNonMintingPage.tsx
+++ b/packages/frontend/src/pages/interop/non-minting/InteropNonMintingPage.tsx
@@ -50,7 +50,7 @@ export function InteropNonMintingPage({
           interopChains={interopChains}
           initialSelection={initialSelection}
         >
-          <SideNavLayout maxWidth="wide">
+          <SideNavLayout variant="wide">
             <Content
               interopChains={interopChains}
               onboardingInteropChains={onboardingInteropChains}

--- a/packages/frontend/src/pages/interop/summary/InteropSummaryPage.tsx
+++ b/packages/frontend/src/pages/interop/summary/InteropSummaryPage.tsx
@@ -58,7 +58,7 @@ export function InteropSummaryPage({
           interopChains={interopChains}
           initialSelection={initialSelection}
         >
-          <SideNavLayout maxWidth="wide">
+          <SideNavLayout variant="wide">
             <MainPageHeader>Interoperability</MainPageHeader>
             <Content
               interopChains={interopChains}

--- a/packages/frontend/src/pages/native-rollups/NativeRollupsPage.tsx
+++ b/packages/frontend/src/pages/native-rollups/NativeRollupsPage.tsx
@@ -21,7 +21,7 @@ interface Props extends AppLayoutProps {
 export function NativeRollupsPage({ talks, contributors, ...props }: Props) {
   return (
     <AppLayout {...props}>
-      <SideNavLayout maxWidth="wide">
+      <SideNavLayout variant="wide">
         <MainPageHeader>Native Rollups</MainPageHeader>
         <main className="[--accent:var(--color-purple-100)] dark:[--accent:var(--color-pink-200)]">
           <Hero />


### PR DESCRIPTION
Follow-up to #11962 (targets the `summary-page` branch), addressing review finding 2: `SideNavLayout` had four overlapping styling channels (`homepageLayout` boolean, `contentAreaClassName`, `maxWidth`, `childrenWrapperClassName`), with the homepage flag branching in four separate places and the home page still needing an extra className override on top.

## Change

- One `variant: 'default' | 'wide' | 'home'` prop replaces `homepageLayout` + `contentAreaClassName` + `maxWidth`.
- Per-surface classes (banner, banner wrapper, content area, footer, footer inner) live in a single `VARIANT_CLASSES` lookup — no inline mode ternaries left in the JSX.
- `childrenWrapperClassName` stays (used for genuinely page-specific tweaks like `md:pt-0`).
- Consumers: 6 `maxWidth="wide"` pages → `variant="wide"`; HomePage → `variant="home"`.

## Behavior preservation

Verified three ways:
- **Screenshot comparison** (Playwright, mock mode, 6 pages × 5 viewports 375–2560px, before vs after): all fully-deterministic pages (`/donate`, `/scaling/summary`, `/native-rollups`) are pixel-identical. `/`, `/interop/summary` and `/scaling/projects/arbitrum` show only run-to-run noise — the same diff magnitude appears when comparing two runs of identical code, and diff overlays show every differing pixel inside the animated interop particle graph / time-derived charts.
- **Class-set equality**: old-vs-new class strings for every surface × every variant computed through the app's actual `cn` (custom tailwind-merge) — all 15 combinations identical as sets.
- **SSR output check**: curl'd rendered HTML per variant matches the expected class lists; `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)