### PR TITLE
Use closest price possible when refreshing financials

### DIFF
--- a/packages/backend/src/modules/interop/engine/financials/InteropFinancialsLoop.test.ts
+++ b/packages/backend/src/modules/interop/engine/financials/InteropFinancialsLoop.test.ts
@@ -1,5 +1,9 @@
 import { Logger } from '@l2beat/backend-tools'
-import type { Database, InteropTransferUpdate } from '@l2beat/database'
+import type {
+  Database,
+  InteropRecentPriceRequest,
+  InteropTransferUpdate,
+} from '@l2beat/database'
 import { Address32, EthereumAddress, UnixTime } from '@l2beat/shared-pure'
 import type { TokenDbClient } from '@l2beat/token-backend'
 import { expect, mockFn, mockObject } from 'earl'
@@ -10,15 +14,32 @@ import { InteropFinancialsLoop } from './InteropFinancialsLoop'
 
 describe(InteropFinancialsLoop.name, () => {
   describe(InteropFinancialsLoop.prototype.run.name, () => {
-    it('skips when hasAnyPrices === false', async () => {
+    it('processes transfers with empty financials when no prices are found', async () => {
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(false),
+        getClosestPricesAtOrBefore: mockPrices(new Map()),
       })
       const interopTransfer = mockObject<Database['interopTransfer']>({
-        getUnprocessed: mockFn().resolvesTo([]),
+        getUnprocessed: mockFn().resolvesTo([
+          {
+            transferId: 'msg1',
+            timestamp: UnixTime(100),
+            srcChain: 'ethereum',
+            dstChain: 'arbitrum',
+          },
+        ]),
+        updateFinancials: mockFn().resolvesTo(undefined),
       })
-      const db = mockObject<Database>({ interopRecentPrices, interopTransfer })
-      const tokenDb = mockObject<TokenDbClient>({} as any)
+      const transaction = mockFn(async (fn) => await fn())
+      const db = mockObject<Database>({
+        interopRecentPrices,
+        interopTransfer,
+        transaction,
+      })
+      const tokenDb = mockObject<TokenDbClient>({
+        deployedTokens: {
+          getByChainAndAddress: { query: mockFn().resolvesTo([]) },
+        },
+      } as any)
       const service = new InteropFinancialsLoop(
         [],
         db,
@@ -29,14 +50,24 @@ describe(InteropFinancialsLoop.name, () => {
 
       await service.run()
 
-      expect(interopRecentPrices.hasAnyPrices).toHaveBeenCalledTimes(1)
-      expect(interopTransfer.getUnprocessed).not.toHaveBeenCalled()
+      expect(interopTransfer.updateFinancials).toHaveBeenCalledWith('msg1', {
+        srcAbstractTokenId: null,
+        srcSymbol: null,
+        srcPrice: null,
+        srcAmount: null,
+        srcValueUsd: null,
+        dstAbstractTokenId: null,
+        dstSymbol: null,
+        dstPrice: null,
+        dstAmount: null,
+        dstValueUsd: null,
+      })
     })
 
     it('skips when unprocessed length === 0', async () => {
-      const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-      })
+      const interopRecentPrices = mockObject<Database['interopRecentPrices']>(
+        {},
+      )
       const interopTransfer = mockObject<Database['interopTransfer']>({
         getUnprocessed: mockFn().resolvesTo([]),
       })
@@ -57,7 +88,6 @@ describe(InteropFinancialsLoop.name, () => {
 
       await service.run()
 
-      expect(interopRecentPrices.hasAnyPrices).toHaveBeenCalledTimes(1)
       expect(interopTransfer.getUnprocessed).toHaveBeenCalledTimes(1)
     })
 
@@ -79,15 +109,19 @@ describe(InteropFinancialsLoop.name, () => {
       const mockTransfers = [
         {
           transferId: 'msg1',
+          timestamp: UnixTime(100),
+          srcTime: UnixTime(99),
           srcChain: 'ethereum',
           srcTokenAddress: Address32.from(DeployedTokenId.address(srcToken1)),
           srcRawAmount: BigInt('1000000000000000000'),
           dstChain: 'arbitrum',
+          dstTime: UnixTime(100),
           dstTokenAddress: Address32.from(DeployedTokenId.address(dstToken1)),
           dstRawAmount: BigInt('2000000000000000000'),
         },
         {
           transferId: 'msg2',
+          timestamp: UnixTime(101),
           srcChain: 'ethereum',
           srcTokenAddress: 'native',
           srcRawAmount: BigInt('500000000000000000'),
@@ -97,6 +131,7 @@ describe(InteropFinancialsLoop.name, () => {
         },
         {
           transferId: 'msg3',
+          timestamp: UnixTime(102),
           srcChain: 'unsupported',
           dstChain: 'ethereum',
           dstTokenAddress: Address32.from(DeployedTokenId.address(dstToken3)),
@@ -112,8 +147,7 @@ describe(InteropFinancialsLoop.name, () => {
       ])
 
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-        getClosestPrices: mockFn().resolvesTo(pricesMap),
+        getClosestPricesAtOrBefore: mockPrices(pricesMap),
       })
       const interopTransfer = mockObject<Database['interopTransfer']>({
         getUnprocessed: mockFn().resolvesTo(mockTransfers),
@@ -216,7 +250,6 @@ describe(InteropFinancialsLoop.name, () => {
 
       await service.run()
 
-      expect(interopRecentPrices.hasAnyPrices).toHaveBeenCalledTimes(1)
       expect(interopTransfer.getUnprocessed).toHaveBeenCalledTimes(1)
 
       expect(mockQuery).toHaveBeenCalledWith([
@@ -227,10 +260,17 @@ describe(InteropFinancialsLoop.name, () => {
         { chain: 'ethereum', address: DeployedTokenId.address(dstToken3) },
       ])
 
-      expect(interopRecentPrices.getClosestPrices).toHaveBeenNthCalledWith(
+      expect(
+        interopRecentPrices.getClosestPricesAtOrBefore,
+      ).toHaveBeenNthCalledWith(
         1,
-        ['ethereum', 'arbitrum', 'base', 'token'],
-        expect.anything(),
+        [
+          { requestId: 0, coingeckoId: 'ethereum', timestamp: UnixTime(99) },
+          { requestId: 1, coingeckoId: 'arbitrum', timestamp: UnixTime(100) },
+          { requestId: 2, coingeckoId: 'ethereum', timestamp: UnixTime(101) },
+          { requestId: 3, coingeckoId: 'base', timestamp: UnixTime(101) },
+          { requestId: 4, coingeckoId: 'token', timestamp: UnixTime(102) },
+        ],
         UnixTime.DAY,
       )
 
@@ -314,8 +354,7 @@ describe(InteropFinancialsLoop.name, () => {
       ]
 
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-        getClosestPrices: mockFn().resolvesTo(new Map()),
+        getClosestPricesAtOrBefore: mockPrices(new Map()),
       })
       const interopTransfer = mockObject<Database['interopTransfer']>({
         getUnprocessed: mockFn().resolvesTo(mockTransfers),
@@ -381,8 +420,7 @@ describe(InteropFinancialsLoop.name, () => {
       )
 
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-        getClosestPrices: mockFn().resolvesTo(
+        getClosestPricesAtOrBefore: mockPrices(
           new Map([
             ['unreliable-token', 3000],
             ['reliable-token', 2],
@@ -480,8 +518,7 @@ describe(InteropFinancialsLoop.name, () => {
       )
 
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-        getClosestPrices: mockFn().resolvesTo(
+        getClosestPricesAtOrBefore: mockPrices(
           new Map([['mega-token', 1_500_000]]),
         ),
       })
@@ -591,8 +628,7 @@ describe(InteropFinancialsLoop.name, () => {
       )
 
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-        getClosestPrices: mockFn().resolvesTo(
+        getClosestPricesAtOrBefore: mockPrices(
           new Map([['whale-token', 20_000]]),
         ),
       })
@@ -741,8 +777,7 @@ describe(InteropFinancialsLoop.name, () => {
       ]
 
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-        getClosestPrices: mockFn().resolvesTo(new Map([['token', 1]])),
+        getClosestPricesAtOrBefore: mockPrices(new Map([['token', 1]])),
       })
       const interopTransfer = mockObject<Database['interopTransfer']>({
         getUnprocessed: mockFn().resolvesTo(mockTransfers),
@@ -818,6 +853,15 @@ describe(InteropFinancialsLoop.name, () => {
       expect(processedTransfers?.[0]?.srcValueUsd).toEqual(600)
       expect(processedTransfers?.[0]?.dstValueUsd).toEqual(100)
       expect(processedTransfers?.[1]?.transferId).toEqual('msg2')
+      expect(
+        interopRecentPrices.getClosestPricesAtOrBefore,
+      ).toHaveBeenCalledWith(
+        [
+          { requestId: 0, coingeckoId: 'token', timestamp: UnixTime(100) },
+          { requestId: 1, coingeckoId: 'token', timestamp: UnixTime(101) },
+        ],
+        UnixTime.DAY,
+      )
     })
 
     it('propagates analyzer errors after financials are updated', async () => {
@@ -831,8 +875,7 @@ describe(InteropFinancialsLoop.name, () => {
       )
 
       const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
-        hasAnyPrices: mockFn().resolvesTo(true),
-        getClosestPrices: mockFn().resolvesTo(new Map([['token', 1]])),
+        getClosestPricesAtOrBefore: mockPrices(new Map([['token', 1]])),
       })
       const interopTransfer = mockObject<Database['interopTransfer']>({
         getUnprocessed: mockFn().resolvesTo([
@@ -917,3 +960,16 @@ describe(InteropFinancialsLoop.name, () => {
     })
   })
 })
+
+function mockPrices(pricesByCoin: Map<string, number>) {
+  return mockFn((requests: InteropRecentPriceRequest[]) =>
+    Promise.resolve(
+      new Map(
+        requests.map((request) => [
+          request.requestId,
+          pricesByCoin.get(request.coingeckoId),
+        ]),
+      ),
+    ),
+  )
+}

--- a/packages/backend/src/modules/interop/engine/financials/InteropFinancialsLoop.ts
+++ b/packages/backend/src/modules/interop/engine/financials/InteropFinancialsLoop.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@l2beat/backend-tools'
 import type {
   Database,
+  InteropRecentPriceRequest,
   InteropTransferRecord,
   InteropTransferUpdate,
 } from '@l2beat/database'
@@ -82,12 +83,6 @@ export class InteropFinancialsLoop extends TimeLoop {
   }
 
   async run() {
-    const hasAnyPrices = await this.db.interopRecentPrices.hasAnyPrices()
-    if (!hasAnyPrices) {
-      this.logger.debug('Skipping run. No prices found.')
-      return
-    }
-
     const unprocessed = (await this.db.interopTransfer.getUnprocessed()).map(
       (u) => ({
         transfer: u,
@@ -117,26 +112,37 @@ export class InteropFinancialsLoop extends TimeLoop {
       this.logger,
     )
 
-    const coingeckoIds = unique(
-      Array.from(tokenInfos.values())
-        .map((t) => t.coingeckoId)
-        .filter((u) => u !== undefined),
-    )
+    const { requests, getRequestId } = createPriceRequests(tokenInfos)
+    const transfersWithPriceRequests = unprocessed.map((transfer) => ({
+      ...transfer,
+      srcPriceRequestId: transfer.srcId
+        ? getRequestId(
+            transfer.srcId,
+            transfer.transfer.srcTime ?? transfer.transfer.timestamp,
+          )
+        : undefined,
+      dstPriceRequestId: transfer.dstId
+        ? getRequestId(
+            transfer.dstId,
+            transfer.transfer.dstTime ?? transfer.transfer.timestamp,
+          )
+        : undefined,
+    }))
 
-    const prices = await this.db.interopRecentPrices.getClosestPrices(
-      coingeckoIds,
-      UnixTime.now(),
+    const prices = await this.db.interopRecentPrices.getClosestPricesAtOrBefore(
+      requests,
       UnixTime.DAY,
     )
 
     const skippedValuations: InteropSkippedTransferValuationNotification[] = []
 
-    const updates = unprocessed.map((t) => {
+    const updates = transfersWithPriceRequests.map((t) => {
       const update: InteropTransferUpdate = getEmptyFinancialUpdate()
       if (t.srcId) {
         const skipped = this.applyTokenUpdate(
           tokenInfos,
           prices,
+          t.srcPriceRequestId,
           t.srcId,
           t.transfer.srcRawAmount,
           t.transfer.srcTime ?? t.transfer.timestamp,
@@ -152,6 +158,7 @@ export class InteropFinancialsLoop extends TimeLoop {
         const skipped = this.applyTokenUpdate(
           tokenInfos,
           prices,
+          t.dstPriceRequestId,
           t.dstId,
           t.transfer.dstRawAmount,
           t.transfer.dstTime ?? t.transfer.timestamp,
@@ -198,7 +205,8 @@ export class InteropFinancialsLoop extends TimeLoop {
 
   private applyTokenUpdate(
     tokenInfos: TokenInfos,
-    prices: Map<string, number | undefined>,
+    prices: Map<number, number | undefined>,
+    priceRequestId: number | undefined,
     id: DeployedTokenId,
     rawAmount: bigint | undefined,
     priceTimestamp: UnixTime,
@@ -212,6 +220,7 @@ export class InteropFinancialsLoop extends TimeLoop {
     const tokenUpdate = this.generateTokenUpdate(
       tokenInfos,
       prices,
+      priceRequestId,
       id,
       rawAmount,
       priceTimestamp,
@@ -252,7 +261,8 @@ export class InteropFinancialsLoop extends TimeLoop {
 
   private generateTokenUpdate(
     tokenInfos: TokenInfos,
-    prices: Map<string, number | undefined>,
+    prices: Map<number, number | undefined>,
+    priceRequestId: number | undefined,
     id: DeployedTokenId,
     rawAmount: bigint | undefined,
     priceTimestamp: UnixTime,
@@ -275,7 +285,8 @@ export class InteropFinancialsLoop extends TimeLoop {
       }
     }
 
-    const price = prices.get(tokenInfo.coingeckoId)
+    const price =
+      priceRequestId === undefined ? undefined : prices.get(priceRequestId)
     if (price === undefined) {
       this.logger.warn('Missing price data', {
         id,
@@ -427,6 +438,48 @@ export async function getTokenInfos(
   }
 
   return result
+}
+
+function createPriceRequests(tokenInfos: TokenInfos) {
+  const requests: InteropRecentPriceRequest[] = []
+  const requestIdsByCoinAndTimestamp = new Map<string, Map<UnixTime, number>>()
+
+  function getRequestId(
+    deployedTokenId: DeployedTokenId,
+    timestamp: UnixTime,
+  ): number | undefined {
+    const tokenInfo = tokenInfos.get(deployedTokenId)
+    if (!tokenInfo || tokenInfo.isPriceUnreliable) {
+      return undefined
+    }
+
+    let requestIdsByTimestamp = requestIdsByCoinAndTimestamp.get(
+      tokenInfo.coingeckoId,
+    )
+    if (!requestIdsByTimestamp) {
+      requestIdsByTimestamp = new Map()
+      requestIdsByCoinAndTimestamp.set(
+        tokenInfo.coingeckoId,
+        requestIdsByTimestamp,
+      )
+    }
+
+    const existingRequestId = requestIdsByTimestamp.get(timestamp)
+    if (existingRequestId !== undefined) {
+      return existingRequestId
+    }
+
+    const requestId = requests.length
+    requests.push({
+      requestId,
+      coingeckoId: tokenInfo.coingeckoId,
+      timestamp,
+    })
+    requestIdsByTimestamp.set(timestamp, requestId)
+    return requestId
+  }
+
+  return { requests, getRequestId }
 }
 
 export function toDeployedId(

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -74,6 +74,7 @@ export type {
   InteropPluginSyncedRangeRecord,
 } from './repositories/InteropPluginSyncedRangeRepository'
 export type { InteropPluginSyncStateRecord } from './repositories/InteropPluginSyncStateRepository'
+export type { InteropRecentPriceRequest } from './repositories/InteropRecentPricesRepository'
 export {
   hasAnyInteropTransferFinancialsFilter,
   type InteropMissingTokenInfo,

--- a/packages/database/src/repositories/InteropRecentPricesRepository.test.ts
+++ b/packages/database/src/repositories/InteropRecentPricesRepository.test.ts
@@ -45,163 +45,59 @@ describeDatabase(InteropRecentPricesRepository.name, (database) => {
     })
   })
 
-  describe(InteropRecentPricesRepository.prototype.hasAnyPrices.name, () => {
-    it('returns true when prices exist', async () => {
-      await repository.insertMany([mock('bitcoin', UnixTime(100))])
-
-      const result = await repository.hasAnyPrices()
-      expect(result).toEqual(true)
-    })
-
-    it('returns false when no prices exist', async () => {
-      const result = await repository.hasAnyPrices()
-      expect(result).toEqual(false)
-    })
-  })
-
   describe(
-    InteropRecentPricesRepository.prototype.getClosestPrices.name,
+    InteropRecentPricesRepository.prototype.getClosestPricesAtOrBefore.name,
     () => {
-      describe('single coingeckoId queries', () => {
-        it('returns closest price within 1 day, earlier than target', async () => {
-          const targetTime = UnixTime(1000)
-          await repository.insertMany([
-            mock('bitcoin', UnixTime(900), 30000),
-            mock('bitcoin', UnixTime(1200), 31000),
-          ])
+      it('returns the latest price at or before each request timestamp', async () => {
+        await repository.insertMany([
+          mock('bitcoin', UnixTime(900), 30000),
+          mock('bitcoin', UnixTime(1100), 31000),
+          mock('bitcoin', UnixTime(1200), 32000),
+          mock('ethereum', UnixTime(1000), 3000),
+        ])
 
-          const result = await repository.getClosestPrices(
-            ['bitcoin'],
-            targetTime,
-            UnixTime.DAY,
-          )
-          expect(result.get('bitcoin')).toEqual(30000)
-        })
+        const result = await repository.getClosestPricesAtOrBefore(
+          [
+            {
+              requestId: 11,
+              coingeckoId: 'bitcoin',
+              timestamp: UnixTime(1000),
+            },
+            {
+              requestId: 12,
+              coingeckoId: 'bitcoin',
+              timestamp: UnixTime(1150),
+            },
+            { requestId: 13, coingeckoId: 'bitcoin', timestamp: UnixTime(800) },
+            {
+              requestId: 14,
+              coingeckoId: 'ethereum',
+              timestamp: UnixTime(1000),
+            },
+          ],
+          UnixTime.DAY,
+        )
 
-        it('returns closest price within 1 day, later than target', async () => {
-          const targetTime = UnixTime(1000)
-          await repository.insertMany([
-            mock('bitcoin', UnixTime(800), 30000),
-            mock('bitcoin', UnixTime(1100), 31000),
-          ])
-
-          const result = await repository.getClosestPrices(
-            ['bitcoin'],
-            targetTime,
-            UnixTime.DAY,
-          )
-          expect(result.get('bitcoin')).toEqual(31000)
-        })
-
-        it('returns exact price when timestamp matches exactly', async () => {
-          const targetTime = UnixTime(1000)
-          await repository.insertMany([
-            mock('bitcoin', targetTime, 30000),
-            mock('bitcoin', UnixTime(900)),
-          ])
-
-          const result = await repository.getClosestPrices(
-            ['bitcoin'],
-            targetTime,
-            UnixTime.DAY,
-          )
-          expect(result.get('bitcoin')).toEqual(30000)
-        })
-
-        it('returns price at boundary of 1 day range, earlier than target', async () => {
-          const targetTime = UnixTime.DAY + 7
-          const oneDayBefore = targetTime - UnixTime.DAY
-          await repository.insertMany([mock('bitcoin', oneDayBefore)])
-
-          const result = await repository.getClosestPrices(
-            ['bitcoin'],
-            targetTime,
-            UnixTime.DAY,
-          )
-          expect(result.get('bitcoin')).toEqual(1000)
-        })
-
-        it('returns price at boundary of 1 day range, later than target', async () => {
-          const targetTime = UnixTime.DAY + 7
-          const oneDayAfter = targetTime + UnixTime.DAY
-          await repository.insertMany([mock('bitcoin', oneDayAfter)])
-
-          const result = await repository.getClosestPrices(
-            ['bitcoin'],
-            targetTime,
-            UnixTime.DAY,
-          )
-          expect(result.get('bitcoin')).toEqual(1000)
-        })
-
-        it('returns undefined when no prices within 1 day', async () => {
-          const targetTime = UnixTime(1000)
-          await repository.insertMany([
-            mock('bitcoin', targetTime + UnixTime.DAY + 1),
-            mock('bitcoin', targetTime - UnixTime.DAY - 1),
-          ])
-
-          const result = await repository.getClosestPrices(
-            ['bitcoin'],
-            targetTime,
-            UnixTime.DAY,
-          )
-          expect(result.get('bitcoin')).toEqual(undefined)
-        })
-
-        it('returns undefined when coingeckoId does not exist', async () => {
-          const targetTime = UnixTime(1000)
-          await repository.insertMany([mock('ethereum', targetTime)])
-
-          const result = await repository.getClosestPrices(
-            ['bitcoin'],
-            targetTime,
-            UnixTime.DAY,
-          )
-          expect(result.get('bitcoin')).toEqual(undefined)
-        })
+        expect(result).toEqual(
+          new Map([
+            [11, 30000],
+            [12, 31000],
+            [13, undefined],
+            [14, 3000],
+          ]),
+        )
       })
 
-      describe('multiple coingeckoIds queries', () => {
-        it('returns closest prices for multiple tokens', async () => {
-          const targetTime = UnixTime(1000)
-          await repository.insertMany([
-            mock('bitcoin', UnixTime(900), 30000),
-            mock('bitcoin', UnixTime(1200), 20000),
-            mock('ethereum', UnixTime(800), 3000),
-            mock('ethereum', UnixTime(1100), 2000),
-            mock('polygon', UnixTime(1000), 0.8),
-            mock('polygon', UnixTime(1100), 0.9),
-          ])
+      it('returns undefined when the only earlier price is too old', async () => {
+        const timestamp = UnixTime(2 * UnixTime.DAY)
+        await repository.insertMany([mock('bitcoin', UnixTime(0), 30000)])
 
-          const result = await repository.getClosestPrices(
-            ['bitcoin', 'ethereum', 'polygon'],
-            targetTime,
-            UnixTime.DAY,
-          )
+        const result = await repository.getClosestPricesAtOrBefore(
+          [{ requestId: 1, coingeckoId: 'bitcoin', timestamp }],
+          UnixTime.DAY,
+        )
 
-          expect(result.get('bitcoin')).toEqual(30000)
-          expect(result.get('ethereum')).toEqual(2000)
-          expect(result.get('polygon')).toEqual(0.8)
-        })
-
-        it('handles mixed scenarios with some tokens having data and others not', async () => {
-          const targetTime = UnixTime(1000)
-          await repository.insertMany([
-            mock('bitcoin', UnixTime(950), 30000),
-            mock('ethereum', targetTime + UnixTime.DAY + 1, 2000),
-          ])
-
-          const result = await repository.getClosestPrices(
-            ['bitcoin', 'ethereum', 'polygon'],
-            targetTime,
-            UnixTime.DAY,
-          )
-
-          expect(result.get('bitcoin')).toEqual(30000)
-          expect(result.get('ethereum')).toEqual(undefined)
-          expect(result.get('polygon')).toEqual(undefined)
-        })
+        expect(result.get(1)).toEqual(undefined)
       })
     },
   )

--- a/packages/database/src/repositories/InteropRecentPricesRepository.ts
+++ b/packages/database/src/repositories/InteropRecentPricesRepository.ts
@@ -10,6 +10,12 @@ export interface InteropRecentPricesRecord {
   priceUsd: number
 }
 
+export interface InteropRecentPriceRequest {
+  requestId: number
+  coingeckoId: string
+  timestamp: UnixTime
+}
+
 export function toRecord(
   row: Selectable<InteropRecentPrices>,
 ): InteropRecentPricesRecord {
@@ -41,49 +47,47 @@ export class InteropRecentPricesRepository extends BaseRepository {
     return rows.length
   }
 
-  async hasAnyPrices(): Promise<boolean> {
-    const row = await this.db
-      .selectFrom('InteropRecentPrices')
-      .selectAll()
-      .limit(1)
-      .executeTakeFirst()
-    return row !== undefined
-  }
-
-  async getClosestPrices(
-    coingeckoIds: string[],
-    timestamp: UnixTime,
+  async getClosestPricesAtOrBefore(
+    requests: InteropRecentPriceRequest[],
     errorMargin: UnixTime,
-  ): Promise<Map<string, number | undefined>> {
-    if (coingeckoIds.length === 0) {
-      return new Map()
+  ): Promise<Map<number, number | undefined>> {
+    const result = new Map<number, number | undefined>()
+    if (requests.length === 0) {
+      return result
     }
 
-    const targetTimestamp = UnixTime.toDate(timestamp)
-    const fromTime = UnixTime.toDate(timestamp - errorMargin)
-    const toTime = UnixTime.toDate(timestamp + errorMargin)
+    await this.batch(requests, 10_000, async (batch) => {
+      const values = sql.join(
+        batch.map(
+          (request) =>
+            sql`(${request.requestId}::integer, ${request.coingeckoId}::varchar, ${UnixTime.toDate(request.timestamp)}::timestamp)`,
+        ),
+      )
 
-    const rows = await this.db
-      .selectFrom('InteropRecentPrices')
-      .select([
-        'coingeckoId',
-        'priceUsd',
-        sql<string>`row_number() over (
-          partition by "coingeckoId"
-          order by abs(extract(epoch from age(timestamp, ${targetTimestamp})))
-        )`.as('rn'),
-      ])
-      .where('coingeckoId', 'in', coingeckoIds)
-      .where('timestamp', '>=', fromTime)
-      .where('timestamp', '<=', toTime)
-      .execute()
+      const rows = await sql<{
+        requestId: number
+        priceUsd: number | null
+      }>`
+        WITH "Requests" ("requestId", "coingeckoId", "timestamp") AS (
+          VALUES ${values}
+        )
+        SELECT "Requests"."requestId", "Price"."priceUsd"
+        FROM "Requests"
+        LEFT JOIN LATERAL (
+          SELECT "priceUsd"
+          FROM "InteropRecentPrices"
+          WHERE "coingeckoId" = "Requests"."coingeckoId"
+            AND "timestamp" <= "Requests"."timestamp"
+            AND "timestamp" >= "Requests"."timestamp" - ${errorMargin} * INTERVAL '1 second'
+          ORDER BY "timestamp" DESC
+          LIMIT 1
+        ) AS "Price" ON true
+      `.execute(this.db)
 
-    const closestRows = rows.filter((row) => row.rn === '1')
-
-    const result = new Map<string, number | undefined>()
-    for (const row of closestRows) {
-      result.set(row.coingeckoId, row?.priceUsd)
-    }
+      for (const row of rows.rows) {
+        result.set(row.requestId, row.priceUsd ?? undefined)
+      }
+    })
 
     return result
   }


### PR DESCRIPTION
@codex review

Financial valuation now resolves prices per transfer side timestamp (srcTime/dstTime, with transfer timestamp fallback), rather than once at processing time. Requests are deduplicated by (coingeckoId, timestamp) and correlated back through numeric request IDs.
The lookup is intentionally causal: it selects the latest stored price at or before the requested timestamp, within the existing one-day window. Missing prices still produce empty financial fields and mark the transfer processed, including when no prices exist at all.
Scope is intentionally limited: no historical CoinGecko fetches and no aggregate changes.
Focus review on the batched VALUES + LATERAL repository query and the intended behavior for transfers with no eligible price.
Backend tests and both package typechecks pass.