### PR TITLE
Make home what's new banner dismissible on mobile

### DIFF
--- a/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
@@ -1,5 +1,6 @@
 import { useLocalStorage } from '~/hooks/useLocalStorage'
 import { ArrowRightIcon } from '~/icons/ArrowRight'
+import { CloseIcon } from '~/icons/Close'
 import { cn } from '~/utils/cn'
 import { HomeCard } from './HomeCard'
 
@@ -24,68 +25,98 @@ export function HomeWhatsNewCard({
     return null
   }
   return (
-    <HomeCard
-      className={cn(
-        'flex flex-col gap-3 overflow-hidden p-0 xl:gap-0 xl:p-0',
-        className,
-      )}
-    >
-      <h2 className="sr-only font-bold text-xl md:not-sr-only xl:sr-only">
-        What's new
-      </h2>
-      <ul className="flex flex-1 flex-col gap-2 xl:gap-0">
-        {items.map((item) => (
-          <li key={item.id} className="flex flex-1">
-            <WhatsNewItemCard item={item} />
-          </li>
-        ))}
-      </ul>
-    </HomeCard>
+    <>
+      <script
+        dangerouslySetInnerHTML={{ __html: getDismissedCheckScript(items) }}
+      />
+      <HomeCard
+        className={cn(
+          'flex flex-col gap-3 overflow-hidden p-0 xl:gap-0 xl:p-0',
+          '[[data-whats-new-dismissed]_&]:max-md:hidden',
+          className,
+        )}
+      >
+        <h2 className="sr-only font-bold text-xl md:not-sr-only xl:sr-only">
+          What's new
+        </h2>
+        <ul className="flex flex-1 flex-col gap-2 xl:gap-0">
+          {items.map((item) => (
+            <li key={item.id} className="relative flex flex-1">
+              <WhatsNewItemCard item={item} />
+            </li>
+          ))}
+        </ul>
+      </HomeCard>
+    </>
   )
+}
+
+/**
+ * Runs during HTML parsing, before first paint, so returning visitors who
+ * already dismissed the card never see it flash on mobile. The attribute lives
+ * on <html> (outside the React root) to keep hydration untouched.
+ */
+function getDismissedCheckScript(items: HomeWhatsNewItem[]): string {
+  const keys = JSON.stringify(items.map((item) => `whats-new-${item.id}`))
+  return `try{if(${keys}.every(function(k){return localStorage.getItem(k)==='true'}))document.documentElement.dataset.whatsNewDismissed='true'}catch{}`
 }
 
 function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
   const [, setWidgetClosed] = useLocalStorage(`whats-new-${item.id}`, false)
+  const dismiss = () => {
+    setWidgetClosed(true)
+    document.documentElement.dataset.whatsNewDismissed = 'true'
+  }
   return (
-    <a
-      href={item.href}
-      onClick={() => setWidgetClosed(true)}
-      className="group relative block flex-1 overflow-hidden md:flex md:flex-row md:rounded-lg md:border-2 md:border-divider xl:block xl:min-h-40 xl:rounded-none xl:border-0"
-    >
-      <div className="relative aspect-video w-full overflow-hidden md:aspect-auto md:w-32 md:shrink-0 xl:absolute xl:inset-0 xl:w-full">
-        <picture className="contents">
-          <source
-            media="(min-width: 1440px)"
-            srcSet={item.verticalImageSrc ?? item.imageSrc}
-          />
-          <img
-            src={item.imageSrc}
-            alt={item.imageAlt}
-            loading="lazy"
-            className="size-full object-cover object-top-left transition-transform duration-300 group-hover:scale-[1.02] md:min-h-[5.5rem] xl:min-h-0"
-          />
-        </picture>
-      </div>
-      <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12">
-        <span
-          aria-hidden
-          className="font-bold text-white/70 text-xs uppercase tracking-wide md:hidden xl:block"
-        >
-          What's new
-        </span>
-        <span className="font-bold text-label-value-14 text-pure-white leading-tight md:text-heading-16 md:text-primary xl:text-pure-white">
-          {item.title}
-        </span>
-        {item.description && (
-          <p className="line-clamp-2 text-label-value-12 text-white/80 leading-snug md:text-label-value-13 md:text-secondary xl:text-white/80">
-            {item.description}
-          </p>
-        )}
-        <span className="mt-0.5 flex items-center gap-1 font-bold text-[#66b2ff] text-xs md:text-link xl:text-[#66b2ff]">
-          Explore
-          <ArrowRightIcon className="size-3 fill-current transition-transform group-hover:translate-x-0.5" />
-        </span>
-      </div>
-    </a>
+    <>
+      <a
+        href={item.href}
+        onClick={() => setWidgetClosed(true)}
+        className="group relative block flex-1 overflow-hidden md:flex md:flex-row md:rounded-lg md:border-2 md:border-divider xl:block xl:min-h-40 xl:rounded-none xl:border-0"
+      >
+        <div className="relative aspect-video w-full overflow-hidden md:aspect-auto md:w-32 md:shrink-0 xl:absolute xl:inset-0 xl:w-full">
+          <picture className="contents">
+            <source
+              media="(min-width: 1440px)"
+              srcSet={item.verticalImageSrc ?? item.imageSrc}
+            />
+            <img
+              src={item.imageSrc}
+              alt={item.imageAlt}
+              loading="lazy"
+              className="size-full object-cover object-top-left transition-transform duration-300 group-hover:scale-[1.02] md:min-h-[5.5rem] xl:min-h-0"
+            />
+          </picture>
+        </div>
+        <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12">
+          <span
+            aria-hidden
+            className="font-bold text-white/70 text-xs uppercase tracking-wide md:hidden xl:block"
+          >
+            What's new
+          </span>
+          <span className="font-bold text-label-value-14 text-pure-white leading-tight md:text-heading-16 md:text-primary xl:text-pure-white">
+            {item.title}
+          </span>
+          {item.description && (
+            <p className="line-clamp-2 text-label-value-12 text-white/80 leading-snug md:text-label-value-13 md:text-secondary xl:text-white/80">
+              {item.description}
+            </p>
+          )}
+          <span className="mt-0.5 flex items-center gap-1 font-bold text-[#66b2ff] text-xs md:text-link xl:text-[#66b2ff]">
+            Explore
+            <ArrowRightIcon className="size-3 fill-current transition-transform group-hover:translate-x-0.5" />
+          </span>
+        </div>
+      </a>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={dismiss}
+        className="absolute top-2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-black/40 transition-colors hover:bg-black/60 md:hidden"
+      >
+        <CloseIcon className="size-[10px] fill-white" />
+      </button>
+    </>
   )
 }

--- a/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
@@ -32,7 +32,7 @@ export function HomeWhatsNewCard({
       <HomeCard
         className={cn(
           'flex flex-col gap-3 overflow-hidden p-0 xl:gap-0 xl:p-0',
-          '[[data-whats-new-dismissed]_&]:max-md:hidden',
+          '[[data-whats-new-dismissed]_&]:max-lg:hidden',
           className,
         )}
       >
@@ -53,8 +53,8 @@ export function HomeWhatsNewCard({
 
 /**
  * Runs during HTML parsing, before first paint, so returning visitors who
- * already dismissed the card never see it flash on mobile. The attribute lives
- * on <html> (outside the React root) to keep hydration untouched.
+ * already dismissed the card never see it flash on small screens. The attribute
+ * lives on <html> (outside the React root) to keep hydration untouched.
  */
 function getDismissedCheckScript(items: HomeWhatsNewItem[]): string {
   const keys = JSON.stringify(items.map((item) => `whats-new-${item.id}`))
@@ -88,7 +88,7 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
             />
           </picture>
         </div>
-        <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12">
+        <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 md:pr-8 lg:pr-3 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12">
           <span
             aria-hidden
             className="font-bold text-white/70 text-xs uppercase tracking-wide md:hidden xl:block"
@@ -113,9 +113,9 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
         type="button"
         aria-label="Dismiss"
         onClick={dismiss}
-        className="absolute top-2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-black/40 transition-colors hover:bg-black/60 md:hidden"
+        className="absolute top-2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-black/40 transition-colors hover:bg-black/60 md:bg-transparent md:hover:bg-surface-tertiary lg:hidden"
       >
-        <CloseIcon className="size-[10px] fill-white" />
+        <CloseIcon className="size-[10px] fill-white md:fill-secondary" />
       </button>
     </>
   )

--- a/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
@@ -32,7 +32,7 @@ export function HomeWhatsNewCard({
       <HomeCard
         className={cn(
           'flex flex-col gap-3 overflow-hidden p-0 xl:gap-0 xl:p-0',
-          '[[data-whats-new-dismissed]_&]:max-lg:hidden',
+          '[[data-whats-new-dismissed]_&]:max-xl:hidden',
           className,
         )}
       >
@@ -88,7 +88,7 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
             />
           </picture>
         </div>
-        <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 md:pr-8 lg:pr-3 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12">
+        <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 md:pr-8 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12 xl:pr-4">
           <span
             aria-hidden
             className="font-bold text-white/70 text-xs uppercase tracking-wide md:hidden xl:block"
@@ -113,7 +113,7 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
         type="button"
         aria-label="Dismiss"
         onClick={dismiss}
-        className="absolute top-2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-black/40 transition-colors hover:bg-black/60 md:bg-transparent md:hover:bg-surface-tertiary lg:hidden"
+        className="absolute top-2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-black/40 transition-colors hover:bg-black/60 md:bg-transparent md:hover:bg-surface-tertiary xl:hidden"
       >
         <CloseIcon className="size-[10px] fill-white md:fill-secondary" />
       </button>

--- a/packages/frontend/src/pages/home/getHomeData.ts
+++ b/packages/frontend/src/pages/home/getHomeData.ts
@@ -1,7 +1,10 @@
 import { type InMemoryCache, ProjectId } from '@l2beat/shared-pure'
 import type { Request } from 'express'
 import { getAppLayoutProps } from '~/common/getAppLayoutProps'
-import { getChangelogEntries } from '~/server/features/changelog/getChangelogEntries'
+import {
+  getChangelogEntries,
+  selectActiveWhatsNewEntry,
+} from '~/server/features/changelog/getChangelogEntries'
 import { getDaProjectEconomicSecurity } from '~/server/features/data-availability/project/utils/getDaProjectEconomicSecurity'
 import { getHomeEthereumCharts } from '~/server/features/home/getHomeEthereumCharts'
 import { getHomeScalingCharts } from '~/server/features/home/getHomeScalingCharts'
@@ -226,7 +229,7 @@ async function getEthereumEconomicSecurity(): Promise<number | undefined> {
 }
 
 function getHomeWhatsNewItems(): HomeWhatsNewItem[] {
-  const entry = getChangelogEntries().find((entry) => entry.whatsNew)
+  const entry = selectActiveWhatsNewEntry(getChangelogEntries(), new Date())
   if (!entry?.whatsNew) {
     return []
   }

--- a/packages/frontend/src/pages/home/getHomeData.ts
+++ b/packages/frontend/src/pages/home/getHomeData.ts
@@ -229,7 +229,13 @@ async function getEthereumEconomicSecurity(): Promise<number | undefined> {
 }
 
 function getHomeWhatsNewItems(): HomeWhatsNewItem[] {
-  const entry = selectActiveWhatsNewEntry(getChangelogEntries(), new Date())
+  // The card is a permanent part of the desktop layout, so unlike the
+  // floating widget it falls back to the most recent entry when no
+  // campaign is currently active.
+  const entries = getChangelogEntries()
+  const entry =
+    selectActiveWhatsNewEntry(entries, new Date()) ??
+    entries.find((entry) => entry.whatsNew)
   if (!entry?.whatsNew) {
     return []
   }

--- a/packages/frontend/src/server/features/changelog/getChangelogEntries.test.ts
+++ b/packages/frontend/src/server/features/changelog/getChangelogEntries.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'earl'
 import type { ChangelogEntry } from './getChangelogEntries'
 import {
   selectActiveChangelogWhatsNewWidget,
+  selectActiveWhatsNewEntry,
   sortChangelogEntries,
 } from './getChangelogEntries'
 
@@ -53,6 +54,25 @@ describe('changelog whats new selection', () => {
     const result = selectActiveChangelogWhatsNewWidget([expired, future], now)
 
     expect(result).toEqual(undefined)
+  })
+
+  it('selects an entry only within its active window', () => {
+    const now = new Date('2026-02-19T14:00:00.000Z')
+    const expired = makeEntry('expired', '2026-02-01T00:00:00.000Z', {
+      image: '/expired.png',
+      alt: 'expired',
+      expiresAt: '2026-02-10T00:00:00.000Z',
+    })
+    const active = makeEntry('active', '2026-02-05T00:00:00.000Z', {
+      image: '/active.png',
+      alt: 'active',
+      expiresAt: '2026-03-01T00:00:00.000Z',
+    })
+
+    expect(selectActiveWhatsNewEntry([expired, active], now)?.id).toEqual(
+      'active',
+    )
+    expect(selectActiveWhatsNewEntry([expired], now)).toEqual(undefined)
   })
 
   it('falls back to changelog anchor link when href is missing', () => {

--- a/packages/frontend/src/server/features/changelog/getChangelogEntries.ts
+++ b/packages/frontend/src/server/features/changelog/getChangelogEntries.ts
@@ -32,10 +32,10 @@ export function sortChangelogEntries(
   )
 }
 
-export function selectActiveChangelogWhatsNewWidget(
+export function selectActiveWhatsNewEntry(
   entries: ChangelogEntry[],
   now: Date,
-): WhatsNewWidget | undefined {
+): ChangelogEntry | undefined {
   for (const entry of sortChangelogEntries(entries)) {
     if (!entry.whatsNew) continue
 
@@ -44,17 +44,29 @@ export function selectActiveChangelogWhatsNewWidget(
     const expiresAt = entry.whatsNew.expiresAt.getTime()
 
     if (publishedAt <= nowTimestamp && nowTimestamp < expiresAt) {
-      return {
-        id: `changelog-${entry.id}`,
-        href: entry.whatsNew.href ?? `/changelog#${entry.id}`,
-        image: entry.whatsNew.image,
-        disabledOnMatches: entry.whatsNew.disabledOnMatches,
-        alt: entry.whatsNew.alt,
-      }
+      return entry
     }
   }
 
   return undefined
+}
+
+export function selectActiveChangelogWhatsNewWidget(
+  entries: ChangelogEntry[],
+  now: Date,
+): WhatsNewWidget | undefined {
+  const entry = selectActiveWhatsNewEntry(entries, now)
+  if (!entry?.whatsNew) {
+    return undefined
+  }
+
+  return {
+    id: `changelog-${entry.id}`,
+    href: entry.whatsNew.href ?? `/changelog#${entry.id}`,
+    image: entry.whatsNew.image,
+    disabledOnMatches: entry.whatsNew.disabledOnMatches,
+    alt: entry.whatsNew.alt,
+  }
 }
 
 export function getActiveChangelogWhatsNewWidget(


### PR DESCRIPTION
Closes L2B-14562

## Context

The what's new card on the mobile home page renders as a full-width 16:9 hero image right under the stats strip, pushing the main content below the fold, and could not be dismissed ([Discord feedback](https://linear.app/l2beat/issue/L2B-14562/solution-for-news-banner-on-mobile)).

## Changes

- **Dismiss button below `xl` (1440px)** on the what's new card — the mobile hero and the compact row (md–xl) are dismissible; on `xl+` the card is a permanent part of the desktop layout and has no dismiss button. Clicking it persists the shared `whats-new-<id>` localStorage key (same one the floating widget uses) and hides the card instantly via a `data-whats-new-dismissed` attribute on `<html>` + a `max-xl:hidden` variant. Dismissal never hides the card on `xl+`.
- **No jump on load**: the card stays in server-rendered HTML and is never conditionally rendered from localStorage. A tiny inline script (runs during HTML parse, before first paint) sets the attribute for returning dismissed visitors, so they never see a flash; hydration is untouched.
- **Entry selection**: extracted `selectActiveWhatsNewEntry` in `getChangelogEntries.ts` (the `publishedAt <= now < expiresAt` window, shared with the floating-widget selector) and added a test. The home card prefers the currently active entry, but since it is a permanent part of the desktop layout it falls back to the most recent what's-new entry when no campaign is active (as is the case today) instead of disappearing. The floating widget keeps respecting `expiresAt`.

## Behavioral note

Because the dismiss state shares the existing `whats-new-<id>` key: tapping "Explore" (which already wrote this key) now also hides the home banner on future sub-`xl` visits, and dismissing also suppresses the floating widget on other pages — one consistent dismiss state.

## Verification

Headless Chromium against `pnpm dev:mock`: banner and X present in server HTML with no pop-in; dismiss hides instantly without navigating (verified live at 390px, 900px and 1250px); after reload the card is already hidden at DOMContentLoaded; with the dismissed state set the banner stays visible with no X on fresh loads at 1500px; with today's all-expired content the card still renders on every viewport via the fallback; closing the floating widget elsewhere hides the sub-`xl` home banner (shared key) and the floating widget never renders on the home page; clearing the key restores the banner; zero hydration warnings. Full frontend suite passes (467), biome lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)