### PR TITLE
Add liveness grouping database support

### DIFF
--- a/packages/database/prisma/migrations/20260723120000_add_liveness_grouping_key/migration.sql
+++ b/packages/database/prisma/migrations/20260723120000_add_liveness_grouping_key/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Liveness" ADD COLUMN "groupingKey" VARCHAR(255);
+
+-- AlterTable
+ALTER TABLE "RealTimeLiveness" ADD COLUMN "groupingKey" VARCHAR(255);

--- a/packages/database/prisma/migrations/20260723120001_add_liveness_grouping_index/migration.sql
+++ b/packages/database/prisma/migrations/20260723120001_add_liveness_grouping_index/migration.sql
@@ -1,0 +1,5 @@
+-- Keep this as a single statement so PostgreSQL can build the index
+-- concurrently, outside an implicit multi-statement transaction.
+CREATE UNIQUE INDEX CONCURRENTLY "Liveness_configurationId_groupingKey_key"
+ON "Liveness"("configurationId", "groupingKey")
+WHERE "groupingKey" IS NOT NULL;

--- a/packages/database/prisma/migrations/20260723120002_add_realtime_liveness_grouping_index/migration.sql
+++ b/packages/database/prisma/migrations/20260723120002_add_realtime_liveness_grouping_index/migration.sql
@@ -1,0 +1,5 @@
+-- Keep this as a single statement so PostgreSQL can build the index
+-- concurrently, outside an implicit multi-statement transaction.
+CREATE UNIQUE INDEX CONCURRENTLY "RealTimeLiveness_configurationId_groupingKey_key"
+ON "RealTimeLiveness"("configurationId", "groupingKey")
+WHERE "groupingKey" IS NOT NULL;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -116,6 +116,8 @@ model Liveness {
   blockNumber     Int
   txHash          String   @db.VarChar(255)
   configurationId String   @db.VarChar(12)
+  // Partial unique grouping index: migration 20260723120001.
+  groupingKey     String?  @db.VarChar(255)
 
   @@id([configurationId, txHash])
   @@index([configurationId, timestamp])
@@ -126,6 +128,8 @@ model RealTimeLiveness {
   txHash          String   @db.VarChar(255)
   timestamp       DateTime @db.Timestamp(6)
   blockNumber     Int
+  // Partial unique grouping index: migration 20260723120002.
+  groupingKey     String?  @db.VarChar(255)
 
   @@id([configurationId, txHash])
   @@index([configurationId, timestamp])

--- a/packages/database/src/repositories/LivenessRepository.test.ts
+++ b/packages/database/src/repositories/LivenessRepository.test.ts
@@ -77,6 +77,66 @@ describeDatabase(LivenessRepository.name, (db) => {
       await expect(repository.insertMany([])).not.toBeRejected()
     })
 
+    it('keeps the earliest transaction for each grouping key', async () => {
+      const grouped = [
+        {
+          timestamp: START - 4 * UnixTime.MINUTE,
+          blockNumber: 20,
+          txHash: '0xgrouped-later',
+          configurationId: txIdA,
+          groupingKey: 'epoch-1',
+        },
+        {
+          timestamp: START - 5 * UnixTime.MINUTE,
+          blockNumber: 10,
+          txHash: '0xgrouped-earlier',
+          configurationId: txIdA,
+          groupingKey: 'epoch-1',
+        },
+        {
+          timestamp: START - 3 * UnixTime.MINUTE,
+          blockNumber: 30,
+          txHash: '0xgrouped-other-config',
+          configurationId: txIdB,
+          groupingKey: 'epoch-1',
+        },
+      ]
+
+      await repository.insertMany(grouped)
+
+      const results = await repository.getAll()
+      expect(results).toEqualUnsorted([...DATA, grouped[1]!, grouped[2]!])
+    })
+
+    it('replaces a grouped transaction only when an earlier one arrives', async () => {
+      const first = {
+        timestamp: START - 4 * UnixTime.MINUTE,
+        blockNumber: 20,
+        txHash: '0xgrouped-first',
+        configurationId: txIdA,
+        groupingKey: 'epoch-1',
+      }
+      const earlier = {
+        ...first,
+        timestamp: START - 5 * UnixTime.MINUTE,
+        blockNumber: 10,
+        txHash: '0xgrouped-earlier',
+      }
+      const later = {
+        ...first,
+        timestamp: START - 3 * UnixTime.MINUTE,
+        blockNumber: 30,
+        txHash: '0xgrouped-later',
+      }
+
+      await repository.insertMany([first])
+      await repository.insertMany([earlier])
+      await repository.insertMany([later])
+
+      const results = await repository.getAll()
+      expect(results).toEqualUnsorted([...DATA, earlier])
+    })
+
     it('big query', async () => {
       const records: LivenessRecord[] = []
       for (let i = 0; i < 15_000; i++) {

--- a/packages/database/src/repositories/LivenessRepository.test.ts
+++ b/packages/database/src/repositories/LivenessRepository.test.ts
@@ -2,7 +2,33 @@ import { createTrackedTxId } from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 import { describeDatabase } from '../test/database'
-import { type LivenessRecord, LivenessRepository } from './LivenessRepository'
+import {
+  type LivenessRecord,
+  LivenessRepository,
+  toRecord,
+} from './LivenessRepository'
+
+describe(toRecord.name, () => {
+  it('maps a null grouping key to undefined', () => {
+    const timestamp = UnixTime(1)
+
+    expect(
+      toRecord({
+        timestamp: UnixTime.toDate(timestamp),
+        blockNumber: 1,
+        txHash: '0x1234',
+        configurationId: 'config-id',
+        groupingKey: null,
+      }),
+    ).toEqual({
+      timestamp,
+      blockNumber: 1,
+      txHash: '0x1234',
+      configurationId: 'config-id',
+      groupingKey: undefined,
+    })
+  })
+})
 
 describeDatabase(LivenessRepository.name, (db) => {
   const repository = db.liveness
@@ -18,24 +44,28 @@ describeDatabase(LivenessRepository.name, (db) => {
       blockNumber: 12345,
       txHash: '0x1234567890abcdef',
       configurationId: txIdA,
+      groupingKey: undefined,
     },
     {
       timestamp: START - 2 * UnixTime.HOUR,
       blockNumber: 12340,
       txHash: '0xabcdef1234567890',
       configurationId: txIdA,
+      groupingKey: undefined,
     },
     {
       timestamp: START - 3 * UnixTime.HOUR,
       blockNumber: 12346,
       txHash: '0xabcdef1234567890',
       configurationId: txIdB,
+      groupingKey: undefined,
     },
     {
       timestamp: START - 3 * UnixTime.HOUR,
       blockNumber: 12347,
       txHash: '0x12345678901abcdef',
       configurationId: txIdC,
+      groupingKey: undefined,
     },
   ]
 
@@ -54,12 +84,14 @@ describeDatabase(LivenessRepository.name, (db) => {
           blockNumber: 12349,
           txHash: '0x1234567890abcdef1',
           configurationId: txIdA,
+          groupingKey: undefined,
         },
         {
           timestamp: START - 6 * UnixTime.HOUR,
           blockNumber: 12350,
           txHash: '0xabcdef1234567892',
           configurationId: txIdA,
+          groupingKey: undefined,
         },
       ]
       await repository.insertMany(newRows)
@@ -212,6 +244,7 @@ describeDatabase(LivenessRepository.name, (db) => {
             blockNumber: 12340,
             txHash: '0xabcdef1234567891',
             configurationId: txIdA,
+            groupingKey: undefined,
           },
         ]
         await repository.insertMany(NEW_DATA)
@@ -252,30 +285,35 @@ describeDatabase(LivenessRepository.name, (db) => {
             blockNumber: 12345,
             txHash: '0x1234567890abcdef',
             configurationId: txIdA,
+            groupingKey: undefined,
           },
           {
             timestamp: START - 2 * UnixTime.HOUR,
             blockNumber: 12340,
             txHash: '0xabcdef1234567890',
             configurationId: txIdA,
+            groupingKey: undefined,
           },
           {
             timestamp: START - 3 * UnixTime.HOUR - 1,
             blockNumber: 12340,
             txHash: '0xabcdef1234567891',
             configurationId: txIdA,
+            groupingKey: undefined,
           },
           {
             timestamp: START - 3 * UnixTime.HOUR,
             blockNumber: 12346,
             txHash: '0xabcdef1234567890',
             configurationId: txIdB,
+            groupingKey: undefined,
           },
           {
             timestamp: START - 4 * UnixTime.HOUR,
             blockNumber: 12346,
             txHash: '0xabcdef1234567891',
             configurationId: txIdB,
+            groupingKey: undefined,
           },
         ]
         await repository.insertMany(NEW_DATA)
@@ -345,24 +383,28 @@ describeDatabase(LivenessRepository.name, (db) => {
           blockNumber: 12345,
           txHash: '0xabcdef1234567891',
           configurationId: txIdA,
+          groupingKey: undefined,
         },
         {
           timestamp: START + 1 * UnixTime.HOUR,
           blockNumber: 12345,
           txHash: '0x1234567890abcdef',
           configurationId: txIdA,
+          groupingKey: undefined,
         },
         {
           timestamp: START + 2 * UnixTime.HOUR,
           blockNumber: 12346,
           txHash: '0xabcdef1234567890',
           configurationId: txIdA,
+          groupingKey: undefined,
         },
         {
           timestamp: START + 2 * UnixTime.HOUR,
           blockNumber: 12346,
           txHash: '0xabcdef1234567890',
           configurationId: txIdB,
+          groupingKey: undefined,
         },
       ]
       await repository.insertMany(records)

--- a/packages/database/src/repositories/LivenessRepository.ts
+++ b/packages/database/src/repositories/LivenessRepository.ts
@@ -3,24 +3,37 @@ import { assert, UnixTime } from '@l2beat/shared-pure'
 import type { Insertable, Selectable } from 'kysely'
 import { BaseRepository } from '../BaseRepository'
 import type { Liveness } from '../kysely/generated/types'
+import {
+  insertGroupedKeepingEarliest,
+  splitLivenessRecords,
+} from './utils/livenessGrouping'
 
 export interface LivenessRecord {
   timestamp: UnixTime
   blockNumber: number
   txHash: string
   configurationId: TrackedTxId
+  groupingKey?: string
 }
 
 export function toRecord(row: Selectable<Liveness>): LivenessRecord {
-  return {
-    ...row,
+  const { groupingKey, ...rest } = row
+  const record: LivenessRecord = {
+    ...rest,
     timestamp: UnixTime.fromDate(row.timestamp),
   }
+
+  if (groupingKey !== null) {
+    record.groupingKey = groupingKey
+  }
+
+  return record
 }
 
 export function toRow(record: LivenessRecord): Insertable<Liveness> {
   return {
     ...record,
+    groupingKey: record.groupingKey ?? null,
     timestamp: UnixTime.toDate(record.timestamp),
   }
 }
@@ -95,11 +108,15 @@ export class LivenessRepository extends BaseRepository {
   async insertMany(records: LivenessRecord[]): Promise<number> {
     if (records.length === 0) return 0
 
-    const rows = records.map(toRow)
-    await this.batch(rows, 10_000, async (batch) => {
+    const { ungrouped, groupedEarliest } = splitLivenessRecords(records)
+
+    await this.batch(ungrouped.map(toRow), 10_000, async (batch) => {
       await this.db.insertInto('Liveness').values(batch).execute()
     })
-    return rows.length
+    await this.batch(groupedEarliest.map(toRow), 10_000, async (batch) => {
+      await insertGroupedKeepingEarliest(this.db, 'Liveness', batch)
+    })
+    return records.length
   }
 
   async deleteFromById(

--- a/packages/database/src/repositories/LivenessRepository.ts
+++ b/packages/database/src/repositories/LivenessRepository.ts
@@ -17,17 +17,11 @@ export interface LivenessRecord {
 }
 
 export function toRecord(row: Selectable<Liveness>): LivenessRecord {
-  const { groupingKey, ...rest } = row
-  const record: LivenessRecord = {
-    ...rest,
+  return {
+    ...row,
+    groupingKey: row.groupingKey ?? undefined,
     timestamp: UnixTime.fromDate(row.timestamp),
   }
-
-  if (groupingKey !== null) {
-    record.groupingKey = groupingKey
-  }
-
-  return record
 }
 
 export function toRow(record: LivenessRecord): Insertable<Liveness> {

--- a/packages/database/src/repositories/RealTimeLivenessRepository.test.ts
+++ b/packages/database/src/repositories/RealTimeLivenessRepository.test.ts
@@ -97,6 +97,66 @@ describeDatabase(RealTimeLivenessRepository.name, (db) => {
     it('empty array', async () => {
       await expect(repository.upsertMany([])).not.toBeRejected()
     })
+
+    it('keeps the earliest transaction for each grouping key', async () => {
+      const grouped = [
+        {
+          timestamp: START - 4 * UnixTime.MINUTE,
+          blockNumber: 20,
+          txHash: '0xgrouped-later',
+          configurationId: txIdA,
+          groupingKey: 'epoch-1',
+        },
+        {
+          timestamp: START - 5 * UnixTime.MINUTE,
+          blockNumber: 10,
+          txHash: '0xgrouped-earlier',
+          configurationId: txIdA,
+          groupingKey: 'epoch-1',
+        },
+        {
+          timestamp: START - 3 * UnixTime.MINUTE,
+          blockNumber: 30,
+          txHash: '0xgrouped-other-config',
+          configurationId: txIdB,
+          groupingKey: 'epoch-1',
+        },
+      ]
+
+      await repository.upsertMany(grouped)
+
+      const results = await repository.getAll()
+      expect(results).toEqualUnsorted([...DATA, grouped[1]!, grouped[2]!])
+    })
+
+    it('replaces a grouped transaction only when an earlier one arrives', async () => {
+      const first = {
+        timestamp: START - 4 * UnixTime.MINUTE,
+        blockNumber: 20,
+        txHash: '0xgrouped-first',
+        configurationId: txIdA,
+        groupingKey: 'epoch-1',
+      }
+      const earlier = {
+        ...first,
+        timestamp: START - 5 * UnixTime.MINUTE,
+        blockNumber: 10,
+        txHash: '0xgrouped-earlier',
+      }
+      const later = {
+        ...first,
+        timestamp: START - 3 * UnixTime.MINUTE,
+        blockNumber: 30,
+        txHash: '0xgrouped-later',
+      }
+
+      await repository.upsertMany([first])
+      await repository.upsertMany([earlier])
+      await repository.upsertMany([later])
+
+      const results = await repository.getAll()
+      expect(results).toEqualUnsorted([...DATA, earlier])
+    })
   })
 
   describe(RealTimeLivenessRepository.prototype.getAll.name, () => {

--- a/packages/database/src/repositories/RealTimeLivenessRepository.test.ts
+++ b/packages/database/src/repositories/RealTimeLivenessRepository.test.ts
@@ -2,7 +2,32 @@ import { createTrackedTxId } from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 import { describeDatabase } from '../test/database'
-import { RealTimeLivenessRepository } from './RealTimeLivenessRepository'
+import {
+  RealTimeLivenessRepository,
+  toRecord,
+} from './RealTimeLivenessRepository'
+
+describe(toRecord.name, () => {
+  it('maps a null grouping key to undefined', () => {
+    const timestamp = UnixTime(1)
+
+    expect(
+      toRecord({
+        timestamp: UnixTime.toDate(timestamp),
+        blockNumber: 1,
+        txHash: '0x1234',
+        configurationId: 'config-id',
+        groupingKey: null,
+      }),
+    ).toEqual({
+      timestamp,
+      blockNumber: 1,
+      txHash: '0x1234',
+      configurationId: 'config-id',
+      groupingKey: undefined,
+    })
+  })
+})
 
 describeDatabase(RealTimeLivenessRepository.name, (db) => {
   const repository = db.realTimeLiveness
@@ -18,24 +43,28 @@ describeDatabase(RealTimeLivenessRepository.name, (db) => {
       blockNumber: 12345,
       txHash: '0x1234567890abcdef',
       configurationId: txIdA,
+      groupingKey: undefined,
     },
     {
       timestamp: START - 2 * UnixTime.HOUR,
       blockNumber: 12340,
       txHash: '0xabcdef1234567890',
       configurationId: txIdA,
+      groupingKey: undefined,
     },
     {
       timestamp: START - 3 * UnixTime.HOUR,
       blockNumber: 12346,
       txHash: '0xabcdef1234567890',
       configurationId: txIdB,
+      groupingKey: undefined,
     },
     {
       timestamp: START - 3 * UnixTime.HOUR,
       blockNumber: 12347,
       txHash: '0x12345678901abcdef',
       configurationId: txIdC,
+      groupingKey: undefined,
     },
   ]
 
@@ -54,12 +83,14 @@ describeDatabase(RealTimeLivenessRepository.name, (db) => {
           blockNumber: 12349,
           txHash: '0x1234567890abcdef1',
           configurationId: txIdA,
+          groupingKey: undefined,
         },
         {
           timestamp: START - 6 * UnixTime.HOUR,
           blockNumber: 12350,
           txHash: '0xabcdef1234567892',
           configurationId: txIdA,
+          groupingKey: undefined,
         },
       ]
       await repository.upsertMany(newRows)
@@ -80,12 +111,14 @@ describeDatabase(RealTimeLivenessRepository.name, (db) => {
           blockNumber: 12348,
           txHash: '0xabcdef1234567890',
           configurationId: txIdB,
+          groupingKey: undefined,
         },
         {
           timestamp: START - 4 * UnixTime.HOUR,
           blockNumber: 12349,
           txHash: '0x12345678901abcdef',
           configurationId: txIdC,
+          groupingKey: undefined,
         },
       ]
       await repository.upsertMany(newRows)

--- a/packages/database/src/repositories/RealTimeLivenessRepository.ts
+++ b/packages/database/src/repositories/RealTimeLivenessRepository.ts
@@ -3,21 +3,33 @@ import { UnixTime } from '@l2beat/shared-pure'
 import type { Insertable, Selectable } from 'kysely'
 import { BaseRepository } from '../BaseRepository'
 import type { RealTimeLiveness } from '../kysely/generated/types'
+import {
+  insertGroupedKeepingEarliest,
+  splitLivenessRecords,
+} from './utils/livenessGrouping'
 
 export interface RealTimeLivenessRecord {
   configurationId: TrackedTxId
   txHash: string
   timestamp: UnixTime
   blockNumber: number
+  groupingKey?: string
 }
 
 export function toRecord(
   row: Selectable<RealTimeLiveness>,
 ): RealTimeLivenessRecord {
-  return {
-    ...row,
+  const { groupingKey, ...rest } = row
+  const record: RealTimeLivenessRecord = {
+    ...rest,
     timestamp: UnixTime.fromDate(row.timestamp),
   }
+
+  if (groupingKey !== null) {
+    record.groupingKey = groupingKey
+  }
+
+  return record
 }
 
 export function toRow(
@@ -25,6 +37,7 @@ export function toRow(
 ): Insertable<RealTimeLiveness> {
   return {
     ...record,
+    groupingKey: record.groupingKey ?? null,
     timestamp: UnixTime.toDate(record.timestamp),
   }
 }
@@ -41,8 +54,9 @@ export class RealTimeLivenessRepository extends BaseRepository {
   async upsertMany(records: RealTimeLivenessRecord[]): Promise<number> {
     if (records.length === 0) return 0
 
-    const rows = records.map(toRow)
-    await this.batch(rows, 10_000, async (batch) => {
+    const { ungrouped, groupedEarliest } = splitLivenessRecords(records)
+
+    await this.batch(ungrouped.map(toRow), 10_000, async (batch) => {
       await this.db
         .insertInto('RealTimeLiveness')
         .values(batch)
@@ -54,7 +68,10 @@ export class RealTimeLivenessRepository extends BaseRepository {
         )
         .execute()
     })
-    return rows.length
+    await this.batch(groupedEarliest.map(toRow), 10_000, async (batch) => {
+      await insertGroupedKeepingEarliest(this.db, 'RealTimeLiveness', batch)
+    })
+    return records.length
   }
 
   async deleteAll(): Promise<number> {

--- a/packages/database/src/repositories/RealTimeLivenessRepository.ts
+++ b/packages/database/src/repositories/RealTimeLivenessRepository.ts
@@ -19,17 +19,11 @@ export interface RealTimeLivenessRecord {
 export function toRecord(
   row: Selectable<RealTimeLiveness>,
 ): RealTimeLivenessRecord {
-  const { groupingKey, ...rest } = row
-  const record: RealTimeLivenessRecord = {
-    ...rest,
+  return {
+    ...row,
+    groupingKey: row.groupingKey ?? undefined,
     timestamp: UnixTime.fromDate(row.timestamp),
   }
-
-  if (groupingKey !== null) {
-    record.groupingKey = groupingKey
-  }
-
-  return record
 }
 
 export function toRow(

--- a/packages/database/src/repositories/utils/livenessGrouping.ts
+++ b/packages/database/src/repositories/utils/livenessGrouping.ts
@@ -1,0 +1,88 @@
+import { type Insertable, type RawBuilder, sql } from 'kysely'
+import type { QueryBuilder } from '../../kysely'
+import type { Liveness, RealTimeLiveness } from '../../kysely/generated/types'
+
+type LivenessTable = 'Liveness' | 'RealTimeLiveness'
+
+interface LivenessLikeRecord {
+  configurationId: string
+  timestamp: number
+  blockNumber: number
+  groupingKey?: string
+}
+
+/** Keeps the earliest grouped record per (configurationId, groupingKey). */
+export function splitLivenessRecords<T extends LivenessLikeRecord>(
+  records: T[],
+): { ungrouped: T[]; groupedEarliest: T[] } {
+  const ungrouped: T[] = []
+  const byConfiguration = new Map<string, Map<string, T>>()
+
+  for (const record of records) {
+    if (record.groupingKey === undefined) {
+      ungrouped.push(record)
+      continue
+    }
+
+    let byGroupingKey = byConfiguration.get(record.configurationId)
+    if (byGroupingKey === undefined) {
+      byGroupingKey = new Map()
+      byConfiguration.set(record.configurationId, byGroupingKey)
+    }
+
+    const current = byGroupingKey.get(record.groupingKey)
+    if (current === undefined || isEarlier(record, current)) {
+      byGroupingKey.set(record.groupingKey, record)
+    }
+  }
+
+  const groupedEarliest = [...byConfiguration.values()].flatMap((records) => [
+    ...records.values(),
+  ])
+
+  return { ungrouped, groupedEarliest }
+}
+
+/** Upserts grouped rows, replacing a stored row only with an earlier one. */
+export async function insertGroupedKeepingEarliest(
+  db: QueryBuilder,
+  table: LivenessTable,
+  rows: Insertable<Liveness | RealTimeLiveness>[],
+): Promise<void> {
+  await db
+    .insertInto(table)
+    .values(rows)
+    .onConflict((cb) =>
+      cb
+        .columns(['configurationId', 'groupingKey'])
+        .where('groupingKey', 'is not', null)
+        .doUpdateSet((eb) => ({
+          timestamp: eb.ref('excluded.timestamp'),
+          blockNumber: eb.ref('excluded.blockNumber'),
+          txHash: eb.ref('excluded.txHash'),
+        }))
+        .where(isEarlierThanStored(table)),
+    )
+    .execute()
+}
+
+function isEarlierThanStored(table: LivenessTable): RawBuilder<boolean> {
+  return sql<boolean>`(
+    ${sql.ref('excluded.timestamp')},
+    ${sql.ref('excluded.blockNumber')}
+  ) < (
+    ${sql.ref(`${table}.timestamp`)},
+    ${sql.ref(`${table}.blockNumber`)}
+  )`
+}
+
+function isEarlier(
+  candidate: LivenessLikeRecord,
+  current: LivenessLikeRecord,
+): boolean {
+  return (
+    candidate.timestamp < current.timestamp ||
+    (candidate.timestamp === current.timestamp &&
+      candidate.blockNumber < current.blockNumber)
+  )
+}


### PR DESCRIPTION
## Summary

- add nullable `groupingKey` columns to liveness tables
- add partial unique indexes for grouped liveness records
- update the Prisma schema to match the migrations
- persist grouped records while keeping the earliest proof per configuration and grouping key

## Why

This is the database prerequisite for #12349. It is split from the application changes so database migrations and the code that starts producing grouping keys land separately and satisfy the migration-isolation check.

The repository changes are included here because Prisma generation exposes the new nullable columns to database row types; keeping the mapping and repository tests with the schema makes this prerequisite independently deployable and testable.

## Validation

- `pnpm --filter @l2beat/database typecheck`
- `pnpm --filter @l2beat/database test -- --reporter dot` (19 passing, 53 database-backed tests pending locally)
- `pnpm --filter @l2beat/database exec prisma validate --schema prisma/schema.prisma`
- Biome on changed repository files