### PR TITLE
EOAs are not entrypoints

### DIFF
--- a/packages/config/src/projects/paradex/diffHistory.md
+++ b/packages/config/src/projects/paradex/diffHistory.md
@@ -1,3 +1,51 @@
+Generated with discovered.json: 0x5bfc25f811e8a6ba775e2785fb0e66cc6d34706b
+
+# Diff at Mon, 27 Jul 2026 10:16:36 GMT:
+
+- author: Mateusz Radomski (<radomski.main@protonmail.com>)
+- comparing to: main@4683097a102db212f2168de1647931e7c0ef98e8 block: 1784193913
+- current timestamp: 1784193913
+
+## Description
+
+shared-sharp-verifier changes rediscover
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1784193913 (main branch discovery), not current.
+
+```diff
+    EOA  (eth:0x0405107a60391Eb51821be373ff978115Ee58488) {
+    +++ description: None
+      type:
+-        "Reference"
++        "EOA"
+      targetType:
+-        "EOA"
+      targetProject:
+-        "shared-sharp-verifier"
+      proxyType:
++        "EOA"
+    }
+```
+
+```diff
+    EOA  (eth:0x59232aC80E6d403b6381393e52f4665ECA328558) {
+    +++ description: None
+      type:
+-        "Reference"
++        "EOA"
+      targetType:
+-        "EOA"
+      targetProject:
+-        "shared-sharp-verifier"
+      proxyType:
++        "EOA"
+    }
+```
+
 Generated with discovered.json: 0x92aa1cedaf3cf244611ffa762f4f2ebb47557c5c
 
 # Diff at Thu, 16 Jul 2026 09:26:20 GMT:

--- a/packages/config/src/projects/paradex/discovered.json
+++ b/packages/config/src/projects/paradex/discovered.json
@@ -5,9 +5,8 @@
   "entries": [
     {
       "address": "eth:0x0405107a60391Eb51821be373ff978115Ee58488",
-      "type": "Reference",
-      "targetType": "EOA",
-      "targetProject": "shared-sharp-verifier"
+      "type": "EOA",
+      "proxyType": "EOA"
     },
     {
       "address": "eth:0x09d1ad25B369A0C48Bdf4CaAb85aFd08a3f07044",
@@ -247,9 +246,8 @@
     },
     {
       "address": "eth:0x59232aC80E6d403b6381393e52f4665ECA328558",
-      "type": "Reference",
-      "targetType": "EOA",
-      "targetProject": "shared-sharp-verifier"
+      "type": "EOA",
+      "proxyType": "EOA"
     },
     {
       "address": "eth:0x64F4396bb0669C72858Cc50C779b48EB25F45770",
@@ -1284,5 +1282,5 @@
     "starknet/StarknetERC20Bridge": "0x823d646295cd3c589fdd26a112b0adb063e5b33a7c751523d6ba995a98d795b6"
   },
   "usedBlockNumbers": { "ethereum": 25544316 },
-  "permissionsConfigHash": "0xc2a41ecb1e1e03c402f8dcd453f42488c4065b23e7b8144c858b92f15c9f710a"
+  "permissionsConfigHash": "0xc3f56e1fee5e2ceb848142e2a14f60abb6615010aa4b22f289617479d33107b3"
 }

--- a/packages/config/src/projects/shared-sharp-verifier/entrypoints.json
+++ b/packages/config/src/projects/shared-sharp-verifier/entrypoints.json
@@ -20,10 +20,6 @@
       "type": "Contract",
       "project": "shared-sharp-verifier"
     },
-    "eth:0x0405107a60391Eb51821be373ff978115Ee58488": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier"
-    },
     "eth:0x047Dd4275bbDc1eE6b8bf026239E203c617E86D1": {
       "name": "PedersenHashPointsXColumn",
       "type": "Contract",
@@ -279,10 +275,6 @@
       "type": "Contract",
       "project": "shared-sharp-verifier"
     },
-    "eth:0x59232aC80E6d403b6381393e52f4665ECA328558": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier"
-    },
     "eth:0x5C1Ce45534A9c5f7F3E6683Cd79a8ad57EE3a9fe": {
       "name": "SHARPVerifier_2026_13_1",
       "type": "Contract",
@@ -411,10 +403,6 @@
     "eth:0x8f3af16cF4eB89f256cDebeaDd46e1b982dC4775": {
       "name": "CpuOods",
       "type": "Contract",
-      "project": "shared-sharp-verifier"
-    },
-    "eth:0x955B978F3ee7818dA71fA25c676062E6BC462Fec": {
-      "type": "EOA",
       "project": "shared-sharp-verifier"
     },
     "eth:0x99480b7c32C4F8965fF1929a368Dd586C6DC3595": {
@@ -707,10 +695,6 @@
       "type": "Contract",
       "project": "shared-sharp-verifier"
     },
-    "eth:0xebc8416179fE90854fe8B3f774801165572cfD7F": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier"
-    },
     "eth:0xECc282Dc2571E43696d3259490faFa3b98790e20": {
       "name": "PoseidonPoseidonPartialRoundKey1Column",
       "type": "Contract",
@@ -745,56 +729,6 @@
       "name": "CpuVerifierPerpetual_2026_13",
       "type": "Contract",
       "project": "shared-sharp-verifier"
-    },
-    "eth:0x3F3380d9e31D53264dEA568E654b6e9D9EB3895A": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0x54B839D988C9E712cd36cBf7C95dedC2B9F9aE6c": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0x6eEDe907dF99F7FBCd26e71e5b157BBB6483Fc8b": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0x8B0A18cc6472Bf429d058948AF78d85CB25cd284": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0x8Cdcf93be2508cb8b348E539EC8EEF2434BFB2DE": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0x93b1F80BaDc57AE16Ef21d25EEc31A3785e7c426": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0xA410aEA6d7ad518165c214a42730A19fB3828170": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0xb641a2035c7340CDff40f069454EB0B8Bbab6a3C": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0xDBf0eDAebbC97931c595f4aC883d7C7fdedc7526": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
-    },
-    "eth:0xfE325F97146124F3767bFA59899Fa4177fd46D2f": {
-      "type": "EOA",
-      "project": "shared-sharp-verifier",
-      "isLegacy": true
     }
   }
 }

--- a/packages/config/src/projects/sorare/diffHistory.md
+++ b/packages/config/src/projects/sorare/diffHistory.md
@@ -1,3 +1,51 @@
+Generated with discovered.json: 0x777ae6e7abc4d7471333e0d93d08b38a8eda2029
+
+# Diff at Mon, 27 Jul 2026 10:16:47 GMT:
+
+- author: Mateusz Radomski (<radomski.main@protonmail.com>)
+- comparing to: main@4683097a102db212f2168de1647931e7c0ef98e8 block: 1780646255
+- current timestamp: 1780646255
+
+## Description
+
+shared-sharp-verifier changes rediscover
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1780646255 (main branch discovery), not current.
+
+```diff
+    EOA  (eth:0x0405107a60391Eb51821be373ff978115Ee58488) {
+    +++ description: None
+      type:
+-        "Reference"
++        "EOA"
+      targetType:
+-        "EOA"
+      targetProject:
+-        "shared-sharp-verifier"
+      proxyType:
++        "EOA"
+    }
+```
+
+```diff
+    EOA  (eth:0x59232aC80E6d403b6381393e52f4665ECA328558) {
+    +++ description: None
+      type:
+-        "Reference"
++        "EOA"
+      targetType:
+-        "EOA"
+      targetProject:
+-        "shared-sharp-verifier"
+      proxyType:
++        "EOA"
+    }
+```
+
 Generated with discovered.json: 0xc6d846c81d9db0374e0cd5811740ff7d039977ed
 
 # Diff at Fri, 12 Jun 2026 12:07:50 GMT:

--- a/packages/config/src/projects/sorare/discovered.json
+++ b/packages/config/src/projects/sorare/discovered.json
@@ -5,9 +5,8 @@
   "entries": [
     {
       "address": "eth:0x0405107a60391Eb51821be373ff978115Ee58488",
-      "type": "Reference",
-      "targetType": "EOA",
-      "targetProject": "shared-sharp-verifier"
+      "type": "EOA",
+      "proxyType": "EOA"
     },
     {
       "address": "eth:0x3DE55343499f59CEB3f1dE47F2Cd7Eab28F2F5C6",
@@ -56,9 +55,8 @@
     },
     {
       "address": "eth:0x59232aC80E6d403b6381393e52f4665ECA328558",
-      "type": "Reference",
-      "targetType": "EOA",
-      "targetProject": "shared-sharp-verifier"
+      "type": "EOA",
+      "proxyType": "EOA"
     },
     {
       "address": "eth:0x63881ac44293E22F3c3183a0C4113586ABb3e653",
@@ -907,5 +905,5 @@
     "starkex/StarkExchange_Frozen": "0x0136ed1863558a0fd0cd5283912fcd12ca49a1e78ee7595141def29b8e331ac1"
   },
   "usedBlockNumbers": { "ethereum": 25249836 },
-  "permissionsConfigHash": "0x854621f9dfca16025c1656672105e013cc7d495bc19f8c2cc24d9985d92a2ebd"
+  "permissionsConfigHash": "0x7be682060fca143a3fbda915ba31730bac298f3d2c7dbc2d1d7c8136742dd9e2"
 }

--- a/packages/config/src/projects/starknet/diffHistory.md
+++ b/packages/config/src/projects/starknet/diffHistory.md
@@ -1,3 +1,38 @@
+Generated with discovered.json: 0x1308e0d801f222644c71695191c9b9bbead94e5e
+
+# Diff at Mon, 27 Jul 2026 10:17:00 GMT:
+
+- author: Mateusz Radomski (<radomski.main@protonmail.com>)
+- comparing to: main@4683097a102db212f2168de1647931e7c0ef98e8 block: 1784036617
+- current timestamp: 1784036617
+
+## Description
+
+shared-sharp-verifier changes rediscover
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1784036617 (main branch discovery), not current.
+
+```diff
+    EOA  (eth:0x59232aC80E6d403b6381393e52f4665ECA328558) {
+    +++ description: None
+      type:
+-        "Reference"
++        "EOA"
+      targetType:
+-        "EOA"
+      targetProject:
+-        "shared-sharp-verifier"
+      proxyType:
++        "EOA"
+      receivedPermissions:
++        [{"permission":"interact","from":"eth:0x283751A21eafBFcD52297820D27C1f1963D9b5b4","description":"enable the withdrawal limit.","role":".secAgentAC","via":[{"address":"eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5"}]},{"permission":"interact","from":"eth:0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419","description":"enable the withdrawal limit.","role":".secAgentAC","via":[{"address":"eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5"}]},{"permission":"interact","from":"eth:0xbb3400F107804DFB482565FF1Ec8D8aE66747605","description":"enable the withdrawal limit.","role":".secAgentAC","via":[{"address":"eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5"}]},{"permission":"interact","from":"eth:0xcE5485Cfb26914C5dcE00B9BAF0580364daFC7a4","description":"enable the withdrawal limit.","role":".secAgentAC","via":[{"address":"eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5"}]},{"permission":"interact","from":"eth:0xF5b6Ee2CAEb6769659f6C091D209DfdCaF3F69Eb","description":"enable the withdrawal limit.","role":".secAgentAC","via":[{"address":"eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5"}]},{"permission":"interact","from":"eth:0xF6080D9fbEEbcd44D89aFfBFd42F098cbFf92816","description":"enable the withdrawal limit.","role":".secAgentAC","via":[{"address":"eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5"}]}]
+    }
+```
+
 Generated with discovered.json: 0x8c84eab26da3a2f511f98d64077248c379574bbb
 
 # Diff at Tue, 14 Jul 2026 17:11:36 GMT:

--- a/packages/config/src/projects/starknet/discovered.json
+++ b/packages/config/src/projects/starknet/discovered.json
@@ -970,9 +970,64 @@
     },
     {
       "address": "eth:0x59232aC80E6d403b6381393e52f4665ECA328558",
-      "type": "Reference",
-      "targetType": "EOA",
-      "targetProject": "shared-sharp-verifier"
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x283751A21eafBFcD52297820D27C1f1963D9b5b4",
+          "description": "enable the withdrawal limit.",
+          "role": ".secAgentAC",
+          "via": [
+            { "address": "eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xae0Ee0A63A2cE6BaeEFFE56e7714FB4EFE48D419",
+          "description": "enable the withdrawal limit.",
+          "role": ".secAgentAC",
+          "via": [
+            { "address": "eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xbb3400F107804DFB482565FF1Ec8D8aE66747605",
+          "description": "enable the withdrawal limit.",
+          "role": ".secAgentAC",
+          "via": [
+            { "address": "eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xcE5485Cfb26914C5dcE00B9BAF0580364daFC7a4",
+          "description": "enable the withdrawal limit.",
+          "role": ".secAgentAC",
+          "via": [
+            { "address": "eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xF5b6Ee2CAEb6769659f6C091D209DfdCaF3F69Eb",
+          "description": "enable the withdrawal limit.",
+          "role": ".secAgentAC",
+          "via": [
+            { "address": "eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xF6080D9fbEEbcd44D89aFfBFd42F098cbFf92816",
+          "description": "enable the withdrawal limit.",
+          "role": ".secAgentAC",
+          "via": [
+            { "address": "eth:0x77Dd0cf03e1cCbDC750c9E5FDc34b8A3671f88c5" }
+          ]
+        }
+      ]
     },
     {
       "address": "eth:0x5C7DcaECB4D8e49Ea2487c5Cc23C5131Ddb2252F",
@@ -5046,5 +5101,5 @@
     "starknet/StarknetMultiBridge_haltable": "0xe8353adf6ac366e8437be00a65d081e1d14c386d2b59bbfc9f50dcc2d80299b9"
   },
   "usedBlockNumbers": { "ethereum": 25531259 },
-  "permissionsConfigHash": "0x01527bea1efb5cd8417a8e38d119e0816098d2a25aca03466b54fdaf6a6fe9b3"
+  "permissionsConfigHash": "0x8d7e07bdf23362ed999fa6b9521fb6f1214328b6851e693ccb9805ebe31ff9d2"
 }

--- a/packages/discovery/src/discovery/shared-modules/generateEntrypoints.test.ts
+++ b/packages/discovery/src/discovery/shared-modules/generateEntrypoints.test.ts
@@ -1,8 +1,12 @@
 import { Logger } from '@l2beat/backend-tools'
 import { ChainSpecificAddress } from '@l2beat/shared-pure'
 import { expect, mockFn } from 'earl'
+import type { ConfigReader } from '../config/ConfigReader'
 import type { Entrypoint } from '../config/StructureConfig'
-import { generateEntrypoints } from './generateEntrypoints'
+import {
+  generateEntrypoints,
+  generateEntrypointsForProject,
+} from './generateEntrypoints'
 
 const entrypoint1: Entrypoint = {
   project: 'project1',
@@ -109,6 +113,67 @@ describe(generateEntrypoints.name, () => {
       [ChainSpecificAddress.from('eth', '0x01')]: {
         ...entrypoint1,
         isLegacy: true,
+      },
+    })
+  })
+
+  it('drops legacy EOA entrypoints because EOAs are never entrypoints', () => {
+    const old = {
+      entrypoints: {
+        [ChainSpecificAddress.from('eth', '0x01')]: entrypoint1,
+        [ChainSpecificAddress.from('eth', '0x02')]: entrypoint2,
+      },
+    }
+    const generator = mockFn().returns({ entrypoints: {} })
+    const result = generateEntrypoints(
+      'testProject',
+      old,
+      generator,
+      Logger.SILENT,
+      { updateOnly: true, keepLegacy: true },
+    )
+
+    expect(result?.entrypoints).toEqual({
+      [ChainSpecificAddress.from('eth', '0x01')]: {
+        ...entrypoint1,
+        isLegacy: true,
+      },
+    })
+  })
+})
+
+describe(generateEntrypointsForProject.name, () => {
+  it('generates entrypoints from contracts only, skipping EOAs and references', () => {
+    const discovery = {
+      entries: [
+        {
+          address: ChainSpecificAddress.from('eth', '0x01'),
+          type: 'Contract',
+          name: 'Contract1',
+        },
+        {
+          address: ChainSpecificAddress.from('eth', '0x02'),
+          type: 'EOA',
+          name: 'MultisigSigner',
+        },
+        {
+          address: ChainSpecificAddress.from('eth', '0x03'),
+          type: 'Reference',
+          targetProject: 'other-project',
+        },
+      ],
+    }
+    const configReader = {
+      readDiscovery: mockFn().returns(discovery),
+    } as unknown as ConfigReader
+
+    const result = generateEntrypointsForProject('project', configReader)
+
+    expect(result.entrypoints).toEqual({
+      [ChainSpecificAddress.from('eth', '0x01')]: {
+        name: 'Contract1',
+        type: 'Contract',
+        project: 'project',
       },
     })
   })

--- a/packages/discovery/src/discovery/shared-modules/generateEntrypoints.test.ts
+++ b/packages/discovery/src/discovery/shared-modules/generateEntrypoints.test.ts
@@ -117,7 +117,7 @@ describe(generateEntrypoints.name, () => {
     })
   })
 
-  it('drops legacy EOA entrypoints because EOAs are never entrypoints', () => {
+  it('drops legacy EOA entrypoints because EOAs must come from current initial addresses', () => {
     const old = {
       entrypoints: {
         [ChainSpecificAddress.from('eth', '0x01')]: entrypoint1,
@@ -143,7 +143,7 @@ describe(generateEntrypoints.name, () => {
 })
 
 describe(generateEntrypointsForProject.name, () => {
-  it('generates entrypoints from contracts only, skipping EOAs and references', () => {
+  it('generates entrypoints from contracts and initial addresses only', () => {
     const discovery = {
       entries: [
         {
@@ -161,10 +161,20 @@ describe(generateEntrypointsForProject.name, () => {
           type: 'Reference',
           targetProject: 'other-project',
         },
+        {
+          address: ChainSpecificAddress.from('eth', '0x04'),
+          type: 'EOA',
+          name: 'InitialEoa',
+        },
       ],
     }
     const configReader = {
       readDiscovery: mockFn().returns(discovery),
+      readConfig: mockFn().returns({
+        structure: {
+          initialAddresses: [ChainSpecificAddress.from('eth', '0x04')],
+        },
+      }),
     } as unknown as ConfigReader
 
     const result = generateEntrypointsForProject('project', configReader)
@@ -173,6 +183,11 @@ describe(generateEntrypointsForProject.name, () => {
       [ChainSpecificAddress.from('eth', '0x01')]: {
         name: 'Contract1',
         type: 'Contract',
+        project: 'project',
+      },
+      [ChainSpecificAddress.from('eth', '0x04')]: {
+        name: 'InitialEoa',
+        type: 'EOA',
         project: 'project',
       },
     })

--- a/packages/discovery/src/discovery/shared-modules/generateEntrypoints.ts
+++ b/packages/discovery/src/discovery/shared-modules/generateEntrypoints.ts
@@ -27,7 +27,8 @@ export function generateEntrypoints(
     logger.info('(keeping legacy entrypoints)')
     const generated = entrypoints.entrypoints ?? []
     const legacyEntries = Object.entries(existingFile.entrypoints ?? [])
-      .filter(([addr, _]) => !(addr in generated))
+      // EOAs are never entrypoints, so legacy ones are garbage-collected
+      .filter(([addr, v]) => !(addr in generated) && v.type === 'Contract')
       .map(([addr, v]) => [addr, { ...v, isLegacy: true }])
     entrypoints.entrypoints = {
       ...entrypoints.entrypoints,
@@ -64,14 +65,17 @@ export async function generateEntrypointsCommand(
   }
 }
 
-function generateEntrypointsForProject(
+export function generateEntrypointsForProject(
   project: string,
   configReader: ConfigReader,
 ) {
   const discovery = configReader.readDiscovery(project)
   const entrypoints: Record<ChainSpecificAddress, Entrypoint> = {}
   discovery.entries.forEach((e) => {
-    if (e.type === 'Reference') {
+    // Only contracts own a project's discovery graph. EOAs (e.g. multisig
+    // signers) can belong to many unrelated projects, so turning one into
+    // a cross-project reference would merge unrelated discoveries.
+    if (e.type !== 'Contract') {
       return
     }
     entrypoints[e.address] = {

--- a/packages/discovery/src/discovery/shared-modules/generateEntrypoints.ts
+++ b/packages/discovery/src/discovery/shared-modules/generateEntrypoints.ts
@@ -27,7 +27,8 @@ export function generateEntrypoints(
     logger.info('(keeping legacy entrypoints)')
     const generated = entrypoints.entrypoints ?? []
     const legacyEntries = Object.entries(existingFile.entrypoints ?? [])
-      // EOAs are never entrypoints, so legacy ones are garbage-collected
+      // EOA entrypoints must come from current initialAddresses (see the
+      // generator), so legacy EOAs are garbage-collected
       .filter(([addr, v]) => !(addr in generated) && v.type === 'Contract')
       .map(([addr, v]) => [addr, { ...v, isLegacy: true }])
     entrypoints.entrypoints = {
@@ -70,12 +71,19 @@ export function generateEntrypointsForProject(
   configReader: ConfigReader,
 ) {
   const discovery = configReader.readDiscovery(project)
+  const initialAddresses = new Set(
+    configReader.readConfig(project).structure.initialAddresses,
+  )
   const entrypoints: Record<ChainSpecificAddress, Entrypoint> = {}
   discovery.entries.forEach((e) => {
-    // Only contracts own a project's discovery graph. EOAs (e.g. multisig
-    // signers) can belong to many unrelated projects, so turning one into
-    // a cross-project reference would merge unrelated discoveries.
-    if (e.type !== 'Contract') {
+    if (e.type === 'Reference') {
+      return
+    }
+    // Discovered EOAs (e.g. multisig signers) can belong to many unrelated
+    // projects, so an EOA may only become an entrypoint when it is
+    // explicitly listed as an initial address. Anything else would merge
+    // unrelated discoveries via cross-project references.
+    if (e.type === 'EOA' && !initialAddresses.has(e.address)) {
       return
     }
     entrypoints[e.address] = {


### PR DESCRIPTION
Part of L2B-13952

EOAs are now not part of the entrypoints by default. You can enforce an EOA to be an entrypoint by placing it in the initialAddresses of a module.