### PR TITLE
Add scaling projects compare page

### DIFF
--- a/packages/frontend/src/env.ts
+++ b/packages/frontend/src/env.ts
@@ -65,6 +65,7 @@ const SERVER_CONFIG = {
     .optional(),
   INTEROP_CHAINS: stringArray.optional(),
   INTEROP_UPCOMING_CHAINS: stringArray.optional(),
+  FEATURE_FLAG_COMPARE_PROJECTS: featureFlag.default(false),
 }
 const ServerEnv = z.object(SERVER_CONFIG)
 
@@ -127,6 +128,7 @@ function getRawEnv(): Record<
     LOG_LEVEL: process.env.LOG_LEVEL,
     INTEROP_CHAINS: process.env.INTEROP_CHAINS,
     INTEROP_UPCOMING_CHAINS: process.env.INTEROP_UPCOMING_CHAINS,
+    FEATURE_FLAG_COMPARE_PROJECTS: process.env.FEATURE_FLAG_COMPARE_PROJECTS,
     // Client
     CLIENT_SIDE_GITCOIN_ROUND_LIVE: process.env.CLIENT_SIDE_GITCOIN_ROUND_LIVE,
     CLIENT_SIDE_SHOW_HIRING_BADGE: process.env.CLIENT_SIDE_SHOW_HIRING_BADGE,

--- a/packages/frontend/src/pages/pageLoaders.ts
+++ b/packages/frontend/src/pages/pageLoaders.ts
@@ -13,6 +13,8 @@ export const pageLoaders = {
   ScalingActivityPage: async () =>
     (await import('./scaling/activity/ScalingActivityPage'))
       .ScalingActivityPage,
+  ScalingComparePage: async () =>
+    (await import('./scaling/compare/ScalingComparePage')).ScalingComparePage,
   ScalingRiskDataAvailabilityPage: async () =>
     (
       await import(

--- a/packages/frontend/src/pages/scaling/ScalingRouter.ts
+++ b/packages/frontend/src/pages/scaling/ScalingRouter.ts
@@ -67,22 +67,13 @@ export function createScalingRouter(
   })
 
   if (env.FEATURE_FLAG_COMPARE_PROJECTS) {
-    router.get(
-      '/scaling/compare',
-      validateRoute({
-        query: v.object({
-          metric: v.string().optional(),
-          projects: v.string().optional(),
-          range: v.string().optional(),
-          scale: v.string().optional(),
-        }),
-      }),
-      async (req, res) => {
-        const data = await getScalingCompareData(req, manifest, cache)
-        const html = await render(data, req.originalUrl)
-        res.status(200).send(html)
-      },
-    )
+    // No validateRoute: the compare page parses and sanitizes its query
+    // params itself (unknown values fall back to defaults, never 400).
+    router.get('/scaling/compare', async (req, res) => {
+      const data = await getScalingCompareData(req, manifest, cache)
+      const html = await render(data, req.originalUrl)
+      res.status(200).send(html)
+    })
   }
 
   router.get(

--- a/packages/frontend/src/pages/scaling/ScalingRouter.ts
+++ b/packages/frontend/src/pages/scaling/ScalingRouter.ts
@@ -1,6 +1,7 @@
 import type { InMemoryCache } from '@l2beat/shared-pure'
 import { v } from '@l2beat/validate'
 import express from 'express'
+import { env } from '~/env'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
@@ -65,22 +66,24 @@ export function createScalingRouter(
     res.status(200).send(html)
   })
 
-  router.get(
-    '/scaling/compare',
-    validateRoute({
-      query: v.object({
-        metric: v.string().optional(),
-        projects: v.string().optional(),
-        range: v.string().optional(),
-        scale: v.string().optional(),
+  if (env.FEATURE_FLAG_COMPARE_PROJECTS) {
+    router.get(
+      '/scaling/compare',
+      validateRoute({
+        query: v.object({
+          metric: v.string().optional(),
+          projects: v.string().optional(),
+          range: v.string().optional(),
+          scale: v.string().optional(),
+        }),
       }),
-    }),
-    async (req, res) => {
-      const data = await getScalingCompareData(req, manifest, cache)
-      const html = await render(data, req.originalUrl)
-      res.status(200).send(html)
-    },
-  )
+      async (req, res) => {
+        const data = await getScalingCompareData(req, manifest, cache)
+        const html = await render(data, req.originalUrl)
+        res.status(200).send(html)
+      },
+    )
+  }
 
   router.get(
     '/scaling/tvs',

--- a/packages/frontend/src/pages/scaling/ScalingRouter.ts
+++ b/packages/frontend/src/pages/scaling/ScalingRouter.ts
@@ -6,6 +6,7 @@ import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
 import { getScalingActivityData } from './activity/getScalingActivityData'
 import { getScalingArchivedData } from './archived/getScalingArchivedData'
+import { getScalingCompareData } from './compare/getScalingCompareData'
 import { getScalingCostsData } from './costs/getScalingCostsData'
 import { getScalingLivenessData } from './liveness/getScalingLivenessData'
 import { getScalingProjectData } from './project/getScalingProjectData'
@@ -63,6 +64,23 @@ export function createScalingRouter(
     const html = await render(data, req.originalUrl)
     res.status(200).send(html)
   })
+
+  router.get(
+    '/scaling/compare',
+    validateRoute({
+      query: v.object({
+        metric: v.string().optional(),
+        projects: v.string().optional(),
+        range: v.string().optional(),
+        scale: v.string().optional(),
+      }),
+    }),
+    async (req, res) => {
+      const data = await getScalingCompareData(req, manifest, cache)
+      const html = await render(data, req.originalUrl)
+      res.status(200).send(html)
+    },
+  )
 
   router.get(
     '/scaling/tvs',

--- a/packages/frontend/src/pages/scaling/compare/ScalingComparePage.tsx
+++ b/packages/frontend/src/pages/scaling/compare/ScalingComparePage.tsx
@@ -1,0 +1,43 @@
+import type { DehydratedState } from '@tanstack/react-query'
+import { HydrationBoundary } from '@tanstack/react-query'
+import { MainPageHeader } from '~/components/MainPageHeader'
+import type { AppLayoutProps } from '~/layouts/AppLayout'
+import { AppLayout } from '~/layouts/AppLayout'
+import { SideNavLayout } from '~/layouts/SideNavLayout'
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import type { ChartRange } from '~/utils/range/range'
+import { ScalingCompareChart } from './components/ScalingCompareChart'
+import type { CompareChartState } from './utils/compareChartState'
+
+interface Props extends AppLayoutProps {
+  allProjects: CompareProjectEntry[]
+  initialState: CompareChartState
+  defaultProjectSlugs: string[]
+  initialChartRange: ChartRange
+  queryState: DehydratedState
+}
+
+export function ScalingComparePage({
+  allProjects,
+  initialState,
+  defaultProjectSlugs,
+  initialChartRange,
+  queryState,
+  ...props
+}: Props) {
+  return (
+    <AppLayout {...props}>
+      <HydrationBoundary state={queryState}>
+        <SideNavLayout>
+          <MainPageHeader>Compare Projects</MainPageHeader>
+          <ScalingCompareChart
+            allProjects={allProjects}
+            initialState={initialState}
+            defaultProjectSlugs={defaultProjectSlugs}
+            initialChartRange={initialChartRange}
+          />
+        </SideNavLayout>
+      </HydrationBoundary>
+    </AppLayout>
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { ChartScale } from '~/components/chart/types'
+import { ChartControlsWrapper } from '~/components/core/chart/ChartControlsWrapper'
+import { ChartRangeControls } from '~/components/core/chart/ChartRangeControls'
+import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
+import { Skeleton } from '~/components/core/Skeleton'
+import { useDebouncedValue } from '~/hooks/useDebouncedValue'
+import { useEventListener } from '~/hooks/useEventListener'
+import { useIsClient } from '~/hooks/useIsClient'
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import type { ChartRange } from '~/utils/range/range'
+import { COMPARE_METRICS } from '../metrics'
+import { buildCompareUrl } from '../utils/buildCompareUrl'
+import {
+  COMPARE_RANGE_OPTIONS,
+  type CompareChartState,
+  chartRangeToCompareRange,
+  compareRangeToChartRange,
+  isSameCompareState,
+} from '../utils/compareChartState'
+import { parseCompareStateFromSearchParams } from '../utils/parseCompareStateFromSearchParams'
+
+interface Props {
+  allProjects: CompareProjectEntry[]
+  initialState: CompareChartState
+  defaultProjectSlugs: string[]
+  initialChartRange: ChartRange
+}
+
+export function ScalingCompareChart({
+  allProjects,
+  initialState,
+  defaultProjectSlugs,
+  initialChartRange,
+}: Props) {
+  const [state, setState] = useState(initialState)
+  // The resolved range is kept separately so the SSR-prefetched query input
+  // (computed once on the server) is reused verbatim on first paint.
+  const [chartRange, setChartRange] = useState(initialChartRange)
+
+  const validSlugs = useMemo(
+    () => allProjects.map((project) => project.slug),
+    [allProjects],
+  )
+  useCompareUrlSync(state, validSlugs, (parsed) => {
+    setState(parsed)
+    setChartRange(compareRangeToChartRange(parsed.range))
+  })
+
+  const selectedProjects = useMemo(() => {
+    const bySlug = new Map(
+      allProjects.map((project) => [project.slug, project]),
+    )
+    const slugs =
+      state.projects.length > 0 ? state.projects : defaultProjectSlugs
+    return slugs
+      .map((slug) => bySlug.get(slug))
+      .filter((project) => project !== undefined)
+  }, [state.projects, allProjects, defaultProjectSlugs])
+
+  const metric = COMPARE_METRICS[state.metric]
+
+  return (
+    <section className="mt-4 flex flex-col gap-2 md:mt-6">
+      <metric.Chart
+        projects={selectedProjects}
+        range={chartRange}
+        scale={state.scale}
+      />
+      <Controls
+        scale={state.scale}
+        setScale={(scale) => setState((prev) => ({ ...prev, scale }))}
+        range={chartRange}
+        setRange={(range) => {
+          setChartRange(range)
+          setState((prev) => ({
+            ...prev,
+            range: chartRangeToCompareRange(range),
+          }))
+        }}
+      />
+    </section>
+  )
+}
+
+/**
+ * Keeps the URL in sync with the chart state (defaults omitted) and applies
+ * URL state on browser back/forward, mirroring the interop pages.
+ */
+function useCompareUrlSync(
+  state: CompareChartState,
+  validSlugs: string[],
+  onPopState: (parsed: CompareChartState) => void,
+) {
+  const debouncedState = useDebouncedValue(state, 300)
+  const skipNextUrlUpdate = useRef(false)
+
+  useEffect(() => {
+    if (skipNextUrlUpdate.current) {
+      skipNextUrlUpdate.current = false
+      return
+    }
+
+    const currentState = parseCompareStateFromSearchParams({
+      searchParams: new URLSearchParams(window.location.search),
+      validSlugs,
+    })
+    if (isSameCompareState(currentState, debouncedState)) {
+      return
+    }
+
+    const nextUrl = buildCompareUrl(window.location.pathname, debouncedState)
+    const currentUrl = window.location.pathname + window.location.search
+    if (nextUrl === currentUrl) {
+      return
+    }
+
+    window.history.pushState({}, '', nextUrl)
+  }, [debouncedState, validSlugs])
+
+  useEventListener('popstate', () => {
+    skipNextUrlUpdate.current = true
+
+    onPopState(
+      parseCompareStateFromSearchParams({
+        searchParams: new URLSearchParams(window.location.search),
+        validSlugs,
+      }),
+    )
+  })
+}
+
+function Controls({
+  scale,
+  setScale,
+  range,
+  setRange,
+}: {
+  scale: ChartScale
+  setScale: (scale: ChartScale) => void
+  range: ChartRange
+  setRange: (range: ChartRange) => void
+}) {
+  const isClient = useIsClient()
+  return (
+    <ChartControlsWrapper>
+      <div className="flex gap-1">
+        {isClient ? (
+          <RadioGroup
+            name="compareChartScale"
+            value={scale}
+            onValueChange={(value) => setScale(value as ChartScale)}
+          >
+            <RadioGroupItem value="symlog">LOG</RadioGroupItem>
+            <RadioGroupItem value="linear">LIN</RadioGroupItem>
+          </RadioGroup>
+        ) : (
+          <Skeleton className="h-8 w-[91px] md:w-[95px]" />
+        )}
+      </div>
+      <ChartRangeControls
+        name="compareChart"
+        value={range}
+        setValue={setRange}
+        options={COMPARE_RANGE_OPTIONS.map((value) => ({
+          value,
+          label: value.toUpperCase(),
+        }))}
+      />
+    </ChartControlsWrapper>
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -14,9 +14,10 @@ import { buildCompareUrl } from '../utils/buildCompareUrl'
 import {
   COMPARE_RANGE_OPTIONS,
   type CompareChartState,
-  chartRangeToCompareRange,
-  compareRangeToChartRange,
+  type CompareClientState,
   isSameCompareState,
+  toCompareClientState,
+  toCompareUrlState,
 } from '../utils/compareChartState'
 import { parseCompareStateFromSearchParams } from '../utils/parseCompareStateFromSearchParams'
 
@@ -33,19 +34,19 @@ export function ScalingCompareChart({
   defaultProjectSlugs,
   initialChartRange,
 }: Props) {
-  const [state, setState] = useState(initialState)
-  // The resolved range is kept separately so the SSR-prefetched query input
-  // (computed once on the server) is reused verbatim on first paint.
-  const [chartRange, setChartRange] = useState(initialChartRange)
+  // Seeded with the server-resolved range so the SSR-prefetched query input
+  // is reused verbatim on first paint.
+  const [state, setState] = useState(() =>
+    toCompareClientState(initialState, initialChartRange),
+  )
 
   const validSlugs = useMemo(
     () => allProjects.map((project) => project.slug),
     [allProjects],
   )
-  useCompareUrlSync(state, validSlugs, (parsed) => {
-    setState(parsed)
-    setChartRange(compareRangeToChartRange(parsed.range))
-  })
+  useCompareUrlSync(state, validSlugs, (parsed) =>
+    setState(toCompareClientState(parsed)),
+  )
 
   const selectedProjects = useMemo(() => {
     const bySlug = new Map(
@@ -64,20 +65,14 @@ export function ScalingCompareChart({
     <section className="mt-4 flex flex-col gap-2 md:mt-6">
       <metric.Chart
         projects={selectedProjects}
-        range={chartRange}
+        range={state.chartRange}
         scale={state.scale}
       />
       <Controls
         scale={state.scale}
         setScale={(scale) => setState((prev) => ({ ...prev, scale }))}
-        range={chartRange}
-        setRange={(range) => {
-          setChartRange(range)
-          setState((prev) => ({
-            ...prev,
-            range: chartRangeToCompareRange(range),
-          }))
-        }}
+        range={state.chartRange}
+        setRange={(chartRange) => setState((prev) => ({ ...prev, chartRange }))}
       />
     </section>
   )
@@ -88,7 +83,7 @@ export function ScalingCompareChart({
  * URL state on browser back/forward, mirroring the interop pages.
  */
 function useCompareUrlSync(
-  state: CompareChartState,
+  state: CompareClientState,
   validSlugs: string[],
   onPopState: (parsed: CompareChartState) => void,
 ) {
@@ -105,11 +100,12 @@ function useCompareUrlSync(
       searchParams: new URLSearchParams(window.location.search),
       validSlugs,
     })
-    if (isSameCompareState(currentState, debouncedState)) {
+    const urlState = toCompareUrlState(debouncedState)
+    if (isSameCompareState(currentState, urlState)) {
       return
     }
 
-    const nextUrl = buildCompareUrl(window.location.pathname, debouncedState)
+    const nextUrl = buildCompareUrl(window.location.pathname, urlState)
     const currentUrl = window.location.pathname + window.location.search
     if (nextUrl === currentUrl) {
       return

--- a/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
+++ b/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
@@ -17,17 +17,7 @@ import {
 import { parseCompareStateFromSearchParams } from './utils/parseCompareStateFromSearchParams'
 
 export async function getScalingCompareData(
-  req: Request<
-    unknown,
-    unknown,
-    unknown,
-    {
-      metric?: string
-      projects?: string
-      range?: string
-      scale?: string
-    }
-  >,
+  req: Request,
   manifest: Manifest,
   cache: InMemoryCache,
 ): Promise<RenderData> {
@@ -83,7 +73,7 @@ async function getCompareData(originalUrl: string, cache: InMemoryCache) {
       ttl: 5 * 60,
       staleWhileRevalidate: 25 * 60,
     },
-    () => getChartData(initialState, allProjects),
+    () => getPrefetchedChartData(initialState, allProjects),
   )
 
   return {
@@ -93,7 +83,7 @@ async function getCompareData(originalUrl: string, cache: InMemoryCache) {
   }
 }
 
-async function getChartData(
+async function getPrefetchedChartData(
   initialState: CompareChartState,
   allProjects: CompareProjectEntry[],
 ) {

--- a/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
+++ b/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
@@ -1,0 +1,134 @@
+import type { InMemoryCache } from '@l2beat/shared-pure'
+import type { Request } from 'express'
+import { getAppLayoutProps } from '~/common/getAppLayoutProps'
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import { getCompareProjectEntries } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import { getMetadata } from '~/ssr/head/getMetadata'
+import type { RenderData } from '~/ssr/types'
+import { getSsrHelpers } from '~/trpc/server'
+import type { Manifest } from '~/utils/Manifest'
+import { COMPARE_SERVER_METRICS } from './server/compareServerMetrics'
+import { buildCompareUrl } from './utils/buildCompareUrl'
+import {
+  type CompareChartState,
+  compareRangeToChartRange,
+  DEFAULT_COMPARE_PROJECTS_COUNT,
+} from './utils/compareChartState'
+import { parseCompareStateFromSearchParams } from './utils/parseCompareStateFromSearchParams'
+
+export async function getScalingCompareData(
+  req: Request<
+    unknown,
+    unknown,
+    unknown,
+    {
+      metric?: string
+      projects?: string
+      range?: string
+      scale?: string
+    }
+  >,
+  manifest: Manifest,
+  cache: InMemoryCache,
+): Promise<RenderData> {
+  const [appLayoutProps, data] = await Promise.all([
+    getAppLayoutProps(),
+    getCompareData(req.originalUrl, cache),
+  ])
+
+  return {
+    head: {
+      manifest,
+      metadata: getMetadata(manifest, {
+        title: 'Compare Projects - L2BEAT',
+        description:
+          'Compare Ethereum scaling projects on a single chart across metrics like value secured.',
+        url: req.originalUrl,
+        openGraph: {
+          image: '/meta-images/scaling/summary/opengraph-image.png',
+        },
+      }),
+    },
+    ssr: {
+      page: 'ScalingComparePage',
+      props: {
+        ...appLayoutProps,
+        ...data,
+      },
+    },
+  }
+}
+
+async function getCompareData(originalUrl: string, cache: InMemoryCache) {
+  const allProjects = await cache.get(
+    {
+      key: ['scaling', 'compare', 'projects'],
+      ttl: 5 * 60,
+      staleWhileRevalidate: 25 * 60,
+    },
+    () => getCompareProjectEntries(),
+  )
+  const searchParams = new URLSearchParams(originalUrl.split('?')[1] ?? '')
+  const initialState = parseCompareStateFromSearchParams({
+    searchParams,
+    validSlugs: allProjects.map((project) => project.slug),
+  })
+
+  // Key by the canonical URL of the parsed state so garbage params collapse
+  // into the same cache entry instead of growing the cache per unique URL.
+  const canonicalUrl = buildCompareUrl('/scaling/compare', initialState)
+  const chartData = await cache.get(
+    {
+      key: ['scaling', 'compare', 'data', canonicalUrl],
+      ttl: 5 * 60,
+      staleWhileRevalidate: 25 * 60,
+    },
+    () => getChartData(initialState, allProjects),
+  )
+
+  return {
+    allProjects,
+    initialState,
+    ...chartData,
+  }
+}
+
+async function getChartData(
+  initialState: CompareChartState,
+  allProjects: CompareProjectEntry[],
+) {
+  const serverMetric = COMPARE_SERVER_METRICS[initialState.metric]
+  const defaultProjects = await serverMetric.getDefaultProjects(
+    allProjects,
+    DEFAULT_COMPARE_PROJECTS_COUNT,
+  )
+  const selectedProjects = getSelectedProjects(
+    initialState.projects,
+    defaultProjects,
+    allProjects,
+  )
+
+  const initialChartRange = compareRangeToChartRange(initialState.range)
+  const helpers = getSsrHelpers()
+  await serverMetric.prefetch(helpers, selectedProjects, initialChartRange)
+
+  return {
+    defaultProjectSlugs: defaultProjects.map((project) => project.slug),
+    initialChartRange,
+    queryState: helpers.dehydrate(),
+  }
+}
+
+function getSelectedProjects(
+  slugs: string[],
+  defaultProjects: CompareProjectEntry[],
+  allProjects: CompareProjectEntry[],
+): CompareProjectEntry[] {
+  if (slugs.length === 0) {
+    return defaultProjects
+  }
+  const bySlug = new Map(allProjects.map((project) => [project.slug, project]))
+  return slugs
+    .map((slug) => bySlug.get(slug))
+    .filter((project) => project !== undefined)
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/index.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/index.ts
@@ -6,7 +6,6 @@ export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
   tvs: {
     id: 'tvs',
     label: 'Value Secured',
-    unit: 'usd',
     Chart: TvsCompareChart,
   },
 }

--- a/packages/frontend/src/pages/scaling/compare/metrics/index.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/index.ts
@@ -1,0 +1,12 @@
+import type { CompareMetricId } from '../utils/compareChartState'
+import { TvsCompareChart } from './tvs/TvsCompareChart'
+import type { CompareMetric } from './types'
+
+export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
+  tvs: {
+    id: 'tvs',
+    label: 'Value Secured',
+    unit: 'usd',
+    Chart: TvsCompareChart,
+  },
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
@@ -1,0 +1,187 @@
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { Line, LineChart } from 'recharts'
+import type {
+  ChartMeta,
+  CustomChartTooltipProps,
+} from '~/components/core/chart/Chart'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipWrapper,
+  useChart,
+} from '~/components/core/chart/Chart'
+import { ChartCommonComponents } from '~/components/core/chart/ChartCommonComponents'
+import { ChartDataIndicator } from '~/components/core/chart/ChartDataIndicator'
+import { ChartLegendToggleAll } from '~/components/core/chart/ChartLegendToggleAll'
+import { ChartTimeRange } from '~/components/core/chart/ChartTimeRange'
+import { useChartDataKeys } from '~/components/core/chart/hooks/useChartDataKeys'
+import { getChartTimeRangeFromData } from '~/components/core/chart/utils/getChartTimeRangeFromData'
+import { useTRPC } from '~/trpc/React'
+import { formatTimestamp } from '~/utils/dates'
+import { generateAccessibleColors } from '~/utils/generateColors'
+import { formatCurrency } from '~/utils/number-format/formatCurrency'
+import type { CompareMetricChartProps } from '../types'
+import { getTvsCompareChartParams } from './getTvsCompareChartParams'
+
+export function TvsCompareChart({
+  projects,
+  range,
+  scale,
+}: CompareMetricChartProps) {
+  const trpc = useTRPC()
+  const { data, isLoading } = useQuery(
+    trpc.tvs.detailedChartWithProjectsRanges.queryOptions(
+      getTvsCompareChartParams(projects, range),
+    ),
+  )
+
+  const chartMeta = useMemo<ChartMeta>(() => {
+    const colors = generateAccessibleColors(projects.length)
+    return projects.reduce<ChartMeta>((acc, project, index) => {
+      acc[project.id] = {
+        label: (
+          <span className="inline-flex items-center gap-1">
+            <img
+              src={project.iconUrl}
+              alt=""
+              width={14}
+              height={14}
+              className="size-3.5 rounded-full"
+            />
+            {project.name}
+          </span>
+        ),
+        legendLabel: project.shortName ?? project.name,
+        color: colors[index] ?? 'var(--secondary)',
+        indicatorType: { shape: 'line' },
+      }
+      return acc
+    }, {})
+  }, [projects])
+
+  const { dataKeys, toggleDataKey, toggleAllDataKeys, showAllSelected } =
+    useChartDataKeys(chartMeta)
+
+  const chartData = useMemo(
+    () =>
+      data?.chart.map(([timestamp, _ethPrice, valuesByProject]) => {
+        const point: { timestamp: number; [key: string]: number | null } = {
+          timestamp,
+        }
+        for (const project of projects) {
+          point[project.id] = valuesByProject[project.id]?.[0] ?? null
+        }
+        return point
+      }),
+    [data, projects],
+  )
+
+  const timeRange = useMemo(
+    () => getChartTimeRangeFromData(chartData),
+    [chartData],
+  )
+
+  return (
+    <div className="flex flex-col">
+      <div className="mt-1 mb-2">
+        <ChartTimeRange timeRange={timeRange} />
+      </div>
+      <ChartContainer
+        data={chartData}
+        meta={chartMeta}
+        isLoading={isLoading}
+        interactiveLegend={{
+          dataKeys,
+          onItemClick: toggleDataKey,
+        }}
+      >
+        {/* Without right:1 the chart last point is not hoverable for some reason */}
+        <LineChart responsive data={chartData} margin={{ top: 20, right: 1 }}>
+          <ChartLegendToggleAll
+            showAllSelected={showAllSelected}
+            onToggleAll={toggleAllDataKeys}
+          />
+          {projects.map((project) => (
+            <Line
+              key={project.id}
+              dataKey={project.id}
+              hide={!dataKeys.includes(project.id)}
+              stroke={chartMeta[project.id]?.color}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+          <ChartCommonComponents
+            data={chartData}
+            isLoading={isLoading}
+            yAxis={{
+              scale: scale === 'symlog' ? 'symlog' : 'auto',
+              tickCount: 4,
+              tickFormatter: (value) => formatCurrency(Number(value), 'usd'),
+            }}
+            syncedUntil={data?.syncedUntil}
+          />
+          <ChartTooltip content={<CustomTooltip />} />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+function CustomTooltip({ payload, label }: CustomChartTooltipProps) {
+  const { meta } = useChart()
+  if (!payload || typeof label !== 'number') return null
+
+  const visible = payload.filter(
+    (entry) =>
+      entry.type !== 'none' &&
+      !entry.hide &&
+      entry.value !== null &&
+      entry.value !== undefined,
+  )
+  if (visible.length === 0) return null
+
+  return (
+    <ChartTooltipWrapper>
+      <div className="flex w-[200px] flex-col [@media(min-width:600px)]:w-60">
+        <div className="font-medium text-label-value-14 text-secondary">
+          {formatTimestamp(label, {
+            longMonthName: true,
+            mode: 'datetime',
+          })}
+        </div>
+        <div className="mt-2 flex flex-col gap-2">
+          {[...visible]
+            .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+            .map((entry) => {
+              const config = entry.name ? meta[entry.name] : undefined
+              if (!config) return null
+              return (
+                <div
+                  key={entry.name}
+                  className="flex items-center justify-between gap-x-3"
+                >
+                  <div className="flex items-center gap-1">
+                    <ChartDataIndicator
+                      backgroundColor={config.color}
+                      type={config.indicatorType}
+                    />
+                    <span className="font-medium text-label-value-14">
+                      {config.label}
+                    </span>
+                  </div>
+                  <span className="whitespace-nowrap font-medium text-label-value-15 text-primary tabular-nums">
+                    {entry.value !== null && entry.value !== undefined
+                      ? formatCurrency(entry.value, 'usd')
+                      : 'No data'}
+                  </span>
+                </div>
+              )
+            })}
+        </div>
+      </div>
+    </ChartTooltipWrapper>
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
@@ -1,0 +1,29 @@
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import type { ChartRange } from '~/utils/range/range'
+
+/**
+ * Builds the `tvs.detailedChartWithProjectsRanges` input for the compare
+ * chart. Shared between the SSR prefetch and the client query so the
+ * hydrated cache always matches and the first paint needs no refetch.
+ */
+export function getTvsCompareChartParams(
+  projects: CompareProjectEntry[],
+  range: ChartRange,
+) {
+  return {
+    range,
+    // Matches the TVS page defaults; control parity is a follow-up ticket.
+    excludeAssociatedTokens: false,
+    excludeRwaRestrictedTokens: true,
+    projects: projects.flatMap((project) =>
+      project.tvsSinceTimestamp !== undefined
+        ? [
+            {
+              projectId: project.id,
+              sinceTimestamp: project.tvsSinceTimestamp,
+            },
+          ]
+        : [],
+    ),
+  }
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/types.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/types.ts
@@ -1,0 +1,24 @@
+import type { ComponentType } from 'react'
+import type { ChartScale } from '~/components/chart/types'
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import type { ChartRange } from '~/utils/range/range'
+import type { CompareMetricId } from '../utils/compareChartState'
+
+export interface CompareMetricChartProps {
+  projects: CompareProjectEntry[]
+  range: ChartRange
+  scale: ChartScale
+}
+
+/**
+ * A compare page metric. The page shell contains no metric-specific
+ * conditionals - adding a metric means adding an entry here and in
+ * `COMPARE_SERVER_METRICS`, no route or page changes.
+ */
+export interface CompareMetric {
+  id: CompareMetricId
+  label: string
+  /** Unit the metric's values are displayed in. */
+  unit: 'usd'
+  Chart: ComponentType<CompareMetricChartProps>
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/types.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/types.ts
@@ -18,7 +18,10 @@ export interface CompareMetricChartProps {
 export interface CompareMetric {
   id: CompareMetricId
   label: string
-  /** Unit the metric's values are displayed in. */
-  unit: 'usd'
+  /**
+   * The metric's chart, including its data query, series extraction and
+   * value formatting. Per-metric controls and unit options land here with
+   * the follow-up metric tickets.
+   */
   Chart: ComponentType<CompareMetricChartProps>
 }

--- a/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
+++ b/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
@@ -1,0 +1,50 @@
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import { get7dTvsBreakdown } from '~/server/features/scaling/tvs/get7dTvsBreakdown'
+import type { getSsrHelpers } from '~/trpc/server'
+import type { ChartRange } from '~/utils/range/range'
+import { getTvsCompareChartParams } from '../metrics/tvs/getTvsCompareChartParams'
+import type { CompareMetricId } from '../utils/compareChartState'
+
+type SsrHelpers = ReturnType<typeof getSsrHelpers>
+
+/**
+ * Server-side half of the metric registry: default top-N ranking and the
+ * SSR prefetch. Keyed by the same ids as `COMPARE_METRICS`.
+ */
+interface CompareServerMetric {
+  getDefaultProjects: (
+    universe: CompareProjectEntry[],
+    count: number,
+  ) => Promise<CompareProjectEntry[]>
+  prefetch: (
+    helpers: SsrHelpers,
+    projects: CompareProjectEntry[],
+    range: ChartRange,
+  ) => Promise<void>
+}
+
+export const COMPARE_SERVER_METRICS: Record<
+  CompareMetricId,
+  CompareServerMetric
+> = {
+  tvs: {
+    getDefaultProjects: async (universe, count) => {
+      const tvs = await get7dTvsBreakdown({ type: 'layer2' })
+      return universe
+        .map((project) => ({
+          project,
+          tvs: tvs.projects[project.id.toString()]?.breakdown.total ?? -1,
+        }))
+        .sort((a, b) => b.tvs - a.tvs)
+        .slice(0, count)
+        .map(({ project }) => project)
+    },
+    prefetch: async (helpers, projects, range) => {
+      await helpers.queryClient.prefetchQuery(
+        helpers.trpc.tvs.detailedChartWithProjectsRanges.queryOptions(
+          getTvsCompareChartParams(projects, range),
+        ),
+      )
+    },
+  },
+}

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
@@ -1,0 +1,52 @@
+import { expect } from 'earl'
+import { buildCompareUrl } from './buildCompareUrl'
+
+const PATH = '/scaling/compare'
+
+describe(buildCompareUrl.name, () => {
+  it('returns a bare path for the default state', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'tvs',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+    })
+
+    expect(url).toEqual(PATH)
+  })
+
+  it('serializes projects as a comma-separated list', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'tvs',
+      projects: ['arbitrum', 'base'],
+      range: '1y',
+      scale: 'linear',
+    })
+
+    expect(url).toEqual('/scaling/compare?projects=arbitrum,base')
+  })
+
+  it('omits defaults and serializes non-default range and scale', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'tvs',
+      projects: ['arbitrum'],
+      range: '30d',
+      scale: 'symlog',
+    })
+
+    expect(url).toEqual(
+      '/scaling/compare?projects=arbitrum&range=30d&scale=log',
+    )
+  })
+
+  it('serializes a custom range as from-to', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'tvs',
+      projects: [],
+      range: { from: 1700000000, to: 1710000000 },
+      scale: 'linear',
+    })
+
+    expect(url).toEqual('/scaling/compare?range=1700000000-1710000000')
+  })
+})

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
@@ -1,0 +1,34 @@
+import {
+  type CompareChartState,
+  DEFAULT_COMPARE_METRIC,
+  DEFAULT_COMPARE_RANGE,
+  DEFAULT_COMPARE_SCALE,
+} from './compareChartState'
+
+/**
+ * Serializes compare page state into a URL, omitting defaults so clean
+ * links stay short. The inverse of `parseCompareStateFromSearchParams`.
+ */
+export function buildCompareUrl(
+  path: string,
+  state: CompareChartState,
+): string {
+  const params = new URLSearchParams()
+  if (state.metric !== DEFAULT_COMPARE_METRIC) {
+    params.set('metric', state.metric)
+  }
+  if (state.projects.length > 0) {
+    params.set('projects', state.projects.join(','))
+  }
+  if (typeof state.range !== 'string') {
+    params.set('range', `${state.range.from}-${state.range.to}`)
+  } else if (state.range !== DEFAULT_COMPARE_RANGE) {
+    params.set('range', state.range)
+  }
+  if (state.scale !== DEFAULT_COMPARE_SCALE) {
+    params.set('scale', 'log')
+  }
+  // Keep commas literal so shared links stay readable.
+  const query = params.toString().replaceAll('%2C', ',')
+  return query ? `${path}?${query}` : path
+}

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -32,6 +32,41 @@ export interface CompareChartState {
   scale: ChartScale
 }
 
+/**
+ * The client-side chart state: identical to `CompareChartState` except the
+ * range is always resolved to concrete timestamps, so there is a single
+ * source of truth for what the chart queries.
+ */
+export interface CompareClientState {
+  metric: CompareMetricId
+  projects: string[]
+  scale: ChartScale
+  chartRange: ChartRange
+}
+
+export function toCompareUrlState(
+  state: CompareClientState,
+): CompareChartState {
+  return {
+    metric: state.metric,
+    projects: state.projects,
+    scale: state.scale,
+    range: chartRangeToCompareRange(state.chartRange),
+  }
+}
+
+export function toCompareClientState(
+  state: CompareChartState,
+  chartRange: ChartRange = compareRangeToChartRange(state.range),
+): CompareClientState {
+  return {
+    metric: state.metric,
+    projects: state.projects,
+    scale: state.scale,
+    chartRange,
+  }
+}
+
 export const DEFAULT_COMPARE_METRIC: CompareMetricId = 'tvs'
 export const DEFAULT_COMPARE_RANGE: CompareRangeOption = '1y'
 export const DEFAULT_COMPARE_SCALE: ChartScale = 'linear'

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -1,0 +1,85 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { ChartScale } from '~/components/chart/types'
+import type { ChartRangeOptionValue } from '~/components/core/chart/ChartRangeControls'
+import {
+  type ChartRange,
+  optionToDays,
+  optionToRange,
+} from '~/utils/range/range'
+import { rangeToDays } from '~/utils/range/rangeToDays'
+
+export const COMPARE_METRIC_IDS = ['tvs'] as const
+export type CompareMetricId = (typeof COMPARE_METRIC_IDS)[number]
+
+export const COMPARE_RANGE_OPTIONS = [
+  '7d',
+  '30d',
+  '90d',
+  '180d',
+  '1y',
+  'max',
+] as const satisfies readonly ChartRangeOptionValue[]
+export type CompareRangeOption = (typeof COMPARE_RANGE_OPTIONS)[number]
+
+/** A predefined range option or a custom calendar range in unix seconds. */
+export type CompareRange = CompareRangeOption | { from: number; to: number }
+
+export interface CompareChartState {
+  metric: CompareMetricId
+  /** Project slugs in selection order. */
+  projects: string[]
+  range: CompareRange
+  scale: ChartScale
+}
+
+export const DEFAULT_COMPARE_METRIC: CompareMetricId = 'tvs'
+export const DEFAULT_COMPARE_RANGE: CompareRangeOption = '1y'
+export const DEFAULT_COMPARE_SCALE: ChartScale = 'linear'
+export const MAX_COMPARE_PROJECTS = 10
+export const DEFAULT_COMPARE_PROJECTS_COUNT = 5
+
+export function compareRangeToChartRange(range: CompareRange): ChartRange {
+  if (typeof range === 'string') {
+    return optionToRange(range)
+  }
+  return [range.from, range.to]
+}
+
+/**
+ * Maps a resolved chart range back to its URL representation. Mirrors the
+ * predefined-option detection of `ChartRangeControls` so the URL matches the
+ * highlighted control.
+ */
+export function chartRangeToCompareRange([from, to]: ChartRange): CompareRange {
+  if (from === null) return 'max'
+  if (
+    UnixTime.toStartOf(to, 'day') === UnixTime.toStartOf(UnixTime.now(), 'day')
+  ) {
+    const days = rangeToDays([from, to])
+    const option = COMPARE_RANGE_OPTIONS.find(
+      (option) => optionToDays(option) === days,
+    )
+    if (option) return option
+  }
+  return { from, to }
+}
+
+export function isSameCompareState(
+  left: CompareChartState,
+  right: CompareChartState,
+): boolean {
+  return (
+    left.metric === right.metric &&
+    left.scale === right.scale &&
+    isSameRange(left.range, right.range) &&
+    left.projects.length === right.projects.length &&
+    left.projects.every((slug, index) => slug === right.projects[index])
+  )
+}
+
+function isSameRange(left: CompareRange, right: CompareRange): boolean {
+  if (typeof left === 'string' || typeof right === 'string') {
+    return left === right
+  }
+  return left.from === right.from && left.to === right.to
+}

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
@@ -1,0 +1,104 @@
+import { expect } from 'earl'
+import { buildCompareUrl } from './buildCompareUrl'
+import type { CompareChartState } from './compareChartState'
+import { parseCompareStateFromSearchParams } from './parseCompareStateFromSearchParams'
+
+const SLUGS = ['arbitrum', 'base', 'optimism']
+
+function parse(search: string) {
+  return parseCompareStateFromSearchParams({
+    searchParams: new URLSearchParams(search),
+    validSlugs: SLUGS,
+  })
+}
+
+describe(parseCompareStateFromSearchParams.name, () => {
+  it('parses a full state', () => {
+    const result = parse('projects=arbitrum,base&range=30d&scale=log')
+
+    expect(result).toEqual({
+      metric: 'tvs',
+      projects: ['arbitrum', 'base'],
+      range: '30d',
+      scale: 'symlog',
+    })
+  })
+
+  it('returns defaults when params are missing', () => {
+    const result = parse('')
+
+    expect(result).toEqual({
+      metric: 'tvs',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+    })
+  })
+
+  it('drops unknown slugs and deduplicates', () => {
+    const result = parse('projects=arbitrum,ethereum,arbitrum,nonsense,base')
+
+    expect(result.projects).toEqual(['arbitrum', 'base'])
+  })
+
+  it('caps the selection at ten projects', () => {
+    const slugs = Array.from({ length: 12 }, (_, i) => `project-${i}`)
+    const result = parseCompareStateFromSearchParams({
+      searchParams: new URLSearchParams(`projects=${slugs.join(',')}`),
+      validSlugs: slugs,
+    })
+
+    expect(result.projects).toEqual(slugs.slice(0, 10))
+  })
+
+  it('parses a custom range', () => {
+    const result = parse('range=1700000000-1710000000')
+
+    expect(result.range).toEqual({ from: 1700000000, to: 1710000000 })
+  })
+
+  it('falls back to defaults on garbage values', () => {
+    const result = parse('metric=bogus&range=yesterday&scale=cubic')
+
+    expect(result).toEqual({
+      metric: 'tvs',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+    })
+  })
+
+  it('falls back to the default range when custom bounds are inverted', () => {
+    const result = parse('range=1710000000-1700000000')
+
+    expect(result.range).toEqual('1y')
+  })
+
+  it('round-trips through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'tvs',
+      projects: ['base', 'arbitrum'],
+      range: '90d',
+      scale: 'symlog',
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(parse(search)).toEqual(state)
+  })
+
+  it('round-trips a custom range through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'tvs',
+      projects: [],
+      range: { from: 1700000000, to: 1710000000 },
+      scale: 'linear',
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(parse(search)).toEqual(state)
+  })
+})

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
@@ -1,0 +1,61 @@
+import {
+  COMPARE_METRIC_IDS,
+  COMPARE_RANGE_OPTIONS,
+  type CompareChartState,
+  type CompareMetricId,
+  type CompareRange,
+  type CompareRangeOption,
+  DEFAULT_COMPARE_METRIC,
+  DEFAULT_COMPARE_RANGE,
+  DEFAULT_COMPARE_SCALE,
+  MAX_COMPARE_PROJECTS,
+} from './compareChartState'
+
+/**
+ * Parses compare page state from URL search params. Tolerates garbage:
+ * unknown slugs, invalid metrics, ranges and scales fall back to defaults.
+ */
+export function parseCompareStateFromSearchParams({
+  searchParams,
+  validSlugs,
+}: {
+  searchParams: URLSearchParams
+  validSlugs: string[]
+}): CompareChartState {
+  return {
+    metric: parseMetric(searchParams.get('metric')),
+    projects: parseProjects(searchParams.get('projects'), validSlugs),
+    range: parseRange(searchParams.get('range')),
+    scale:
+      searchParams.get('scale') === 'log' ? 'symlog' : DEFAULT_COMPARE_SCALE,
+  }
+}
+
+function parseMetric(value: string | null): CompareMetricId {
+  const metric = COMPARE_METRIC_IDS.find((id) => id === value)
+  return metric ?? DEFAULT_COMPARE_METRIC
+}
+
+function parseProjects(value: string | null, validSlugs: string[]): string[] {
+  if (!value) return []
+  const slugSet = new Set(validSlugs)
+  const unique = [...new Set(value.split(','))]
+  return unique
+    .filter((slug) => slugSet.has(slug))
+    .slice(0, MAX_COMPARE_PROJECTS)
+}
+
+function parseRange(value: string | null): CompareRange {
+  if (!value) return DEFAULT_COMPARE_RANGE
+  const option = COMPARE_RANGE_OPTIONS.find(
+    (option): option is CompareRangeOption => option === value,
+  )
+  if (option) return option
+  const match = /^(\d+)-(\d+)$/.exec(value)
+  if (match) {
+    const from = Number(match[1])
+    const to = Number(match[2])
+    if (from < to) return { from, to }
+  }
+  return DEFAULT_COMPARE_RANGE
+}

--- a/packages/frontend/src/server/features/scaling/compare/getCompareProjectEntries.ts
+++ b/packages/frontend/src/server/features/scaling/compare/getCompareProjectEntries.ts
@@ -1,0 +1,76 @@
+import type {
+  AmountFormula,
+  CalculationFormula,
+  TvsToken,
+  ValueFormula,
+} from '@l2beat/config'
+import type { ProjectId } from '@l2beat/shared-pure'
+import { ps } from '~/server/projects'
+import { manifest } from '~/utils/Manifest'
+
+export interface CompareProjectEntry {
+  id: ProjectId
+  slug: string
+  name: string
+  shortName: string | undefined
+  iconUrl: string
+  /**
+   * Earliest TVS data timestamp derived from the project's TVS config.
+   * Undefined when the project has no TVS tracking.
+   */
+  tvsSinceTimestamp: number | undefined
+}
+
+/**
+ * The selectable universe of the compare page: live scaling projects only
+ * (rollups, validiums & optimiums, others) - no archived, no upcoming,
+ * no Ethereum.
+ */
+export async function getCompareProjectEntries(): Promise<
+  CompareProjectEntry[]
+> {
+  const projects = await ps.getProjects({
+    select: ['scalingInfo'],
+    optional: ['tvsConfig'],
+    where: ['scalingInfo'],
+    whereNot: ['archivedAt'],
+  })
+
+  return projects.map((project) => ({
+    id: project.id,
+    slug: project.slug,
+    name: project.name,
+    shortName: project.shortName,
+    iconUrl: manifest.getUrl(`/icons/${project.slug}.png`),
+    tvsSinceTimestamp: getTvsSinceTimestamp(project.tvsConfig),
+  }))
+}
+
+function getTvsSinceTimestamp(
+  tvsConfig: TvsToken[] | undefined,
+): number | undefined {
+  if (!tvsConfig || tvsConfig.length === 0) return undefined
+  const timestamps = tvsConfig
+    .map((token) => getFormulaSinceTimestamp(token.amount))
+    .filter((timestamp) => timestamp !== undefined)
+  if (timestamps.length === 0) return undefined
+  return Math.min(...timestamps)
+}
+
+function getFormulaSinceTimestamp(
+  formula: CalculationFormula | ValueFormula | AmountFormula,
+): number | undefined {
+  switch (formula.type) {
+    case 'calculation': {
+      const timestamps = formula.arguments
+        .map(getFormulaSinceTimestamp)
+        .filter((timestamp) => timestamp !== undefined)
+      if (timestamps.length === 0) return undefined
+      return Math.min(...timestamps)
+    }
+    case 'value':
+      return getFormulaSinceTimestamp(formula.amount)
+    default:
+      return formula.sinceTimestamp
+  }
+}

--- a/packages/frontend/src/server/pagePaths.ts
+++ b/packages/frontend/src/server/pagePaths.ts
@@ -1,4 +1,5 @@
 import { getCollection } from '~/content/getCollection'
+import { env } from '~/env'
 import { shouldHaveNoBridgePage } from './features/data-availability/utils/shouldHaveNoBridgePage'
 import { ps } from './projects'
 
@@ -7,7 +8,6 @@ type PagePath = `/${string}`
 export const STATIC_PAGE_PATHS = [
   '/scaling/summary',
   '/scaling/activity',
-  '/scaling/compare',
   '/scaling/risk',
   '/scaling/risk/state-validation',
   '/scaling/risk/data-availability',
@@ -47,7 +47,14 @@ export const STATIC_PAGE_PATHS = [
 ] as const satisfies PagePath[]
 
 export async function getPagePaths(): Promise<PagePath[]> {
-  return [...STATIC_PAGE_PATHS, ...(await getDynamicPagePaths())]
+  const flaggedPaths: PagePath[] = env.FEATURE_FLAG_COMPARE_PROJECTS
+    ? ['/scaling/compare']
+    : []
+  return [
+    ...STATIC_PAGE_PATHS,
+    ...flaggedPaths,
+    ...(await getDynamicPagePaths()),
+  ]
 }
 
 async function getDynamicPagePaths(): Promise<PagePath[]> {

--- a/packages/frontend/src/server/pagePaths.ts
+++ b/packages/frontend/src/server/pagePaths.ts
@@ -7,6 +7,7 @@ type PagePath = `/${string}`
 export const STATIC_PAGE_PATHS = [
   '/scaling/summary',
   '/scaling/activity',
+  '/scaling/compare',
   '/scaling/risk',
   '/scaling/risk/state-validation',
   '/scaling/risk/data-availability',


### PR DESCRIPTION
## Summary

- Add new `/scaling/compare` route for side-by-side project comparison
- Implement TVS (Value Secured) comparison chart with 1y default range
- Support project selection (up to 10), configurable via URL with browser back/forward
- Add time range and log/linear scale controls
- Default to top 5 projects by 7-day TVS ranking
- Include server-side metric registry for extensibility to future metrics
- URL state management preserves defaults (clean links for sharing)

## Testing

- Navigate to `/scaling/compare` and verify page loads with default projects
- Select projects via the project picker and confirm URL updates (`?projects=...`)
- Verify chart updates as projects are added/removed
- Test browser back/forward navigation
- Confirm time range and log/linear scale controls persist in URL
- Verify custom date ranges serialize/deserialize correctly (from-to format)
- Check that garbage URL params (invalid slugs, unknown metrics) fall back to defaults
- Confirm TVS values and timestamps align with main TVS page
- Test that selecting >10 projects caps at 10
- Verify project icons and names display correctly in legend and tooltip