### PR TITLE
Set up config structure for DeFi projects

### DIFF
--- a/packages/config/src/ProjectDatabase.test.ts
+++ b/packages/config/src/ProjectDatabase.test.ts
@@ -95,10 +95,12 @@ describe(ProjectDatabase.name, () => {
       },
       externalDependencies: [
         {
+          type: 'tracked',
           projectId: ProjectId('reviewed-dependency'),
           description: 'Provides a price feed.',
         },
         {
+          type: 'not-tracked',
           name: 'External dependency',
           icon: 'external-dependency',
           description: 'Provides an exchange rate.',

--- a/packages/config/src/ProjectDatabase.test.ts
+++ b/packages/config/src/ProjectDatabase.test.ts
@@ -83,6 +83,41 @@ describe(ProjectDatabase.name, () => {
     expect(result).toEqual([projectB])
   })
 
+  it('can add and query DeFi project data', async () => {
+    const project: BaseProject = {
+      id: ProjectId('defi-project'),
+      slug: 'defi-project',
+      name: 'DeFi project',
+      shortName: undefined,
+      addedAt: 0,
+      defiInfo: {
+        category: 'Stablecoin',
+      },
+      externalDependencies: [
+        {
+          projectId: ProjectId('reviewed-dependency'),
+          description: 'Provides a price feed.',
+        },
+        {
+          name: 'External dependency',
+          icon: 'external-dependency',
+          description: 'Provides an exchange rate.',
+        },
+      ],
+    }
+
+    await db.saveProject(project)
+
+    const result = await db.getProject({
+      id: project.id,
+      select: ['defiInfo', 'externalDependencies'],
+      whereNotNull: [],
+      whereNull: [],
+    })
+
+    expect(result).toEqual(project)
+  })
+
   it('can add and retrieve a token', async () => {
     const token: LegacyToken = {
       id: AssetId('foo'),

--- a/packages/config/src/ProjectDatabase.test.ts
+++ b/packages/config/src/ProjectDatabase.test.ts
@@ -83,43 +83,6 @@ describe(ProjectDatabase.name, () => {
     expect(result).toEqual([projectB])
   })
 
-  it('can add and query DeFi project data', async () => {
-    const project: BaseProject = {
-      id: ProjectId('defi-project'),
-      slug: 'defi-project',
-      name: 'DeFi project',
-      shortName: undefined,
-      addedAt: 0,
-      defiInfo: {
-        category: 'Stablecoin',
-      },
-      externalDependencies: [
-        {
-          type: 'tracked',
-          projectId: ProjectId('reviewed-dependency'),
-          description: 'Provides a price feed.',
-        },
-        {
-          type: 'not-tracked',
-          name: 'External dependency',
-          icon: 'external-dependency',
-          description: 'Provides an exchange rate.',
-        },
-      ],
-    }
-
-    await db.saveProject(project)
-
-    const result = await db.getProject({
-      id: project.id,
-      select: ['defiInfo', 'externalDependencies'],
-      whereNotNull: [],
-      whereNull: [],
-    })
-
-    expect(result).toEqual(project)
-  })
-
   it('can add and retrieve a token', async () => {
     const token: LegacyToken = {
       id: AssetId('foo'),

--- a/packages/config/src/ProjectDatabase.ts
+++ b/packages/config/src/ProjectDatabase.ts
@@ -53,6 +53,8 @@ const schema = {
 
   interopConfig: 'TEXT',
   privacyInfo: 'TEXT',
+  defiInfo: 'TEXT',
+  externalDependencies: 'TEXT',
 
   tvsInfo: 'TEXT',
   tvsConfig: 'TEXT',

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -970,16 +970,15 @@ export interface ProjectDefiInfo {
 
 export type ProjectExternalDependency =
   | {
+      type: 'tracked'
       /** An L2BEAT project this project depends on. */
       projectId: ProjectId
-      name?: never
-      icon?: never
       /** How this project depends on the referenced project. */
       description: string
     }
   | {
+      type: 'not-tracked'
       /** An external dependency that is not represented by an L2BEAT project. */
-      projectId?: never
       name: string
       /** Icon slug under /icons, e.g. "reth" for /icons/reth.png. */
       icon: string

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -191,6 +191,12 @@ export interface BaseProject {
   // privacy data
   privacyInfo?: ProjectPrivacyInfo
 
+  // defi data
+  defiInfo?: ProjectDefiInfo
+
+  // external dependency data
+  externalDependencies?: ProjectExternalDependency[]
+
   // feature configs
   tvsInfo?: ProjectTvsInfo
   tvsConfig?: TvsToken[]
@@ -237,6 +243,7 @@ export interface ProjectStatuses {
 export interface ProjectDisplay {
   description: string
   detailedDescription?: string
+  references?: ReferenceLink[]
   links: ProjectLinks
   badges: Badge[]
   redWarning?: ProjectRedWarning
@@ -949,6 +956,36 @@ export interface TrustedSetup {
   longDescription: string
   participantCount?: number
 }
+
+// #endregion
+
+// #region defi data
+
+export type ProjectDefiCategory = 'DEX' | 'Oracle' | 'Stablecoin'
+
+export interface ProjectDefiInfo {
+  /** Short category label shown in the DeFi table, e.g. "Stablecoin". */
+  category: ProjectDefiCategory
+}
+
+export type ProjectExternalDependency =
+  | {
+      /** An L2BEAT project this project depends on. */
+      projectId: ProjectId
+      name?: never
+      icon?: never
+      /** How this project depends on the referenced project. */
+      description: string
+    }
+  | {
+      /** An external dependency that is not represented by an L2BEAT project. */
+      projectId?: never
+      name: string
+      /** Icon slug under /icons, e.g. "reth" for /icons/reth.png. */
+      icon: string
+      /** How this project depends on the external dependency. */
+      description: string
+    }
 
 // #endregion
 


### PR DESCRIPTION
## Summary

- add typed DeFi category metadata to project configs
- model reviewed and external dependencies with project-specific descriptions
- allow research references on project display data
- persist the new fields in the project database and cover both dependency variants

## Why

This establishes the config contract required by L2B-14579 and unblocks the BOLD and Uniswap V3 project configuration work.

## Validation

- `pnpm typecheck` in `packages/config`
- `pnpm test` in `packages/config` (23,596 passing, 2 pending)
- `pnpm build` in `packages/config`
- `pnpm format` in `packages/config`
- `pnpm lint` in `packages/config`
- `git diff --check`