### PR TITLE
Replace per-blob cache with TxWithBlobs, add DA emitter filtering

### DIFF
--- a/da-tracking-history-audit.md
+++ b/da-tracking-history-audit.md
@@ -1,0 +1,101 @@
+# DA Tracking History Audit — removed/re-keyed configs across all projects
+
+Date: 2026-07-31. Scope: every project with a `daTracking` identity (196 identities / 166 projects
+in `src/snapshots/daTracking/snapshot.json`), traced through git history since the DA module start
+(2025-02-12, `dabce19233`). The identity-hash guard only exists since 2026-07-29 (`be8875e906`), so
+everything before that could be (and was) silently re-keyed.
+
+Method:
+- **File sweep**: every historical version of the 34 explicit-`daTracking` project files, the 20
+  celestia/avail template-var files, and the DA-layer customer lists (`avail.ts`, `celestia.ts`,
+  `eigenda.ts`), parsing identity fields (inbox/sequencers/namespace/appIds/customerId).
+- **Discovery sweep**: for the 33 template-derived projects (no `nonTemplateDaTracking` override),
+  the history of `discovered.json` identity inputs — opStack: `SystemConfig.sequencerInbox` +
+  `batcherHash`; orbit: `SequencerInbox` address + `batchPosters`; zkStack: `ValidatorTimelock`
+  address + `validatorsVTL`.
+- Also checked: deleted project files (none carried daTracking), celestia/avail template projects
+  for hidden earlier ethereum-blob eras (none), and DA-layer switches.
+
+Dates below are **commit dates of the discovery update**; the on-chain rotation is slightly
+earlier. Every restoration needs on-chain boundary verification (last tx of old era / first tx of
+new era) before writing since/until blocks.
+
+## A. Wiped history that needs restoring (no override exists)
+
+These are template-derived projects where the identity re-keyed while tracking was live. The wipe
+is effectively permanent for ethereum-type tracking: the new identity only scans the new
+sequencer/inbox, so the old era is never re-indexed. Fix = snapshot full history into
+`nonTemplateDaTracking` (current era byte-identical to what the template derives), like `ink` and
+`zksync2` already have.
+
+### opStack (batcher rotation and/or inbox change)
+
+| project | wiped era (inbox \| batcher) | live until | current era since |
+|---|---|---|---|
+| arenaz | `0x00f9bCee08DcE4f0e7906c1f6CFb10C77802eEd0` \| `0x2b8733e8c60a928b19bb7db1d79b918e8e09ac8c` | 2026-04-07 `1b75a189a3` | batcher `0x47827645ba78eb18c3d64fe2146efde66f74894b` |
+| hemi | `0xff00…0254` \| `0xde794bec196832474f2f218135bfd0f7ca7fb038` | 2025-06-23 `7c2a365088` | inbox `0xff00…43111` \| batcher `0x65115c6d…` |
+| mint | `0x4e31448a098393727B786e25B54e59DcA1B77FE1` \| `0x68bdfece01535090c8f3c27ec3b1ae97e83fa4aa` | 2025-12-11 `21947a46fe` | batcher `0x560afa9cf6b39d8c83938c77036e80807a56da16` |
+| r0ar | `0x0004cb44C80B6FBF8CEb1d80AF688C9F7c0b2Ab5` \| `0x9391791f7cb74f8bfda65edc0749efd964311b55` (since 2025-01-22) | 2025-04-04 `defc50d87b` | inbox `0xff00…193939` \| batcher `0xf263a0aa…` |
+| snaxchain | 3 eras: `0xff00…01111111`\|`0x5bef09f1…` → 2025-02-21; `0x3276053c…`\|`0x5c89b56b…` → 2025-03-31; `0x8612014a…`\|`0xa9b074b2…` → 2025-04-04 | see left | inbox `0xfec57bd3729a5f930d4ee8ac5992fdc8988426e4` \| batcher `0x060b915c…` |
+| superseed | 2 eras: `0xff00…01111111`\|`0x5bef09f1…` → 2025-02-21; `0x3276053c…`\|`0x5c89b56b…` → 2025-03-31 | see left | inbox `0x8612014a343089f1ddbacfd42baf4afbf9133593` \| batcher `0xa9b074b2…` |
+
+⚠️ **snaxchain and superseed had byte-identical inbox+batcher values until 2025-04** — two chains
+cannot share these on-chain, so one project's early discovered.json was wrong (likely cloned) and
+its "eras" are fictitious / misattributed. Verify on-chain which chain those contracts actually
+belong to before restoring either. Similarly the 2025-01-08 values for r0ar/unichain/phala were
+identical to ink's genuine inbox (`0x005969bf…`) — early discovery data was cloned; treat any
+pre-Feb-2025 "era" with suspicion (harmless anyway: pre-module).
+
+### orbit (batchPosters / SequencerInbox changes)
+
+| project | what was lost |
+|---|---|
+| powerloom | Inbox changed twice while live: era `0x47861e0419be83d0175818a09221b6df2efd7793` (posters incl. original `0x74978411…`, removed 2025-07-11) until 2025-07-15; era `0x661b39a5eb200dfcbb436d98453bdbf88da02aa1` until 2025-09-10; current inbox `0x903af716aa8c7c27fd785f453d5a59c20e06bdec`. Poster set (9 addrs) unchanged since 2025-06-20. |
+| robinhood | Era `0x4ad144ea249a98f77e0b78104d3b6eb6cd3a76da` \| poster `0x9298413c…` (poster dropped 2025-07-22 → that era wiped), then full inbox+poster change 2026-07-03 `167aafe84e` → everything before wiped again. Current: `0xbd0d173eeb87d57a09521c24388a12789f33ba96` \| `0xdaa52608…`. |
+
+### zkStack
+
+| project | what was lost |
+|---|---|
+| lachain | validatorsVTL rotated 2025-05-28 `9ecb994231`: `0x0f9b807d…`,`0x479b7c95…` → `0xb66d4af4…`,`0xdac93613…` (disjoint) on inbox `0x8c0bfc04ada21fd496c55b8c50331f904306f564`. Era between zk-tracking enablement (2025-04-22, #7540) and 2025-05-28 wiped. |
+
+### Explicit config files
+
+| project | what was lost |
+|---|---|
+| taiko | Pre-Shasta era: inbox `0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a`, topics BlockProposedV2+BatchProposed, replaced in-place by `e48cbe39b8` (2026-04-10). Verified boundaries: first proposeBlock block 19945276, Shasta MainnetInbox (`0x6f21C543…`) activation block 24792175 (ts 1775135903); last old-inbox BatchProposed at 24792119. |
+| morph | Sequencer `0x34e387b37d3adeaa6d5b92ce3059d5c66c1e5e19`-era wiped ~2025-12-30 `af64ce9071` when `sequencers` was emptied on inbox `0x759894ced0e6af42c26668076ffa84d02e3cef60` (disjoint identity change). |
+| megaeth | eigen-da customer `0xcd1161b78f01da838ce0d42ec750891ec8708f1d` (added 2025-10-22 #9722) dropped 2025-10-24 in the EigenDA-V2 refactor `e314998832`; re-added 2026-01-19 `4c65833eee` with a *different* id `0x42b5ea5238752cc6f70d93fa4249feae480a0b39` and sinceTimestamp 2025-11-13. Verify which id is correct and whether Oct–Nov 2025 has a hole. |
+
+### Low severity — superset re-keys (full re-download, self-healing)
+
+- **arbitrum**: batchPoster `0x0237e0ea…` added 2025-06-04 (superset) → re-key + re-download only.
+- **robinhood** 2025-06-28 poster addition — same.
+- **adi**: sequencers grew 2→4 (superset) since creation — same.
+
+## B. Transient gaps (removed then restored; wiped at removal, re-synced after)
+
+Verify backfill actually completed for each:
+- **mantle** eigen-da `0x24f0a3716805e8973bf48eb908d6d4a2f34af785`: absent 2026-04-21 → 2026-05-06.
+- **karak** celestia namespace `AAAA…JBA=`: absent 2026-07-07 → 2026-07-09.
+- **aevo** celestia namespace `AAAA…DBuw7+PjGs8=`: absent for one commit on 2025-10-24.
+
+## C. Intentional / already handled — no action
+
+- **zksync2**: multi-era `nonTemplateDaTracking` restored by the team 2026-07-29..31 (#12409/#12417/#12425).
+- **ink**: batcher rotated 2026-07-31; guard caught it; two-era override committed same day (#12411). This is the model fix.
+- **avail appId→appIds migration** (2025-08-22 #8971): re-keyed every Avail customer; data re-synced from Avail. Includes **sophon**: sophon-mainnet-2/3/4 merged into sophon appIds `[17,36,37,38]`.
+- **space-and-time**: deliberately delisted (tracking removed 2026-01-05 #10417, project deleted 2026-06-30 #12174).
+- **rise**: eigen-da entry moved eigenda.ts → rise.ts with identical customerId — identity preserved.
+- **aevo** eigen-da `0x24f0…` (2025-10-22, one day): misassigned id, actually mantle's.
+- **base, blast, bob, dbk, ethernity, kinto, lambda, lisk, metal, mode, optopia, polynomial, race, shape, soneium*, superlumio, swan, syndicate, thebinaryholdings, treasure*, worldchain, zora, phala*, unichain***: no identity change while tracking was live (*changes were pre-module / pre-enablement; unichain changed 2025-02-11, one day before module start).
+- All 20 celestia/avail template projects: namespaces/appIds stable; none ever had an ethereum-blob era.
+
+## Structural risk that remains
+
+Template-derived projects still re-key silently on the *next* rotation (the guard turns it into a
+test failure, which is the point). Per the config skill: once a project has any era transition,
+snapshot the full history into `nonTemplateDaTracking` — which is exactly the fix needed for every
+project in section A.
+
+Raw data: `/tmp/da_audit/` (classification.json, file_findings.json, discovery_findings.json).

--- a/packages/backend/src/modules/data-availability/indexers/BlobIndexer.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/BlobIndexer.test.ts
@@ -25,7 +25,10 @@ describe(BlobIndexer.name, () => {
           size: ETHEREUM_BLOB_SIZE_BYTES,
           inbox: '0x123',
           sequencer: '0x456',
+          txHash: '0xtx1',
+          blobCount: 1,
           topics: ['0xabc', '0xdef'],
+          logs: [{ emitter: '0x789', topics: ['0xabc', '0xdef'] }],
         },
       ]
 

--- a/packages/backend/src/modules/data-availability/indexers/DaIndexer.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/DaIndexer.test.ts
@@ -126,6 +126,104 @@ describe(DaIndexer.name, () => {
       expect(safeHeight).toEqual(150)
     })
 
+    it('fetches from provider when emitter filtering needs logs missing from cache', async () => {
+      const configurations: BlockDaIndexedConfig[] = [
+        {
+          ...config('project-a'),
+          event: {
+            topics: ['topic'],
+            emitters: [EthereumAddress.random()],
+          },
+        },
+      ]
+      const cachedBlobs = [blob(100, 100_000)] // legacy row: logs === null
+      const providerBlobs: DaBlob[] = [
+        {
+          daLayer: DA_LAYER,
+          blockTimestamp: UnixTime(100),
+          blockNumber: 1,
+          size: 100_000n,
+          type: 'ethereum',
+          inbox: '',
+          sequencer: '',
+          txHash: '0xtx1',
+          blobCount: 1,
+          topics: ['0x1234'],
+          logs: [{ emitter: EthereumAddress.random(), topics: ['0x1234'] }],
+        },
+      ]
+
+      const { indexer, daService, daProvider, blobService } = mockIndexer({
+        configurations,
+        blobs: providerBlobs,
+        cachedBlobs,
+        useBlobService: true,
+      })
+
+      const updateCallback = await indexer.multiUpdate(
+        100,
+        200,
+        toIndexerConfigurations(configurations),
+      )
+      await updateCallback()
+
+      expect(blobService!.get).toHaveBeenOnlyCalledWith(DA_LAYER, 100, 200)
+      expect(daProvider.getBlobs).toHaveBeenOnlyCalledWith(DA_LAYER, 100, 200)
+      expect(daService.generateRecords).toHaveBeenOnlyCalledWith(
+        providerBlobs,
+        [],
+        configurations,
+      )
+    })
+
+    it('stays on cache when emitter filtering is needed but cached blobs have logs', async () => {
+      const configurations: BlockDaIndexedConfig[] = [
+        {
+          ...config('project-a'),
+          event: {
+            topics: ['topic'],
+            emitters: [EthereumAddress.random()],
+          },
+        },
+      ]
+      const cachedBlobs: DaBlob[] = [
+        {
+          daLayer: DA_LAYER,
+          blockTimestamp: UnixTime(100),
+          blockNumber: 1,
+          size: 100_000n,
+          type: 'ethereum',
+          inbox: '',
+          sequencer: '',
+          txHash: '0xtx1',
+          blobCount: 1,
+          topics: ['topic'],
+          logs: [{ emitter: EthereumAddress.random(), topics: ['topic'] }],
+        },
+      ]
+
+      const { indexer, daService, daProvider, blobService } = mockIndexer({
+        configurations,
+        cachedBlobs,
+        useBlobService: true,
+      })
+
+      const updateCallback = await indexer.multiUpdate(
+        100,
+        200,
+        toIndexerConfigurations(configurations),
+      )
+      await updateCallback()
+
+      expect(blobService!.get).toHaveBeenOnlyCalledWith(DA_LAYER, 100, 200)
+      expect(daProvider.getBlobs).not.toHaveBeenCalled()
+      expect(daService.generateRecords).toHaveBeenOnlyCalledWith(
+        cachedBlobs,
+        [],
+        configurations,
+      )
+    })
+
     describe('handles batch size', () => {
       it('from + batchSize > to', async () => {
         const { indexer, daProvider } = mockIndexer({
@@ -211,6 +309,7 @@ function mockIndexer($: {
   batchSize?: number
   indexerService?: IndexerService
   blobs?: DaBlob[]
+  cachedBlobs?: DaBlob[]
   previousRecords?: DataAvailabilityRecord[]
   generatedRecords?: DataAvailabilityRecord[]
   useBlobService?: boolean
@@ -240,7 +339,7 @@ function mockIndexer($: {
 
   const blobService = $.useBlobService
     ? mockObject<BlobService>({
-        get: mockFn().resolvesTo($.blobs ?? []), // Empty response
+        get: mockFn().resolvesTo($.cachedBlobs ?? $.blobs ?? []),
       })
     : undefined
 
@@ -277,7 +376,10 @@ function mockIndexer($: {
   }
 }
 
-function config(project: string, inbox?: string): BlockDaIndexedConfig {
+function config(
+  project: string,
+  inbox?: string,
+): Extract<BlockDaIndexedConfig, { type: 'ethereum' }> {
   return {
     type: 'ethereum',
     configurationId: createId(project),
@@ -286,7 +388,12 @@ function config(project: string, inbox?: string): BlockDaIndexedConfig {
     inbox: inbox ?? EthereumAddress.random(),
     sequencers: [],
     sinceBlock: 1,
-    topics: inbox ? ['topic'] : [],
+    event: inbox
+      ? {
+          topics: ['topic'],
+          emitters: null,
+        }
+      : undefined,
   }
 }
 
@@ -299,7 +406,10 @@ function blob(timestamp: number, size: number): DaBlob {
     type: 'ethereum',
     inbox: '',
     sequencer: '',
+    txHash: null,
+    blobCount: 1,
     topics: [],
+    logs: null,
   }
 }
 

--- a/packages/backend/src/modules/data-availability/indexers/DaIndexer.ts
+++ b/packages/backend/src/modules/data-availability/indexers/DaIndexer.ts
@@ -67,6 +67,13 @@ export class DaIndexer extends ManagedMultiIndexer<BlockDaIndexedConfig> {
           to: adjustedTo,
         })
 
+        const needsEmitters = configurations.some(
+          (c) =>
+            c.properties.type === 'ethereum' &&
+            c.properties.event !== undefined &&
+            c.properties.event.emitters !== null,
+        )
+
         let blobs: DaBlob[] = []
         if (this.$.blobService) {
           blobs = await this.$.blobService.get(this.daLayer, from, adjustedTo)
@@ -74,6 +81,23 @@ export class DaIndexer extends ManagedMultiIndexer<BlockDaIndexedConfig> {
           this.logger.info('Fetched blobs from cache', {
             blobs: blobs.length,
           })
+
+          const hasLegacyBlobs = blobs.some(
+            (blob) => blob.type === 'ethereum' && blob.logs === null,
+          )
+
+          if (needsEmitters && hasLegacyBlobs) {
+            blobs = await this.$.daProvider.getBlobs(
+              this.daLayer,
+              from,
+              adjustedTo,
+            )
+
+            this.logger.info(
+              'Fetched blobs from provider because cached blobs have no logs',
+              { blobs: blobs.length },
+            )
+          }
         } else {
           blobs = await this.$.daProvider.getBlobs(
             this.daLayer,

--- a/packages/backend/src/modules/data-availability/indexers/EthereumBlobNotifierIndexer.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/EthereumBlobNotifierIndexer.test.ts
@@ -210,14 +210,14 @@ function config(
     daLayer: 'ethereum' as EthereumDaTrackingConfig['daLayer'],
     inbox: overrides.inbox,
     sequencers: overrides.sequencers,
-    topics: overrides.topics,
+    event: overrides.event,
     sinceBlock: overrides.sinceBlock ?? 0,
     untilBlock: overrides.untilBlock,
   }
 }
 
 function mockBlobsRepository(pairs: BlobPairCount[]) {
-  return mockObject<Database['blobs']>({
+  return mockObject<Database['txWithBlobs']>({
     getCountPerAddressInbox: mockFn().resolvesTo(pairs),
   })
 }
@@ -238,7 +238,7 @@ function createIndexer($?: {
   return new EthereumBlobNotifierIndexer(
     {
       db: mockDatabase({
-        blobs: $?.blobsRepository ?? mockBlobsRepository([]),
+        txWithBlobs: $?.blobsRepository ?? mockBlobsRepository([]),
       }),
       configurations: $?.configurations ?? [],
       discordClient: $?.discordClient ?? mockDiscordClient(),

--- a/packages/backend/src/modules/data-availability/indexers/EthereumBlobNotifierIndexer.ts
+++ b/packages/backend/src/modules/data-availability/indexers/EthereumBlobNotifierIndexer.ts
@@ -75,7 +75,7 @@ export class EthereumBlobNotifierIndexer extends ManagedChildIndexer {
     const todayStart = UnixTime.toStartOf(to, 'day')
     const yesterdayStart = todayStart - UnixTime.DAY
 
-    const pairs = await this.$.db.blobs.getCountPerAddressInbox(
+    const pairs = await this.$.db.txWithBlobs.getCountPerAddressInbox(
       'ethereum',
       yesterdayStart,
       todayStart,
@@ -92,6 +92,7 @@ export class EthereumBlobNotifierIndexer extends ManagedChildIndexer {
             inbox: pair.to ?? '',
             sequencer: pair.from,
             topics: [],
+            logs: null,
           },
           config,
         ),

--- a/packages/backend/src/modules/data-availability/services/BlobService.test.ts
+++ b/packages/backend/src/modules/data-availability/services/BlobService.test.ts
@@ -1,4 +1,4 @@
-import type { BlobRecord, Database } from '@l2beat/database'
+import type { Database, TxWithBlobsRecord } from '@l2beat/database'
 import { ETHEREUM_BLOB_SIZE_BYTES, type EthereumBlob } from '@l2beat/shared'
 import { expect, mockFn, mockObject } from 'earl'
 import { mockDatabase } from '../../../test/database'
@@ -6,48 +6,53 @@ import { BlobService } from './BlobService'
 
 describe(BlobService.name, () => {
   describe(BlobService.prototype.save.name, () => {
-    it('should save blobs', async () => {
+    it('should save blob txs', async () => {
       const blobs: EthereumBlob[] = [
         {
           type: 'ethereum',
           daLayer: 'ethereum',
           blockTimestamp: 100_000,
           blockNumber: 1,
-          size: ETHEREUM_BLOB_SIZE_BYTES,
+          size: 2n * ETHEREUM_BLOB_SIZE_BYTES,
           inbox: '0x123',
           sequencer: '0x456',
+          txHash: '0xtx1',
+          blobCount: 2,
           topics: ['0xabc', '0xdef'],
+          logs: [{ emitter: '0x789', topics: ['0xabc', '0xdef'] }],
         },
       ]
 
-      const mockBlobRepository = mockObject<Database['blobs']>({
+      const mockTxWithBlobsRepository = mockObject<Database['txWithBlobs']>({
         insertMany: mockFn().resolvesTo(undefined),
       })
 
       const mockDb = mockDatabase({
-        blobs: mockBlobRepository,
+        txWithBlobs: mockTxWithBlobsRepository,
       })
 
       const blobService = new BlobService(mockDb)
       await blobService.save(blobs)
 
-      expect(mockBlobRepository.insertMany).toHaveBeenCalledWith(
+      expect(mockTxWithBlobsRepository.insertMany).toHaveBeenCalledWith(
         blobs.map((blob) => ({
           blockNumber: blob.blockNumber,
           timestamp: blob.blockTimestamp,
           daLayer: blob.daLayer,
           from: blob.sequencer,
           to: blob.inbox,
-          topics: blob.topics ?? null,
-          size: null,
+          txHash: blob.txHash,
+          blobCount: blob.blobCount,
+          logs: blob.logs,
+          topics: null,
         })),
       )
     })
   })
 
   describe(BlobService.prototype.get.name, () => {
-    it('should get blobs', async () => {
-      const records: BlobRecord[] = [
+    it('should get blob txs', async () => {
+      const records: TxWithBlobsRecord[] = [
         {
           id: 1,
           blockNumber: 100,
@@ -55,52 +60,81 @@ describe(BlobService.name, () => {
           daLayer: 'ethereum',
           from: '0x123',
           to: '0x456',
-          topics: ['0xabc', '0xdef'],
-          size: null,
+          txHash: '0xtx1',
+          blobCount: 2,
+          logs: [{ emitter: '0x789', topics: ['0xabc', '0xdef'] }],
+          topics: null,
+        },
+        {
+          // Legacy row backfilled from the per-blob table.
+          id: 2,
+          blockNumber: 99,
+          timestamp: 99_000,
+          daLayer: 'ethereum',
+          from: '0xabc',
+          to: '0xdef',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
+          topics: ['0xlegacy'],
         },
       ]
 
-      const mockBlobRepository = mockObject<Database['blobs']>({
+      const mockTxWithBlobsRepository = mockObject<Database['txWithBlobs']>({
         getByBlockRangeInclusive: mockFn().resolvesTo(records),
       })
 
       const mockDb = mockDatabase({
-        blobs: mockBlobRepository,
+        txWithBlobs: mockTxWithBlobsRepository,
       })
 
       const blobService = new BlobService(mockDb)
       const blobs = await blobService.get('ethereum', 1, 100)
 
-      expect(blobs).toEqualUnsorted(
-        records.map((record) => ({
+      expect(blobs).toEqualUnsorted([
+        {
           type: 'ethereum',
-          daLayer: record.daLayer,
-          blockTimestamp: record.timestamp,
-          blockNumber: record.blockNumber,
+          daLayer: 'ethereum',
+          blockTimestamp: 100_000,
+          blockNumber: 100,
+          size: 2n * ETHEREUM_BLOB_SIZE_BYTES,
+          inbox: '0x456',
+          sequencer: '0x123',
+          txHash: '0xtx1',
+          blobCount: 2,
+          topics: ['0xabc', '0xdef'],
+          logs: [{ emitter: '0x789', topics: ['0xabc', '0xdef'] }],
+        },
+        {
+          type: 'ethereum',
+          daLayer: 'ethereum',
+          blockTimestamp: 99_000,
+          blockNumber: 99,
           size: ETHEREUM_BLOB_SIZE_BYTES,
-          inbox: record.to ?? '',
-          sequencer: record.from,
-          topics: record.topics ?? [],
-        })),
-      )
+          inbox: '0xdef',
+          sequencer: '0xabc',
+          txHash: null,
+          blobCount: 1,
+          topics: ['0xlegacy'],
+          logs: null,
+        },
+      ])
 
-      expect(mockBlobRepository.getByBlockRangeInclusive).toHaveBeenCalledWith(
-        'ethereum',
-        1,
-        100,
-      )
+      expect(
+        mockTxWithBlobsRepository.getByBlockRangeInclusive,
+      ).toHaveBeenCalledWith('ethereum', 1, 100)
     })
   })
 
   describe(BlobService.prototype.deleteAfter.name, () => {
-    it('should delete blobs', async () => {
+    it('should delete blob txs', async () => {
       const deletedRecords = 2
-      const mockBlobRepository = mockObject<Database['blobs']>({
+      const mockTxWithBlobsRepository = mockObject<Database['txWithBlobs']>({
         deleteAfter: mockFn().resolvesTo(deletedRecords),
       })
 
       const mockDb = mockDatabase({
-        blobs: mockBlobRepository,
+        txWithBlobs: mockTxWithBlobsRepository,
       })
 
       const blobService = new BlobService(mockDb)
@@ -108,7 +142,7 @@ describe(BlobService.name, () => {
 
       expect(result).toEqual(deletedRecords)
 
-      expect(mockBlobRepository.deleteAfter).toHaveBeenCalledWith(
+      expect(mockTxWithBlobsRepository.deleteAfter).toHaveBeenCalledWith(
         'ethereum',
         100,
       )

--- a/packages/backend/src/modules/data-availability/services/BlobService.ts
+++ b/packages/backend/src/modules/data-availability/services/BlobService.ts
@@ -17,12 +17,14 @@ export class BlobService {
         daLayer: blob.daLayer,
         from: blob.sequencer,
         to: blob.inbox,
-        topics: blob.topics ?? null,
-        size: null, // size is constant for Ethereum blobs
+        txHash: blob.txHash,
+        blobCount: blob.blobCount,
+        logs: blob.logs,
+        topics: null, // legacy column: new writes derive topics from logs
       }
     })
 
-    await this.db.blobs.insertMany(records)
+    await this.db.txWithBlobs.insertMany(records)
   }
 
   async get(daLayer: string, from: number, to: number): Promise<DaBlob[]> {
@@ -31,7 +33,7 @@ export class BlobService {
       'Only ethereum blobs are supported in BlobService',
     )
 
-    const records = await this.db.blobs.getByBlockRangeInclusive(
+    const records = await this.db.txWithBlobs.getByBlockRangeInclusive(
       daLayer,
       from,
       to,
@@ -42,10 +44,13 @@ export class BlobService {
       daLayer: record.daLayer,
       blockTimestamp: record.timestamp,
       blockNumber: record.blockNumber,
-      size: ETHEREUM_BLOB_SIZE_BYTES,
+      size: ETHEREUM_BLOB_SIZE_BYTES * BigInt(record.blobCount),
       inbox: record.to ?? '',
       sequencer: record.from,
-      topics: record.topics ?? [],
+      txHash: record.txHash,
+      blobCount: record.blobCount,
+      topics: record.logs?.flatMap((log) => log.topics) ?? record.topics ?? [],
+      logs: record.logs,
     }))
   }
 
@@ -55,6 +60,6 @@ export class BlobService {
       'Only ethereum blobs are supported in BlobService',
     )
 
-    return await this.db.blobs.deleteAfter(daLayer, from)
+    return await this.db.txWithBlobs.deleteAfter(daLayer, from)
   }
 }

--- a/packages/backend/src/modules/data-availability/services/DaService.test.ts
+++ b/packages/backend/src/modules/data-availability/services/DaService.test.ts
@@ -1,9 +1,10 @@
+import type { EthereumDaTrackingConfig } from '@l2beat/config'
 import type { DataAvailabilityRecord } from '@l2beat/database'
 import type { AvailBlob, CelestiaBlob, EthereumBlob } from '@l2beat/shared'
 import { ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 import type { BlockDaIndexedConfig } from '../../../config/Config'
-import { DaService } from './DaService'
+import { DaService, matchEthereumProject } from './DaService'
 
 describe(DaService.name, () => {
   const service = new DaService()
@@ -19,6 +20,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-1-inbox',
           sequencer: 'ethereum-1-seq1',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           blockTimestamp: TIME,
           blockNumber: 1,
@@ -30,6 +34,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-1-inbox',
           sequencer: 'ethereum-1-seq1',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           blockTimestamp: TIME,
           blockNumber: 1,
@@ -41,6 +48,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-1-inbox',
           sequencer: 'ethereum-1-seq1',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: ['0x1234'],
           blockTimestamp: TIME,
           blockNumber: 1,
@@ -52,6 +62,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-2-inbox',
           sequencer: 'any',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           blockTimestamp: TIME,
           blockNumber: 1,
@@ -63,6 +76,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'any',
           sequencer: 'any',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           size: BigInt(400),
           blockTimestamp: TIME,
@@ -226,6 +242,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-1-inbox',
           sequencer: 'ethereum-1-seq1',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           blockTimestamp: TIME,
           blockNumber: 1,
@@ -237,6 +256,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-1-inbox',
           sequencer: 'ethereum-1-seq1',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           blockTimestamp: TIME,
           blockNumber: 1,
@@ -248,6 +270,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-1-inbox',
           sequencer: 'ethereum-1-seq1',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           blockTimestamp: TIME - 1 * UnixTime.HOUR,
           blockNumber: 1,
@@ -259,6 +284,9 @@ describe(DaService.name, () => {
           daLayer: 'ethereum',
           inbox: 'ethereum-1-inbox',
           sequencer: 'ethereum-1-seq1',
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: [],
           blockTimestamp: TIME + 1 * UnixTime.HOUR,
           blockNumber: 1,
@@ -355,6 +383,108 @@ describe(DaService.name, () => {
         latestTimestamp: TIME + 1 * UnixTime.HOUR,
       })
     })
+
+    it('counts every blob of a multi-blob tx via its total size', async () => {
+      const TIME = UnixTime.now()
+
+      const mockBlobs = [
+        {
+          type: 'ethereum',
+          daLayer: 'ethereum',
+          inbox: 'ethereum-1-inbox',
+          sequencer: 'ethereum-1-seq1',
+          txHash: '0xtx1',
+          blobCount: 3,
+          topics: [],
+          logs: null,
+          blockTimestamp: TIME,
+          blockNumber: 1,
+          size: 393216n, // 3 * 131072
+        } as EthereumBlob,
+      ]
+
+      const result = service.generateRecords(
+        mockBlobs,
+        [],
+        [MOCK_ETHEREUM_CONFIGS[1]],
+      )
+
+      expect(result.records).toEqual([
+        {
+          configurationId: 'eth-2',
+          projectId: 'project-ethereum-1',
+          daLayer: 'ethereum',
+          timestamp: UnixTime.toStartOf(TIME, 'hour'),
+          totalSize: 393216n,
+        },
+      ])
+    })
+  })
+})
+
+describe(matchEthereumProject.name, () => {
+  const config: EthereumDaTrackingConfig = {
+    type: 'ethereum',
+    daLayer: ProjectId('ethereum'),
+    inbox: 'inbox',
+    sinceBlock: 0,
+    event: {
+      topics: ['0x1234'],
+      emitters: ['0xAbC'],
+    },
+  }
+
+  const match = (
+    blob: Partial<Parameters<typeof matchEthereumProject>[0]>,
+    override = config,
+  ) =>
+    matchEthereumProject(
+      {
+        inbox: 'other',
+        sequencer: 'sequencer',
+        topics: [],
+        logs: [],
+        ...blob,
+      },
+      override,
+    )
+
+  it('matches topic and emitter from the same log', () => {
+    expect(match({ logs: [{ emitter: '0xaBc', topics: ['0x1234'] }] })).toEqual(
+      true,
+    )
+  })
+
+  it('does not match a wrong emitter or combine separate logs', () => {
+    expect(
+      match({
+        logs: [
+          { emitter: '0xabc', topics: ['0x5678'] },
+          { emitter: '0xdef', topics: ['0x1234'] },
+        ],
+      }),
+    ).toEqual(false)
+  })
+
+  it('uses legacy topics only when any emitter is accepted', () => {
+    const legacyBlob = { topics: ['0x1234'], logs: null }
+
+    expect(match(legacyBlob)).toEqual(false)
+    expect(
+      match(legacyBlob, {
+        ...config,
+        event: { topics: ['0x1234'], emitters: null },
+      }),
+    ).toEqual(true)
+  })
+
+  it('still matches by inbox when the event does not match', () => {
+    expect(
+      match({
+        inbox: 'INBOX',
+        logs: [{ emitter: '0xdef', topics: ['0x1234'] }],
+      }),
+    ).toEqual(true)
   })
 })
 
@@ -374,7 +504,10 @@ const MOCK_ETHEREUM_CONFIGS: BlockDaIndexedConfig[] = [
     inbox: 'ethereum-1-inbox',
     sequencers: ['Ethereum-1-seq1', 'ethereum-1-seq1'],
     sinceBlock: 0,
-    topics: ['0x1234', '0x5678'],
+    event: {
+      topics: ['0x1234', '0x5678'],
+      emitters: null,
+    },
   },
   {
     configurationId: 'eth-3',

--- a/packages/backend/src/modules/data-availability/services/DaService.ts
+++ b/packages/backend/src/modules/data-availability/services/DaService.ts
@@ -4,7 +4,12 @@ import type {
   EthereumDaTrackingConfig,
 } from '@l2beat/config'
 import type { DataAvailabilityRecord } from '@l2beat/database'
-import type { AvailBlob, CelestiaBlob, DaBlob } from '@l2beat/shared'
+import type {
+  AvailBlob,
+  CelestiaBlob,
+  DaBlob,
+  EthereumBlobLog,
+} from '@l2beat/shared'
 import { assert, UnixTime } from '@l2beat/shared-pure'
 import type { BlockDaIndexedConfig } from '../../../config/Config'
 
@@ -115,15 +120,36 @@ export class DaService {
 }
 
 export function matchEthereumProject(
-  blob: { inbox: string; sequencer: string; topics: string[] },
+  blob: {
+    inbox: string
+    sequencer: string
+    topics: string[]
+    logs: EthereumBlobLog[] | null
+  },
   config: EthereumDaTrackingConfig,
 ) {
-  if (config.topics) {
-    const hasTopicMatch = config.topics.some((topic) =>
-      blob.topics.includes(topic.toLowerCase()),
-    )
+  const event = config.event
+  if (event) {
+    const wantedTopics = event.topics.map((topic) => topic.toLowerCase())
+    const emitters = event.emitters
 
-    if (hasTopicMatch) {
+    const hasEventMatch =
+      emitters === null
+        ? blob.topics.some((topic) =>
+            wantedTopics.includes(topic.toLowerCase()),
+          )
+        : blob.logs?.some(
+            (log) =>
+              emitters.some(
+                (emitter) =>
+                  emitter.toLowerCase() === log.emitter.toLowerCase(),
+              ) &&
+              log.topics.some((topic) =>
+                wantedTopics.includes(topic.toLowerCase()),
+              ),
+          )
+
+    if (hasEventMatch) {
       return true
     }
   }

--- a/packages/backend/src/modules/data-availability/trpc/status.test.ts
+++ b/packages/backend/src/modules/data-availability/trpc/status.test.ts
@@ -85,7 +85,10 @@ describe(getDaTrackingStatusRows.name, () => {
             configurationId: 'ethereum',
             inbox: '0x123',
             sequencers: ['0x456'],
-            topics: ['0x789'],
+            event: {
+              topics: ['0x789'],
+              emitters: null,
+            },
           }),
           mockCelestiaConfig({
             configurationId: 'celestia',
@@ -123,7 +126,7 @@ describe(getDaTrackingStatusRows.name, () => {
       status: 'missing',
     })
     expect(rowsByConfigId.get('ethereum')?.details).toEqual(
-      'inbox: 0x123; sequencers: 0x456; topics: 0x789',
+      'inbox: 0x123; sequencers: 0x456; topics: 0x789; emitters: any',
     )
     expect(rowsByConfigId.get('celestia')?.details).toEqual(
       'namespace: namespace',

--- a/packages/backend/src/modules/data-availability/trpc/status.ts
+++ b/packages/backend/src/modules/data-availability/trpc/status.ts
@@ -109,8 +109,9 @@ function getConfigDetails(
       if (config.sequencers && config.sequencers.length > 0) {
         parts.push(`sequencers: ${config.sequencers.join(', ')}`)
       }
-      if (config.topics && config.topics.length > 0) {
-        parts.push(`topics: ${config.topics.join(', ')}`)
+      if (config.event) {
+        parts.push(`topics: ${config.event.topics.join(', ')}`)
+        parts.push(`emitters: ${config.event.emitters?.join(', ') ?? 'any'}`)
       }
       return parts.join('; ')
     }

--- a/packages/config/src/processing/getProjects.test.ts
+++ b/packages/config/src/processing/getProjects.test.ts
@@ -80,6 +80,7 @@ describe('getProjects', () => {
         typeof value === 'boolean' ||
         typeof value === 'number' ||
         typeof value === 'string' ||
+        value === null ||
         value === undefined
       ) {
         return undefined

--- a/packages/config/src/projects/aztecnetwork/aztecnetwork.ts
+++ b/packages/config/src/projects/aztecnetwork/aztecnetwork.ts
@@ -174,6 +174,11 @@ const escapeHatchAddress = ChainSpecificAddress.address(escapeHatch.address)
 
 const v5ActivationTimestamp = UnixTime(1784060567) // 14 July 2026 20:22:47 UTC
 const v5ActivationBlock = 25533241 // https://etherscan.io/tx/0xff2db4e4bba583f2451478bfe4703e16afc79f0b463fb60615ebe3494142437b
+// Keep versioned DA emitters stable when discovery moves to a newer Rollup.
+// Later versions should get a separate, bounded DA tracking config.
+const v5RollupAddress = EthereumAddress(
+  '0x91fF8bbD8Ebb07893010D50A48A1609e5EBd8E34',
+)
 
 function formatAztecAmount(amount: bigint): string {
   return `${formatLargeNumber(Number(amount / 10n ** 18n))} AZTEC`
@@ -352,9 +357,12 @@ export const aztecnetwork: ScalingProject = {
         daLayer: ProjectId('ethereum'),
         sinceBlock: v5ActivationBlock,
         inbox: EthereumAddress.ZERO, // Event-only tracking
-        topics: [
-          '0x6ff492bf2b4ca1b93a175167d14b3e46085b935cab3f39ca94013000799b93a0', // CheckpointProposed
-        ],
+        event: {
+          topics: [
+            '0x6ff492bf2b4ca1b93a175167d14b3e46085b935cab3f39ca94013000799b93a0', // CheckpointProposed
+          ],
+          emitters: [v5RollupAddress],
+        },
       },
     ],
     trackedTxs: [

--- a/packages/config/src/projects/taiko/taiko.ts
+++ b/packages/config/src/projects/taiko/taiko.ts
@@ -191,9 +191,12 @@ export const taiko: ScalingProject = {
         sinceBlock: 0, // Edge Case: config added @ DA Module start
         inbox: mainnetInboxAddress,
         sequencers: [],
-        topics: [
-          '0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213', // Proposed
-        ],
+        event: {
+          topics: [
+            '0x7c4c4523e17533e451df15762a093e0693a2cd8b279fe54c6cd3777ed5771213', // Proposed
+          ],
+          emitters: null, // Inbox matching already identifies Taiko blobs.
+        },
       },
     ],
     trackedTxs: [

--- a/packages/config/src/snapshots/daTracking/snapshot.json
+++ b/packages/config/src/snapshots/daTracking/snapshot.json
@@ -119,7 +119,7 @@
   ],
   "aztecnetwork": [
     {
-      "id": "7926e2fc5a89",
+      "id": "15c163b94db1",
       "label": "ethereum inbox 0x0000000000000000000000000000000000000000 since 25533241"
     }
   ],

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1223,7 +1223,11 @@ export interface EthereumDaTrackingConfig {
   daLayer: ProjectId
   inbox: string
   sequencers?: string[]
-  topics?: string[]
+  event?: {
+    topics: [string, ...string[]]
+    /** Null explicitly matches logs from any emitter. */
+    emitters: [string, ...string[]] | null
+  }
   sinceBlock: number
   untilBlock?: number
 }

--- a/packages/database/prisma/migrations/20260731120000_replace_blob_with_tx_with_blobs/migration.sql
+++ b/packages/database/prisma/migrations/20260731120000_replace_blob_with_tx_with_blobs/migration.sql
@@ -1,0 +1,72 @@
+-- Replace the per-blob "Blob" cache with a per-transaction "TxWithBlobs" cache:
+-- one row per blob-carrying tx, with "blobCount" holding the multiplicity.
+-- Every other column of "Blob" was transaction-level already, so the old table
+-- stored identical tx metadata once per blob (~2.5-3x rows). "size" is dropped:
+-- it was always NULL for ethereum rows and is recomputed as
+-- blobCount * 131072 (ETHEREUM_BLOB_SIZE_BYTES) on read.
+--
+-- Lock ordering matters. We take an EXCLUSIVE lock on "Blob" FIRST, before the
+-- backfill snapshot. Old backend pods still running the previous code block on
+-- this lock when inserting and then fail loudly after we commit (the table is
+-- gone); BlobIndexer's infinite retry strategy freezes its safe height until
+-- the new code deploys and resumes against "TxWithBlobs". This closes the
+-- window in which old code could commit rows to "Blob" AFTER the backfill read
+-- it (those rows would otherwise be silently dropped). EXCLUSIVE (not ACCESS
+-- EXCLUSIVE) still allows old readers (DaIndexer cache reads, the blob
+-- notifier) to proceed while the backfill runs.
+LOCK TABLE "Blob" IN EXCLUSIVE MODE;
+
+-- CreateTable
+CREATE TABLE "TxWithBlobs" (
+    "id" SERIAL NOT NULL,
+    "blockNumber" INTEGER NOT NULL,
+    "timestamp" TIMESTAMP(6) NOT NULL,
+    "daLayer" INTEGER NOT NULL,
+    "from" VARCHAR(255) NOT NULL,
+    "to" VARCHAR(255),
+    "txHash" VARCHAR(255),
+    "blobCount" INTEGER NOT NULL,
+    "logs" JSONB,
+    "topics" TEXT,
+
+    CONSTRAINT "TxWithBlobs_pkey" PRIMARY KEY ("id")
+);
+
+-- Backfill (~25M source rows, back to block 19,426,618). "txHash" and "logs"
+-- stay NULL to mark these as legacy rows; readers fall back to the legacy
+-- "topics" column for them. Per-blob rows of one tx always share one identical
+-- topics string (written by a single JSON.stringify), so a tx never splits
+-- across groups. Different txs in one block with identical (from, to, topics)
+-- merge into one row - acceptable: "blobCount" preserves the total and
+-- matching only uses (from, to, topics), which are identical.
+INSERT INTO "TxWithBlobs"
+  ("blockNumber", "timestamp", "daLayer", "from", "to", "blobCount", "topics")
+SELECT
+  "blockNumber", "timestamp", "daLayer", "from", "to",
+  count(*)::int, "topics"
+FROM "Blob"
+GROUP BY "blockNumber", "timestamp", "daLayer", "from", "to", "topics";
+
+-- Safety check: total blob multiplicity must be preserved, otherwise abort the
+-- whole migration transaction.
+DO $$
+DECLARE
+  source_rows bigint;
+  migrated_blobs bigint;
+BEGIN
+  SELECT count(*) INTO source_rows FROM "Blob";
+  SELECT coalesce(sum("blobCount"), 0) INTO migrated_blobs FROM "TxWithBlobs";
+  IF source_rows <> migrated_blobs THEN
+    RAISE EXCEPTION 'Blob backfill mismatch: % source rows vs % blobCount',
+      source_rows, migrated_blobs;
+  END IF;
+END $$;
+
+-- CreateIndex (after the bulk insert, so each index is built once).
+-- (daLayer, timestamp) is new: the daily notifier query filters on exactly
+-- this pair and used to seq-scan the per-blob table.
+CREATE INDEX "TxWithBlobs_blockNumber_idx" ON "TxWithBlobs"("blockNumber");
+CREATE INDEX "TxWithBlobs_daLayer_timestamp_idx" ON "TxWithBlobs"("daLayer", "timestamp");
+
+-- DropTable (also drops "Blob_id_seq" and "Blob_blockNumber_idx")
+DROP TABLE "Blob";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -337,17 +337,23 @@ model Notification {
   @@id([id])
 }
 
-model Blob {
+model TxWithBlobs {
   id          Int      @id @default(autoincrement())
   blockNumber Int
   timestamp   DateTime @db.Timestamp(6)
   daLayer     Int
   from        String   @db.VarChar(255)
   to          String?  @db.VarChar(255)
+  /// Null for rows backfilled from the legacy per-blob "Blob" table.
+  txHash      String?  @db.VarChar(255)
+  blobCount   Int
+  /// [{emitter, topics}] for every log of the tx. Null for backfilled rows.
+  logs        Json?
+  /// Legacy JSON-stringified topic list; only set on backfilled rows.
   topics      String?
-  size        BigInt?
 
   @@index([blockNumber])
+  @@index([daLayer, timestamp])
 }
 
 model SyncMetadata {

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -11,7 +11,6 @@ import { AggregatedLivenessRepository } from './repositories/AggregatedLivenessR
 import { AnomaliesRepository } from './repositories/AnomaliesRepository'
 import { AnomalyStatsRepository } from './repositories/AnomalyStatsRepository'
 import { AppStateRepository } from './repositories/AppStateRepository'
-import { BlobsRepository } from './repositories/BlobsRepository'
 import { CurrentPriceRepository } from './repositories/CurrentPriceRepository'
 import { DaBeatStatsRepository } from './repositories/DaBeatStatsRepository'
 import { DataAvailabilityRepository } from './repositories/DataAvailabilityRepository'
@@ -44,6 +43,7 @@ import { TokenValueRepository } from './repositories/TokenValueRepository'
 import { TvsAmountRepository } from './repositories/TvsAmountRepository'
 import { TvsBlockTimestampRepository } from './repositories/TvsBlockTimestampRepository'
 import { TvsPriceRepository } from './repositories/TvsPriceRepository'
+import { TxWithBlobsRepository } from './repositories/TxWithBlobsRepository'
 import { UpdateDiffRepository } from './repositories/UpdateDiffRepository'
 import { UpdateMessageRepository } from './repositories/UpdateMessageRepository'
 import { UpdateMonitorRepository } from './repositories/UpdateMonitorRepository'
@@ -85,7 +85,7 @@ export function createDatabase(
     currentPrice: new CurrentPriceRepository(db),
     daBeatStats: new DaBeatStatsRepository(db),
     dataAvailability: new DataAvailabilityRepository(db),
-    blobs: new BlobsRepository(db),
+    txWithBlobs: new TxWithBlobsRepository(db),
     // #endregion
 
     // #region Discovery

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -32,7 +32,6 @@ export {
   AppStatePair,
   type AppStateRecord,
 } from './repositories/AppStateRepository'
-export type { BlobPairCount, BlobRecord } from './repositories/BlobsRepository'
 export type {
   ChainApi,
   ChainRecord,
@@ -143,6 +142,10 @@ export type {
 export type { TvsAmountRecord } from './repositories/TvsAmountRepository'
 export type { TvsBlockTimestampRecord } from './repositories/TvsBlockTimestampRepository'
 export type { TvsPriceRecord } from './repositories/TvsPriceRepository'
+export type {
+  BlobPairCount,
+  TxWithBlobsRecord,
+} from './repositories/TxWithBlobsRepository'
 export type { UpdateDiffRecord } from './repositories/UpdateDiffRepository'
 export type { UpdateMessageRecord } from './repositories/UpdateMessageRepository'
 export type { UpdateMonitorRecord } from './repositories/UpdateMonitorRepository'

--- a/packages/database/src/repositories/TxWithBlobsRepository.test.ts
+++ b/packages/database/src/repositories/TxWithBlobsRepository.test.ts
@@ -1,13 +1,16 @@
 import { UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 import { describeDatabase } from '../test/database'
-import { type BlobRecord, BlobsRepository } from './BlobsRepository'
+import {
+  type TxWithBlobsRecord,
+  TxWithBlobsRepository,
+} from './TxWithBlobsRepository'
 
-describeDatabase(BlobsRepository.name, (db) => {
-  const repository = db.blobs
+describeDatabase(TxWithBlobsRepository.name, (db) => {
+  const repository = db.txWithBlobs
 
   const START = UnixTime.now()
-  const DATA: BlobRecord[] = [
+  const DATA: TxWithBlobsRecord[] = [
     {
       id: 1,
       blockNumber: 1000,
@@ -15,18 +18,23 @@ describeDatabase(BlobsRepository.name, (db) => {
       daLayer: 'ethereum',
       from: '0x123',
       to: '0x456',
-      topics: ['0xabc', '0xdef'],
-      size: BigInt(1000),
+      txHash: '0xtx1',
+      blobCount: 2,
+      logs: [{ emitter: '0x789', topics: ['0xabc', '0xdef'] }],
+      topics: null,
     },
     {
+      // Legacy shape: backfilled from the per-blob table.
       id: 2,
       blockNumber: 2000,
       timestamp: START - 2 * UnixTime.HOUR,
       daLayer: 'avail',
       from: '0x789',
       to: null,
+      txHash: null,
+      blobCount: 1,
+      logs: null,
       topics: null,
-      size: BigInt(2000),
     },
     {
       id: 3,
@@ -35,8 +43,10 @@ describeDatabase(BlobsRepository.name, (db) => {
       daLayer: 'avail',
       from: '0xabc',
       to: '0xdef',
+      txHash: null,
+      blobCount: 3,
+      logs: null,
       topics: ['0x123'],
-      size: BigInt(3000),
     },
   ]
 
@@ -46,9 +56,9 @@ describeDatabase(BlobsRepository.name, (db) => {
     await repository.insertMany(DATA)
   })
 
-  describe(BlobsRepository.prototype.insertMany.name, () => {
+  describe(TxWithBlobsRepository.prototype.insertMany.name, () => {
     it('add new', async () => {
-      const newRows: BlobRecord[] = [
+      const newRows: TxWithBlobsRecord[] = [
         {
           id: 4,
           blockNumber: 4000,
@@ -56,8 +66,10 @@ describeDatabase(BlobsRepository.name, (db) => {
           daLayer: 'eigen-da',
           from: '0x111',
           to: '0x222',
-          topics: ['0x333'],
-          size: BigInt(4000),
+          txHash: '0xtx4',
+          blobCount: 1,
+          logs: [{ emitter: '0x444', topics: ['0x333'] }],
+          topics: null,
         },
         {
           id: 5,
@@ -66,8 +78,10 @@ describeDatabase(BlobsRepository.name, (db) => {
           daLayer: 'ethereum',
           from: '0x444',
           to: null,
+          txHash: null,
+          blobCount: 1,
+          logs: null,
           topics: null,
-          size: BigInt(5000),
         },
       ]
 
@@ -82,7 +96,7 @@ describeDatabase(BlobsRepository.name, (db) => {
     })
   })
 
-  describe(BlobsRepository.prototype.getAll.name, () => {
+  describe(TxWithBlobsRepository.prototype.getAll.name, () => {
     it('should return all rows', async () => {
       const results = await repository.getAll()
 
@@ -94,42 +108,62 @@ describeDatabase(BlobsRepository.name, (db) => {
     })
   })
 
-  describe(BlobsRepository.prototype.getByBlockRangeInclusive.name, () => {
-    it('should return all rows for related entity', async () => {
-      const results = await repository.getByBlockRangeInclusive(
-        'avail',
-        2000,
-        3000,
-      )
+  describe(
+    TxWithBlobsRepository.prototype.getByBlockRangeInclusive.name,
+    () => {
+      it('should return all rows for related entity', async () => {
+        const results = await repository.getByBlockRangeInclusive(
+          'avail',
+          2000,
+          3000,
+        )
 
-      expect(results).toEqualUnsorted(DATA.slice(1, 3))
-    })
-  })
+        expect(results).toEqualUnsorted(DATA.slice(1, 3))
+      })
 
-  describe(BlobsRepository.prototype.getCountPerAddressInbox.name, () => {
-    it('should group by from and to and return counts', async () => {
+      it('should return rows in ascending block order', async () => {
+        await repository.deleteAll()
+        await repository.insertMany([
+          txWithBlobs({ blockNumber: 30 }),
+          txWithBlobs({ blockNumber: 10 }),
+          txWithBlobs({ blockNumber: 20 }),
+        ])
+
+        const results = await repository.getByBlockRangeInclusive(
+          'ethereum',
+          0,
+          100,
+        )
+
+        expect(results.map((r) => r.blockNumber)).toEqual([10, 20, 30])
+      })
+    },
+  )
+
+  describe(TxWithBlobsRepository.prototype.getCountPerAddressInbox.name, () => {
+    it('should group by from and to and sum blob counts', async () => {
       await repository.deleteAll()
       const base = UnixTime.toStartOf(UnixTime.now(), 'day')
       await repository.insertMany([
-        blob({
+        txWithBlobs({
           from: '0xA',
           to: '0xB',
+          blobCount: 3,
           timestamp: base + 1,
-          daLayer: 'ethereum',
           blockNumber: 10,
         }),
-        blob({
+        txWithBlobs({
           from: '0xA',
           to: '0xB',
+          blobCount: 2,
           timestamp: base + 2,
-          daLayer: 'ethereum',
           blockNumber: 11,
         }),
-        blob({
+        txWithBlobs({
           from: '0xA',
           to: '0xC',
+          blobCount: 1,
           timestamp: base + 3,
-          daLayer: 'ethereum',
           blockNumber: 12,
         }),
       ])
@@ -141,7 +175,7 @@ describeDatabase(BlobsRepository.name, (db) => {
       )
 
       expect(results).toEqualUnsorted([
-        { from: '0xA', to: '0xB', count: 2 },
+        { from: '0xA', to: '0xB', count: 5 },
         { from: '0xA', to: '0xC', count: 1 },
       ])
     })
@@ -150,34 +184,10 @@ describeDatabase(BlobsRepository.name, (db) => {
       await repository.deleteAll()
       const base = UnixTime.toStartOf(UnixTime.now(), 'day')
       await repository.insertMany([
-        blob({
-          from: '0xA',
-          to: '0xB',
-          timestamp: base - 1,
-          daLayer: 'ethereum',
-          blockNumber: 10,
-        }),
-        blob({
-          from: '0xA',
-          to: '0xB',
-          timestamp: base,
-          daLayer: 'ethereum',
-          blockNumber: 11,
-        }),
-        blob({
-          from: '0xA',
-          to: '0xB',
-          timestamp: base + 100,
-          daLayer: 'ethereum',
-          blockNumber: 12,
-        }),
-        blob({
-          from: '0xA',
-          to: '0xB',
-          timestamp: base + UnixTime.DAY,
-          daLayer: 'ethereum',
-          blockNumber: 13,
-        }),
+        txWithBlobs({ timestamp: base - 1, blockNumber: 10 }),
+        txWithBlobs({ timestamp: base, blockNumber: 11 }),
+        txWithBlobs({ timestamp: base + 100, blockNumber: 12 }),
+        txWithBlobs({ timestamp: base + UnixTime.DAY, blockNumber: 13 }),
       ])
 
       const results = await repository.getCountPerAddressInbox(
@@ -186,7 +196,7 @@ describeDatabase(BlobsRepository.name, (db) => {
         base + UnixTime.DAY,
       )
 
-      expect(results).toEqual([{ from: '0xA', to: '0xB', count: 2 }])
+      expect(results).toEqual([{ from: '0x0', to: null, count: 2 }])
     })
 
     it('should return empty array when no data matches', async () => {
@@ -203,7 +213,7 @@ describeDatabase(BlobsRepository.name, (db) => {
     })
   })
 
-  describe(BlobsRepository.prototype.deleteAll.name, () => {
+  describe(TxWithBlobsRepository.prototype.deleteAll.name, () => {
     it('should delete all rows', async () => {
       await repository.deleteAll()
 
@@ -213,7 +223,7 @@ describeDatabase(BlobsRepository.name, (db) => {
     })
   })
 
-  describe(BlobsRepository.prototype.deleteAfter.name, () => {
+  describe(TxWithBlobsRepository.prototype.deleteAfter.name, () => {
     it('should delete all rows', async () => {
       await repository.deleteAfter('avail', 2000)
 
@@ -224,16 +234,18 @@ describeDatabase(BlobsRepository.name, (db) => {
   })
 })
 
-function blob(
-  overrides: Partial<Omit<BlobRecord, 'id'>>,
-): Omit<BlobRecord, 'id'> {
+function txWithBlobs(
+  overrides: Partial<Omit<TxWithBlobsRecord, 'id'>>,
+): Omit<TxWithBlobsRecord, 'id'> {
   return {
     blockNumber: overrides.blockNumber ?? 1,
     timestamp: overrides.timestamp ?? UnixTime.now(),
     daLayer: overrides.daLayer ?? 'ethereum',
     from: overrides.from ?? '0x0',
     to: overrides.to ?? null,
+    txHash: overrides.txHash ?? null,
+    blobCount: overrides.blobCount ?? 1,
+    logs: overrides.logs ?? null,
     topics: overrides.topics ?? null,
-    size: overrides.size ?? BigInt(100),
   }
 }

--- a/packages/database/src/repositories/TxWithBlobsRepository.ts
+++ b/packages/database/src/repositories/TxWithBlobsRepository.ts
@@ -1,18 +1,25 @@
+import type { EthereumBlobLog } from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import type { Insertable, Selectable } from 'kysely'
 import { sql } from 'kysely'
 import { BaseRepository } from '../BaseRepository'
-import type { Blob } from '../kysely/generated/types'
+import type { TxWithBlobs } from '../kysely/generated/types'
 
-export interface BlobRecord {
+/** One blob-carrying transaction; blobCount holds the blob multiplicity. */
+export interface TxWithBlobsRecord {
   id: number
   blockNumber: number
   timestamp: UnixTime
   daLayer: string
   from: string
   to: string | null
+  /** Null for rows backfilled from the legacy per-blob table. */
+  txHash: string | null
+  blobCount: number
+  /** Null for rows backfilled from the legacy per-blob table. */
+  logs: EthereumBlobLog[] | null
+  /** Legacy topic list; only set on backfilled rows, null on new writes. */
   topics: string[] | null
-  size: bigint | null
 }
 
 export interface BlobPairCount {
@@ -21,7 +28,7 @@ export interface BlobPairCount {
   count: number
 }
 
-export function toRecord(row: Selectable<Blob>): BlobRecord {
+export function toRecord(row: Selectable<TxWithBlobs>): TxWithBlobsRecord {
   return {
     id: row.id,
     blockNumber: row.blockNumber,
@@ -29,20 +36,26 @@ export function toRecord(row: Selectable<Blob>): BlobRecord {
     daLayer: numberToDaLayer(row.daLayer),
     from: row.from,
     to: row.to ?? null,
+    txHash: row.txHash ?? null,
+    blobCount: row.blobCount,
+    logs: row.logs as EthereumBlobLog[] | null,
     topics: row.topics ? JSON.parse(row.topics) : null,
-    size: row.size ? BigInt(row.size) : null,
   }
 }
 
-export function toRow(record: Omit<BlobRecord, 'id'>): Insertable<Blob> {
+export function toRow(
+  record: Omit<TxWithBlobsRecord, 'id'>,
+): Insertable<TxWithBlobs> {
   return {
     blockNumber: record.blockNumber,
     timestamp: UnixTime.toDate(record.timestamp),
     daLayer: daLayerToNumber(record.daLayer),
     from: record.from,
     to: record.to ?? null,
+    txHash: record.txHash ?? null,
+    blobCount: record.blobCount,
+    logs: record.logs !== null ? JSON.stringify(record.logs) : null,
     topics: record.topics ? JSON.stringify(record.topics) : null,
-    size: record.size ? record.size.toString() : null,
   }
 }
 
@@ -76,13 +89,13 @@ export function numberToDaLayer(daLayer: number): string {
   }
 }
 
-export class BlobsRepository extends BaseRepository {
-  async insertMany(records: Omit<BlobRecord, 'id'>[]): Promise<number> {
+export class TxWithBlobsRepository extends BaseRepository {
+  async insertMany(records: Omit<TxWithBlobsRecord, 'id'>[]): Promise<number> {
     if (records.length === 0) return 0
 
     const rows = records.map(toRow)
     await this.batch(rows, 10_000, async (batch) => {
-      await this.db.insertInto('Blob').values(batch).execute()
+      await this.db.insertInto('TxWithBlobs').values(batch).execute()
     })
     return rows.length
   }
@@ -93,9 +106,9 @@ export class BlobsRepository extends BaseRepository {
     to: UnixTime,
   ): Promise<BlobPairCount[]> {
     const rows = await this.db
-      .selectFrom('Blob')
+      .selectFrom('TxWithBlobs')
       .select(['from', 'to'])
-      .select((eb) => eb.fn.countAll<number>().as('count'))
+      .select((eb) => eb.fn.sum<number>('blobCount').as('count'))
       .where('daLayer', '=', daLayerToNumber(daLayer))
       .where('timestamp', '>=', UnixTime.toDate(from))
       .where('timestamp', '<', UnixTime.toDate(to))
@@ -109,8 +122,8 @@ export class BlobsRepository extends BaseRepository {
     }))
   }
 
-  async getAll(): Promise<BlobRecord[]> {
-    const rows = await this.db.selectFrom('Blob').selectAll().execute()
+  async getAll(): Promise<TxWithBlobsRecord[]> {
+    const rows = await this.db.selectFrom('TxWithBlobs').selectAll().execute()
 
     return rows.map(toRecord)
   }
@@ -119,22 +132,25 @@ export class BlobsRepository extends BaseRepository {
     daLayer: string,
     from: number,
     to: number,
-  ): Promise<BlobRecord[]> {
+  ): Promise<TxWithBlobsRecord[]> {
     const rows = await this.db
-      .selectFrom('Blob')
+      .selectFrom('TxWithBlobs')
       .selectAll()
       .where('daLayer', '=', daLayerToNumber(daLayer))
       .where('blockNumber', '>=', from)
       .where('blockNumber', '<=', to)
+      .orderBy('blockNumber', 'asc')
       .execute()
     return rows.map(toRecord)
   }
 
   async deleteAll(): Promise<number> {
-    const result = await this.db.deleteFrom('Blob').executeTakeFirst()
+    const result = await this.db.deleteFrom('TxWithBlobs').executeTakeFirst()
 
     const resetIdQuery =
-      sql`ALTER SEQUENCE public."Blob_id_seq" RESTART WITH 1`.compile(this.db)
+      sql`ALTER SEQUENCE public."TxWithBlobs_id_seq" RESTART WITH 1`.compile(
+        this.db,
+      )
     await this.db.executeQuery(resetIdQuery)
 
     return Number(result.numDeletedRows)
@@ -142,7 +158,7 @@ export class BlobsRepository extends BaseRepository {
 
   async deleteAfter(daLayer: string, blockNumber: number): Promise<number> {
     const result = await this.db
-      .deleteFrom('Blob')
+      .deleteFrom('TxWithBlobs')
       .where('daLayer', '=', daLayerToNumber(daLayer))
       .where('blockNumber', '>', blockNumber)
       .executeTakeFirst()

--- a/packages/frontend/src/components/projects/sections/data-posted/DataPostedTrackedTransactions.tsx
+++ b/packages/frontend/src/components/projects/sections/data-posted/DataPostedTrackedTransactions.tsx
@@ -143,12 +143,26 @@ function TransactionDetails({
                 </div>
               </div>
             )}
-            {transaction.topics && transaction.topics.length > 0 && (
+            {transaction.event && (
               <div className="mb-1 text-sm">
                 <span className="text-secondary">Topics: </span>
                 <div>
-                  {transaction.topics?.map((topic) => (
+                  {transaction.event.topics.map((topic) => (
                     <span key={topic}>{topic}</span>
+                  ))}
+                </div>
+              </div>
+            )}
+            {transaction.event?.emitters && (
+              <div className="mb-1 text-sm">
+                <span className="text-secondary">Emitters: </span>
+                <div className="inline-flex gap-2">
+                  {transaction.event.emitters.map((emitter) => (
+                    <EtherscanLink
+                      key={emitter}
+                      address={emitter}
+                      className="whitespace-nowrap"
+                    />
                   ))}
                 </div>
               </div>

--- a/packages/shared/src/providers/da/EthereumDaProvider.test.ts
+++ b/packages/shared/src/providers/da/EthereumDaProvider.test.ts
@@ -3,7 +3,6 @@ import { expect, mockFn, mockObject } from 'earl'
 import { utils } from 'ethers'
 import type { BeaconChainClient, RpcClient } from '../../clients'
 import { EthereumDaProvider } from './EthereumDaProvider'
-import type { EthereumBlob } from './types'
 
 describe(EthereumDaProvider.name, () => {
   describe(EthereumDaProvider.prototype.getBlobs.name, () => {
@@ -54,21 +53,15 @@ describe(EthereumDaProvider.name, () => {
           daLayer: 'ethereum',
           inbox: '0xto1',
           sequencer: '0xfrom1',
+          txHash,
+          blobCount: 2,
           topics: ['topic1-1'],
+          logs: [{ emitter: 'inbox1', topics: ['topic1-1'] }],
           blockTimestamp: UnixTime.fromDate(mockDate),
           blockNumber: 1,
-          size: 131072n,
-        } as EthereumBlob,
-        {
-          type: 'ethereum',
-          daLayer: 'ethereum',
-          inbox: '0xto1',
-          sequencer: '0xfrom1',
-          topics: ['topic1-1'],
-          blockTimestamp: UnixTime.fromDate(mockDate),
-          blockNumber: 1,
-          size: 131072n,
-        } as EthereumBlob,
+          // one row per blob-carrying tx; size is the total for all its blobs
+          size: 262144n,
+        },
       ])
     })
   })

--- a/packages/shared/src/providers/da/EthereumDaProvider.ts
+++ b/packages/shared/src/providers/da/EthereumDaProvider.ts
@@ -72,20 +72,24 @@ export class EthereumDaProvider implements DaBlobProvider {
       }
 
       const txLogs = logs.filter((l) => l.transactionHash === tx.hash)
-      const topics = txLogs.flatMap((log) => log.topics)
+      const blobCount = tx.blobVersionedHashes.length
 
-      tx.blobVersionedHashes.forEach(() =>
-        blobs.push({
-          type: 'ethereum',
-          daLayer: this.daLayer,
-          blockTimestamp: block.timestamp,
-          blockNumber: block.number,
-          size: ETHEREUM_BLOB_SIZE_BYTES,
-          inbox: tx.to ?? '',
-          sequencer: tx.from,
-          topics,
-        }),
-      )
+      blobs.push({
+        type: 'ethereum',
+        daLayer: this.daLayer,
+        blockTimestamp: block.timestamp,
+        blockNumber: block.number,
+        size: ETHEREUM_BLOB_SIZE_BYTES * BigInt(blobCount),
+        inbox: tx.to ?? '',
+        sequencer: tx.from,
+        txHash: tx.hash,
+        blobCount,
+        topics: txLogs.flatMap((log) => log.topics),
+        logs: txLogs.map((log) => ({
+          emitter: log.address,
+          topics: log.topics,
+        })),
+      })
     }
 
     return blobs

--- a/packages/shared/src/providers/da/types.ts
+++ b/packages/shared/src/providers/da/types.ts
@@ -1,5 +1,10 @@
 import type { UnixTime } from '@l2beat/shared-pure'
 
+export interface EthereumBlobLog {
+  emitter: string
+  topics: string[]
+}
+
 export interface DaBlobBase {
   daLayer: string
   blockTimestamp: UnixTime
@@ -7,11 +12,22 @@ export interface DaBlobBase {
   size: bigint
 }
 
+/**
+ * One blob-carrying transaction, not one blob - `size` is the total for all
+ * `blobCount` blobs of the tx. All matching inputs (inbox, sequencer, logs)
+ * are transaction-level anyway.
+ */
 export interface EthereumBlob extends DaBlobBase {
   type: 'ethereum'
   inbox: string
   sequencer: string
+  /** Null for cache rows backfilled from the legacy per-blob table. */
+  txHash: string | null
+  blobCount: number
+  /** All log topics of the tx, flattened. Derived from `logs` when present. */
   topics: string[]
+  /** Null for cache rows written before logs were persisted. */
+  logs: EthereumBlobLog[] | null
 }
 
 export interface AvailBlob extends DaBlobBase {

--- a/packages/shared/src/tools/createDaTrackingId.test.ts
+++ b/packages/shared/src/tools/createDaTrackingId.test.ts
@@ -64,16 +64,56 @@ describe(createDaTrackingId.name, () => {
     ).toEqual('158f67fc279d')
   })
 
-  it('matches the pinned id for an ethereum config with topics', () => {
+  it('matches the pinned id for an ethereum config with topics (emitters: null)', () => {
+    // Pinned against the pre-event `topics: string[]` shape - a topic-only
+    // event config must not re-key data indexed under plain topics.
     expect(
       createDaTrackingId({
         type: 'ethereum',
         daLayer: 'ethereum',
         inbox: '0x8c0Bfc04AdA21fd496c55B8C50331f904306F564',
         sequencers: ['0xb', '0xa'],
-        topics: ['0x2', '0x1'],
+        event: { topics: ['0x2', '0x1'], emitters: null },
       }),
     ).toEqual('7b0e365a57ff')
+  })
+
+  it('emitters are part of the identity', () => {
+    const base = {
+      type: 'ethereum' as const,
+      daLayer: 'ethereum',
+      inbox: '0x8c0Bfc04AdA21fd496c55B8C50331f904306F564',
+    }
+    expect(
+      createDaTrackingId({
+        ...base,
+        event: { topics: ['0x1'], emitters: ['0xa'] },
+      }),
+    ).not.toEqual(
+      createDaTrackingId({
+        ...base,
+        event: { topics: ['0x1'], emitters: null },
+      }),
+    )
+  })
+
+  it('does not collide topic-only and emitter-bearing configs with the same strings', () => {
+    const base = {
+      type: 'ethereum' as const,
+      daLayer: 'ethereum',
+      inbox: '0x8c0Bfc04AdA21fd496c55B8C50331f904306F564',
+    }
+    expect(
+      createDaTrackingId({
+        ...base,
+        event: { topics: ['0x1', '0x2'], emitters: null },
+      }),
+    ).not.toEqual(
+      createDaTrackingId({
+        ...base,
+        event: { topics: ['0x1'], emitters: ['0x2'] },
+      }),
+    )
   })
 
   it('matches the pinned id for a celestia config', () => {

--- a/packages/shared/src/tools/createDaTrackingId.ts
+++ b/packages/shared/src/tools/createDaTrackingId.ts
@@ -6,7 +6,10 @@ export type DaTrackingIdInput =
       daLayer: string
       inbox: string
       sequencers?: string[]
-      topics?: string[]
+      event?: {
+        topics: string[]
+        emitters: string[] | null
+      }
     }
   | {
       type: 'celestia'
@@ -45,8 +48,20 @@ export function createDaTrackingId(config: DaTrackingIdInput): string {
       if (config.sequencers) {
         input.push(...[...config.sequencers].sort((a, b) => a.localeCompare(b)))
       }
-      if (config.topics) {
-        input.push(...[...config.topics].sort((a, b) => a.localeCompare(b)))
+      if (config.event) {
+        input.push(
+          ...[...config.event.topics].sort((a, b) => a.localeCompare(b)),
+        )
+        if (config.event.emitters !== null) {
+          // Marker keeps {topics: [A, B], emitters: null} and
+          // {topics: [A], emitters: [B]} from hashing identically. It sits
+          // inside the null check so topic-only configs keep their pre-event
+          // hash input and are not re-keyed.
+          input.push('emitters')
+          input.push(
+            ...[...config.event.emitters].sort((a, b) => a.localeCompare(b)),
+          )
+        }
       }
       break
     case 'celestia':


### PR DESCRIPTION
## Overview

Supersedes the storage layer of #12398 (credit to @vilcht for the config/matching design, carried over here) with a transaction-level blob cache.

Two changes in one coherent step:

1. **Emitter filtering for Ethereum DA tracking.** `EthereumDaTrackingConfig.topics` becomes `event: { topics, emitters | null }`. Matching with emitters requires the topic and the emitter to come from the **same log**, so a wrong-emitter event and a right-topic event in the same tx no longer combine into a false positive. Aztec pins `CheckpointProposed` to the v5 Rollup address; Taiko migrates to the new shape with `emitters: null` (hash-stable, see below).
2. **`Blob` table → `TxWithBlobs`.** Every column of the old table except the id was transaction-level, so it stored identical tx metadata once per blob (~2.5–3× rows). The new table stores one row per blob-carrying tx with `blobCount`, `txHash`, and per-log `logs` JSONB. `size` is dropped (recomputed as `blobCount × 131072` on read). Cuts current table size ~67% and future growth ~85% vs the per-blob shape; growth now tracks blob **txs**, not blob count, so higher blob targets barely move it.

`DaService` needed zero changes: the tx-level `EthereumBlob` carries `size = blobCount × ETHEREUM_BLOB_SIZE_BYTES` and `generateRecords` only ever consumes `blob.size`. The notifier query flips from `count(*)` to `sum(blobCount)` — byte-identical semantics.

## Migration (ops notes)

Single-transaction migration with **lock-first ordering**: `LOCK TABLE "Blob" IN EXCLUSIVE MODE` is taken *before* the backfill `GROUP BY` snapshot, so old-code inserts either land before the copy (included) or block and fail unpersisted — `blob_indexer`'s safe height freezes and its infinite retry resumes cleanly on the new code. No silent write-gap, no manual runbook. A `DO`-block invariant (`count(Blob) == sum(blobCount)`) aborts the whole migration on any mismatch.

- Backfill of ~25M rows takes minutes; ethereum `BlobIndexer` writes stall during it (reads keep working). **Deploy promptly after migrating.**
- Backfilled rows have `txHash`/`logs` NULL (legacy); a retained nullable `topics` column serves topic-matching for them. New writes leave `topics` NULL and derive it from `logs`.
- New `(daLayer, timestamp)` index serves the daily notifier query, which previously seq-scanned.

## Expected behavior after deploy

- **Aztec resyncs** from the v5 activation block (config identity changed — the one-line `daTracking` snapshot diff is the explicit sign-off for the wipe). Over the pre-migration range, cached rows have no logs, so the emitter config triggers whole-batch provider refetches — expect elevated RPC/beacon usage until the resync passes the deploy block, then back to cache speed.
- **Taiko's configuration id is byte-identical** to main (`a250938b2846`) — pinned in `createDaTrackingId.test.ts` and the snapshot. No resync.
- `createDaTrackingId` gains an `'emitters'` marker in the hash input (inside the non-null branch only) so `{topics: [A, B], emitters: null}` and `{topics: [A], emitters: [B]}` cannot collide.

## Verification

- 26,568 tests passing across shared / database / backend / config / frontend.
- Migration exercised end-to-end on a local Postgres with seeded per-blob rows (multi-blob txs collapse to correct `blobCount`s, invariant holds, old table dropped) and on a from-scratch migration chain.
- New targeted tests: steady-state no-refetch (emitter config + logged cache rows ⇒ provider not called), legacy-fallback refetch, `sum(blobCount)` semantics, multi-blob-tx size aggregation, same-log matching, hash identity pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)