### PR TITLE
Decode packed OP dispute game arguments in decoder-3

### DIFF
--- a/packages/tools/src/decoder-3/packed.test.ts
+++ b/packages/tools/src/decoder-3/packed.test.ts
@@ -1,0 +1,149 @@
+import { expect } from 'earl'
+import { describe } from 'mocha'
+import { decodePacked, type PackedSchema } from './packed'
+import {
+  OP_PERMISSIONED_GAME_ARGS_SCHEMA,
+  OP_PERMISSIONLESS_GAME_ARGS_SCHEMA,
+  OP_SUPER_PERMISSIONED_GAME_ARGS_SCHEMA,
+  OP_ZK_GAME_ARGS_SCHEMA,
+} from './packedSchemas'
+
+describe(decodePacked.name, () => {
+  it('decodes fixed-width packed fields', () => {
+    const schema: PackedSchema = {
+      name: 'test',
+      fields: [
+        { name: 'enabled', type: 'bool' },
+        { name: 'delta', type: 'int16' },
+        { name: 'count', type: 'uint24' },
+        { name: 'tag', type: 'bytes3' },
+        { name: 'target', type: 'address' },
+      ],
+    }
+    const encoded =
+      '0x01fffe010203abcdef1234567890123456789012345678901234567890'
+
+    expect(decodePacked(schema, encoded, 1)).toEqual({
+      type: 'tuple',
+      value: '',
+      bytes: encoded,
+      chainId: 1,
+      members: [
+        {
+          name: 'enabled',
+          type: 'bool',
+          value: 'true',
+          bytes: '0x01',
+          chainId: 1,
+        },
+        {
+          name: 'delta',
+          type: 'number',
+          value: '-2',
+          bytes: '0xfffe',
+          chainId: 1,
+        },
+        {
+          name: 'count',
+          type: 'number',
+          value: '66051',
+          bytes: '0x010203',
+          chainId: 1,
+        },
+        {
+          name: 'tag',
+          type: 'bytes',
+          value: '0xabcdef',
+          bytes: '0xabcdef',
+          chainId: 1,
+        },
+        {
+          name: 'target',
+          type: 'address',
+          value: '0x1234567890123456789012345678901234567890',
+          bytes: '0x1234567890123456789012345678901234567890',
+          chainId: 1,
+        },
+      ],
+    })
+  })
+
+  it('decodes OP permissioned game args', () => {
+    const encoded =
+      '0xdead000000000000000000000000000000000000000000000000000000000000acc005dcd857b401e4732e6f7837135a22825cfaee018baf058227872540ac60efbd38b023d9dae257b4c29daee99a28e6e86778b499361294c134ea000000000000000000000000000000000000000000000000000000000000def13832bfbef03173e4c49a00ec0dd178817a02d1779ba6e03d8b90de867373db8cf1a58d2f7f006b3a'
+    const decoded = decodePacked(OP_PERMISSIONED_GAME_ARGS_SCHEMA, encoded, 1)
+
+    expect(
+      decoded.members?.map(({ name, type, value }) => ({ name, type, value })),
+    ).toEqual([
+      {
+        name: 'absolutePrestate',
+        type: 'bytes',
+        value:
+          '0xdead000000000000000000000000000000000000000000000000000000000000',
+      },
+      {
+        name: 'vm',
+        type: 'address',
+        value: '0xacc005dcd857b401e4732e6f7837135a22825cfa',
+      },
+      {
+        name: 'anchorStateRegistry',
+        type: 'address',
+        value: '0xee018baf058227872540ac60efbd38b023d9dae2',
+      },
+      {
+        name: 'weth',
+        type: 'address',
+        value: '0x57b4c29daee99a28e6e86778b499361294c134ea',
+      },
+      { name: 'l2ChainId', type: 'number', value: '57073' },
+      {
+        name: 'proposer',
+        type: 'address',
+        value: '0x3832bfbef03173e4c49a00ec0dd178817a02d177',
+      },
+      {
+        name: 'challenger',
+        type: 'address',
+        value: '0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a',
+      },
+    ])
+  })
+
+  it('defines all canonical OP game args lengths', () => {
+    const schemas: [PackedSchema, number][] = [
+      [OP_PERMISSIONLESS_GAME_ARGS_SCHEMA, 124],
+      [OP_PERMISSIONED_GAME_ARGS_SCHEMA, 164],
+      [OP_SUPER_PERMISSIONED_GAME_ARGS_SCHEMA, 40],
+      [OP_ZK_GAME_ARGS_SCHEMA, 172],
+    ]
+    const lengths = schemas.map(([schema, length]) => {
+      const decoded = decodePacked(schema, `0x${'00'.repeat(length)}`)
+      return (decoded.bytes.length - 2) / 2
+    })
+
+    expect(lengths).toEqual([124, 164, 40, 172])
+  })
+
+  it('rejects data with a different length', () => {
+    expect(() =>
+      decodePacked(OP_PERMISSIONED_GAME_ARGS_SCHEMA, '0xdeadbeef'),
+    ).toThrow()
+  })
+
+  it('rejects dynamic and invalid packed types', () => {
+    expect(() =>
+      decodePacked(
+        { name: 'dynamic', fields: [{ name: 'data', type: 'bytes' }] },
+        '0x',
+      ),
+    ).toThrow()
+    expect(() =>
+      decodePacked(
+        { name: 'invalid integer', fields: [{ name: 'n', type: 'uint7' }] },
+        '0x00',
+      ),
+    ).toThrow()
+  })
+})

--- a/packages/tools/src/decoder-3/packed.ts
+++ b/packages/tools/src/decoder-3/packed.ts
@@ -1,0 +1,113 @@
+import { type DecodedValue, sliceBytes } from './decode'
+
+export interface PackedField {
+  name: string
+  type: string
+}
+
+export interface PackedSchema {
+  name: string
+  fields: readonly PackedField[]
+}
+
+export function decodePacked(
+  schema: PackedSchema,
+  encoded: `0x${string}`,
+  chainId?: number,
+): DecodedValue {
+  if (!/^0x[\da-f]*$/i.test(encoded)) {
+    throw new Error(`Invalid ${schema.name} encoding`)
+  }
+
+  const fields = schema.fields.map((field) => ({
+    ...field,
+    size: packedTypeSize(field.type),
+  }))
+  const expectedLength = fields.reduce((sum, field) => sum + field.size, 0)
+  const actualLength = (encoded.length - 2) / 2
+
+  if (!Number.isInteger(actualLength) || actualLength !== expectedLength) {
+    throw new Error(
+      `Invalid ${schema.name} length: expected ${expectedLength}, got ${actualLength}`,
+    )
+  }
+
+  let offset = 0
+  const members = fields.map((field) => {
+    const bytes = sliceBytes(encoded, offset, offset + field.size)
+    offset += field.size
+    return decodePackedField(field.name, field.type, bytes, chainId)
+  })
+
+  const decoded: DecodedValue = {
+    type: 'tuple',
+    value: '',
+    bytes: encoded,
+    members,
+  }
+  if (chainId !== undefined) decoded.chainId = chainId
+  return decoded
+}
+
+function decodePackedField(
+  name: string,
+  type: string,
+  bytes: `0x${string}`,
+  chainId?: number,
+): DecodedValue {
+  const common: Pick<DecodedValue, 'name' | 'bytes' | 'chainId'> = {
+    name,
+    bytes,
+  }
+  if (chainId !== undefined) common.chainId = chainId
+
+  if (type === 'address') {
+    return { ...common, type: 'address', value: bytes }
+  }
+
+  if (type === 'bool') {
+    const value = BigInt(bytes)
+    if (value !== 0n && value !== 1n) {
+      throw new Error('Invalid packed bool')
+    }
+    return { ...common, type: 'bool', value: value === 1n ? 'true' : 'false' }
+  }
+
+  if (/^bytes\d+$/.test(type)) {
+    return { ...common, type: 'bytes', value: bytes }
+  }
+
+  const integer = /^(u?)int(\d*)$/.exec(type)
+  if (integer) {
+    const signed = integer[1] === ''
+    const bits = integer[2] === '' ? 256 : Number(integer[2])
+    let value = BigInt(bytes)
+    if (signed && value >= 2n ** BigInt(bits - 1)) {
+      value -= 2n ** BigInt(bits)
+    }
+    return { ...common, type: 'number', value: value.toString() }
+  }
+
+  throw new Error(`Unsupported packed type: ${type}`)
+}
+
+function packedTypeSize(type: string): number {
+  if (type === 'address') return 20
+  if (type === 'bool') return 1
+
+  const bytes = /^bytes(\d+)$/.exec(type)
+  if (bytes) {
+    const size = Number(bytes[1])
+    if (size >= 1 && size <= 32) return size
+    throw new Error(`Invalid packed type: ${type}`)
+  }
+
+  const integer = /^(?:u?int)(\d*)$/.exec(type)
+  if (integer) {
+    const bits = integer[1] === '' ? 256 : Number(integer[1])
+    if (bits >= 8 && bits <= 256 && bits % 8 === 0) return bits / 8
+    throw new Error(`Invalid packed type: ${type}`)
+  }
+
+  throw new Error(`Unsupported packed type: ${type}`)
+}

--- a/packages/tools/src/decoder-3/packedSchemas.ts
+++ b/packages/tools/src/decoder-3/packedSchemas.ts
@@ -1,0 +1,46 @@
+import type { PackedSchema } from './packed'
+
+// Mirrors the fixed-width abi.encodePacked layouts in op-contracts' LibGameArgs.
+const COMMON_GAME_ARGS_FIELDS = [
+  { name: 'absolutePrestate', type: 'bytes32' },
+  { name: 'vm', type: 'address' },
+  { name: 'anchorStateRegistry', type: 'address' },
+  { name: 'weth', type: 'address' },
+  { name: 'l2ChainId', type: 'uint256' },
+] as const
+
+export const OP_PERMISSIONLESS_GAME_ARGS_SCHEMA: PackedSchema = {
+  name: 'OP permissionless game args',
+  fields: COMMON_GAME_ARGS_FIELDS,
+}
+
+export const OP_PERMISSIONED_GAME_ARGS_SCHEMA: PackedSchema = {
+  name: 'OP permissioned game args',
+  fields: [
+    ...COMMON_GAME_ARGS_FIELDS,
+    { name: 'proposer', type: 'address' },
+    { name: 'challenger', type: 'address' },
+  ],
+}
+
+export const OP_SUPER_PERMISSIONED_GAME_ARGS_SCHEMA: PackedSchema = {
+  name: 'OP super permissioned game args',
+  fields: [
+    { name: 'anchorStateRegistry', type: 'address' },
+    { name: 'proposer', type: 'address' },
+  ],
+}
+
+export const OP_ZK_GAME_ARGS_SCHEMA: PackedSchema = {
+  name: 'OP ZK game args',
+  fields: [
+    { name: 'absolutePrestate', type: 'bytes32' },
+    { name: 'verifier', type: 'address' },
+    { name: 'maxChallengeDuration', type: 'uint64' },
+    { name: 'maxProveDuration', type: 'uint64' },
+    { name: 'challengerBond', type: 'uint256' },
+    { name: 'anchorStateRegistry', type: 'address' },
+    { name: 'weth', type: 'address' },
+    { name: 'l2ChainId', type: 'uint256' },
+  ],
+}

--- a/packages/tools/src/decoder-3/plugins.test.ts
+++ b/packages/tools/src/decoder-3/plugins.test.ts
@@ -1,0 +1,79 @@
+import { expect } from 'earl'
+import { describe } from 'mocha'
+import { encodeFunctionData, parseAbi } from 'viem'
+import { decode } from './plugins'
+
+const SET_IMPLEMENTATION_ABI =
+  'function setImplementation(uint32 _gameType, address _impl, bytes _args)'
+const ABI = parseAbi([SET_IMPLEMENTATION_ABI])
+const IMPLEMENTATION = '0xe1dffcbe4e22b813f26d2106d943c102e7cab87e'
+const OTHER_IMPLEMENTATION = '0x1111111111111111111111111111111111111111'
+const FACTORY = '0x10d7b35078d3baabb96dd45a9143b94be65b12cd'
+const GAME_ARGS =
+  '0xdead000000000000000000000000000000000000000000000000000000000000acc005dcd857b401e4732e6f7837135a22825cfaee018baf058227872540ac60efbd38b023d9dae257b4c29daee99a28e6e86778b499361294c134ea000000000000000000000000000000000000000000000000000000000000def13832bfbef03173e4c49a00ec0dd178817a02d1779ba6e03d8b90de867373db8cf1a58d2f7f006b3a'
+
+describe('packed argument plugin', () => {
+  it('decodes PermissionedDisputeGame args in setImplementation', () => {
+    const calldata = encodeFunctionData({
+      abi: ABI,
+      functionName: 'setImplementation',
+      args: [1, IMPLEMENTATION, GAME_ARGS],
+    })
+    const decoded = decode(calldata, [], 1, FACTORY)
+
+    expect(decoded?.functionName).toEqual('setImplementation')
+    const args = decoded?.members?.find((member) => member.name === 'args')
+    expect(args?.type).toEqual('tuple')
+    expect(args?.members?.map(({ name, value }) => ({ name, value }))).toEqual([
+      {
+        name: 'absolutePrestate',
+        value:
+          '0xdead000000000000000000000000000000000000000000000000000000000000',
+      },
+      { name: 'vm', value: '0xacc005dcd857b401e4732e6f7837135a22825cfa' },
+      {
+        name: 'anchorStateRegistry',
+        value: '0xee018baf058227872540ac60efbd38b023d9dae2',
+      },
+      {
+        name: 'weth',
+        value: '0x57b4c29daee99a28e6e86778b499361294c134ea',
+      },
+      { name: 'l2ChainId', value: '57073' },
+      {
+        name: 'proposer',
+        value: '0x3832bfbef03173e4c49a00ec0dd178817a02d177',
+      },
+      {
+        name: 'challenger',
+        value: '0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a',
+      },
+    ])
+  })
+
+  it('does not apply the schema to an unknown implementation', () => {
+    const calldata = encodeFunctionData({
+      abi: ABI,
+      functionName: 'setImplementation',
+      args: [1, OTHER_IMPLEMENTATION, GAME_ARGS],
+    })
+    const decoded = decode(calldata, [SET_IMPLEMENTATION_ABI], 1, FACTORY)
+
+    const args = decoded?.members?.find((member) => member.name === 'args')
+    expect(args?.type).toEqual('bytes')
+    expect(args?.value).toEqual(GAME_ARGS)
+  })
+
+  it('does not apply the schema to malformed packed args', () => {
+    const calldata = encodeFunctionData({
+      abi: ABI,
+      functionName: 'setImplementation',
+      args: [1, IMPLEMENTATION, '0xdeadbeef'],
+    })
+    const decoded = decode(calldata, [SET_IMPLEMENTATION_ABI], 1, FACTORY)
+
+    const args = decoded?.members?.find((member) => member.name === 'args')
+    expect(args?.type).toEqual('bytes')
+    expect(args?.value).toEqual('0xdeadbeef')
+  })
+})

--- a/packages/tools/src/decoder-3/plugins.ts
+++ b/packages/tools/src/decoder-3/plugins.ts
@@ -1,7 +1,9 @@
 import { getCreate2Address, toFunctionSelector } from 'viem'
 import { type DecodedValue, decodeType } from './decode'
+import { decodePacked, type PackedSchema } from './packed'
+import { OP_PERMISSIONED_GAME_ARGS_SCHEMA } from './packedSchemas'
 
-const plugins = [multiSendPlugin, create2FactoryPlugin]
+const plugins = [packedArgumentPlugin, multiSendPlugin, create2FactoryPlugin]
 
 export function decode(
   data: `0x${string}`,
@@ -29,6 +31,63 @@ export function decode(
 }
 
 const ADDRESS_ZERO = '0x0000000000000000000000000000000000000000'
+
+interface PackedArgumentCodec {
+  functionAbi: string
+  selector: `0x${string}`
+  parameter: string
+  matches: Readonly<Record<string, string>>
+  schema: PackedSchema
+}
+
+const SET_IMPLEMENTATION_ABI =
+  'function setImplementation(uint32 _gameType, address _impl, bytes _args)'
+const OP_PERMISSIONED_DISPUTE_GAME_V2_4_0 =
+  '0xe1dffcbe4e22b813f26d2106d943c102e7cab87e'
+
+const packedArgumentCodecs: PackedArgumentCodec[] = [
+  {
+    functionAbi: SET_IMPLEMENTATION_ABI,
+    selector: toFunctionSelector(SET_IMPLEMENTATION_ABI),
+    parameter: 'args',
+    matches: {
+      gameType: '1',
+      impl: OP_PERMISSIONED_DISPUTE_GAME_V2_4_0,
+    },
+    schema: OP_PERMISSIONED_GAME_ARGS_SCHEMA,
+  },
+]
+
+function packedArgumentPlugin(
+  data: `0x${string}`,
+  chainId: number,
+  address?: `0x${string}`,
+): DecodedValue | undefined {
+  for (const codec of packedArgumentCodecs) {
+    if (data.slice(0, 10).toLowerCase() !== codec.selector) continue
+
+    const decoded = decodeType(codec.functionAbi, data, chainId, address)
+    const members = decoded.members ?? []
+    const matches = Object.entries(codec.matches).every(([name, value]) =>
+      members.some(
+        (member) =>
+          member.name === name &&
+          member.value.toLowerCase() === value.toLowerCase(),
+      ),
+    )
+    if (!matches) continue
+
+    const parameter = members.find((member) => member.name === codec.parameter)
+    if (!parameter || parameter.type !== 'bytes') continue
+
+    const packed = decodePacked(codec.schema, parameter.bytes, chainId)
+    packed.name = parameter.name
+    decoded.members = members.map((member) =>
+      member === parameter ? packed : member,
+    )
+    return decoded
+  }
+}
 
 function applyCallTargetHeuristic(value: DecodedValue) {
   if (!value.members) return


### PR DESCRIPTION
## Summary

- add a reusable, exact-length decoder for fixed-width ABI-packed fields
- define the current OP Stack LibGameArgs schemas declaratively
- decode the known PermissionedDisputeGame v2.4.0 arguments when the selector, game type, and implementation all match
- preserve raw bytes for unknown implementations or malformed packed data

The codec is deterministic and performs no CWIA getter probing or other runtime contract calls.

## Manual test

Run the tools frontend, open /decoder-3, select Ethereum, and paste the following transaction input.

**To**

~~~text
0xca11bde05977b3631167028862be2a173976ca11
~~~

**Calldata**

~~~text
0x174dea710000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000440000000000000000000000000c2819dc788505aac350142a7a707bf9d03e3bd0300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000003446a761202000000000000000000000000ca11bde05977b3631167028862be2a173976ca110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002c00000000000000000000000000000000000000000000000000000000000000144174dea710000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000200000000000000000000000005a0aae59d09fccbddb6c6cceb07b7279367c3d2a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000024d4d9bdcdff21287dc91ef8d0d631df016c6d1c3de6ea14b4208d23467c7e874f24f196bc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041000000000000000000000000ca11bde05977b3631167028862be2a173976ca1100000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005a0aae59d09fccbddb6c6cceb07b7279367c3d2a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000004646a761202000000000000000000000000ca11bde05977b3631167028862be2a173976ca110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003e00000000000000000000000000000000000000000000000000000000000000264174dea7100000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000002000000000000000000000000010d7b35078d3baabb96dd45a9143b94be65b12cd0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000144b10709570000000000000000000000000000000000000000000000000000000000000001000000000000000000000000e1dffcbe4e22b813f26d2106d943c102e7cab87e000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000a4dead000000000000000000000000000000000000000000000000000000000000acc005dcd857b401e4732e6f7837135a22825cfaee018baf058227872540ac60efbd38b023d9dae257b4c29daee99a28e6e86778b499361294c134ea000000000000000000000000000000000000000000000000000000000000def13832bfbef03173e4c49a00ec0dd178817a02d1779ba6e03d8b90de867373db8cf1a58d2f7f006b3a0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000041000000000000000000000000c2819dc788505aac350142a7a707bf9d03e3bd030000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
~~~

Expand the nested setImplementation call. Its args field should decode to:

~~~text
absolutePrestate    0xdead000000000000000000000000000000000000000000000000000000000000
vm                  0xacc005dcd857b401e4732e6f7837135a22825cfa
anchorStateRegistry 0xee018baf058227872540ac60efbd38b023d9dae2
weth                0x57b4c29daee99a28e6e86778b499361294c134ea
l2ChainId           57073
proposer            0x3832bfbef03173e4c49a00ec0dd178817a02d177
challenger          0x9ba6e03d8b90de867373db8cf1a58d2f7f006b3a
~~~

## Automated testing

- pnpm --filter @l2beat/tools test
- pnpm --filter @l2beat/tools lint
- pnpm --filter @l2beat/tools typecheck
- git diff --check