### PR TITLE
Fix TokenRelations Part 1 - DB migration

### DIFF
--- a/packages/database/prisma/migrations/20260728120000_rename_token_relation_endpoints_add_locked_token/migration.sql
+++ b/packages/database/prisma/migrations/20260728120000_rename_token_relation_endpoints_add_locked_token/migration.sql
@@ -1,0 +1,54 @@
+-- Reshapes `TokenRelation` from a pair of endpoints that read like a direction
+-- into an explicitly unordered pair with a role.
+--
+-- Both statements below are metadata-only, so this migration is effectively
+-- instantaneous regardless of table size, and Prisma runs the file in a single
+-- transaction — either both changes land or neither does.
+-- See docs/mdbook/specs/l2b_specs/token_db/token_relations.md.
+
+-- 1. `tokenFrom`/`tokenTo` never meant a direction: the endpoints of a relation
+--    are an unordered pair, and reading the names as "the transfer went from
+--    here to there" is exactly the mistake that made the graph arrows and the
+--    Relations tab arbitrary. `tokenA`/`tokenB` cannot be misread that way.
+--    Which endpoint is which is decided by lexicographic order, and the role
+--    each one plays is carried by `lockedToken` below.
+--
+--    `RENAME COLUMN` rewrites the primary key and both endpoint indexes in
+--    place: no table rewrite and no index rebuild.
+--
+--    This is the one change here that is NOT backwards compatible — code
+--    deployed before this migration queries columns that no longer exist. The
+--    same PR updates the repository to address the new names while still
+--    exposing the old field names to its callers, so the only affected window
+--    is between this migration landing and that PR's own deploy. Relation
+--    ingestion fails loudly and is retried from an unadvanced cursor
+--    (`TokenIngestionLoop` catches it), so nothing is lost.
+ALTER TABLE "TokenRelation" RENAME COLUMN "tokenFromChain" TO "tokenAChain";
+ALTER TABLE "TokenRelation" RENAME COLUMN "tokenFromAddress" TO "tokenAAddress";
+ALTER TABLE "TokenRelation" RENAME COLUMN "tokenToChain" TO "tokenBChain";
+ALTER TABLE "TokenRelation" RENAME COLUMN "tokenToAddress" TO "tokenBAddress";
+
+--    Index definitions follow the rename automatically, but their names do not.
+--    Prisma derives an index name from its columns and reports a mismatch as
+--    drift, so rename them to what `schema.prisma` now implies. Also
+--    metadata-only.
+ALTER INDEX "TokenRelation_tokenFromChain_tokenFromAddress_idx"
+  RENAME TO "TokenRelation_tokenAChain_tokenAAddress_idx";
+ALTER INDEX "TokenRelation_tokenToChain_tokenToAddress_idx"
+  RENAME TO "TokenRelation_tokenBChain_tokenBAddress_idx";
+
+-- 2. Which endpoint of a `lockAndMint` relation holds the locked (escrowed)
+--    token: 'A' or 'B'. The complementary endpoint holds the minted
+--    representation, so this one field carries the whole role assignment.
+--
+--    Nullable and NOT part of the primary key, deliberately:
+--      * `burnAndMint` relations are symmetric — nothing is locked, so NULL is
+--        the correct terminal value for them.
+--      * a `lockAndMint` relation whose evidence never identified a side stays
+--        NULL until an observation does identify one; because the column is
+--        outside the key, that later observation can simply update it.
+--
+--    Additive and backwards compatible on its own. Existing rows are normalized
+--    by a separate migration that runs AFTER the writer which populates this
+--    column is live.
+ALTER TABLE "TokenRelation" ADD COLUMN "lockedToken" CHAR(1);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -554,20 +554,28 @@ model TokenDbHistory {
 // observation of an on-chain transfer between two token addresses and must be
 // recordable before (or without) either endpoint being catalogued as a
 // deployed token. The observed burn/mint flags are deliberately not columns —
-// they are nullable observations and live in the `transfer` evidence JSON.
+// they are nullable per-transfer observations and live in the `transfer`
+// evidence JSON.
+//
+// A relation describes an unordered pair of tokens, so the endpoints are named
+// `tokenA`/`tokenB` rather than from/to: there is no direction between them.
+// They are stored in a fixed lexicographic order — A before B — so one pair
+// cannot occupy two rows, and `lockedToken` ('A' or 'B') names the endpoint
+// holding the locked token of a `lockAndMint` pair.
 // See docs/mdbook/specs/l2b_specs/token_db/token_relations.md.
 model TokenRelation {
-  tokenFromChain   String @db.VarChar(32)
-  tokenFromAddress String @db.VarChar(255)
-  tokenToChain     String @db.VarChar(32)
-  tokenToAddress   String @db.VarChar(255)
-  plugin           String @db.VarChar(64)
-  bridgeType       String @db.VarChar(32)
-  transfer         Json
+  tokenAChain   String  @db.VarChar(32)
+  tokenAAddress String  @db.VarChar(255)
+  tokenBChain   String  @db.VarChar(32)
+  tokenBAddress String  @db.VarChar(255)
+  plugin        String  @db.VarChar(64)
+  bridgeType    String  @db.VarChar(32)
+  lockedToken   String? @db.Char(1)
+  transfer      Json
 
-  @@id([tokenFromChain, tokenFromAddress, tokenToChain, tokenToAddress, plugin, bridgeType])
-  @@index([tokenFromChain, tokenFromAddress])
-  @@index([tokenToChain, tokenToAddress])
+  @@id([tokenAChain, tokenAAddress, tokenBChain, tokenBAddress, plugin, bridgeType])
+  @@index([tokenAChain, tokenAAddress])
+  @@index([tokenBChain, tokenBAddress])
 }
 
 model InteropRecentPrices {

--- a/packages/database/src/repositories/TokenRelationRepository.ts
+++ b/packages/database/src/repositories/TokenRelationRepository.ts
@@ -12,6 +12,13 @@ export type JsonValue =
   | JsonValue[]
   | { [key: string]: JsonValue }
 
+/**
+ * TRANSITIONAL: the endpoint columns are now named `tokenA*`/`tokenB*`, but the
+ * record this repository hands out still uses the old `tokenFrom*`/`tokenTo*`
+ * names, so every caller keeps compiling and keeps working across the column
+ * rename. The follow-up release renames the record fields too and this mismatch
+ * disappears — do not build anything on the old names.
+ */
 export type TokenRelationRecord = {
   tokenFromChain: string
   tokenFromAddress: string
@@ -39,9 +46,17 @@ export type TokenRelationUpdateable = Omit<
   keyof TokenRelationPrimaryKey
 >
 
+// Columns are listed explicitly rather than spread, both because the record
+// names differ from the column names for now and so that a column the record
+// type does not model yet — `lockedToken` — cannot leak into API responses and
+// history snapshots.
 function toRecord(row: Selectable<TokenRelation>): TokenRelationRecord {
   return {
-    ...row,
+    tokenFromChain: row.tokenAChain,
+    tokenFromAddress: row.tokenAAddress,
+    tokenToChain: row.tokenBChain,
+    tokenToAddress: row.tokenBAddress,
+    plugin: row.plugin,
     bridgeType: row.bridgeType as InteropBridgeType,
     transfer: row.transfer as JsonValue,
   }
@@ -49,9 +64,13 @@ function toRecord(row: Selectable<TokenRelation>): TokenRelationRecord {
 
 function toRow(record: TokenRelationRecord): Insertable<TokenRelation> {
   return {
-    ...record,
-    tokenFromAddress: record.tokenFromAddress.toLowerCase(),
-    tokenToAddress: record.tokenToAddress.toLowerCase(),
+    tokenAChain: record.tokenFromChain,
+    tokenAAddress: record.tokenFromAddress.toLowerCase(),
+    tokenBChain: record.tokenToChain,
+    tokenBAddress: record.tokenToAddress.toLowerCase(),
+    plugin: record.plugin,
+    bridgeType: record.bridgeType,
+    transfer: record.transfer,
   }
 }
 
@@ -70,10 +89,10 @@ export class TokenRelationRepository extends BaseRepository {
     const row = await this.db
       .selectFrom('TokenRelation')
       .selectAll()
-      .where('tokenFromChain', '=', pk.tokenFromChain)
-      .where('tokenFromAddress', '=', pk.tokenFromAddress.toLowerCase())
-      .where('tokenToChain', '=', pk.tokenToChain)
-      .where('tokenToAddress', '=', pk.tokenToAddress.toLowerCase())
+      .where('tokenAChain', '=', pk.tokenFromChain)
+      .where('tokenAAddress', '=', pk.tokenFromAddress.toLowerCase())
+      .where('tokenBChain', '=', pk.tokenToChain)
+      .where('tokenBAddress', '=', pk.tokenToAddress.toLowerCase())
       .where('plugin', '=', pk.plugin)
       .where('bridgeType', '=', pk.bridgeType)
       .executeTakeFirst()
@@ -107,10 +126,10 @@ export class TokenRelationRepository extends BaseRepository {
                   eb('bridgeType', '=', bridgeType),
                   eb(
                     eb.refTuple(
-                      'tokenFromChain',
-                      'tokenFromAddress',
-                      'tokenToChain',
-                      'tokenToAddress',
+                      'tokenAChain',
+                      'tokenAAddress',
+                      'tokenBChain',
+                      'tokenBAddress',
                       'plugin',
                     ),
                     'in',
@@ -142,10 +161,10 @@ export class TokenRelationRepository extends BaseRepository {
     const result = await this.db
       .updateTable('TokenRelation')
       .set(patch)
-      .where('tokenFromChain', '=', pk.tokenFromChain)
-      .where('tokenFromAddress', '=', pk.tokenFromAddress.toLowerCase())
-      .where('tokenToChain', '=', pk.tokenToChain)
-      .where('tokenToAddress', '=', pk.tokenToAddress.toLowerCase())
+      .where('tokenAChain', '=', pk.tokenFromChain)
+      .where('tokenAAddress', '=', pk.tokenFromAddress.toLowerCase())
+      .where('tokenBChain', '=', pk.tokenToChain)
+      .where('tokenBAddress', '=', pk.tokenToAddress.toLowerCase())
       .where('plugin', '=', pk.plugin)
       .where('bridgeType', '=', pk.bridgeType)
       .executeTakeFirst()
@@ -162,17 +181,21 @@ export class TokenRelationRepository extends BaseRepository {
     const rows = await this.db
       .selectFrom('TokenRelation')
       .select([
-        'tokenFromChain',
-        'tokenFromAddress',
-        'tokenToChain',
-        'tokenToAddress',
+        'tokenAChain',
+        'tokenAAddress',
+        'tokenBChain',
+        'tokenBAddress',
         'plugin',
         'bridgeType',
       ])
       .execute()
 
     return rows.map((row) => ({
-      ...row,
+      tokenFromChain: row.tokenAChain,
+      tokenFromAddress: row.tokenAAddress,
+      tokenToChain: row.tokenBChain,
+      tokenToAddress: row.tokenBAddress,
+      plugin: row.plugin,
       bridgeType: row.bridgeType as InteropBridgeType,
     }))
   }
@@ -183,8 +206,8 @@ export class TokenRelationRepository extends BaseRepository {
     const rows = await this.db
       .selectFrom('TokenRelation')
       .selectAll()
-      .where('tokenFromChain', '=', token.chain)
-      .where('tokenFromAddress', '=', token.address.toLowerCase())
+      .where('tokenAChain', '=', token.chain)
+      .where('tokenAAddress', '=', token.address.toLowerCase())
       .execute()
 
     return rows.map(toRecord)
@@ -196,8 +219,8 @@ export class TokenRelationRepository extends BaseRepository {
     const rows = await this.db
       .selectFrom('TokenRelation')
       .selectAll()
-      .where('tokenToChain', '=', token.chain)
-      .where('tokenToAddress', '=', token.address.toLowerCase())
+      .where('tokenBChain', '=', token.chain)
+      .where('tokenBAddress', '=', token.address.toLowerCase())
       .execute()
 
     return rows.map(toRecord)
@@ -206,10 +229,10 @@ export class TokenRelationRepository extends BaseRepository {
   async deleteByPrimaryKey(pk: TokenRelationPrimaryKey): Promise<number> {
     const result = await this.db
       .deleteFrom('TokenRelation')
-      .where('tokenFromChain', '=', pk.tokenFromChain)
-      .where('tokenFromAddress', '=', pk.tokenFromAddress.toLowerCase())
-      .where('tokenToChain', '=', pk.tokenToChain)
-      .where('tokenToAddress', '=', pk.tokenToAddress.toLowerCase())
+      .where('tokenAChain', '=', pk.tokenFromChain)
+      .where('tokenAAddress', '=', pk.tokenFromAddress.toLowerCase())
+      .where('tokenBChain', '=', pk.tokenToChain)
+      .where('tokenBAddress', '=', pk.tokenToAddress.toLowerCase())
       .where('plugin', '=', pk.plugin)
       .where('bridgeType', '=', pk.bridgeType)
       .executeTakeFirst()


### PR DESCRIPTION
`tokenFrom`/`tokenTo` read like a transfer direction, but the endpoints of a relation are an unordered pair — that misreading is what made the graph arrows and the Relations tab arbitrary. Renames the four endpoint columns to `tokenA*`/`tokenB*`, which cannot be misread, and adds `lockedToken` ('A' or 'B') to carry the role that actually distinguishes the two tokens.

Both statements are metadata-only and share one transaction. The repository starts addressing the new column names in this PR while still handing its callers the old field names, so nothing outside `packages/database` changes and the deployed code keeps working. The follow-up release renames the record fields and normalizes existing rows.