### PR TITLE
fix(discovery): use Blockscout v2 for contract creation lookups

### DIFF
--- a/packages/discovery/src/config/chains.ts
+++ b/packages/discovery/src/config/chains.ts
@@ -65,10 +65,6 @@ export const chains: ChainConfig[] = [
       {
         type: 'blockscout',
         url: 'https://robinhoodchain.blockscout.com/api',
-        // The public RPC is non-archival; getContractCreation triggers a
-        // creation-block lookup that probes historical state and fails.
-        // Discovery only needs latest state here, so skip deployment lookups.
-        unsupported: { getContractCreation: true },
       },
       { type: 'sourcify' },
     ],


### PR DESCRIPTION
Blockscout's Etherscan-compatible v1 API for getcontractcreation returns blockNumber/contractCreator/contractFactory/creationBytecode but omits txHash, causing our schema parse to always fail and the caller to fall back to EthereumAddress.ZERO deployer.

Switch getContractDeploymentTx() to Blockscout v2
(/api/v2/addresses/{address}) which returns creation_transaction_hash directly. Drop the defensive 'unsupported: { getContractCreation }' flag on robinhood now that discovery matches UpdateMonitor's output.