### PR TITLE
Activity metric and metric switcher for scaling compare page

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -15,6 +15,7 @@ import {
   COMPARE_RANGE_OPTIONS,
   type CompareChartState,
   type CompareClientState,
+  type CompareMetricId,
   isSameCompareState,
   toCompareClientState,
   toCompareUrlState,
@@ -63,11 +64,16 @@ export function ScalingCompareChart({
 
   return (
     <section className="mt-4 flex flex-col gap-2 md:mt-6">
-      <metric.Chart
-        projects={selectedProjects}
-        range={state.chartRange}
-        scale={state.scale}
-      />
+      <div className="flex items-center justify-between gap-2">
+        <MetricSwitcher
+          value={state.metric}
+          onValueChange={(metric) => setState((prev) => ({ ...prev, metric }))}
+        />
+        {metric.Controls && (
+          <metric.Controls state={state} setState={setState} />
+        )}
+      </div>
+      <metric.Chart projects={selectedProjects} state={state} />
       <Controls
         scale={state.scale}
         setScale={(scale) => setState((prev) => ({ ...prev, scale }))}
@@ -124,6 +130,42 @@ function useCompareUrlSync(
       }),
     )
   })
+}
+
+/**
+ * The metric switcher, driven entirely by the registry so new metrics show
+ * up without page changes. Switching keeps projects, range and view mode.
+ */
+function MetricSwitcher({
+  value,
+  onValueChange,
+}: {
+  value: CompareMetricId
+  onValueChange: (metric: CompareMetricId) => void
+}) {
+  const isClient = useIsClient()
+  if (!isClient) {
+    return <Skeleton className="h-9 w-[180px]" />
+  }
+  return (
+    <RadioGroup
+      name="compareMetric"
+      value={value}
+      onValueChange={(value) => onValueChange(value as CompareMetricId)}
+      variant="highlighted"
+      className="h-9"
+    >
+      {Object.values(COMPARE_METRICS).map((metric) => (
+        <RadioGroupItem
+          key={metric.id}
+          value={metric.id}
+          className="h-full px-2 text-sm"
+        >
+          {metric.label}
+        </RadioGroupItem>
+      ))}
+    </RadioGroup>
+  )
 }
 
 function Controls({

--- a/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareChart.tsx
@@ -1,3 +1,4 @@
+import { UnixTime } from '@l2beat/shared-pure'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 import { Line, LineChart } from 'recharts'
@@ -19,7 +20,7 @@ import { useChartDataKeys } from '~/components/core/chart/hooks/useChartDataKeys
 import { getChartTimeRangeFromData } from '~/components/core/chart/utils/getChartTimeRangeFromData'
 import { countPerSecond } from '~/server/features/scaling/activity/utils/countPerSecond'
 import { useTRPC } from '~/trpc/React'
-import { formatTimestamp } from '~/utils/dates'
+import { formatRange } from '~/utils/dates'
 import { generateAccessibleColors } from '~/utils/generateColors'
 import { formatActivityCount } from '~/utils/number-format/formatActivityCount'
 import type { CompareActivityUnit } from '../../utils/compareChartState'
@@ -156,10 +157,7 @@ function CustomTooltip({
     <ChartTooltipWrapper>
       <div className="flex w-[200px] flex-col [@media(min-width:600px)]:w-60">
         <div className="font-medium text-label-value-14 text-secondary">
-          {formatTimestamp(label, {
-            longMonthName: true,
-            mode: 'datetime',
-          })}
+          {formatRange(label, label + UnixTime.DAY)}
         </div>
         <div className="mt-2 flex flex-col gap-2">
           {[...visible]

--- a/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareChart.tsx
@@ -17,20 +17,26 @@ import { ChartLegendToggleAll } from '~/components/core/chart/ChartLegendToggleA
 import { ChartTimeRange } from '~/components/core/chart/ChartTimeRange'
 import { useChartDataKeys } from '~/components/core/chart/hooks/useChartDataKeys'
 import { getChartTimeRangeFromData } from '~/components/core/chart/utils/getChartTimeRangeFromData'
+import { countPerSecond } from '~/server/features/scaling/activity/utils/countPerSecond'
 import { useTRPC } from '~/trpc/React'
 import { formatTimestamp } from '~/utils/dates'
 import { generateAccessibleColors } from '~/utils/generateColors'
-import { formatCurrency } from '~/utils/number-format/formatCurrency'
+import { formatActivityCount } from '~/utils/number-format/formatActivityCount'
+import type { CompareActivityUnit } from '../../utils/compareChartState'
 import type { CompareMetricChartProps } from '../types'
-import { getTvsCompareChartParams } from './getTvsCompareChartParams'
+import { getActivityCompareChartParams } from './getActivityCompareChartParams'
 
-export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
+export function ActivityCompareChart({
+  projects,
+  state,
+}: CompareMetricChartProps) {
   const trpc = useTRPC()
   const { data, isLoading } = useQuery(
-    trpc.tvs.detailedChartWithProjectsRanges.queryOptions(
-      getTvsCompareChartParams(projects, state.chartRange),
+    trpc.activity.detailedChartWithProjectsRanges.queryOptions(
+      getActivityCompareChartParams(projects, state.chartRange),
     ),
   )
+  const unit = state.activityUnit
 
   const chartMeta = useMemo<ChartMeta>(() => {
     const colors = generateAccessibleColors(projects.length)
@@ -61,16 +67,19 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
 
   const chartData = useMemo(
     () =>
-      data?.chart.map(([timestamp, _ethPrice, valuesByProject]) => {
+      data?.chart.map(([timestamp, valuesByProject]) => {
         const point: { timestamp: number; [key: string]: number | null } = {
           timestamp,
         }
         for (const project of projects) {
-          point[project.id] = valuesByProject[project.id]?.[0] ?? null
+          const values = valuesByProject[project.id]
+          point[project.id] = values
+            ? countPerSecond(unit === 'tps' ? values[0] : values[1])
+            : null
         }
         return point
       }),
-    [data, projects],
+    [data, projects, unit],
   )
 
   const timeRange = useMemo(
@@ -115,18 +124,22 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
             yAxis={{
               scale: state.scale === 'symlog' ? 'symlog' : 'auto',
               tickCount: 4,
-              tickFormatter: (value) => formatCurrency(Number(value), 'usd'),
+              tickFormatter: (value) => formatActivityCount(Number(value)),
             }}
             syncedUntil={data?.syncedUntil}
           />
-          <ChartTooltip content={<CustomTooltip />} />
+          <ChartTooltip content={<CustomTooltip unit={unit} />} />
         </LineChart>
       </ChartContainer>
     </div>
   )
 }
 
-function CustomTooltip({ payload, label }: CustomChartTooltipProps) {
+function CustomTooltip({
+  payload,
+  label,
+  unit,
+}: CustomChartTooltipProps & { unit: CompareActivityUnit }) {
   const { meta } = useChart()
   if (!payload || typeof label !== 'number') return null
 
@@ -170,7 +183,7 @@ function CustomTooltip({ payload, label }: CustomChartTooltipProps) {
                   </div>
                   <span className="whitespace-nowrap font-medium text-label-value-15 text-primary tabular-nums">
                     {entry.value !== null && entry.value !== undefined
-                      ? formatCurrency(entry.value, 'usd')
+                      ? `${formatActivityCount(entry.value)} ${unit.toUpperCase()}`
                       : 'No data'}
                   </span>
                 </div>

--- a/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareControls.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareControls.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from '~/components/core/Skeleton'
+import { useIsClient } from '~/hooks/useIsClient'
+import { ActivityMetricControls } from '~/pages/scaling/activity/components/ActivityMetricControls'
+import type { CompareActivityUnit } from '../../utils/compareChartState'
+import type { CompareMetricControlsProps } from '../types'
+
+export function ActivityCompareControls({
+  state,
+  setState,
+}: CompareMetricControlsProps) {
+  const isClient = useIsClient()
+  if (!isClient) {
+    return <Skeleton className="h-9 w-[104px]" />
+  }
+  return (
+    <ActivityMetricControls<CompareActivityUnit>
+      value={state.activityUnit}
+      onValueChange={(activityUnit) =>
+        setState((prev) => ({ ...prev, activityUnit }))
+      }
+      projectChart
+      className="h-9"
+    />
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/activity/getActivityCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/activity/getActivityCompareChartParams.ts
@@ -1,0 +1,17 @@
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import type { ChartRange } from '~/utils/range/range'
+
+/**
+ * Builds the `activity.detailedChartWithProjectsRanges` input for the compare
+ * chart. Shared between the SSR prefetch and the client query so the
+ * hydrated cache always matches and the first paint needs no refetch.
+ */
+export function getActivityCompareChartParams(
+  projects: CompareProjectEntry[],
+  range: ChartRange,
+) {
+  return {
+    range,
+    projects: projects.map((project) => project.id),
+  }
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/index.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/index.ts
@@ -1,4 +1,6 @@
 import type { CompareMetricId } from '../utils/compareChartState'
+import { ActivityCompareChart } from './activity/ActivityCompareChart'
+import { ActivityCompareControls } from './activity/ActivityCompareControls'
 import { TvsCompareChart } from './tvs/TvsCompareChart'
 import type { CompareMetric } from './types'
 
@@ -7,5 +9,11 @@ export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
     id: 'tvs',
     label: 'Value Secured',
     Chart: TvsCompareChart,
+  },
+  activity: {
+    id: 'activity',
+    label: 'Activity',
+    Chart: ActivityCompareChart,
+    Controls: ActivityCompareControls,
   },
 }

--- a/packages/frontend/src/pages/scaling/compare/metrics/types.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/types.ts
@@ -1,13 +1,18 @@
-import type { ComponentType } from 'react'
-import type { ChartScale } from '~/components/chart/types'
+import type { ComponentType, Dispatch, SetStateAction } from 'react'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
-import type { ChartRange } from '~/utils/range/range'
-import type { CompareMetricId } from '../utils/compareChartState'
+import type {
+  CompareClientState,
+  CompareMetricId,
+} from '../utils/compareChartState'
 
 export interface CompareMetricChartProps {
   projects: CompareProjectEntry[]
-  range: ChartRange
-  scale: ChartScale
+  state: CompareClientState
+}
+
+export interface CompareMetricControlsProps {
+  state: CompareClientState
+  setState: Dispatch<SetStateAction<CompareClientState>>
 }
 
 /**
@@ -20,8 +25,12 @@ export interface CompareMetric {
   label: string
   /**
    * The metric's chart, including its data query, series extraction and
-   * value formatting. Per-metric controls and unit options land here with
-   * the follow-up metric tickets.
+   * value formatting.
    */
   Chart: ComponentType<CompareMetricChartProps>
+  /**
+   * Metric-specific controls (e.g. the UOPS/TPS switch), rendered in the
+   * per-metric slot next to the metric switcher.
+   */
+  Controls?: ComponentType<CompareMetricControlsProps>
 }

--- a/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
+++ b/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
@@ -1,7 +1,9 @@
+import { getActivityLatestUops } from '~/server/features/scaling/activity/getActivityLatestTps'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
 import { get7dTvsBreakdown } from '~/server/features/scaling/tvs/get7dTvsBreakdown'
 import type { getSsrHelpers } from '~/trpc/server'
-import type { ChartRange } from '~/utils/range/range'
+import { type ChartRange, optionToRange } from '~/utils/range/range'
+import { getActivityCompareChartParams } from '../metrics/activity/getActivityCompareChartParams'
 import { getTvsCompareChartParams } from '../metrics/tvs/getTvsCompareChartParams'
 import type { CompareMetricId } from '../utils/compareChartState'
 
@@ -43,6 +45,28 @@ export const COMPARE_SERVER_METRICS: Record<
       await helpers.queryClient.prefetchQuery(
         helpers.trpc.tvs.detailedChartWithProjectsRanges.queryOptions(
           getTvsCompareChartParams(projects, range),
+        ),
+      )
+    },
+  },
+  activity: {
+    getDefaultProjects: async (universe, count) => {
+      // The ranking only needs the latest daily counts, so a short range
+      // keeps the query far cheaper than the summary page's 1y default.
+      const uops = await getActivityLatestUops(universe, optionToRange('30d'))
+      return universe
+        .map((project) => ({
+          project,
+          uops: uops[project.id.toString()]?.pastDayUops ?? -1,
+        }))
+        .sort((a, b) => b.uops - a.uops)
+        .slice(0, count)
+        .map(({ project }) => project)
+    },
+    prefetch: async (helpers, projects, range) => {
+      await helpers.queryClient.prefetchQuery(
+        helpers.trpc.activity.detailedChartWithProjectsRanges.queryOptions(
+          getActivityCompareChartParams(projects, range),
         ),
       )
     },

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
@@ -10,6 +10,7 @@ describe(buildCompareUrl.name, () => {
       projects: [],
       range: '1y',
       scale: 'linear',
+      activityUnit: 'uops',
     })
 
     expect(url).toEqual(PATH)
@@ -21,6 +22,7 @@ describe(buildCompareUrl.name, () => {
       projects: ['arbitrum', 'base'],
       range: '1y',
       scale: 'linear',
+      activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?projects=arbitrum,base')
@@ -32,6 +34,7 @@ describe(buildCompareUrl.name, () => {
       projects: ['arbitrum'],
       range: '30d',
       scale: 'symlog',
+      activityUnit: 'uops',
     })
 
     expect(url).toEqual(
@@ -45,8 +48,45 @@ describe(buildCompareUrl.name, () => {
       projects: [],
       range: { from: 1700000000, to: 1710000000 },
       scale: 'linear',
+      activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?range=1700000000-1710000000')
+  })
+
+  it('serializes a non-default metric with its non-default unit', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'activity',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+      activityUnit: 'tps',
+    })
+
+    expect(url).toEqual('/scaling/compare?metric=activity&unit=tps')
+  })
+
+  it('omits the default activity unit', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'activity',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+      activityUnit: 'uops',
+    })
+
+    expect(url).toEqual('/scaling/compare?metric=activity')
+  })
+
+  it('omits the activity unit for other metrics', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'tvs',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+      activityUnit: 'tps',
+    })
+
+    expect(url).toEqual(PATH)
   })
 })

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
@@ -1,5 +1,6 @@
 import {
   type CompareChartState,
+  DEFAULT_COMPARE_ACTIVITY_UNIT,
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
@@ -27,6 +28,13 @@ export function buildCompareUrl(
   }
   if (state.scale !== DEFAULT_COMPARE_SCALE) {
     params.set('scale', 'log')
+  }
+  // Per-metric controls are only encoded for the metric they belong to.
+  if (
+    state.metric === 'activity' &&
+    state.activityUnit !== DEFAULT_COMPARE_ACTIVITY_UNIT
+  ) {
+    params.set('unit', state.activityUnit)
   }
   // Keep commas literal so shared links stay readable.
   const query = params.toString().replaceAll('%2C', ',')

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -8,8 +8,11 @@ import {
 } from '~/utils/range/range'
 import { rangeToDays } from '~/utils/range/rangeToDays'
 
-export const COMPARE_METRIC_IDS = ['tvs'] as const
+export const COMPARE_METRIC_IDS = ['tvs', 'activity'] as const
 export type CompareMetricId = (typeof COMPARE_METRIC_IDS)[number]
+
+export const COMPARE_ACTIVITY_UNITS = ['uops', 'tps'] as const
+export type CompareActivityUnit = (typeof COMPARE_ACTIVITY_UNITS)[number]
 
 export const COMPARE_RANGE_OPTIONS = [
   '7d',
@@ -30,6 +33,8 @@ export interface CompareChartState {
   projects: string[]
   range: CompareRange
   scale: ChartScale
+  /** Per-metric control of the activity metric; ignored elsewhere. */
+  activityUnit: CompareActivityUnit
 }
 
 /**
@@ -41,6 +46,7 @@ export interface CompareClientState {
   metric: CompareMetricId
   projects: string[]
   scale: ChartScale
+  activityUnit: CompareActivityUnit
   chartRange: ChartRange
 }
 
@@ -51,6 +57,7 @@ export function toCompareUrlState(
     metric: state.metric,
     projects: state.projects,
     scale: state.scale,
+    activityUnit: state.activityUnit,
     range: chartRangeToCompareRange(state.chartRange),
   }
 }
@@ -63,6 +70,7 @@ export function toCompareClientState(
     metric: state.metric,
     projects: state.projects,
     scale: state.scale,
+    activityUnit: state.activityUnit,
     chartRange,
   }
 }
@@ -70,6 +78,7 @@ export function toCompareClientState(
 export const DEFAULT_COMPARE_METRIC: CompareMetricId = 'tvs'
 export const DEFAULT_COMPARE_RANGE: CompareRangeOption = '1y'
 export const DEFAULT_COMPARE_SCALE: ChartScale = 'linear'
+export const DEFAULT_COMPARE_ACTIVITY_UNIT: CompareActivityUnit = 'uops'
 export const MAX_COMPARE_PROJECTS = 10
 export const DEFAULT_COMPARE_PROJECTS_COUNT = 5
 
@@ -106,6 +115,9 @@ export function isSameCompareState(
   return (
     left.metric === right.metric &&
     left.scale === right.scale &&
+    // The unit is only encoded for the activity metric, so two states that
+    // differ solely by a hidden unit map to the same URL.
+    (left.metric !== 'activity' || left.activityUnit === right.activityUnit) &&
     isSameRange(left.range, right.range) &&
     left.projects.length === right.projects.length &&
     left.projects.every((slug, index) => slug === right.projects[index])

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
@@ -14,13 +14,16 @@ function parse(search: string) {
 
 describe(parseCompareStateFromSearchParams.name, () => {
   it('parses a full state', () => {
-    const result = parse('projects=arbitrum,base&range=30d&scale=log')
+    const result = parse(
+      'metric=activity&projects=arbitrum,base&range=30d&scale=log&unit=tps',
+    )
 
     expect(result).toEqual({
-      metric: 'tvs',
+      metric: 'activity',
       projects: ['arbitrum', 'base'],
       range: '30d',
       scale: 'symlog',
+      activityUnit: 'tps',
     })
   })
 
@@ -32,6 +35,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: [],
       range: '1y',
       scale: 'linear',
+      activityUnit: 'uops',
     })
   })
 
@@ -58,13 +62,14 @@ describe(parseCompareStateFromSearchParams.name, () => {
   })
 
   it('falls back to defaults on garbage values', () => {
-    const result = parse('metric=bogus&range=yesterday&scale=cubic')
+    const result = parse('metric=bogus&range=yesterday&scale=cubic&unit=gas')
 
     expect(result).toEqual({
       metric: 'tvs',
       projects: [],
       range: '1y',
       scale: 'linear',
+      activityUnit: 'uops',
     })
   })
 
@@ -80,6 +85,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: ['base', 'arbitrum'],
       range: '90d',
       scale: 'symlog',
+      activityUnit: 'uops',
     }
 
     const url = buildCompareUrl('/scaling/compare', state)
@@ -94,6 +100,22 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: [],
       range: { from: 1700000000, to: 1710000000 },
       scale: 'linear',
+      activityUnit: 'uops',
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(parse(search)).toEqual(state)
+  })
+
+  it('round-trips the activity metric with its unit through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'activity',
+      projects: ['optimism'],
+      range: '7d',
+      scale: 'linear',
+      activityUnit: 'tps',
     }
 
     const url = buildCompareUrl('/scaling/compare', state)

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
@@ -1,10 +1,13 @@
 import {
+  COMPARE_ACTIVITY_UNITS,
   COMPARE_METRIC_IDS,
   COMPARE_RANGE_OPTIONS,
+  type CompareActivityUnit,
   type CompareChartState,
   type CompareMetricId,
   type CompareRange,
   type CompareRangeOption,
+  DEFAULT_COMPARE_ACTIVITY_UNIT,
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
@@ -28,12 +31,18 @@ export function parseCompareStateFromSearchParams({
     range: parseRange(searchParams.get('range')),
     scale:
       searchParams.get('scale') === 'log' ? 'symlog' : DEFAULT_COMPARE_SCALE,
+    activityUnit: parseActivityUnit(searchParams.get('unit')),
   }
 }
 
 function parseMetric(value: string | null): CompareMetricId {
   const metric = COMPARE_METRIC_IDS.find((id) => id === value)
   return metric ?? DEFAULT_COMPARE_METRIC
+}
+
+function parseActivityUnit(value: string | null): CompareActivityUnit {
+  const unit = COMPARE_ACTIVITY_UNITS.find((unit) => unit === value)
+  return unit ?? DEFAULT_COMPARE_ACTIVITY_UNIT
 }
 
 function parseProjects(value: string | null, validSlugs: string[]): string[] {

--- a/packages/frontend/src/server/features/scaling/activity/getActivityLatestTps.ts
+++ b/packages/frontend/src/server/features/scaling/activity/getActivityLatestTps.ts
@@ -24,7 +24,7 @@ export type ActivityLatestUopsData = Record<
 >
 
 export async function getActivityLatestUops(
-  projects: Project[],
+  projects: Pick<Project, 'id'>[],
   range?: ChartRange,
 ): Promise<ActivityLatestUopsData> {
   if (env.MOCK) {
@@ -89,7 +89,7 @@ export async function getActivityLatestUops(
 }
 
 function getMockActivityLatestUopsData(
-  projects: Project[],
+  projects: Pick<Project, 'id'>[],
 ): ActivityLatestUopsData {
   return Object.fromEntries(
     projects.map((p) => [

--- a/packages/frontend/src/server/features/scaling/activity/getDetailedActivityChartWithProjectsRanges.test.ts
+++ b/packages/frontend/src/server/features/scaling/activity/getDetailedActivityChartWithProjectsRanges.test.ts
@@ -1,0 +1,154 @@
+import type { ActivityRecord, Database } from '@l2beat/database'
+import { ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { expect, mockObject } from 'earl'
+import { getActivityChartData } from './getDetailedActivityChartWithProjectsRanges'
+
+const DAY = UnixTime.DAY
+// 2023-11-15T00:00:00Z, aligned to a full day
+const T = UnixTime(1700006400)
+
+const ARBITRUM = ProjectId('arbitrum')
+const BASE = ProjectId('base')
+
+describe(getActivityChartData.name, () => {
+  it('returns one series per project with uops falling back to count', async () => {
+    const repository = repositoryMock(
+      [
+        record(ARBITRUM, T, 100, 150),
+        record(ARBITRUM, T + DAY, 200, null),
+        record(BASE, T, 10, 15),
+        record(BASE, T + DAY, 20, 25),
+      ],
+      { [ARBITRUM]: T, [BASE]: T },
+    )
+
+    const result = await getActivityChartData(
+      repository,
+      [ARBITRUM, BASE],
+      [T, T + DAY],
+    )
+
+    expect(result).toEqual({
+      chart: [
+        [T, { [ARBITRUM]: [100, 150], [BASE]: [10, 15] }],
+        [T + DAY, { [ARBITRUM]: [200, 200], [BASE]: [20, 25] }],
+      ],
+      projects: [
+        { projectId: ARBITRUM, sinceTimestamp: T },
+        { projectId: BASE, sinceTimestamp: T },
+      ],
+      syncedUntil: T + DAY,
+    })
+  })
+
+  it('fills zeros for missing days after launch and nulls before launch', async () => {
+    const repository = repositoryMock(
+      [
+        record(ARBITRUM, T, 100, 150),
+        record(ARBITRUM, T + 2 * DAY, 300, 350),
+        record(BASE, T + DAY, 10, 15),
+        record(BASE, T + 2 * DAY, 20, 25),
+      ],
+      { [ARBITRUM]: T, [BASE]: T + DAY },
+    )
+
+    const result = await getActivityChartData(
+      repository,
+      [ARBITRUM, BASE],
+      [T, T + 2 * DAY],
+    )
+
+    expect(result.chart).toEqual([
+      [T, { [ARBITRUM]: [100, 150], [BASE]: null }],
+      [T + DAY, { [ARBITRUM]: [0, 0], [BASE]: [10, 15] }],
+      [T + 2 * DAY, { [ARBITRUM]: [300, 350], [BASE]: [20, 25] }],
+    ])
+  })
+
+  it('returns a null series and no range entry for a project without data', async () => {
+    const noActivity = ProjectId('no-activity')
+    const repository = repositoryMock([record(ARBITRUM, T, 100, 150)], {
+      [ARBITRUM]: T,
+    })
+
+    const result = await getActivityChartData(
+      repository,
+      [ARBITRUM, noActivity],
+      [T, T],
+    )
+
+    expect(result.chart).toEqual([
+      [T, { [ARBITRUM]: [100, 150], [noActivity]: null }],
+    ])
+    expect(result.projects).toEqual([
+      { projectId: ARBITRUM, sinceTimestamp: T },
+    ])
+  })
+
+  it('starts the max range at the first project data point', async () => {
+    const repository = repositoryMock(
+      [
+        record(ARBITRUM, T + DAY, 100, 150),
+        record(ARBITRUM, T + 2 * DAY, 200, 250),
+      ],
+      { [ARBITRUM]: T + DAY },
+    )
+
+    const result = await getActivityChartData(
+      repository,
+      [ARBITRUM],
+      [null, T + 2 * DAY],
+    )
+
+    expect(result.chart).toEqual([
+      [T + DAY, { [ARBITRUM]: [100, 150] }],
+      [T + 2 * DAY, { [ARBITRUM]: [200, 250] }],
+    ])
+  })
+
+  it('returns an empty chart when there are no records', async () => {
+    const repository = repositoryMock([], {})
+
+    const result = await getActivityChartData(
+      repository,
+      [ARBITRUM],
+      [T, T + DAY],
+    )
+
+    expect(result).toEqual({
+      chart: [],
+      projects: [],
+      syncedUntil: T + DAY,
+    })
+  })
+})
+
+function repositoryMock(
+  records: ActivityRecord[],
+  sinceTimestamps: Record<string, UnixTime>,
+): Database['activity'] {
+  return mockObject<Database['activity']>({
+    getByProjectsAndTimeRange: async () => records,
+    getActivityTotalsForProjects: async () =>
+      Object.fromEntries(
+        Object.entries(sinceTimestamps).map(([projectId, sinceTimestamp]) => [
+          projectId,
+          {
+            count: 0,
+            uopsCount: 0,
+            sinceTimestamp,
+            uopsSinceTimestamp: sinceTimestamp,
+          },
+        ]),
+      ),
+  })
+}
+
+function record(
+  projectId: ProjectId,
+  timestamp: UnixTime,
+  count: number,
+  uopsCount: number | null,
+): ActivityRecord {
+  return { projectId, timestamp, count, uopsCount, start: 0, end: 0 }
+}

--- a/packages/frontend/src/server/features/scaling/activity/getDetailedActivityChartWithProjectsRanges.ts
+++ b/packages/frontend/src/server/features/scaling/activity/getDetailedActivityChartWithProjectsRanges.ts
@@ -1,0 +1,186 @@
+import type { ActivityRecord, Database } from '@l2beat/database'
+import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { v } from '@l2beat/validate'
+import { env } from '~/env'
+import { getDb } from '~/server/database'
+import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
+import { getChartStartTimestamp } from '~/server/features/utils/getChartStartTimestamp'
+import { ChartRange } from '~/utils/range/range'
+import { getFullySyncedActivityRange } from './utils/getFullySyncedActivityRange'
+
+export const ActivityChartWithProjectsRangesDataParams = v.object({
+  range: ChartRange,
+  projects: v.array(v.string().transform((value) => value as ProjectId)),
+})
+
+export type ActivityChartWithProjectsRangesDataParams = v.infer<
+  typeof ActivityChartWithProjectsRangesDataParams
+>
+
+export type ProjectActivityChartDataPoint = [count: number, uopsCount: number]
+
+export type DetailedActivityChartWithProjectsRangesDataPoint = [
+  timestamp: number,
+  projects: Record<string, ProjectActivityChartDataPoint | null>,
+]
+
+export type ActivityChartProjectRange = {
+  projectId: ProjectId
+  /** First day with activity data, floored to the day resolution. */
+  sinceTimestamp: number
+}
+
+export type DetailedActivityChartWithProjectsRangesData = {
+  chart: DetailedActivityChartWithProjectsRangesDataPoint[]
+  projects: ActivityChartProjectRange[]
+  syncedUntil: number
+}
+
+/**
+ * @returns activity chart data split by project id and timestamp, mirroring
+ * the shape of `getDetailedTvsChartWithProjectsRanges`
+ */
+export async function getDetailedActivityChartWithProjectsRanges({
+  range,
+  projects,
+}: ActivityChartWithProjectsRangesDataParams): Promise<DetailedActivityChartWithProjectsRangesData> {
+  if (env.MOCK) {
+    return getMockDetailedActivityChartWithProjectsRangesData({
+      range,
+      projects,
+    })
+  }
+
+  if (projects.length === 0) {
+    return { chart: [], projects: [], syncedUntil: UnixTime.now() }
+  }
+
+  const db = getDb()
+  const adjustedRange = await getFullySyncedActivityRange(range)
+  return getActivityChartData(db.activity, projects, adjustedRange)
+}
+
+/**
+ * The unit behind the tRPC procedure, taking the repository so tests can
+ * exercise it with mocked records. `range` is already clamped to fully
+ * synced days, so every generated timestamp is treated as synced.
+ */
+export async function getActivityChartData(
+  repository: Database['activity'],
+  projectIds: ProjectId[],
+  range: ChartRange,
+): Promise<DetailedActivityChartWithProjectsRangesData> {
+  const [records, totals] = await Promise.all([
+    repository.getByProjectsAndTimeRange(projectIds, range),
+    repository.getActivityTotalsForProjects(projectIds),
+  ])
+
+  const projectRanges: ActivityChartProjectRange[] = projectIds.flatMap(
+    (projectId) => {
+      const sinceTimestamp = totals[projectId]?.sinceTimestamp
+      return sinceTimestamp !== undefined
+        ? [
+            {
+              projectId,
+              sinceTimestamp: UnixTime.toStartOf(sinceTimestamp, 'day'),
+            },
+          ]
+        : []
+    },
+  )
+
+  const syncedUntil = range[1]
+  if (records.length === 0) {
+    return { chart: [], projects: projectRanges, syncedUntil }
+  }
+
+  const recordsByProjectId = new Map<string, Map<number, ActivityRecord>>()
+  let dataStart = Number.POSITIVE_INFINITY
+  for (const record of records) {
+    dataStart = Math.min(dataStart, record.timestamp)
+    const projectRecords = recordsByProjectId.get(record.projectId)
+    if (projectRecords) {
+      projectRecords.set(record.timestamp, record)
+      continue
+    }
+    recordsByProjectId.set(
+      record.projectId,
+      new Map([[record.timestamp, record]]),
+    )
+  }
+
+  const sinceByProjectId = new Map(
+    projectRanges.map((p) => [p.projectId, p.sinceTimestamp]),
+  )
+  const firstProjectTimestamp =
+    projectRanges.length > 0
+      ? Math.min(...projectRanges.map((p) => p.sinceTimestamp))
+      : undefined
+
+  const startTimestamp = getChartStartTimestamp({
+    rangeStart: range[0],
+    firstProjectTimestamp,
+    dataStart,
+    resolution: 'day',
+  })
+  const timestamps = generateTimestamps([startTimestamp, range[1]], 'day')
+
+  const chart: DetailedActivityChartWithProjectsRangesDataPoint[] =
+    timestamps.map((timestamp) => {
+      const projectsForTimestamp: Record<
+        string,
+        ProjectActivityChartDataPoint | null
+      > = {}
+
+      for (const projectId of projectIds) {
+        const record = recordsByProjectId.get(projectId)?.get(timestamp)
+        if (record) {
+          projectsForTimestamp[projectId] = [
+            record.count,
+            record.uopsCount ?? record.count,
+          ]
+          continue
+        }
+
+        // Zero only after the project's first record; null marks days before
+        // launch (or projects without activity tracking) so the client can
+        // distinguish "no activity" from "no data".
+        const sinceTimestamp = sinceByProjectId.get(projectId)
+        projectsForTimestamp[projectId] =
+          sinceTimestamp !== undefined && timestamp >= sinceTimestamp
+            ? [0, 0]
+            : null
+      }
+
+      return [timestamp, projectsForTimestamp]
+    })
+
+  return { chart, projects: projectRanges, syncedUntil }
+}
+
+function getMockDetailedActivityChartWithProjectsRangesData({
+  range,
+  projects,
+}: ActivityChartWithProjectsRangesDataParams): DetailedActivityChartWithProjectsRangesData {
+  const timestamps = generateTimestamps(
+    [range[0] ?? 1590883200, range[1]],
+    'day',
+  )
+
+  return {
+    chart: timestamps.map((timestamp) => [
+      timestamp,
+      Object.fromEntries(
+        projects.map((projectId, index) => [
+          projectId,
+          [1_000_000 * (index + 1), 1_500_000 * (index + 1)],
+        ]),
+      ),
+    ]),
+    projects: projects.map((projectId) => ({
+      projectId,
+      sinceTimestamp: timestamps[0] ?? 0,
+    })),
+    syncedUntil: timestamps[timestamps.length - 1] ?? 0,
+  }
+}

--- a/packages/frontend/src/server/trpc/routers/activity.ts
+++ b/packages/frontend/src/server/trpc/routers/activity.ts
@@ -5,6 +5,10 @@ import {
 } from '~/server/features/scaling/activity/getActivityChart'
 import { getActivityChartStats } from '~/server/features/scaling/activity/getActivityChartStats'
 import {
+  ActivityChartWithProjectsRangesDataParams,
+  getDetailedActivityChartWithProjectsRanges,
+} from '~/server/features/scaling/activity/getDetailedActivityChartWithProjectsRanges'
+import {
   EthereumActivityChartParams,
   getEthereumActivityChart,
 } from '~/server/features/scaling/activity/getEthereumActivityChart'
@@ -17,6 +21,9 @@ export const activityRouter = router({
   chart: procedure
     .input(ActivityChartParams)
     .query(({ input }) => getActivityChart(input)),
+  detailedChartWithProjectsRanges: procedure
+    .input(ActivityChartWithProjectsRangesDataParams)
+    .query(({ input }) => getDetailedActivityChartWithProjectsRanges(input)),
   ethereumChart: procedure
     .input(EthereumActivityChartParams)
     .query(({ input }) => getEthereumActivityChart(input)),


### PR DESCRIPTION
Implements [L2B-14549](https://linear.app/l2beat/issue/L2B-14549/activity-metric-and-metric-switcher): the second metric on `/scaling/compare` plus the metric switcher, proving the metric registry is universal.

## Backend

- New tRPC procedure `activity.detailedChartWithProjectsRanges`: given a set of project ids and a range, returns one series per project (`[count, uopsCount]` per day), mirroring the shape and batching approach of `tvs.detailedChartWithProjectsRanges` — one batched repository query per request, no new caching strategy (the page-level in-memory SSR cache and react-query cover it, same as TVS).
- Days before a project's first activity record are `null` (vs `[0, 0]` after launch), so the client can distinguish "not launched" from "no activity" — this is what indexed mode needs to rebase mid-range launches at their first data point.
- Per-project `sinceTimestamp` ranges and `syncedUntil` returned alongside the chart, like the TVS endpoint.
- `getActivityLatestUops` now takes `Pick<Project, 'id'>[]` so the compare universe can reuse it for ranking.

## Frontend

- **Metric switcher** (Value Secured ↔ Activity) rendered from the registry — the shell iterates `COMPARE_METRICS`, no metric-specific conditionals. Switching preserves projects, range, scale; only per-metric controls swap.
- **Activity registry entry**: chart (per-project overlaid lines, values shown per second via `countPerSecond`), UOPS/TPS control in the new per-metric `Controls` slot (reuses `ActivityMetricControls`).
- **URL codec**: `?metric=activity` and `?unit=tps` round-trip; defaults (`tvs`, `uops`) omitted; the unit is only encoded for the activity metric.
- **SSR**: landing on `?metric=activity` prefetches the per-project activity series; with no projects selected the default top 5 is ranked by latest UOPS (30d window — the ranking only needs the last day, no need for the summary page's 1y query).

## Tests

- `getActivityChartData` (the unit behind the procedure) tested with `mockObject<Database['activity']>` repository mocks: per-project series, uops→count fallback, zero-fill after launch vs null before launch, max-range start, empty result.
- URL codec round-trip/default-omission/garbage-tolerance tests extended for metric + unit.

## Verification

- `tsc --noEmit`, `biome check`, and `pnpm test` (480 passing) are clean.
- Smoke-tested against the mock dev server: `/scaling/compare?metric=activity&unit=tps` SSRs with the correct initial state and a dehydrated `activity.detailedChartWithProjectsRanges` query; the default page still prefetches TVS.

Note: this branch replaces some broken uncommitted WIP found in the worktree for this ticket (wrong repository field names, wrong helper signatures); the endpoint/router naming from it was kept.

The "Indexed mode works for activity series" acceptance criterion depends on L2B-14547 (parallel ticket, not yet in the base branch); the data contract here (per-project series with null gaps) is what its client-side rebase transform consumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)