### PR TITLE
Deduplicate home chart series merging and category counts shape

### DIFF
--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -17,6 +17,7 @@ import { HomeEthereumCard } from './components/HomeEthereumCard'
 import { HomeInteropCard } from './components/HomeInteropCard'
 import { HomeRecentChangesTile } from './components/HomeRecentChangesTile'
 import { HomeRecentProjectsCard } from './components/HomeRecentProjectsCard'
+import type { HomeScalingCategoryCounts } from './components/HomeScalingCard'
 import { HomeScalingCard } from './components/HomeScalingCard'
 import { HomeStatsStrip } from './components/HomeStatsStrip'
 import { HomeTopChainsCard } from './components/HomeTopChainsCard'
@@ -36,11 +37,7 @@ interface Props extends AppLayoutProps {
   interopChains: InteropChainWithIcon[]
   interopProtocols: InteropFlowsProtocol[]
   defaultSelectedFlowChains: string[]
-  scalingCategoryCounts: {
-    rollups: number
-    validiumsAndOptimiums: number
-    others: number
-  }
+  scalingCategoryCounts: HomeScalingCategoryCounts
   recentChangesCount: number
   ongoingAnomalies: OngoingAnomaliesOverview
 }

--- a/packages/frontend/src/pages/home/components/HomeScalingCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeScalingCard.tsx
@@ -16,13 +16,14 @@ import {
 } from './HomeChartSection'
 import { HomeStatValue } from './HomeStatValue'
 
+export interface HomeScalingCategoryCounts {
+  rollups: number
+  validiumsAndOptimiums: number
+}
+
 interface Props {
   charts: HomeScalingCharts
-  scalingCategoryCounts: {
-    rollups: number
-    validiumsAndOptimiums: number
-    others: number
-  }
+  scalingCategoryCounts: HomeScalingCategoryCounts
 }
 
 export function HomeScalingCard({ charts, scalingCategoryCounts }: Props) {
@@ -61,10 +62,11 @@ export function HomeScalingCard({ charts, scalingCategoryCounts }: Props) {
     [charts.activity.chart],
   )
 
-  const pastDayActivityUops = useMemo(() => {
-    const last = [...activitySparkline].reverse().find((d) => d.value !== null)
-    return last?.value ?? undefined
-  }, [activitySparkline])
+  const pastDayActivityUops = useMemo(
+    () =>
+      activitySparkline.findLast((d) => d.value !== null)?.value ?? undefined,
+    [activitySparkline],
+  )
 
   return (
     <HomeCard className="flex h-full flex-col pb-4 xl:py-4">
@@ -127,15 +129,7 @@ export function HomeScalingCard({ charts, scalingCategoryCounts }: Props) {
   )
 }
 
-function CountsLine({
-  counts,
-}: {
-  counts: {
-    rollups: number
-    validiumsAndOptimiums: number
-    others: number
-  }
-}) {
+function CountsLine({ counts }: { counts: HomeScalingCategoryCounts }) {
   const items = [
     { label: 'Rollups', value: counts.rollups, dot: 'bg-pink-100' },
     {

--- a/packages/frontend/src/pages/home/getHomeData.ts
+++ b/packages/frontend/src/pages/home/getHomeData.ts
@@ -21,6 +21,7 @@ import {
   MIN_SELECTED_CHAINS,
   MIN_SELECTED_PROTOCOLS,
 } from '../interop/components/flows/consts'
+import type { HomeScalingCategoryCounts } from './components/HomeScalingCard'
 import { getHomeProjectCounts } from './getHomeProjectCounts'
 import { HOME_CHART_RANGE } from './homeChartRanges'
 
@@ -142,10 +143,9 @@ async function getCachedData(manifest: Manifest) {
   ])
 
   const summaryTabs = summaryData.tabs
-  const scalingCategoryCounts = {
+  const scalingCategoryCounts: HomeScalingCategoryCounts = {
     rollups: summaryTabs.rollups.length,
     validiumsAndOptimiums: summaryTabs.validiumsAndOptimiums.length,
-    others: summaryTabs.others.length,
   }
 
   const protocols = interopProtocols.map((protocol) => ({

--- a/packages/frontend/src/server/features/home/getHomeScalingCharts.test.ts
+++ b/packages/frontend/src/server/features/home/getHomeScalingCharts.test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'earl'
+import { mergeSeriesByTimestamp } from './getHomeScalingCharts'
+
+describe(mergeSeriesByTimestamp.name, () => {
+  it('zips values from both series by timestamp', () => {
+    expect(
+      mergeSeriesByTimestamp(
+        [
+          { timestamp: 1, value: 10 },
+          { timestamp: 2, value: 20 },
+        ],
+        [
+          { timestamp: 1, value: 100 },
+          { timestamp: 2, value: 200 },
+        ],
+      ),
+    ).toEqual([
+      [1, 10, 100],
+      [2, 20, 200],
+    ])
+  })
+
+  it('fills null for timestamps missing from one series', () => {
+    expect(
+      mergeSeriesByTimestamp(
+        [{ timestamp: 1, value: 10 }],
+        [{ timestamp: 2, value: 200 }],
+      ),
+    ).toEqual([
+      [1, 10, null],
+      [2, null, 200],
+    ])
+  })
+
+  it('sorts rows by timestamp', () => {
+    expect(
+      mergeSeriesByTimestamp(
+        [
+          { timestamp: 3, value: 30 },
+          { timestamp: 1, value: 10 },
+        ],
+        [{ timestamp: 2, value: 200 }],
+      ),
+    ).toEqual([
+      [1, 10, null],
+      [2, null, 200],
+      [3, 30, null],
+    ])
+  })
+
+  it('preserves null values present in the input series', () => {
+    expect(
+      mergeSeriesByTimestamp(
+        [{ timestamp: 1, value: null }],
+        [{ timestamp: 1, value: 100 }],
+      ),
+    ).toEqual([[1, null, 100]])
+  })
+
+  it('returns an empty chart for empty inputs', () => {
+    expect(mergeSeriesByTimestamp([], [])).toEqual([])
+  })
+})

--- a/packages/frontend/src/server/features/home/getHomeScalingCharts.ts
+++ b/packages/frontend/src/server/features/home/getHomeScalingCharts.ts
@@ -72,28 +72,7 @@ async function getHomeTvsChart(
     getSummedTvsValues(validiumsAndOptimiums, range, options),
   ])
 
-  const byTimestamp = new Map<number, [number | null, number | null]>()
-  for (const value of rollupValues) {
-    byTimestamp.set(value.timestamp, [value.value, null])
-  }
-  for (const value of validiumAndOptimiumValues) {
-    const entry = byTimestamp.get(value.timestamp)
-    if (entry) {
-      entry[1] = value.value
-    } else {
-      byTimestamp.set(value.timestamp, [null, value.value])
-    }
-  }
-
-  const chart: [number, number | null, number | null][] = [
-    ...byTimestamp.entries(),
-  ]
-    .sort(([a], [b]) => a - b)
-    .map(([timestamp, [rollupsValue, vAndOValue]]) => [
-      timestamp,
-      rollupsValue,
-      vAndOValue,
-    ])
+  const chart = mergeSeriesByTimestamp(rollupValues, validiumAndOptimiumValues)
 
   const syncedUntil =
     chart.findLast(([_, r, v]) => r !== null || v !== null)?.[0] ??
@@ -128,34 +107,46 @@ async function getHomeActivityChart(
     db.activity.getSummedByTimestamp(validiumsAndOptimiums, adjustedRange),
   ])
 
-  const byTimestamp = new Map<number, [number | null, number | null]>()
-  for (const entry of rollupEntries) {
-    byTimestamp.set(entry.timestamp, [entry.uopsCount, null])
-  }
-  for (const entry of validiumAndOptimiumEntries) {
-    const existing = byTimestamp.get(entry.timestamp)
-    if (existing) {
-      existing[1] = entry.uopsCount
-    } else {
-      byTimestamp.set(entry.timestamp, [null, entry.uopsCount])
-    }
-  }
-
-  const chart: [number, number | null, number | null][] = [
-    ...byTimestamp.entries(),
-  ]
-    .sort(([a], [b]) => a - b)
-    .map(([timestamp, [rollupsUops, vAndOUops]]) => [
-      timestamp,
-      rollupsUops,
-      vAndOUops,
-    ])
+  const toSeries = (entries: { timestamp: number; uopsCount: number }[]) =>
+    entries.map((entry) => ({
+      timestamp: entry.timestamp,
+      value: entry.uopsCount,
+    }))
+  const chart = mergeSeriesByTimestamp(
+    toSeries(rollupEntries),
+    toSeries(validiumAndOptimiumEntries),
+  )
 
   return {
     chart,
     syncedUntil: adjustedRange[1],
     change: computeSummedSeriesChange(chart),
   }
+}
+
+/**
+ * Zip two per-timestamp series into [timestamp, a, b] rows sorted by
+ * timestamp. A timestamp present in only one series gets null for the other.
+ */
+export function mergeSeriesByTimestamp(
+  seriesA: { timestamp: number; value: number | null }[],
+  seriesB: { timestamp: number; value: number | null }[],
+): [number, number | null, number | null][] {
+  const byTimestamp = new Map<number, [number | null, number | null]>()
+  for (const { timestamp, value } of seriesA) {
+    byTimestamp.set(timestamp, [value, null])
+  }
+  for (const { timestamp, value } of seriesB) {
+    const entry = byTimestamp.get(timestamp)
+    if (entry) {
+      entry[1] = value
+    } else {
+      byTimestamp.set(timestamp, [null, value])
+    }
+  }
+  return [...byTimestamp.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([timestamp, [a, b]]) => [timestamp, a, b])
 }
 
 function computeSummedSeriesChange(


### PR DESCRIPTION
Follow-up to #11962 (targets the `summary-page` branch), addressing the remaining parts of review finding 3 — the divergent change-computation half was already fixed by `move calculations to server side` (`computeSeriesChange`). Replaces #12334, which was based on `layer2s-rename`; this is the same change ported to the pre-rename naming (verified line-identical modulo Layer2s→Scaling).

## Change

- `getHomeScalingCharts.ts`: the two verbatim-identical ~20-line `byTimestamp` merge blocks (TVS + activity) collapse into one `mergeSeriesByTimestamp` helper, covered by unit tests.
- `HomeScalingCategoryCounts` is now a single exported type (defined next to the card that renders it) instead of three inline `{rollups, validiumsAndOptimiums, others}` copies in HomePage, HomeScalingCard and CountsLine.
- The `others` count — computed and serialized into page props but never rendered anywhere — is dropped.
- Tiny consistency cleanup: `pastDayActivityUops` uses `findLast` like the adjacent `latestTvs` instead of `[...arr].reverse().find`.

## Behavior preservation

- **Fuzz equivalence**: the new helper vs a verbatim copy of the old inline block over 10,000 randomized series (duplicate timestamps, nulls, empty inputs) — byte-identical output on every case.
- **Unit tests**: 5 new cases for `mergeSeriesByTimestamp`; full suite passes (449 tests).
- **Screenshots** (from the original #12334 verification of this same change): home page before/after at 5 viewports (375–2560px) in mock mode — only the known interop particle-graph animation noise differs; the Layer 2s card region (counts line, sparklines, stat values, change badges) is pixel-identical. SSR props confirmed to no longer serialize `others`.
- `tsc --noEmit` and biome pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)