### PR TITLE
Restore wiped daTracking histories for 6 projects

### DIFF
--- a/packages/config/src/projects/arenaz/arenaz.ts
+++ b/packages/config/src/projects/arenaz/arenaz.ts
@@ -1,4 +1,4 @@
-import { ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { EthereumAddress, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { DERIVATION, REASON_FOR_BEING_OTHER } from '../../common'
 import { BADGES } from '../../common/badges'
 import { ProjectDiscovery } from '../../discovery/ProjectDiscovery'
@@ -15,6 +15,28 @@ export const arenaz = opStackL2({
   addedAt: UnixTime(1737720994), // 2025-01-24T12:16:34+00:00
   archivedAt: UnixTime.fromDate(new Date('2026-05-07')),
   discovery,
+  nonTemplateDaTracking: [
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 21169100, // first batch of the original batcher
+      untilBlock: 24776391, // batcher rotation, last old-batcher batch @ 24774882
+      inbox: EthereumAddress('0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0'),
+      sequencers: [
+        EthereumAddress('0x2b8733E8c60A928b19BB7db1D79b918e8E09AC8c'),
+      ],
+    },
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 24776391, // first batch of the rotated batcher
+      untilBlock: 25228892, // last batch before archival
+      inbox: EthereumAddress('0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0'),
+      sequencers: [
+        EthereumAddress('0x47827645bA78EB18c3d64Fe2146EfdE66F74894B'),
+      ],
+    },
+  ],
   additionalBadges: [BADGES.RaaS.Gelato],
   additionalPurposes: ['Gaming'],
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],

--- a/packages/config/src/projects/mint/mint.ts
+++ b/packages/config/src/projects/mint/mint.ts
@@ -14,6 +14,28 @@ export const mint: ScalingProject = opStackL2({
   addedAt: UnixTime(1715644800), // 2024-05-14T00:00:00Z
   archivedAt: UnixTime(1775534349), // 2026-04-07T03:59:09Z
   discovery,
+  nonTemplateDaTracking: [
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 19862462, // first batch of the original batcher
+      untilBlock: 23979599, // batcher rotation, last old-batcher batch @ 23969121
+      inbox: EthereumAddress('0x4e31448a098393727b786e25B54E59DcA1b77FE1'),
+      sequencers: [
+        EthereumAddress('0x68bdFecE01535090c8f3C27ec3b1AE97E83fA4aA'),
+      ],
+    },
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 23979599, // first batch of the rotated batcher
+      untilBlock: 24824990, // last batch before archival
+      inbox: EthereumAddress('0x4e31448a098393727b786e25B54E59DcA1b77FE1'),
+      sequencers: [
+        EthereumAddress('0x560aFA9cF6B39D8C83938C77036E80807a56Da16'),
+      ],
+    },
+  ],
   additionalBadges: [],
   additionalPurposes: ['NFT'],
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],

--- a/packages/config/src/projects/morph/morph.ts
+++ b/packages/config/src/projects/morph/morph.ts
@@ -164,7 +164,23 @@ export const morph: ScalingProject = {
       {
         type: 'ethereum',
         daLayer: ProjectId('ethereum'),
-        sinceBlock: 0, // Edge Case: config added @ DA Module start
+        sinceBlock: 21013218, // first batch
+        untilBlock: 22744283, // last batch of the original staker set, before it shrank
+        inbox: EthereumAddress('0x759894Ced0e6af42c26668076Ffa84d02E3CeF60'),
+        sequencers: [
+          EthereumAddress('0x34E387B37d3ADEAa6D5B92cE30dE3af3DCa39796'),
+          EthereumAddress('0x61F2945d4bc9E40B66a6376d1094a50438f613e2'),
+          EthereumAddress('0x6aB0E960911b50f6d14f249782ac12EC3E7584A0'),
+          EthereumAddress('0xa59B26DB10C5Ca26a97AA2Fd2E74CB8DA9D1EB65'),
+          EthereumAddress('0xb6cF39ee72e0127E6Ea6059e38B8C197227a6ac7'),
+          EthereumAddress('0xBBA36CdF020788f0D08D5688c0Bee3fb30ce1C80'),
+          EthereumAddress('0xf834ffbeb6bB3F4841afc6b5FB40B94cd580fa23'),
+        ],
+      },
+      {
+        type: 'ethereum',
+        daLayer: ProjectId('ethereum'),
+        sinceBlock: 22744284, // first block after the original staker set shrank
         inbox: EthereumAddress('0x759894Ced0e6af42c26668076Ffa84d02E3CeF60'),
         sequencers: sequencers.map((s) => ChainSpecificAddress.address(s)),
       },

--- a/packages/config/src/projects/taiko/taiko.ts
+++ b/packages/config/src/projects/taiko/taiko.ts
@@ -188,7 +188,19 @@ export const taiko: ScalingProject = {
       {
         type: 'ethereum',
         daLayer: ProjectId('ethereum'),
-        sinceBlock: 0, // Edge Case: config added @ DA Module start
+        sinceBlock: 19945276, // first proposeBlock on the pre-Shasta inbox
+        untilBlock: 24792175, // Shasta MainnetInbox activation, last BatchProposed @ 24792119
+        inbox: preShastaInboxAddress,
+        sequencers: [],
+        topics: [
+          '0xefe9c6c0b5cbd9c0eed2d1e9c00cfc1a010d6f1aff50f7facd665a639b622b26', // BlockProposedV2
+          '0x9eb7fc80523943f28950bbb71ed6d584effe3e1e02ca4ddc8c86e5ee1558c096', // BatchProposed
+        ],
+      },
+      {
+        type: 'ethereum',
+        daLayer: ProjectId('ethereum'),
+        sinceBlock: 24792175, // first Proposed on the Shasta MainnetInbox
         inbox: mainnetInboxAddress,
         sequencers: [],
         topics: [

--- a/packages/config/src/projects/thebinaryholdings/thebinaryholdings.ts
+++ b/packages/config/src/projects/thebinaryholdings/thebinaryholdings.ts
@@ -1,4 +1,4 @@
-import { ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { EthereumAddress, ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { REASON_FOR_BEING_OTHER } from '../../common'
 import { BADGES } from '../../common/badges'
 import { ProjectDiscovery } from '../../discovery/ProjectDiscovery'
@@ -15,6 +15,28 @@ export const thebinaryholdings: ScalingProject = opStackL2({
   addedAt: UnixTime(1726668186), // 2024-09-18T14:03:06Z
   archivedAt: UnixTime(1737676800), // 2025-01-24T00:00:00.000Z,
   discovery,
+  nonTemplateDaTracking: [
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 20175709, // first batch of the original batcher
+      untilBlock: 21394748, // batcher rotation, last old-batcher batch @ 21308840
+      inbox: EthereumAddress('0xFF00000000000000000000000000000000000624'),
+      sequencers: [
+        EthereumAddress('0x7f9D9c1BCE1062E1077845eA39a0303429600a06'),
+      ],
+    },
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 21394748, // first batch of the rotated batcher
+      untilBlock: 22594787, // last batch, chain dormant since
+      inbox: EthereumAddress('0xFF00000000000000000000000000000000000624'),
+      sequencers: [
+        EthereumAddress('0x68d5BBf3a01ECbB47CE38Cf64a7d6C0eA618040f'),
+      ],
+    },
+  ],
   additionalBadges: [BADGES.RaaS.Zeeve],
   associatedTokens: ['BNRY'],
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],

--- a/packages/config/src/projects/treasure/treasure.ts
+++ b/packages/config/src/projects/treasure/treasure.ts
@@ -21,6 +21,30 @@ export const treasure: ScalingProject = zkStackL2({
   additionalBadges: [BADGES.DA.CustomDA],
   addedAt: UnixTime(1733875200), // 2024-12-11T00:00:00Z
   archivedAt: UnixTime(1752676593), // 2025-07-16T15:36:00Z
+  nonTemplateDaTracking: [
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 21272191, // first batch on the old shared ValidatorTimelock
+      untilBlock: 22126211, // migration to the new shared ValidatorTimelock, last old batch @ 22126178
+      inbox: EthereumAddress('0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E'),
+      sequencers: [
+        EthereumAddress('0x2572835e02b59078711aa0800490e80975e4169d'),
+        EthereumAddress('0x4131719fb0FA1CB3e3A052A4A309ea7575d8c283'),
+      ],
+    },
+    {
+      type: 'ethereum',
+      daLayer: ProjectId('ethereum'),
+      sinceBlock: 22126211, // first batch on the new shared ValidatorTimelock
+      untilBlock: 22925013, // last batch before archival
+      inbox: EthereumAddress('0x8c0Bfc04AdA21fd496c55B8C50331f904306F564'),
+      sequencers: [
+        EthereumAddress('0x2572835e02b59078711aa0800490e80975e4169d'),
+        EthereumAddress('0x4131719fb0FA1CB3e3A052A4A309ea7575d8c283'),
+      ],
+    },
+  ],
   additionalPurposes: ['Gaming'],
   reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_DA_ORACLE],
   display: {

--- a/packages/config/src/snapshots/daTracking/snapshot.json
+++ b/packages/config/src/snapshots/daTracking/snapshot.json
@@ -96,7 +96,11 @@
   "arenaz": [
     {
       "id": "5f18f8f53116",
-      "label": "ethereum inbox 0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0 sequencers[1] since 21167590"
+      "label": "ethereum inbox 0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0 sequencers[1] since 24776391"
+    },
+    {
+      "id": "f21be91c0dea",
+      "label": "ethereum inbox 0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0 sequencers[1] since 21169100"
     }
   ],
   "art-peace": [
@@ -620,7 +624,11 @@
   "mint": [
     {
       "id": "3476c2371021",
-      "label": "ethereum inbox 0x4e31448a098393727b786e25B54E59DcA1b77FE1 sequencers[1] since 19861572"
+      "label": "ethereum inbox 0x4e31448a098393727b786e25B54E59DcA1b77FE1 sequencers[1] since 23979599"
+    },
+    {
+      "id": "641172c76c99",
+      "label": "ethereum inbox 0x4e31448a098393727b786e25B54E59DcA1b77FE1 sequencers[1] since 19862462"
     }
   ],
   "mode": [
@@ -638,7 +646,11 @@
   "morph": [
     {
       "id": "0ec705a4c807",
-      "label": "ethereum inbox 0x759894Ced0e6af42c26668076Ffa84d02E3CeF60 sequencers[5] since 0"
+      "label": "ethereum inbox 0x759894Ced0e6af42c26668076Ffa84d02E3CeF60 sequencers[5] since 22744284"
+    },
+    {
+      "id": "f634e6308d3b",
+      "label": "ethereum inbox 0x759894Ced0e6af42c26668076Ffa84d02E3CeF60 sequencers[7] since 21013218"
     }
   ],
   "nillion": [
@@ -993,17 +1005,33 @@
   ],
   "taiko": [
     {
+      "id": "54bc2e52b67f",
+      "label": "ethereum inbox 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a sequencers[0] since 19945276"
+    },
+    {
       "id": "a250938b2846",
-      "label": "ethereum inbox 0x6f21C543a4aF5189eBdb0723827577e1EF57ef1f sequencers[0] since 0"
+      "label": "ethereum inbox 0x6f21C543a4aF5189eBdb0723827577e1EF57ef1f sequencers[0] since 24792175"
     }
   ],
   "thebinaryholdings": [
     {
       "id": "d0276630c6a1",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000000624 sequencers[1] since 20175362"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000000624 sequencers[1] since 21394748"
+    },
+    {
+      "id": "ef8681c6492f",
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000000624 sequencers[1] since 20175709"
     }
   ],
   "treasure": [
+    {
+      "id": "5ccf265ea913",
+      "label": "ethereum inbox 0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E sequencers[2] since 21272191"
+    },
+    {
+      "id": "60f76c4af34f",
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 22126211"
+    },
     {
       "id": "cfd04b0ba930",
       "label": "eigen-da customer 0x96561d11f55f99f7cda780b77e524195bde1dcde since 0"


### PR DESCRIPTION
## Context

DA tracking configs are keyed by an identity hash over `type`/`daLayer`/`inbox`/`sequencers`. Before the snapshot guard (#12380), in-place config edits and discovery-driven re-keys (batcher rotations, inbox migrations) silently wiped indexed history — the new identity only scans the new sequencer/inbox, so the old era is never re-indexed. This is the same class of issue already fixed for zksync (#12417/#12425) and ink (#12411).

An audit of all 196 daTracking identities across git history since the DA module start (Feb 2025) found six projects with genuinely lost eras. This PR restores them following the ink/zksync pattern: full era history in `daTracking`/`nonTemplateDaTracking`, with **every boundary verified on-chain** (first/last batch tx of each era via Etherscan). Archived projects' final eras are closed at their last real batch.

## Restored eras

| project | restored |
|---|---|
| **taiko** | Pre-Shasta era: inbox `0x06a9Ab27…`, BlockProposedV2+BatchProposed topics, since 19945276 (first `proposeBlock`, 2024-05-25) until 24792175 (Shasta MainnetInbox activation; last old `BatchProposed` @ 24792119). Wiped in-place by e48cbe39b8. |
| **arenaz** (archived) | Batcher rotation 2026-03-31: era `0x2b8733E8…` since 21169100 until 24776391; current batcher era closed at 25228892 (last batch before archival). |
| **mint** (archived) | Batcher rotation 2025-12-10: era `0x68bdFecE…` since 19862462 until 23979599; current batcher era closed at 24824990. |
| **thebinaryholdings** (archived) | Batcher rotation 2024-12-13 predates the DA module, so the first era (`0x7f9D9c1B…`, since 20175709) was never indexed at all; current era closed at 22594787 (dormant since 2025-05-30). |
| **treasure** (archived) | Old shared ValidatorTimelock era (`0x5D8ba173…`, since 21272191) until the VT migration 2025-03-25 (22126211); new-VT era closed at 22925013. The old era predates zk-tracking enablement (#7540) and was never indexed. |
| **morph** | Original 7-staker era (since 21013218, until 22744283) covering four departed stakers whose batches the current discovery-driven identity can't index. The existing dynamic entry is re-anchored at 22744284 — boundaries are disjoint because the eras share still-active stakers and equal-chaining would double-count. `0xc412b4e6…` from the old hardcoded list never posted a batch and is excluded. |

## Notes

- Snapshot regenerated: +6 restored era identities, **zero existing identities re-keyed** (guard test green) — live data is untouched, the backend will backfill the restored eras.
- Not restored on purpose: megaeth's short-lived eigen-da customerId `0xcd1161…` (2025-10-22..24) — it was later *replaced* with a different id in #10704, so it appears to have been wrong; restoring it would index another customer's data. Worth a confirmation from the DA team.
- The audit also cleared hemi, r0ar, snaxchain, superseed, lachain, powerloom and robinhood: their apparent "old eras" came from `git log --follow` jumping across unrelated projects' discovered.json files; on-chain checks confirm their current identities cover the chains' full life.

## Verification

- `pnpm typecheck`, all 23,599 config tests (incl. snapshot guard), `pnpm build`, lint/format — all green.
- Era boundaries cross-checked on Etherscan (first/last batch per sequencer/inbox pair; no activity outside the ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)