### PR TITLE
Fix eth:-prefixed daTracking inboxes for zksync2 and adi

### DIFF
--- a/packages/config/src/processing/getProjects.test.ts
+++ b/packages/config/src/processing/getProjects.test.ts
@@ -736,6 +736,26 @@ describe('getProjects', () => {
       }
     })
 
+    // The backend compares these raw strings against tx to/from addresses,
+    // so a chain-prefixed address (e.g. 'eth:0x...') silently matches nothing
+    describe('every ethereum inbox and sequencer is a plain unprefixed address', () => {
+      for (const project of projects) {
+        if (project.daTrackingConfig) {
+          it(project.id, () => {
+            assert(project.daTrackingConfig) // type issue
+            for (const config of project.daTrackingConfig) {
+              if (config.type === 'ethereum') {
+                expect(() => EthereumAddress(config.inbox)).not.toThrow()
+                for (const sequencer of config.sequencers ?? []) {
+                  expect(() => EthereumAddress(sequencer)).not.toThrow()
+                }
+              }
+            }
+          })
+        }
+      }
+    })
+
     describe('every appId is unique for Avail projects', () => {
       const appIds = new Map<string, string>()
       for (const project of projects) {

--- a/packages/config/src/projects/adi/adi.ts
+++ b/packages/config/src/projects/adi/adi.ts
@@ -107,7 +107,7 @@ export const adi: ScalingProject = {
         type: 'ethereum',
         daLayer: ProjectId('ethereum'),
         sinceBlock: 23874833,
-        inbox: 'eth:0xE28cAc160C2a79dFA1fbd2169AC5fa5d061cf186',
+        inbox: '0xE28cAc160C2a79dFA1fbd2169AC5fa5d061cf186',
         sequencers: [
           '0xF8fF3e62E94807a5C687f418Fe36942dD3a24524',
           '0x6090e365149d005517e2013926cD18d767f04Aa1',

--- a/packages/config/src/projects/zksync2/zksync2.ts
+++ b/packages/config/src/projects/zksync2/zksync2.ts
@@ -104,7 +104,7 @@ export const zksync2: ScalingProject = zkStackL2({
       daLayer: ProjectId('ethereum'),
       sinceBlock: 21809364,
       untilBlock: 23016895, // migration to Gateway
-      inbox: 'eth:0x8c0Bfc04AdA21fd496c55B8C50331f904306F564',
+      inbox: '0x8c0Bfc04AdA21fd496c55B8C50331f904306F564',
       sequencers: [
         '0xE1D8d4C8656949764c2c9Fa9faB2C15d3F42e6C2',
         '0x30066439887C0a509Cb38E45c9262E6924a29BbD',
@@ -118,7 +118,7 @@ export const zksync2: ScalingProject = zkStackL2({
       daLayer: ProjectId('ethereum'),
       sinceBlock: 23016895, // migration to Gateway
       untilBlock: 23633924, // v29 upgrade
-      inbox: 'eth:0x8c0Bfc04AdA21fd496c55B8C50331f904306F564',
+      inbox: '0x8c0Bfc04AdA21fd496c55B8C50331f904306F564',
       sequencers: [
         '0x14F19299476664665eDa17DBb7dA7e62E3253aa8',
         '0x7d95f0B9D3383D58E39a75a67760aA2153D355A2',
@@ -128,7 +128,7 @@ export const zksync2: ScalingProject = zkStackL2({
       type: 'ethereum',
       daLayer: ProjectId('ethereum'),
       sinceBlock: 23633924,
-      inbox: 'eth:0x2e5110cF18678Ec99818bFAa849B8C881744b776',
+      inbox: '0x2e5110cF18678Ec99818bFAa849B8C881744b776',
       sequencers: [
         '0x14F19299476664665eDa17DBb7dA7e62E3253aa8',
         '0x7d95f0B9D3383D58E39a75a67760aA2153D355A2',


### PR DESCRIPTION
## Problem

The backend DA-tracking matcher (`matchEthereumProject` in `DaService.ts`) compares the config's `inbox` string against the blob transaction's `to` address verbatim — there is no chain-prefix stripping anywhere in the pipeline (`EthereumDaProvider` sets `blob.inbox = tx.to`, a plain `0x…` address).

Four config entries use `eth:`-prefixed inboxes and therefore **match zero blobs**:

- **zksync2** — all 3 `nonTemplateDaTracking` entries (prefixed since the Gateway migration commits, Aug/Oct 2025), so ZKsync Era's ethereum DA tracking has been dark since then
- **adi** — its single `daTracking` entry, dead since the project was added

## Fix

- Strip the `eth:` prefix from the four inbox values. This mints new config identities; the current ones hold no data, so nothing is wiped, and the existing since/until blocks drive a full backfill.
- Add a test in `getProjects.test.ts` asserting every ethereum daTracking `inbox` and `sequencer` parses as a plain `EthereumAddress` (a prefixed value throws). Verified the test fails on the pre-fix config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)