### PR TITLE
Dark-launch /projects/:slug rendering the scaling facet via the unified orchestrator

### DIFF
--- a/packages/frontend/.mocharc.json
+++ b/packages/frontend/.mocharc.json
@@ -1,5 +1,6 @@
 {
   "spec": ["src/**/*.test.ts", "scripts/**/*.test.ts"],
+  "require": ["./mocha.setup.js"],
   "node-option": ["import=tsx"],
   "watchExtensions": "ts",
   "extension": "ts"

--- a/packages/frontend/mocha.setup.js
+++ b/packages/frontend/mocha.setup.js
@@ -1,0 +1,3 @@
+// Unit tests must never touch a real database. Force mock data mode before
+// any module under test parses the environment (env.MOCK is read at import).
+process.env.MOCK = 'true'

--- a/packages/frontend/src/pages/ServerPageRouter.ts
+++ b/packages/frontend/src/pages/ServerPageRouter.ts
@@ -17,6 +17,7 @@ import { createInteropRouter } from './interop/InteropRouter'
 import { createMultisigReportRouter } from './multisig-report/MutlisigReportRouter'
 import { createNativeRollupsRouter } from './native-rollups/NativeRollupsRouter'
 import { createPrivacyRouter } from './privacy/PrivacyRouter'
+import { createProjectsRouter } from './projects/ProjectsRouter'
 import { createPublicationsRouter } from './publications/PublicationsRouter'
 import { createScalingRouter } from './scaling/ScalingRouter'
 import { createStagesRouter } from './stages/StagesRouter'
@@ -50,6 +51,7 @@ export function createServerPageRouter(
   })
 
   const routers = [
+    createProjectsRouter,
     createScalingRouter,
     createInteropRouter,
     createDataAvailabilityRouter,

--- a/packages/frontend/src/pages/projects/ProjectsRouter.ts
+++ b/packages/frontend/src/pages/projects/ProjectsRouter.ts
@@ -1,0 +1,40 @@
+import type { InMemoryCache } from '@l2beat/shared-pure'
+import { v } from '@l2beat/validate'
+import express from 'express'
+import type { RenderFunction } from '~/ssr/types'
+import type { Manifest } from '~/utils/Manifest'
+import { validateRoute } from '~/utils/validateRoute'
+import { getProjectData } from './getProjectData'
+
+export function createProjectsRouter(
+  manifest: Manifest,
+  render: RenderFunction,
+  cache: InMemoryCache,
+) {
+  const router = express.Router()
+
+  router.get(
+    '/projects/:slug',
+    validateRoute({
+      params: v.object({ slug: v.string() }),
+    }),
+    async (req, res) => {
+      const data = await cache.get(
+        {
+          key: ['projects', req.params.slug],
+          ttl: 5 * 60,
+          staleWhileRevalidate: 25 * 60,
+        },
+        () => getProjectData(manifest, req.params.slug, req.originalUrl),
+      )
+      if (!data) {
+        res.status(404).send('Not found')
+        return
+      }
+      const html = await render(data, req.originalUrl)
+      res.status(200).send(html)
+    },
+  )
+
+  return router
+}

--- a/packages/frontend/src/pages/projects/getProjectData.ts
+++ b/packages/frontend/src/pages/projects/getProjectData.ts
@@ -1,0 +1,51 @@
+import { getAppLayoutProps } from '~/common/getAppLayoutProps'
+import {
+  getProjectEntry,
+  getUnifiedProject,
+} from '~/server/features/projects/project/getProjectEntry'
+import { getMetadata } from '~/ssr/head/getMetadata'
+import { getProjectMetadataDescription } from '~/ssr/head/getProjectMetadataDescription'
+import type { RenderData } from '~/ssr/types'
+import { getSsrHelpers } from '~/trpc/server'
+import type { Manifest } from '~/utils/Manifest'
+
+export async function getProjectData(
+  manifest: Manifest,
+  slug: string,
+  url: string,
+): Promise<RenderData | undefined> {
+  const helpers = getSsrHelpers()
+  const project = await getUnifiedProject(slug)
+  if (!project) return undefined
+
+  const [appLayoutProps, projectEntry] = await Promise.all([
+    getAppLayoutProps(),
+    getProjectEntry(project, helpers),
+  ])
+  if (!projectEntry) return undefined
+
+  return {
+    head: {
+      manifest,
+      metadata: getMetadata(manifest, {
+        title: `${project.name} - L2BEAT`,
+        description: getProjectMetadataDescription(project),
+        url,
+        openGraph: {
+          image: `/meta-images/scaling/projects/${project.slug}/opengraph-image.png`,
+        },
+        // Dark launch: keep the unified page out of search engines until
+        // parity is verified and the product flips happen.
+        excludeFromSearchEngines: true,
+      }),
+    },
+    ssr: {
+      page: 'ScalingProjectPage',
+      props: {
+        ...appLayoutProps,
+        projectEntry,
+        queryState: helpers.dehydrate(),
+      },
+    },
+  }
+}

--- a/packages/frontend/src/pages/scaling/project/getScalingProjectData.ts
+++ b/packages/frontend/src/pages/scaling/project/getScalingProjectData.ts
@@ -1,5 +1,9 @@
 import { getAppLayoutProps } from '~/common/getAppLayoutProps'
-import { getScalingProjectEntry } from '~/server/features/scaling/project/getScalingProjectEntry'
+import {
+  getScalingProjectEntry,
+  SCALING_PROJECT_FACET_KEYS,
+  SCALING_PROJECT_OPTIONAL_KEYS,
+} from '~/server/features/scaling/project/getScalingProjectEntry'
 import { ps } from '~/server/projects'
 import { getMetadata } from '~/ssr/head/getMetadata'
 import { getProjectMetadataDescription } from '~/ssr/head/getProjectMetadataDescription'
@@ -15,34 +19,8 @@ export async function getScalingProjectData(
   const helpers = getSsrHelpers()
   const project = await ps.getProject({
     slug,
-    select: [
-      'display',
-      'statuses',
-      'scalingInfo',
-      'scalingRisks',
-      'scalingStage',
-      'scalingTechnology',
-      'tvsInfo',
-    ],
-    optional: [
-      'contracts',
-      'permissions',
-      'chainConfig',
-      'scalingDa',
-      'livenessInfo',
-      'livenessConfig',
-      'customDa',
-      'archivedAt',
-      'milestones',
-      'trackedTxsConfig',
-      'tvsConfig',
-      'colors',
-      'ecosystemColors',
-      'discoveryInfo',
-      'daTrackingConfig',
-      'costsInfo',
-      'activityConfig',
-    ],
+    select: ['display', 'statuses', ...SCALING_PROJECT_FACET_KEYS],
+    optional: [...SCALING_PROJECT_OPTIONAL_KEYS],
   })
   if (!project) return undefined
 

--- a/packages/frontend/src/server/features/projects/project/getProjectEntry.test.ts
+++ b/packages/frontend/src/server/features/projects/project/getProjectEntry.test.ts
@@ -1,0 +1,87 @@
+import { expect } from 'earl'
+import { projectDetailsToNavigationSections } from '~/components/projects/navigation/types'
+import { ps } from '~/server/projects'
+import { getSsrHelpers } from '~/trpc/server'
+import { getScalingProjectEntry } from '../../scaling/project/getScalingProjectEntry'
+import { getProjectEntry, getUnifiedProject } from './getProjectEntry'
+
+describe(getProjectEntry.name, function () {
+  this.timeout(0)
+
+  const originalRandom = Math.random
+  before(() => {
+    // Mock data generators randomize values; pin them so both entry builds
+    // produce identical structures.
+    Math.random = () => 0.5
+  })
+  after(() => {
+    Math.random = originalRandom
+  })
+
+  it('produces the same sections and side navigation as the scaling entry builder for every scaling project', async () => {
+    // The same query getScalingProjectData uses to load a scaling project.
+    const scalingProjects = await ps.getProjects({
+      select: [
+        'display',
+        'statuses',
+        'scalingInfo',
+        'scalingRisks',
+        'scalingStage',
+        'scalingTechnology',
+        'tvsInfo',
+      ],
+      optional: [
+        'contracts',
+        'permissions',
+        'chainConfig',
+        'scalingDa',
+        'livenessInfo',
+        'livenessConfig',
+        'customDa',
+        'archivedAt',
+        'milestones',
+        'trackedTxsConfig',
+        'tvsConfig',
+        'colors',
+        'ecosystemColors',
+        'discoveryInfo',
+        'daTrackingConfig',
+        'costsInfo',
+        'activityConfig',
+      ],
+    })
+    expect(scalingProjects.length).toBeGreaterThan(0)
+
+    for (const scalingProject of scalingProjects) {
+      const unifiedProject = await getUnifiedProject(scalingProject.slug)
+      expect({ slug: scalingProject.slug, found: !!unifiedProject }).toEqual({
+        slug: scalingProject.slug,
+        found: true,
+      })
+      if (!unifiedProject) continue
+
+      const oldEntry = await getScalingProjectEntry(
+        scalingProject,
+        getSsrHelpers(),
+      )
+      const newEntry = await getProjectEntry(unifiedProject, getSsrHelpers())
+
+      expect({
+        slug: scalingProject.slug,
+        sections: newEntry?.sections.map((section) => ({
+          id: section.props.id,
+          type: section.type,
+        })),
+        navigation:
+          newEntry && projectDetailsToNavigationSections(newEntry.sections),
+      }).toEqual({
+        slug: scalingProject.slug,
+        sections: oldEntry.sections.map((section) => ({
+          id: section.props.id,
+          type: section.type,
+        })),
+        navigation: projectDetailsToNavigationSections(oldEntry.sections),
+      })
+    }
+  })
+})

--- a/packages/frontend/src/server/features/projects/project/getProjectEntry.test.ts
+++ b/packages/frontend/src/server/features/projects/project/getProjectEntry.test.ts
@@ -2,11 +2,15 @@ import { expect } from 'earl'
 import { projectDetailsToNavigationSections } from '~/components/projects/navigation/types'
 import { ps } from '~/server/projects'
 import { getSsrHelpers } from '~/trpc/server'
-import { getScalingProjectEntry } from '../../scaling/project/getScalingProjectEntry'
+import {
+  getScalingProjectEntry,
+  SCALING_PROJECT_FACET_KEYS,
+  SCALING_PROJECT_OPTIONAL_KEYS,
+} from '../../scaling/project/getScalingProjectEntry'
 import { getProjectEntry, getUnifiedProject } from './getProjectEntry'
 
 describe(getProjectEntry.name, function () {
-  this.timeout(0)
+  this.timeout(300_000)
 
   const originalRandom = Math.random
   before(() => {
@@ -21,34 +25,8 @@ describe(getProjectEntry.name, function () {
   it('produces the same sections and side navigation as the scaling entry builder for every scaling project', async () => {
     // The same query getScalingProjectData uses to load a scaling project.
     const scalingProjects = await ps.getProjects({
-      select: [
-        'display',
-        'statuses',
-        'scalingInfo',
-        'scalingRisks',
-        'scalingStage',
-        'scalingTechnology',
-        'tvsInfo',
-      ],
-      optional: [
-        'contracts',
-        'permissions',
-        'chainConfig',
-        'scalingDa',
-        'livenessInfo',
-        'livenessConfig',
-        'customDa',
-        'archivedAt',
-        'milestones',
-        'trackedTxsConfig',
-        'tvsConfig',
-        'colors',
-        'ecosystemColors',
-        'discoveryInfo',
-        'daTrackingConfig',
-        'costsInfo',
-        'activityConfig',
-      ],
+      select: ['display', 'statuses', ...SCALING_PROJECT_FACET_KEYS],
+      optional: [...SCALING_PROJECT_OPTIONAL_KEYS],
     })
     expect(scalingProjects.length).toBeGreaterThan(0)
 

--- a/packages/frontend/src/server/features/projects/project/getProjectEntry.ts
+++ b/packages/frontend/src/server/features/projects/project/getProjectEntry.ts
@@ -3,50 +3,25 @@ import type { SsrHelpers } from '~/trpc/server'
 import {
   getScalingProjectEntry,
   type ProjectScalingEntry,
+  SCALING_PROJECT_FACET_KEYS,
+  SCALING_PROJECT_OPTIONAL_KEYS,
+  type ScalingProject,
 } from '../../scaling/project/getScalingProjectEntry'
-
-export type ProjectEntry = ProjectScalingEntry
 
 export async function getUnifiedProject(slug: string) {
   return await ps.getProject({
     slug,
     select: ['display', 'statuses'],
-    optional: [
-      // scaling facet
-      'scalingInfo',
-      'scalingRisks',
-      'scalingStage',
-      'scalingTechnology',
-      'tvsInfo',
-      'contracts',
-      'permissions',
-      'chainConfig',
-      'scalingDa',
-      'livenessInfo',
-      'livenessConfig',
-      'customDa',
-      'archivedAt',
-      'milestones',
-      'trackedTxsConfig',
-      'tvsConfig',
-      'colors',
-      'ecosystemColors',
-      'discoveryInfo',
-      'daTrackingConfig',
-      'costsInfo',
-      'activityConfig',
-    ],
+    optional: [...SCALING_PROJECT_FACET_KEYS, ...SCALING_PROJECT_OPTIONAL_KEYS],
   })
 }
 
-export type UnifiedProject = NonNullable<
-  Awaited<ReturnType<typeof getUnifiedProject>>
->
+type UnifiedProject = NonNullable<Awaited<ReturnType<typeof getUnifiedProject>>>
 
 export async function getProjectEntry(
   project: UnifiedProject,
   helpers: SsrHelpers,
-): Promise<ProjectEntry | undefined> {
+): Promise<ProjectScalingEntry | undefined> {
   const scalingProject = getScalingFacet(project)
   if (scalingProject) {
     return await getScalingProjectEntry(scalingProject, helpers)
@@ -55,14 +30,8 @@ export async function getProjectEntry(
 }
 
 function getScalingFacet(project: UnifiedProject) {
-  if (
-    !project.scalingInfo ||
-    !project.scalingRisks ||
-    !project.scalingStage ||
-    !project.scalingTechnology ||
-    !project.tvsInfo
-  ) {
-    return undefined
-  }
-  return project as Parameters<typeof getScalingProjectEntry>[0]
+  const hasScalingFacet = SCALING_PROJECT_FACET_KEYS.every(
+    (key) => project[key] !== undefined,
+  )
+  return hasScalingFacet ? (project as ScalingProject) : undefined
 }

--- a/packages/frontend/src/server/features/projects/project/getProjectEntry.ts
+++ b/packages/frontend/src/server/features/projects/project/getProjectEntry.ts
@@ -1,0 +1,68 @@
+import { ps } from '~/server/projects'
+import type { SsrHelpers } from '~/trpc/server'
+import {
+  getScalingProjectEntry,
+  type ProjectScalingEntry,
+} from '../../scaling/project/getScalingProjectEntry'
+
+export type ProjectEntry = ProjectScalingEntry
+
+export async function getUnifiedProject(slug: string) {
+  return await ps.getProject({
+    slug,
+    select: ['display', 'statuses'],
+    optional: [
+      // scaling facet
+      'scalingInfo',
+      'scalingRisks',
+      'scalingStage',
+      'scalingTechnology',
+      'tvsInfo',
+      'contracts',
+      'permissions',
+      'chainConfig',
+      'scalingDa',
+      'livenessInfo',
+      'livenessConfig',
+      'customDa',
+      'archivedAt',
+      'milestones',
+      'trackedTxsConfig',
+      'tvsConfig',
+      'colors',
+      'ecosystemColors',
+      'discoveryInfo',
+      'daTrackingConfig',
+      'costsInfo',
+      'activityConfig',
+    ],
+  })
+}
+
+export type UnifiedProject = NonNullable<
+  Awaited<ReturnType<typeof getUnifiedProject>>
+>
+
+export async function getProjectEntry(
+  project: UnifiedProject,
+  helpers: SsrHelpers,
+): Promise<ProjectEntry | undefined> {
+  const scalingProject = getScalingFacet(project)
+  if (scalingProject) {
+    return await getScalingProjectEntry(scalingProject, helpers)
+  }
+  return undefined
+}
+
+function getScalingFacet(project: UnifiedProject) {
+  if (
+    !project.scalingInfo ||
+    !project.scalingRisks ||
+    !project.scalingStage ||
+    !project.scalingTechnology ||
+    !project.tvsInfo
+  ) {
+    return undefined
+  }
+  return project as Parameters<typeof getScalingProjectEntry>[0]
+}

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -143,34 +143,45 @@ export interface ProjectScalingEntry {
   discoUiHref: string | undefined
 }
 
+// Single source for the ProjectService keys this entry builder reads. Every
+// query that loads a project for this builder (the scaling page, the unified
+// project page orchestrator, and the section-parity test) derives from these
+// lists, so they cannot drift from the builder's contract.
+export const SCALING_PROJECT_FACET_KEYS = [
+  'scalingInfo',
+  'scalingRisks',
+  'scalingStage',
+  'scalingTechnology',
+  'tvsInfo',
+] as const
+
+export const SCALING_PROJECT_OPTIONAL_KEYS = [
+  'contracts',
+  'tvsConfig',
+  'permissions',
+  'scalingDa',
+  'customDa',
+  'chainConfig',
+  'archivedAt',
+  'milestones',
+  'trackedTxsConfig',
+  'livenessInfo',
+  'livenessConfig',
+  'costsInfo',
+  'activityConfig',
+  'colors',
+  'ecosystemColors',
+  'discoveryInfo',
+  'daTrackingConfig',
+] as const
+
+export type ScalingProject = Project<
+  'display' | 'statuses' | (typeof SCALING_PROJECT_FACET_KEYS)[number],
+  (typeof SCALING_PROJECT_OPTIONAL_KEYS)[number]
+>
+
 export async function getScalingProjectEntry(
-  project: Project<
-    | 'display'
-    | 'statuses'
-    | 'scalingInfo'
-    | 'scalingRisks'
-    | 'scalingStage'
-    | 'scalingTechnology'
-    | 'tvsInfo',
-    // optional
-    | 'contracts'
-    | 'tvsConfig'
-    | 'permissions'
-    | 'scalingDa'
-    | 'customDa'
-    | 'chainConfig'
-    | 'archivedAt'
-    | 'milestones'
-    | 'trackedTxsConfig'
-    | 'livenessInfo'
-    | 'livenessConfig'
-    | 'costsInfo'
-    | 'activityConfig'
-    | 'colors'
-    | 'ecosystemColors'
-    | 'discoveryInfo'
-    | 'daTrackingConfig'
-  >,
+  project: ScalingProject,
   helpers: SsrHelpers,
 ): Promise<ProjectScalingEntry> {
   const daSolutions = await getScalingDaSolutions(project)

--- a/packages/frontend/src/server/routers/LegacyPathsRouter.ts
+++ b/packages/frontend/src/server/routers/LegacyPathsRouter.ts
@@ -7,10 +7,6 @@ export function createLegacyPathsRouter() {
     res.redirect(301, `/scaling/projects/${req.params.name}`)
   })
 
-  router.get('/projects/:name', (req, res) => {
-    res.redirect(301, `/scaling/projects/${req.params.name}`)
-  })
-
   router.get('/scaling/tvl', (_, res) => {
     res.redirect(301, '/scaling/tvs')
   })


### PR DESCRIPTION
Resolves L2B-14498 (tracer bullet for the unified project pages, PRD in L2B-14496).

## What

- **Unified orchestrator** (`src/server/features/projects/project/getProjectEntry.ts`): `getUnifiedProject(slug)` loads the project from ProjectService with all scaling facet keys optional; `getProjectEntry` calls the existing `getScalingProjectEntry` when the scaling facet is present and returns `undefined` otherwise, so unknown slugs and facet-less projects 404.
- **New route** `/projects/:slug` (`src/pages/projects/ProjectsRouter.ts` + `getProjectData.ts`), registered in `ServerPageRouter`. For this slice it reuses the existing `ScalingProjectPage` component, so header/summary and the shared `ProjectDetails` renderer are identical to the old route (merged header is a later slice; product-neutral metadata/OG is L2B-14503).
- **Dark launch**: pages set `excludeFromSearchEngines`, nothing links to the route, and it is deliberately absent from `pagePaths`/sitemap/search bar.
- **Legacy redirect removed**: the `/projects/:name → /scaling/projects/:name` 301 in `LegacyPathsRouter` (mounted before the page router) would have shadowed the new route. `/project/:name` and all other legacy redirects are untouched. The old scaling route is unchanged.
- **Section-parity test** (`getProjectEntry.test.ts`): for every scaling project, the old entry builder and the orchestrator must produce identical section id/type lists and side-navigation structure. Entry builders read `env.MOCK` at import time, so a new `mocha.setup.js` (wired via `.mocharc.json` `require`) forces `MOCK=true` for the whole frontend unit-test suite — unit tests never touch a real database.

## Verification

- turbo typecheck, biome lint/format, full mocha suite (445 tests incl. the new parity test, ~13s) all green
- Smoke test in MOCK mode: `/projects/base` renders a section list identical to `/scaling/projects/base`; unified page carries `noindex` even with `DEPLOYMENT_ENV=production` while the scaling page does not; unknown slugs and privacy-only projects (e.g. `tornado-cash`) 404; `/project/base` still 301s to the scaling page

🤖 Generated with [Claude Code](https://claude.com/claude-code)