### PR TITLE
Add STRK20 privacy pool stats & TVS

### DIFF
--- a/packages/backend/src/config/features/privacy.test.ts
+++ b/packages/backend/src/config/features/privacy.test.ts
@@ -8,12 +8,21 @@ const ps = new ProjectService()
 const env = new Env({})
 
 describe(getPrivacyConfig.name, () => {
-  it('returns false if enabled privacy projects have no tracked buckets', async () => {
+  it('creates Starknet flow configs for STRK-20', async () => {
     const flags = new FeatureFlags('privacy,!privacy.*,privacy.strk20')
 
     const config = await getPrivacyConfig(ps, env, flags)
 
-    expect(config).toEqual(false)
+    expect(config === false).toEqual(false)
+    if (config === false) return
+
+    expect(config.flowConfigs).toEqual([])
+    expect(config.starknetFlowConfigs.map((x) => x.extractor)).toEqual([
+      'strk20Deposit',
+      'strk20Withdrawal',
+      'strk20Deposit',
+      'strk20Withdrawal',
+    ])
   })
 
   describe('price is tracked no later than flows', () => {

--- a/packages/backend/src/config/features/privacy.test.ts
+++ b/packages/backend/src/config/features/privacy.test.ts
@@ -17,11 +17,19 @@ describe(getPrivacyConfig.name, () => {
     if (config === false) return
 
     expect(config.flowConfigs).toEqual([])
-    expect(config.starknetFlowConfigs.map((x) => x.extractor)).toEqual([
-      'strk20Deposit',
-      'strk20Withdrawal',
-      'strk20Deposit',
-      'strk20Withdrawal',
+    expect(
+      config.starknetFlowConfigs.map((x) => [x.bucketId, x.direction]),
+    ).toEqual([
+      ['strk20-STRK', 'deposit'],
+      ['strk20-STRK', 'withdrawal'],
+      ['strk20-USDC', 'deposit'],
+      ['strk20-USDC', 'withdrawal'],
+      ['strk20-strkBTC', 'deposit'],
+      ['strk20-strkBTC', 'withdrawal'],
+      ['strk20-WBTC', 'deposit'],
+      ['strk20-WBTC', 'withdrawal'],
+      ['strk20-ETH', 'deposit'],
+      ['strk20-ETH', 'withdrawal'],
     ])
   })
 

--- a/packages/backend/src/config/features/privacy.test.ts
+++ b/packages/backend/src/config/features/privacy.test.ts
@@ -1,38 +1,10 @@
-import { Env } from '@l2beat/backend-tools'
 import { ProjectService } from '@l2beat/config'
 import { expect } from 'earl'
-import { FeatureFlags } from '../FeatureFlags'
 import { getPrivacyConfig } from './privacy'
 
 const ps = new ProjectService()
-const env = new Env({})
 
 describe(getPrivacyConfig.name, () => {
-  it('creates Starknet flow configs for STRK-20', async () => {
-    const flags = new FeatureFlags('privacy,!privacy.*,privacy.strk20')
-
-    const config = await getPrivacyConfig(ps, env, flags)
-
-    expect(config === false).toEqual(false)
-    if (config === false) return
-
-    expect(config.flowConfigs).toEqual([])
-    expect(
-      config.starknetFlowConfigs.map((x) => [x.bucketId, x.direction]),
-    ).toEqual([
-      ['strk20-STRK', 'deposit'],
-      ['strk20-STRK', 'withdrawal'],
-      ['strk20-USDC', 'deposit'],
-      ['strk20-USDC', 'withdrawal'],
-      ['strk20-strkBTC', 'deposit'],
-      ['strk20-strkBTC', 'withdrawal'],
-      ['strk20-WBTC', 'deposit'],
-      ['strk20-WBTC', 'withdrawal'],
-      ['strk20-ETH', 'deposit'],
-      ['strk20-ETH', 'withdrawal'],
-    ])
-  })
-
   describe('price is tracked no later than flows', () => {
     it('every privacy bucket starts at or after its token price', async () => {
       const projects = await ps.getProjects({ select: ['privacyInfo'] })

--- a/packages/backend/src/config/features/privacy.ts
+++ b/packages/backend/src/config/features/privacy.ts
@@ -1,19 +1,26 @@
 import type { Env } from '@l2beat/backend-tools'
 import type {
+  PrivacyBucketAddress,
   ProjectPrivacyBucket,
   ProjectPrivacyToken,
   ProjectService,
 } from '@l2beat/config'
-import { ChainSpecificAddress, type UnixTime } from '@l2beat/shared-pure'
+import {
+  ChainSpecificAddress,
+  EthereumAddress,
+  type UnixTime,
+} from '@l2beat/shared-pure'
 import { createHash } from 'crypto'
 import { PrivacyBlockTimestampIndexer } from '../../modules/privacy/indexers/PrivacyBlockTimestampIndexer'
 import { PrivacyFlowIndexer } from '../../modules/privacy/indexers/PrivacyFlowIndexer'
 import { PrivacyPriceIndexer } from '../../modules/privacy/indexers/PrivacyPriceIndexer'
+import { StarknetPrivacyFlowIndexer } from '../../modules/privacy/indexers/StarknetPrivacyFlowIndexer'
 import type {
   PrivacyBlockTimestampConfig,
   PrivacyConfig,
   PrivacyFlowIndexerConfig,
   PrivacyPriceIndexerConfig,
+  StarknetPrivacyFlowIndexerConfig,
 } from '../../modules/privacy/types'
 import type { FeatureFlags } from '../FeatureFlags'
 
@@ -43,10 +50,11 @@ export async function getPrivacyConfig(
   }
 
   const flowConfigs: PrivacyFlowIndexerConfig[] = []
+  const starknetFlowConfigs: StarknetPrivacyFlowIndexerConfig[] = []
   for (const project of projects) {
     for (const token of project.privacyInfo.tokens) {
       for (const bucket of token.buckets) {
-        flowConfigs.push(
+        const configs = [
           toFlowConfig(
             project.projectId,
             bucket,
@@ -61,7 +69,17 @@ export async function getPrivacyConfig(
             token.token,
             minTimestamp,
           ),
-        )
+        ]
+        for (const config of configs) {
+          if (
+            config.extractor === 'strk20Deposit' ||
+            config.extractor === 'strk20Withdrawal'
+          ) {
+            starknetFlowConfigs.push(config)
+          } else {
+            flowConfigs.push(config)
+          }
+        }
       }
     }
   }
@@ -92,12 +110,15 @@ export async function getPrivacyConfig(
     }
   })
 
-  const chains = Array.from(new Set(flowConfigs.map((config) => config.chain)))
+  const allFlowConfigs = [...flowConfigs, ...starknetFlowConfigs]
+  const chains = Array.from(
+    new Set(allFlowConfigs.map((config) => config.chain)),
+  )
 
   const blockTimestampConfigs: PrivacyBlockTimestampConfig[] = chains.map(
     (chain) => {
       const sinceTimestamp = Math.min(
-        ...flowConfigs
+        ...allFlowConfigs
           .filter((c) => c.chain === chain)
           .map((c) => c.sinceTimestamp),
       )
@@ -112,6 +133,7 @@ export async function getPrivacyConfig(
   return {
     projects,
     flowConfigs,
+    starknetFlowConfigs,
     priceConfigs,
     blockTimestampConfigs,
     chains,
@@ -128,21 +150,47 @@ function toFlowConfig(
   direction: 'deposit' | 'withdrawal',
   token: ProjectPrivacyToken['token'],
   minTimestamp: UnixTime,
-): PrivacyFlowIndexerConfig {
+): PrivacyFlowIndexerConfig | StarknetPrivacyFlowIndexerConfig {
   const source = bucket[direction]
+  const privacyAddress = getPrivacyBucketAddress(bucket.address)
   const base = {
     projectId,
     bucketId: bucket.id,
     direction,
-    chain: ChainSpecificAddress.longChain(bucket.address),
-    address: ChainSpecificAddress.address(bucket.address),
+    chain: privacyAddress.chain,
+    address: privacyAddress.address,
     sinceTimestamp: Math.max(bucket.sinceTimestamp, minTimestamp),
     priceId: token.priceId,
     decimals: token.decimals,
+  }
+  if (
+    source.extractor === 'strk20Deposit' ||
+    source.extractor === 'strk20Withdrawal'
+  ) {
+    const config = { ...base, ...source }
+    return {
+      id: StarknetPrivacyFlowIndexer.idToConfigurationId(config),
+      ...config,
+    }
+  }
+
+  const config = {
+    ...base,
+    address: EthereumAddress(privacyAddress.address),
     ...source,
   }
+  return { id: PrivacyFlowIndexer.idToConfigurationId(config), ...config }
+}
+
+function getPrivacyBucketAddress(address: PrivacyBucketAddress): {
+  chain: string
+  address: string
+} {
+  if (typeof address !== 'string') {
+    return address
+  }
   return {
-    id: PrivacyFlowIndexer.idToConfigurationId(base),
-    ...base,
+    chain: ChainSpecificAddress.longChain(address),
+    address: ChainSpecificAddress.address(address).toString(),
   }
 }

--- a/packages/backend/src/config/features/tvs.ts
+++ b/packages/backend/src/config/features/tvs.ts
@@ -74,6 +74,7 @@ export async function getTvsConfig(
           case 'balanceOfEscrow':
           case 'totalSupply':
           case 'starknetTotalSupply':
+          case 'starknetBalanceOf':
             return a.chain
           case 'const':
             return undefined

--- a/packages/backend/src/modules/privacy/PrivacyModule.ts
+++ b/packages/backend/src/modules/privacy/PrivacyModule.ts
@@ -6,7 +6,11 @@ import type { ApplicationModule, ModuleDependencies } from '../types'
 import { PrivacyBlockTimestampIndexer } from './indexers/PrivacyBlockTimestampIndexer'
 import { PrivacyFlowIndexer } from './indexers/PrivacyFlowIndexer'
 import { PrivacyPriceIndexer } from './indexers/PrivacyPriceIndexer'
-import type { PrivacyFlowIndexerConfig } from './types'
+import { StarknetPrivacyFlowIndexer } from './indexers/StarknetPrivacyFlowIndexer'
+import type {
+  PrivacyFlowIndexerConfig,
+  StarknetPrivacyFlowIndexerConfig,
+} from './types'
 
 export function createPrivacyModule({
   config,
@@ -49,12 +53,25 @@ export function createPrivacyModule({
     ])
   }
 
+  const starknetFlowConfigsByChain = new Map<
+    string,
+    StarknetPrivacyFlowIndexerConfig[]
+  >()
+  for (const flowConfig of config.privacy.starknetFlowConfigs) {
+    starknetFlowConfigsByChain.set(flowConfig.chain, [
+      ...(starknetFlowConfigsByChain.get(flowConfig.chain) ?? []),
+      flowConfig,
+    ])
+  }
+
   for (const blockTimestampConfig of config.privacy.blockTimestampConfigs) {
     const sinceTimestamp = UnixTime.toStartOf(
       blockTimestampConfig.sinceTimestamp,
       'hour',
     )
     const flowConfigs = flowConfigsByChain.get(blockTimestampConfig.chain) ?? []
+    const starknetFlowConfigs =
+      starknetFlowConfigsByChain.get(blockTimestampConfig.chain) ?? []
 
     const blockTimestampIndexer = new PrivacyBlockTimestampIndexer(
       {
@@ -74,34 +91,65 @@ export function createPrivacyModule({
       logger,
     )
 
-    const flowIndexer = new PrivacyFlowIndexer(
-      {
-        chain: blockTimestampConfig.chain,
-        parents: [priceIndexer, blockTimestampIndexer],
-        indexerService,
-        blockProvider: providers.block.getBlockProvider(
-          blockTimestampConfig.chain,
-        ),
-        logsProvider: providers.logs.getLogsProvider(
-          blockTimestampConfig.chain,
-        ),
-        configurations: flowConfigs.map((flowConfig) => ({
-          id: flowConfig.id,
-          minHeight: flowConfig.sinceTimestamp,
-          maxHeight: null,
-          properties: flowConfig,
-        })),
-        db,
-      },
-      logger,
-    )
+    indexers.push(blockTimestampIndexer)
 
-    indexers.push(blockTimestampIndexer, flowIndexer)
+    if (flowConfigs.length > 0) {
+      indexers.push(
+        new PrivacyFlowIndexer(
+          {
+            chain: blockTimestampConfig.chain,
+            parents: [priceIndexer, blockTimestampIndexer],
+            indexerService,
+            blockProvider: providers.block.getBlockProvider(
+              blockTimestampConfig.chain,
+            ),
+            logsProvider: providers.logs.getLogsProvider(
+              blockTimestampConfig.chain,
+            ),
+            configurations: flowConfigs.map((flowConfig) => ({
+              id: flowConfig.id,
+              minHeight: flowConfig.sinceTimestamp,
+              maxHeight: null,
+              properties: flowConfig,
+            })),
+            db,
+          },
+          logger,
+        ),
+      )
+    }
+
+    if (starknetFlowConfigs.length > 0) {
+      indexers.push(
+        new StarknetPrivacyFlowIndexer(
+          {
+            chain: blockTimestampConfig.chain,
+            parents: [priceIndexer, blockTimestampIndexer],
+            indexerService,
+            blockProvider: providers.block.getBlockProvider(
+              blockTimestampConfig.chain,
+            ),
+            starknetClient: providers.clients.getStarknetClient(
+              blockTimestampConfig.chain,
+            ),
+            configurations: starknetFlowConfigs.map((flowConfig) => ({
+              id: flowConfig.id,
+              minHeight: flowConfig.sinceTimestamp,
+              maxHeight: null,
+              properties: flowConfig,
+            })),
+            db,
+          },
+          logger,
+        ),
+      )
+    }
   }
 
   logger.info('Privacy config loaded', {
     projects: config.privacy.projects.length,
     flowConfigs: config.privacy.flowConfigs.length,
+    starknetFlowConfigs: config.privacy.starknetFlowConfigs.length,
     priceConfigs: config.privacy.priceConfigs.length,
     chains: config.privacy.chains.length,
   })

--- a/packages/backend/src/modules/privacy/indexers/StarknetPrivacyFlowIndexer.test.ts
+++ b/packages/backend/src/modules/privacy/indexers/StarknetPrivacyFlowIndexer.test.ts
@@ -14,7 +14,7 @@ import type { StarknetPrivacyFlowIndexerConfig } from '../types'
 import { StarknetPrivacyFlowIndexer } from './StarknetPrivacyFlowIndexer'
 
 const POOL = '0xpool'
-const TOKEN = '0xtoken'
+const TOKEN = '0x0123'
 const DEPOSIT = '0xdeposit'
 const WITHDRAWAL = '0xwithdrawal'
 
@@ -45,21 +45,21 @@ describe(StarknetPrivacyFlowIndexer.name, () => {
             block_number: 100,
             transaction_hash: '0xdeposit-tx',
             event_index: 0,
-            keys: [DEPOSIT, '0xuser', TOKEN],
+            keys: [DEPOSIT, '0xuser', '0x123'],
             data: ['0x2625a00'],
           }),
           event({
             block_number: 101,
             transaction_hash: '0xwithdrawal-tx',
             event_index: 1,
-            keys: [WITHDRAWAL, '0xrecipient', TOKEN],
+            keys: [WITHDRAWAL, '0xrecipient', '0x123'],
             data: ['0xencrypted1', '0xencrypted2', '0xencrypted3', '0xf4240'],
           }),
           event({
             block_number: 102,
             transaction_hash: '0xother-token-tx',
             event_index: 0,
-            keys: [DEPOSIT, '0xuser', '0xother-token'],
+            keys: [DEPOSIT, '0xuser', '0x456'],
             data: ['0xf4240'],
           }),
         ]),

--- a/packages/backend/src/modules/privacy/indexers/StarknetPrivacyFlowIndexer.test.ts
+++ b/packages/backend/src/modules/privacy/indexers/StarknetPrivacyFlowIndexer.test.ts
@@ -1,0 +1,187 @@
+import { Logger } from '@l2beat/backend-tools'
+import type { Database } from '@l2beat/database'
+import type {
+  BlockProvider,
+  StarknetClient,
+  StarknetEvent,
+} from '@l2beat/shared'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import { mockDatabase } from '../../../test/database'
+import type { IndexerService } from '../../../tools/uif/IndexerService'
+import type { Configuration } from '../../../tools/uif/multi/types'
+import type { StarknetPrivacyFlowIndexerConfig } from '../types'
+import { StarknetPrivacyFlowIndexer } from './StarknetPrivacyFlowIndexer'
+
+const POOL = '0xpool'
+const TOKEN = '0xtoken'
+const DEPOSIT = '0xdeposit'
+const WITHDRAWAL = '0xwithdrawal'
+
+describe(StarknetPrivacyFlowIndexer.name, () => {
+  describe(StarknetPrivacyFlowIndexer.prototype.multiUpdate.name, () => {
+    it('fetches Starknet events, extracts flows, and saves valued records', async () => {
+      const from = UnixTime.toStartOf(UnixTime(0), 'day')
+      const to = from + UnixTime.HOUR
+      const timestamp = from + UnixTime.HOUR
+      const configurations = [
+        config({
+          id: 'deposit-config',
+          direction: 'deposit',
+          event: DEPOSIT,
+          extractor: 'strk20Deposit',
+        }),
+        config({
+          id: 'withdrawal-config',
+          direction: 'withdrawal',
+          event: WITHDRAWAL,
+          extractor: 'strk20Withdrawal',
+        }),
+      ]
+
+      const starknetClient = mockObject<StarknetClient>({
+        getEvents: mockFn().returnsOnce([
+          event({
+            block_number: 100,
+            transaction_hash: '0xdeposit-tx',
+            event_index: 0,
+            keys: [DEPOSIT, '0xuser', TOKEN],
+            data: ['0x2625a00'],
+          }),
+          event({
+            block_number: 101,
+            transaction_hash: '0xwithdrawal-tx',
+            event_index: 1,
+            keys: [WITHDRAWAL, '0xrecipient', TOKEN],
+            data: ['0xencrypted1', '0xencrypted2', '0xencrypted3', '0xf4240'],
+          }),
+          event({
+            block_number: 102,
+            transaction_hash: '0xother-token-tx',
+            event_index: 0,
+            keys: [DEPOSIT, '0xuser', '0xother-token'],
+            data: ['0xf4240'],
+          }),
+        ]),
+      })
+      const blockProvider = mockObject<BlockProvider>({
+        getBlockTimestamps: mockFn().returnsOnce(
+          new Map([
+            [100, timestamp],
+            [101, timestamp],
+            [102, timestamp],
+          ]),
+        ),
+      })
+      const privacyBlockTimestampRepo = mockObject<
+        Database['privacyBlockTimestamp']
+      >({
+        findBlockNumberByChainAndTimestamp: mockFn()
+          .returnsOnce(50)
+          .returnsOnce(150),
+      })
+      const privacyPriceRepo = mockObject<Database['privacyPrice']>({
+        getPricesByPriceIdsInRange: mockFn().returnsOnce([
+          {
+            priceId: 'usd-coin',
+            timestamp: UnixTime.toStartOf(timestamp, 'hour'),
+            priceUsd: 1.01,
+            configurationId: 'price-config',
+          },
+        ]),
+      })
+      const privacyFlowEventRepo = mockObject<Database['privacyFlowEvent']>({
+        upsertMany: mockFn().returnsOnce(undefined),
+      })
+
+      const indexer = new StarknetPrivacyFlowIndexer(
+        {
+          chain: 'starknet',
+          configurations,
+          blockProvider,
+          starknetClient,
+          db: mockDatabase({
+            privacyBlockTimestamp: privacyBlockTimestampRepo,
+            privacyPrice: privacyPriceRepo,
+            privacyFlowEvent: privacyFlowEventRepo,
+          }),
+          parents: [],
+          indexerService: mockObject<IndexerService>({}),
+        },
+        Logger.SILENT,
+      )
+
+      const update = await indexer.multiUpdate(from, to, configurations)
+      const safeHeight = await update()
+
+      expect(starknetClient.getEvents).toHaveBeenOnlyCalledWith(50, 150, POOL, [
+        DEPOSIT,
+        WITHDRAWAL,
+      ])
+      expect(blockProvider.getBlockTimestamps).toHaveBeenOnlyCalledWith([
+        100, 101, 102,
+      ])
+      expect(privacyFlowEventRepo.upsertMany).toHaveBeenOnlyCalledWith([
+        {
+          configurationId: 'deposit-config',
+          projectId: 'strk20',
+          bucketId: 'strk20-USDC',
+          chain: 'starknet',
+          direction: 'deposit',
+          timestamp,
+          blockNumber: 100,
+          txHash: '0xdeposit-tx',
+          logIndex: 0,
+          count: 1,
+          amount: 40_000_000n,
+          priceId: 'usd-coin',
+          valueUsd: 40.4,
+        },
+        {
+          configurationId: 'withdrawal-config',
+          projectId: 'strk20',
+          bucketId: 'strk20-USDC',
+          chain: 'starknet',
+          direction: 'withdrawal',
+          timestamp,
+          blockNumber: 101,
+          txHash: '0xwithdrawal-tx',
+          logIndex: 1,
+          count: 1,
+          amount: 1_000_000n,
+          priceId: 'usd-coin',
+          valueUsd: 1.01,
+        },
+      ])
+      expect(safeHeight).toEqual(to)
+    })
+  })
+})
+
+function config(
+  properties: Pick<
+    StarknetPrivacyFlowIndexerConfig,
+    'id' | 'direction' | 'event' | 'extractor'
+  >,
+): Configuration<StarknetPrivacyFlowIndexerConfig> {
+  return {
+    id: properties.id,
+    minHeight: UnixTime(0),
+    maxHeight: null,
+    properties: {
+      ...properties,
+      projectId: 'strk20',
+      bucketId: 'strk20-USDC',
+      chain: 'starknet',
+      address: POOL,
+      sinceTimestamp: UnixTime(0),
+      priceId: 'usd-coin',
+      decimals: 6,
+      params: { tokenAddress: TOKEN },
+    },
+  }
+}
+
+function event(event: StarknetEvent): StarknetEvent {
+  return event
+}

--- a/packages/backend/src/modules/privacy/indexers/StarknetPrivacyFlowIndexer.ts
+++ b/packages/backend/src/modules/privacy/indexers/StarknetPrivacyFlowIndexer.ts
@@ -1,0 +1,247 @@
+import type { Logger } from '@l2beat/backend-tools'
+import type { Database, PrivacyFlowEventRecord } from '@l2beat/database'
+import type { BlockProvider, StarknetClient } from '@l2beat/shared'
+import { assert, UnixTime } from '@l2beat/shared-pure'
+import { Indexer } from '@l2beat/uif'
+import { createPrivacyConfigurationId } from '../../../config/features/privacy'
+import { INDEXER_NAMES } from '../../../tools/uif/indexerIdentity'
+import { ManagedMultiIndexer } from '../../../tools/uif/multi/ManagedMultiIndexer'
+import type {
+  Configuration,
+  ManagedMultiIndexerOptions,
+  TrimRemovalConfiguration,
+  WipeRemovalConfiguration,
+} from '../../../tools/uif/multi/types'
+import type {
+  StarknetPrivacyEvent,
+  StarknetPrivacyFlowIndexerConfig,
+} from '../types'
+import { extractStarknetPrivacyFlow } from '../utils/extractStarknetPrivacyFlow'
+
+interface StarknetPrivacyFlowIndexerDeps
+  extends Omit<
+    ManagedMultiIndexerOptions<StarknetPrivacyFlowIndexerConfig>,
+    'name' | 'logger'
+  > {
+  chain: string
+  blockProvider: BlockProvider
+  starknetClient: StarknetClient
+  db: Database
+}
+
+export class StarknetPrivacyFlowIndexer extends ManagedMultiIndexer<StarknetPrivacyFlowIndexerConfig> {
+  constructor(
+    private readonly $: StarknetPrivacyFlowIndexerDeps,
+    logger: Logger,
+  ) {
+    super(
+      {
+        ...$,
+        name: INDEXER_NAMES.PRIVACY_STARKNET_FLOW,
+        tags: { tag: $.chain, chain: $.chain },
+        updateRetryStrategy: Indexer.getInfiniteRetryStrategy(),
+      },
+      logger,
+    )
+  }
+
+  override async multiUpdate(
+    from: number,
+    to: number,
+    configurations: Configuration<StarknetPrivacyFlowIndexerConfig>[],
+  ) {
+    const adjustedTo = Math.min(UnixTime.toNext(from, 'day'), to)
+    const records = await this.fetchRecords(configurations, from, adjustedTo)
+
+    return async () => {
+      await this.$.db.privacyFlowEvent.upsertMany(records)
+      this.logger.info('Saved Starknet privacy flow events', {
+        from,
+        to: adjustedTo,
+        records: records.length,
+      })
+      return adjustedTo
+    }
+  }
+
+  override async wipeData(configurations: WipeRemovalConfiguration[]) {
+    await this.$.db.privacyFlowEvent.deleteByConfigIds(
+      configurations.map((c) => c.id),
+    )
+  }
+
+  override async trimData(configurations: TrimRemovalConfiguration[]) {
+    for (const configuration of configurations) {
+      await this.$.db.privacyFlowEvent.deleteByConfigInTimeRange(
+        configuration.id,
+        configuration.range[0],
+        configuration.range[1],
+      )
+    }
+  }
+
+  private async fetchRecords(
+    configurations: Configuration<StarknetPrivacyFlowIndexerConfig>[],
+    from: number,
+    to: number,
+  ): Promise<PrivacyFlowEventRecord[]> {
+    if (configurations.length === 0) return []
+
+    const [blockFrom, blockTo] = await Promise.all([
+      this.$.db.privacyBlockTimestamp.findBlockNumberByChainAndTimestamp(
+        this.$.chain,
+        UnixTime.toStartOf(from, 'hour'),
+      ),
+      this.$.db.privacyBlockTimestamp.findBlockNumberByChainAndTimestamp(
+        this.$.chain,
+        UnixTime.toEndOf(to, 'hour'),
+      ),
+    ])
+    assert(blockFrom !== undefined, `Missing block mapping: from=${from}`)
+    assert(blockTo !== undefined, `Missing block mapping: to=${to}`)
+
+    const events = await this.fetchEvents(configurations, blockFrom, blockTo)
+    if (events.length === 0) return []
+
+    const configMap = new Map<
+      string,
+      Configuration<StarknetPrivacyFlowIndexerConfig>[]
+    >()
+    for (const configuration of configurations) {
+      const key = configKey(
+        configuration.properties.address,
+        configuration.properties.event,
+      )
+      configMap.set(key, [...(configMap.get(key) ?? []), configuration])
+    }
+
+    const timestamps = await this.$.blockProvider.getBlockTimestamps(
+      Array.from(new Set(events.map((event) => event.blockNumber))),
+    )
+    const rawRecords = events.flatMap((event) => {
+      const matching =
+        configMap.get(configKey(event.address, event.keys[0] ?? '')) ?? []
+      const timestamp = timestamps.get(event.blockNumber)
+      assert(timestamp, `Missing block timestamp for ${event.blockNumber}`)
+      return matching.flatMap((configuration) => {
+        const extracted = extractStarknetPrivacyFlow(
+          configuration.properties,
+          event,
+        )
+        return extracted
+          ? [{ configuration, event, timestamp, ...extracted }]
+          : []
+      })
+    })
+
+    if (rawRecords.length === 0) return []
+
+    const priceIds = Array.from(
+      new Set(
+        rawRecords.map((record) => record.configuration.properties.priceId),
+      ),
+    )
+    const minTimestamp = UnixTime.toStartOf(
+      Math.min(...rawRecords.map((record) => record.timestamp)),
+      'hour',
+    )
+    const maxTimestamp = UnixTime.toStartOf(
+      Math.max(...rawRecords.map((record) => record.timestamp)),
+      'hour',
+    )
+    const prices = await this.$.db.privacyPrice.getPricesByPriceIdsInRange(
+      priceIds,
+      minTimestamp,
+      maxTimestamp,
+    )
+    const priceLookup = new Map(
+      prices.map((price) => [
+        `${price.priceId}:${price.timestamp}`,
+        price.priceUsd,
+      ]),
+    )
+
+    return rawRecords.map((record) => {
+      const config = record.configuration.properties
+      const hourTimestamp = UnixTime.toStartOf(record.timestamp, 'hour')
+      const price = priceLookup.get(`${config.priceId}:${hourTimestamp}`)
+      assert(price !== undefined, `Missing price for ${config.priceId}`)
+      return {
+        configurationId: record.configuration.id,
+        projectId: config.projectId,
+        bucketId: config.bucketId,
+        chain: config.chain,
+        direction: config.direction,
+        timestamp: record.timestamp,
+        blockNumber: record.event.blockNumber,
+        txHash: record.event.transactionHash,
+        logIndex: record.event.eventIndex,
+        count: record.count,
+        amount: record.amount,
+        priceId: config.priceId,
+        valueUsd: bigintToFloat(record.amount, config.decimals) * price,
+      }
+    })
+  }
+
+  private async fetchEvents(
+    configurations: Configuration<StarknetPrivacyFlowIndexerConfig>[],
+    blockFrom: number,
+    blockTo: number,
+  ): Promise<StarknetPrivacyEvent[]> {
+    const selectorsByAddress = new Map<string, Set<string>>()
+    for (const configuration of configurations) {
+      const address = configuration.properties.address
+      const selectors = selectorsByAddress.get(address) ?? new Set<string>()
+      selectors.add(configuration.properties.event)
+      selectorsByAddress.set(address, selectors)
+    }
+
+    const events = await Promise.all(
+      Array.from(selectorsByAddress.entries()).map(
+        async ([address, selectors]) => {
+          const result = await this.$.starknetClient.getEvents(
+            blockFrom,
+            blockTo,
+            address,
+            Array.from(selectors),
+          )
+          return result.map((event) => ({
+            address,
+            blockNumber: event.block_number,
+            transactionHash: event.transaction_hash,
+            eventIndex: event.event_index,
+            keys: event.keys,
+            data: event.data,
+          }))
+        },
+      ),
+    )
+    return events.flat()
+  }
+
+  static idToConfigurationId(
+    config: Omit<StarknetPrivacyFlowIndexerConfig, 'id'>,
+  ): string {
+    return createPrivacyConfigurationId([
+      'privacy-starknet-flow',
+      config.projectId,
+      config.bucketId,
+      config.direction,
+      config.chain,
+      config.address,
+      config.event,
+      config.extractor,
+      config.params.tokenAddress,
+    ])
+  }
+}
+
+function configKey(address: string, event: string): string {
+  return `${address.toLowerCase()}:${event.toLowerCase()}`
+}
+
+function bigintToFloat(amount: bigint, decimals: number): number {
+  const divisor = 10n ** BigInt(decimals)
+  return Number(amount / divisor) + Number(amount % divisor) / Number(divisor)
+}

--- a/packages/backend/src/modules/privacy/types.ts
+++ b/packages/backend/src/modules/privacy/types.ts
@@ -12,6 +12,7 @@ export interface PrivacyProjectConfig {
 export interface PrivacyConfig {
   projects: PrivacyProjectConfig[]
   flowConfigs: PrivacyFlowIndexerConfig[]
+  starknetFlowConfigs: StarknetPrivacyFlowIndexerConfig[]
   priceConfigs: PrivacyPriceIndexerConfig[]
   blockTimestampConfigs: PrivacyBlockTimestampConfig[]
   chains: string[]
@@ -28,7 +29,35 @@ export type PrivacyFlowIndexerConfig = {
   sinceTimestamp: UnixTime
   priceId: string
   decimals: number
-} & PrivacyFlowExtractorConfig
+} & Exclude<
+  PrivacyFlowExtractorConfig,
+  { extractor: 'strk20Deposit' | 'strk20Withdrawal' }
+>
+
+export type StarknetPrivacyFlowIndexerConfig = {
+  id: string
+  projectId: string
+  bucketId: string
+  direction: 'deposit' | 'withdrawal'
+  chain: string
+  address: string
+  event: string
+  sinceTimestamp: UnixTime
+  priceId: string
+  decimals: number
+} & Extract<
+  PrivacyFlowExtractorConfig,
+  { extractor: 'strk20Deposit' | 'strk20Withdrawal' }
+>
+
+export interface StarknetPrivacyEvent {
+  address: string
+  blockNumber: number
+  transactionHash: string
+  eventIndex: number
+  keys: string[]
+  data: string[]
+}
 
 export interface PrivacyBlockTimestampConfig {
   id: string

--- a/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.test.ts
+++ b/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.test.ts
@@ -8,10 +8,10 @@ import { extractStarknetPrivacyFlow } from './extractStarknetPrivacyFlow'
 const TOKEN = '0x123'
 
 describe(extractStarknetPrivacyFlow.name, () => {
-  it('extracts a STRK-20 deposit amount for the configured token', () => {
+  it('extracts a deposit when the RPC omits leading zeroes from the token address', () => {
     const result = extractStarknetPrivacyFlow(
       config('strk20Deposit'),
-      event(['0xdeposit', '0xuser', TOKEN], ['0x1234']),
+      event(['0xdeposit', '0xuser', '0x0123'], ['0x1234']),
     )
 
     expect(result).toEqual({ count: 1, amount: 0x1234n })

--- a/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.test.ts
+++ b/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.test.ts
@@ -1,0 +1,70 @@
+import { expect } from 'earl'
+import type {
+  StarknetPrivacyEvent,
+  StarknetPrivacyFlowIndexerConfig,
+} from '../types'
+import { extractStarknetPrivacyFlow } from './extractStarknetPrivacyFlow'
+
+const TOKEN = '0x123'
+
+describe(extractStarknetPrivacyFlow.name, () => {
+  it('extracts a STRK-20 deposit amount for the configured token', () => {
+    const result = extractStarknetPrivacyFlow(
+      config('strk20Deposit'),
+      event(['0xdeposit', '0xuser', TOKEN], ['0x1234']),
+    )
+
+    expect(result).toEqual({ count: 1, amount: 0x1234n })
+  })
+
+  it('extracts a STRK-20 withdrawal amount after encrypted user data', () => {
+    const result = extractStarknetPrivacyFlow(
+      config('strk20Withdrawal'),
+      event(
+        ['0xwithdrawal', '0xrecipient', TOKEN],
+        ['0xencrypted1', '0xencrypted2', '0xencrypted3', '0x4567'],
+      ),
+    )
+
+    expect(result).toEqual({ count: 1, amount: 0x4567n })
+  })
+
+  it('ignores events for another token', () => {
+    const result = extractStarknetPrivacyFlow(
+      config('strk20Deposit'),
+      event(['0xdeposit', '0xuser', '0x456'], ['0x1234']),
+    )
+
+    expect(result).toEqual(undefined)
+  })
+})
+
+function config(
+  extractor: 'strk20Deposit' | 'strk20Withdrawal',
+): StarknetPrivacyFlowIndexerConfig {
+  return {
+    id: 'id',
+    projectId: 'strk20',
+    bucketId: 'bucket',
+    direction: extractor === 'strk20Deposit' ? 'deposit' : 'withdrawal',
+    chain: 'starknet',
+    address: '0xpool',
+    event: '0xevent',
+    sinceTimestamp: 0,
+    priceId: 'starknet',
+    decimals: 18,
+    extractor,
+    params: { tokenAddress: TOKEN },
+  }
+}
+
+function event(keys: string[], data: string[]): StarknetPrivacyEvent {
+  return {
+    address: '0xpool',
+    blockNumber: 100,
+    transactionHash: '0xtx',
+    eventIndex: 0,
+    keys,
+    data,
+  }
+}

--- a/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.ts
+++ b/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.ts
@@ -1,0 +1,26 @@
+import { assert } from '@l2beat/shared-pure'
+import type {
+  PrivacyFlowExtractResult,
+  StarknetPrivacyEvent,
+  StarknetPrivacyFlowIndexerConfig,
+} from '../types'
+
+export function extractStarknetPrivacyFlow(
+  source: StarknetPrivacyFlowIndexerConfig,
+  event: StarknetPrivacyEvent,
+): PrivacyFlowExtractResult | undefined {
+  if (
+    event.keys[2]?.toLowerCase() !== source.params.tokenAddress.toLowerCase()
+  ) {
+    return undefined
+  }
+
+  switch (source.extractor) {
+    case 'strk20Deposit':
+      assert(event.data.length === 1, 'Invalid STRK-20 deposit event')
+      return { count: 1, amount: BigInt(event.data[0]) }
+    case 'strk20Withdrawal':
+      assert(event.data.length === 4, 'Invalid STRK-20 withdrawal event')
+      return { count: 1, amount: BigInt(event.data[3]) }
+  }
+}

--- a/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.ts
+++ b/packages/backend/src/modules/privacy/utils/extractStarknetPrivacyFlow.ts
@@ -9,8 +9,10 @@ export function extractStarknetPrivacyFlow(
   source: StarknetPrivacyFlowIndexerConfig,
   event: StarknetPrivacyEvent,
 ): PrivacyFlowExtractResult | undefined {
+  const tokenAddress = event.keys[2]
   if (
-    event.keys[2]?.toLowerCase() !== source.params.tokenAddress.toLowerCase()
+    tokenAddress === undefined ||
+    BigInt(tokenAddress) !== BigInt(source.params.tokenAddress)
   ) {
     return undefined
   }

--- a/packages/backend/src/modules/tvs/TvsModule.ts
+++ b/packages/backend/src/modules/tvs/TvsModule.ts
@@ -157,6 +157,7 @@ export function initTvsModule({
         chain: chain,
         totalSupplyProvider: providers.totalSupply,
         starknetTotalSupplyProvider: providers.starknetTotalSupply,
+        starknetBalanceProvider: providers.starknetBalance,
         balanceProvider: providers.balance,
         parents: [blockTimestampIndexer],
         indexerService,

--- a/packages/backend/src/modules/tvs/indexers/OnchainAmountIndexer.test.ts
+++ b/packages/backend/src/modules/tvs/indexers/OnchainAmountIndexer.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@l2beat/backend-tools'
 import type { Database, TvsAmountRecord } from '@l2beat/database'
 import type {
   BalanceProvider,
+  StarknetBalanceProvider,
   StarknetTotalSupplyProvider,
   TotalSupplyProvider,
 } from '@l2beat/shared'
@@ -61,6 +62,10 @@ describe(OnchainAmountIndexer.name, () => {
           getTotalSupplies: mockFn(),
         })
 
+      const starknetBalanceProvider = mockObject<StarknetBalanceProvider>({
+        getBalances: mockFn(),
+      })
+
       const tvsAmountRepository = mockObject<Database['tvsAmount']>({
         upsertMany: mockFn().returnsOnce(undefined),
       })
@@ -72,6 +77,7 @@ describe(OnchainAmountIndexer.name, () => {
           balanceProvider,
           totalSupplyProvider,
           starknetTotalSupplyProvider,
+          starknetBalanceProvider,
           db: mockDatabase({
             tvsAmount: tvsAmountRepository,
             tvsBlockTimestamp: tvsBlockTimestampRepository,
@@ -110,6 +116,7 @@ describe(OnchainAmountIndexer.name, () => {
       expect(
         starknetTotalSupplyProvider.getTotalSupplies,
       ).not.toHaveBeenCalled()
+      expect(starknetBalanceProvider.getBalances).not.toHaveBeenCalled()
 
       const expectedRecords: TvsAmountRecord[] = [
         record('escrow-config-1', timestamp, 1000),
@@ -132,6 +139,7 @@ describe(OnchainAmountIndexer.name, () => {
 
       const token1 = '0x1234'
       const token2 = '0x5678'
+      const holder = '0xabcd'
 
       const mockStarknetTotalSupplyConfig1 = starknetTotalSupply(
         'starknet-supply-config-1',
@@ -141,10 +149,16 @@ describe(OnchainAmountIndexer.name, () => {
         'starknet-supply-config-2',
         token2,
       )
+      const mockStarknetBalanceConfig = starknetBalanceOf(
+        'starknet-balance-config',
+        token1,
+        holder,
+      )
 
       const configs = [
         mockStarknetTotalSupplyConfig1,
         mockStarknetTotalSupplyConfig2,
+        mockStarknetBalanceConfig,
       ]
 
       const syncOptimizer = mockObject<SyncOptimizer>({
@@ -170,6 +184,10 @@ describe(OnchainAmountIndexer.name, () => {
           getTotalSupplies: mockFn().returnsOnce([BigInt(1000), BigInt(2000)]),
         })
 
+      const starknetBalanceProvider = mockObject<StarknetBalanceProvider>({
+        getBalances: mockFn().returnsOnce([BigInt(3000)]),
+      })
+
       const tvsAmountRepository = mockObject<Database['tvsAmount']>({
         upsertMany: mockFn().returnsOnce(undefined),
       })
@@ -181,6 +199,7 @@ describe(OnchainAmountIndexer.name, () => {
           balanceProvider,
           totalSupplyProvider,
           starknetTotalSupplyProvider,
+          starknetBalanceProvider,
           db: mockDatabase({
             tvsAmount: tvsAmountRepository,
             tvsBlockTimestamp: tvsBlockTimestampRepository,
@@ -208,10 +227,16 @@ describe(OnchainAmountIndexer.name, () => {
       expect(
         starknetTotalSupplyProvider.getTotalSupplies,
       ).toHaveBeenOnlyCalledWith([token1, token2], blockNumber, 'starknet')
+      expect(starknetBalanceProvider.getBalances).toHaveBeenOnlyCalledWith(
+        [{ token: token1, holder }],
+        blockNumber,
+        'starknet',
+      )
 
       const expectedRecords: TvsAmountRecord[] = [
         record('starknet-supply-config-1', timestamp, 1000),
         record('starknet-supply-config-2', timestamp, 2000),
+        record('starknet-balance-config', timestamp, 3000),
       ]
 
       expect(tvsAmountRepository.upsertMany).toHaveBeenOnlyCalledWith(
@@ -244,6 +269,7 @@ describe(OnchainAmountIndexer.name, () => {
           starknetTotalSupplyProvider: mockObject<StarknetTotalSupplyProvider>(
             {},
           ),
+          starknetBalanceProvider: mockObject<StarknetBalanceProvider>({}),
           db: mockDatabase({}),
           syncOptimizer,
           parents: [],
@@ -289,6 +315,7 @@ describe(OnchainAmountIndexer.name, () => {
           starknetTotalSupplyProvider: mockObject<StarknetTotalSupplyProvider>(
             {},
           ),
+          starknetBalanceProvider: mockObject<StarknetBalanceProvider>({}),
           db: mockDatabase({
             tvsBlockTimestamp: tvsBlockTimestampRepository,
           }),
@@ -331,6 +358,7 @@ describe(OnchainAmountIndexer.name, () => {
           starknetTotalSupplyProvider: mockObject<StarknetTotalSupplyProvider>(
             {},
           ),
+          starknetBalanceProvider: mockObject<StarknetBalanceProvider>({}),
           db: mockDatabase({ tvsAmount: tvsAmountRepository }),
           syncOptimizer: mockObject<SyncOptimizer>({}),
           parents: [],
@@ -417,6 +445,26 @@ function starknetTotalSupply(id: string, tokenAddress: string) {
     properties: {
       type: 'starknetTotalSupply' as const,
       address: tokenAddress,
+      sinceTimestamp: 0,
+      chain: 'chain',
+      decimals: 18,
+    },
+  }
+}
+
+function starknetBalanceOf(
+  id: string,
+  tokenAddress: string,
+  escrowAddress: string,
+) {
+  return {
+    id,
+    minHeight: 0,
+    maxHeight: null,
+    properties: {
+      type: 'starknetBalanceOf' as const,
+      address: tokenAddress,
+      escrowAddress,
       sinceTimestamp: 0,
       chain: 'chain',
       decimals: 18,

--- a/packages/backend/src/modules/tvs/indexers/OnchainAmountIndexer.ts
+++ b/packages/backend/src/modules/tvs/indexers/OnchainAmountIndexer.ts
@@ -1,11 +1,13 @@
 import type { Logger } from '@l2beat/backend-tools'
 import type {
   BalanceOfEscrowAmountFormula,
+  StarknetBalanceOfAmountFormula,
   StarknetTotalSupplyAmountFormula,
   TotalSupplyAmountFormula,
 } from '@l2beat/config'
 import type {
   BalanceProvider,
+  StarknetBalanceProvider,
   StarknetTotalSupplyProvider,
   TotalSupplyProvider,
 } from '@l2beat/shared'
@@ -26,6 +28,7 @@ export type OnchainAmountConfig =
   | BalanceOfEscrowAmountFormula
   | TotalSupplyAmountFormula
   | StarknetTotalSupplyAmountFormula
+  | StarknetBalanceOfAmountFormula
 
 interface OnchainAmountIndexerDeps
   extends Omit<
@@ -36,6 +39,7 @@ interface OnchainAmountIndexerDeps
   chain: string
   totalSupplyProvider: TotalSupplyProvider
   starknetTotalSupplyProvider: StarknetTotalSupplyProvider
+  starknetBalanceProvider: StarknetBalanceProvider
   balanceProvider: BalanceProvider
 }
 
@@ -98,10 +102,17 @@ export class OnchainAmountIndexer extends ManagedMultiIndexer<OnchainAmountConfi
             blockNumber,
           )
 
+        const starknetBalanceRecords = await this.fetchStarknetBalances(
+          configurations,
+          timestamp,
+          blockNumber,
+        )
+
         const amounts = [
           ...escrowBalanceRecords,
           ...totalSupplyRecords,
           ...starknetTotalSupplyRecords,
+          ...starknetBalanceRecords,
         ]
 
         return async () => {
@@ -231,6 +242,42 @@ export class OnchainAmountIndexer extends ManagedMultiIndexer<OnchainAmountConfi
     return totalSupplies.map((supply, i) => ({
       configurationId: tokens[i].id,
       amount: supply,
+      timestamp,
+    }))
+  }
+
+  private async fetchStarknetBalances(
+    configurations: Configuration<OnchainAmountConfig>[],
+    timestamp: number,
+    blockNumber: number,
+  ) {
+    const balances = configurations.filter(
+      (c) => c.properties.type === 'starknetBalanceOf',
+    ) as Configuration<StarknetBalanceOfAmountFormula>[]
+
+    if (balances.length === 0) {
+      return []
+    }
+
+    this.logger.info('Fetching starknet balances', {
+      blockNumber,
+      balances: balances.length,
+    })
+
+    const amounts = await this.$.starknetBalanceProvider.getBalances(
+      balances.map((balance) => ({
+        token: balance.properties.address,
+        holder: balance.properties.escrowAddress,
+      })),
+      blockNumber,
+      this.$.chain,
+    )
+
+    this.logger.info('Fetched starknet balances')
+
+    return amounts.map((amount, i) => ({
+      configurationId: balances[i].id,
+      amount,
       timestamp,
     }))
   }

--- a/packages/backend/src/modules/tvs/tools/DataFormulaExecutor.ts
+++ b/packages/backend/src/modules/tvs/tools/DataFormulaExecutor.ts
@@ -5,6 +5,7 @@ import type {
   BlockTimestampProvider,
   CirculatingSupplyProvider,
   PriceProvider,
+  StarknetBalanceProvider,
   StarknetTotalSupplyProvider,
   TotalSupplyProvider,
 } from '@l2beat/shared'
@@ -29,6 +30,7 @@ export class DataFormulaExecutor {
     private blockTimestampProvider: BlockTimestampProvider,
     private totalSupplyProvider: TotalSupplyProvider,
     private starknetTotalSupplyProvider: StarknetTotalSupplyProvider,
+    private starknetBalanceProvider: StarknetBalanceProvider,
     private balanceProvider: BalanceProvider,
     private logger: Logger,
   ) {}
@@ -285,6 +287,25 @@ export class DataFormulaExecutor {
                     block,
                     chain,
                   )
+                await this.localStorage.writeAmounts(
+                  timestamp,
+                  Array.from(values.values()).map((value, i) => ({
+                    id: configs[i].id,
+                    amount: value,
+                  })),
+                )
+                break
+              }
+              case 'starknetBalanceOf': {
+                assert(configs.every((c) => c.type === 'starknetBalanceOf'))
+                const values = await this.starknetBalanceProvider.getBalances(
+                  configs.map((c) => ({
+                    token: c.address,
+                    holder: c.escrowAddress,
+                  })),
+                  block,
+                  chain,
+                )
                 await this.localStorage.writeAmounts(
                   timestamp,
                   Array.from(values.values()).map((value, i) => ({

--- a/packages/backend/src/modules/tvs/tools/LocalExecutor.ts
+++ b/packages/backend/src/modules/tvs/tools/LocalExecutor.ts
@@ -16,6 +16,7 @@ import {
   PriceProvider,
   RpcClientCompat,
   StarknetClient,
+  StarknetBalanceProvider,
   StarknetTotalSupplyProvider,
   TotalSupplyProvider,
 } from '@l2beat/shared'
@@ -104,6 +105,10 @@ export class LocalExecutor {
       starknetClients,
       logger,
     )
+    const starknetBalanceProvider = new StarknetBalanceProvider(
+      starknetClients,
+      logger,
+    )
     const balanceProvider = new BalanceProvider(rpcs, logger)
 
     return new DataFormulaExecutor(
@@ -115,6 +120,7 @@ export class LocalExecutor {
       blockTimestampProvider,
       totalSupplyProvider,
       starknetTotalSupplyProvider,
+      starknetBalanceProvider,
       balanceProvider,
       this.logger,
     )

--- a/packages/backend/src/modules/tvs/tools/LocalExecutor.ts
+++ b/packages/backend/src/modules/tvs/tools/LocalExecutor.ts
@@ -15,8 +15,8 @@ import {
   MulticallV3Client,
   PriceProvider,
   RpcClientCompat,
-  StarknetClient,
   StarknetBalanceProvider,
+  StarknetClient,
   StarknetTotalSupplyProvider,
   TotalSupplyProvider,
 } from '@l2beat/shared'

--- a/packages/backend/src/modules/tvs/tools/extractPricesAndAmounts.ts
+++ b/packages/backend/src/modules/tvs/tools/extractPricesAndAmounts.ts
@@ -4,6 +4,7 @@ import type {
   CalculationFormula,
   CirculatingSupplyAmountFormula,
   ConstAmountFormula,
+  StarknetBalanceOfAmountFormula,
   StarknetTotalSupplyAmountFormula,
   TotalSupplyAmountFormula,
   TvsToken,
@@ -249,6 +250,7 @@ export function createAmountConfig(
     | BalanceOfEscrowAmountFormula
     | TotalSupplyAmountFormula
     | StarknetTotalSupplyAmountFormula
+    | StarknetBalanceOfAmountFormula
     | CirculatingSupplyAmountFormula
     | ConstAmountFormula,
 ): AmountConfig {
@@ -265,6 +267,7 @@ export function createAmountConfig(
         ...formula,
       }
     case 'starknetTotalSupply':
+    case 'starknetBalanceOf':
     case 'totalSupply':
       return {
         id: generateConfigurationId([
@@ -272,6 +275,9 @@ export function createAmountConfig(
           formula.address,
           formula.chain,
           formula.decimals.toString(),
+          ...(formula.type === 'starknetBalanceOf'
+            ? [formula.escrowAddress]
+            : []),
         ]),
         ...formula,
       }

--- a/packages/backend/src/modules/tvs/types.ts
+++ b/packages/backend/src/modules/tvs/types.ts
@@ -2,6 +2,7 @@ import type {
   BalanceOfEscrowAmountFormula,
   CirculatingSupplyAmountFormula,
   ConstAmountFormula,
+  StarknetBalanceOfAmountFormula,
   StarknetTotalSupplyAmountFormula,
   TotalSupplyAmountFormula,
   TvsToken,
@@ -45,6 +46,9 @@ export type TotalSupplyAmountConfig = TotalSupplyAmountFormula &
 export type StarknetTotalSupplyAmountConfig = StarknetTotalSupplyAmountFormula &
   AmountConfigBase
 
+export type StarknetBalanceOfAmountConfig = StarknetBalanceOfAmountFormula &
+  AmountConfigBase
+
 export type CirculatingSupplyAmountConfig = CirculatingSupplyAmountFormula &
   AmountConfigBase
 
@@ -54,6 +58,7 @@ export type AmountConfig =
   | BalanceOfEscrowAmountConfig
   | TotalSupplyAmountConfig
   | StarknetTotalSupplyAmountConfig
+  | StarknetBalanceOfAmountConfig
   | CirculatingSupplyAmountConfig
   | ConstAmountConfig
 
@@ -61,6 +66,7 @@ export type OnchainAmountConfig =
   | BalanceOfEscrowAmountConfig
   | TotalSupplyAmountConfig
   | StarknetTotalSupplyAmountConfig
+  | StarknetBalanceOfAmountConfig
 
 export function isOnchainAmountConfig(
   config: AmountConfig,
@@ -68,7 +74,8 @@ export function isOnchainAmountConfig(
   return (
     config.type === 'totalSupply' ||
     config.type === 'balanceOfEscrow' ||
-    config.type === 'starknetTotalSupply'
+    config.type === 'starknetTotalSupply' ||
+    config.type === 'starknetBalanceOf'
   )
 }
 

--- a/packages/backend/src/providers/Providers.ts
+++ b/packages/backend/src/providers/Providers.ts
@@ -13,6 +13,7 @@ import {
   EthereumDaProvider,
   PriceProvider,
   SlotTimestampProvider,
+  StarknetBalanceProvider,
   StarknetTotalSupplyProvider,
   SvmBlockProvider,
   TotalSupplyProvider,
@@ -42,6 +43,7 @@ export class Providers {
   blockTimestamp: BlockTimestampProvider
   totalSupply: TotalSupplyProvider
   starknetTotalSupply: StarknetTotalSupplyProvider
+  starknetBalance: StarknetBalanceProvider
   balance: BalanceProvider
   svmBlock: SvmBlockProviders
   aztecBlock: AztecBlockProviders
@@ -119,6 +121,10 @@ export class Providers {
 
     this.totalSupply = new TotalSupplyProvider(this.clients.rpcClients, logger)
     this.starknetTotalSupply = new StarknetTotalSupplyProvider(
+      this.clients.starknetClients,
+      logger,
+    )
+    this.starknetBalance = new StarknetBalanceProvider(
       this.clients.starknetClients,
       logger,
     )

--- a/packages/backend/src/tools/uif/indexerIdentity.ts
+++ b/packages/backend/src/tools/uif/indexerIdentity.ts
@@ -17,6 +17,7 @@ export const INDEXER_NAMES = {
   TVS_CLEANER: 'tvs_cleaner',
   PRIVACY_BLOCK_TIMESTAMP: 'privacy_block_timestamp_indexer',
   PRIVACY_FLOW: 'privacy_flow_indexer',
+  PRIVACY_STARKNET_FLOW: 'privacy_starknet_flow_indexer',
   PRIVACY_PRICE: 'privacy_price_indexer',
   PRIVACY_BUCKET_VALUE: 'privacy_bucket_value_indexer',
   ETHEREUM_BLOB_NOTIFIER: 'ethereum_blob_notifier',

--- a/packages/config/src/projects/strk20/strk20.ts
+++ b/packages/config/src/projects/strk20/strk20.ts
@@ -12,9 +12,7 @@ const STRK20_DEPOSIT_EVENT =
 const STRK20_WITHDRAWAL_EVENT =
   '0x2eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8'
 const STRK20_SINCE = UnixTime.fromDate(new Date('2026-06-17'))
-const STRK20_POOL_SINCE = UnixTime.fromDate(
-  new Date('2026-04-20T10:08:48Z'),
-)
+const STRK20_POOL_SINCE = UnixTime.fromDate(new Date('2026-04-20T10:08:48Z'))
 const STRK20_TOKENS = [
   {
     address:

--- a/packages/config/src/projects/strk20/strk20.ts
+++ b/packages/config/src/projects/strk20/strk20.ts
@@ -1,6 +1,6 @@
 import { ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { PRIVACY_ATTRIBUTES } from '../../common/privacyAttributes'
-import type { BaseProject } from '../../types'
+import type { BaseProject, ProjectPrivacyToken } from '../../types'
 import { readProjectMarkdown } from '../../utils/readMarkdown'
 
 const STRK20_POOL = {
@@ -12,6 +12,53 @@ const STRK20_DEPOSIT_EVENT =
 const STRK20_WITHDRAWAL_EVENT =
   '0x2eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8'
 const STRK20_SINCE = UnixTime.fromDate(new Date('2026-06-17'))
+const STRK20_TOKENS = [
+  {
+    address:
+      '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
+    iconUrl:
+      'https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507',
+    symbol: 'STRK',
+    decimals: 18,
+    priceId: 'starknet',
+  },
+  {
+    address:
+      '0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb',
+    iconUrl:
+      'https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696501661',
+    symbol: 'USDC',
+    decimals: 6,
+    priceId: 'usd-coin',
+  },
+  {
+    address:
+      '0x0787150e306e6eae6e3f79dea881770e8bbff2c1b8eb490f969669ee945b3135',
+    iconUrl:
+      'https://coin-images.coingecko.com/coins/images/102173511/large/strkBTC_Logo.png?1779888214',
+    symbol: 'strkBTC',
+    decimals: 8,
+    priceId: 'strkbtc',
+  },
+  {
+    address:
+      '0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac',
+    iconUrl:
+      'https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857',
+    symbol: 'WBTC',
+    decimals: 8,
+    priceId: 'wrapped-bitcoin',
+  },
+  {
+    address:
+      '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7',
+    iconUrl:
+      'https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880',
+    symbol: 'ETH',
+    decimals: 18,
+    priceId: 'ethereum',
+  },
+] as const
 
 export const strk20: BaseProject = {
   id: ProjectId('strk20'),
@@ -44,82 +91,7 @@ export const strk20: BaseProject = {
     badges: [],
   },
   privacyInfo: {
-    tokens: [
-      {
-        token: {
-          address:
-            '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
-          iconUrl:
-            'https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507',
-          symbol: 'STRK',
-          decimals: 18,
-          priceId: 'starknet',
-          sinceTimestamp: STRK20_SINCE,
-        },
-        buckets: [
-          {
-            id: 'strk20-STRK',
-            type: 'pool',
-            label: 'STRK pool',
-            address: STRK20_POOL,
-            sinceTimestamp: STRK20_SINCE,
-            deposit: {
-              event: STRK20_DEPOSIT_EVENT,
-              extractor: 'strk20Deposit',
-              params: {
-                tokenAddress:
-                  '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
-              },
-            },
-            withdrawal: {
-              event: STRK20_WITHDRAWAL_EVENT,
-              extractor: 'strk20Withdrawal',
-              params: {
-                tokenAddress:
-                  '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
-              },
-            },
-          },
-        ],
-      },
-      {
-        token: {
-          address:
-            '0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb',
-          iconUrl:
-            'https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696501661',
-          symbol: 'USDC',
-          decimals: 6,
-          priceId: 'usd-coin',
-          sinceTimestamp: STRK20_SINCE,
-        },
-        buckets: [
-          {
-            id: 'strk20-USDC',
-            type: 'pool',
-            label: 'USDC pool',
-            address: STRK20_POOL,
-            sinceTimestamp: STRK20_SINCE,
-            deposit: {
-              event: STRK20_DEPOSIT_EVENT,
-              extractor: 'strk20Deposit',
-              params: {
-                tokenAddress:
-                  '0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb',
-              },
-            },
-            withdrawal: {
-              event: STRK20_WITHDRAWAL_EVENT,
-              extractor: 'strk20Withdrawal',
-              params: {
-                tokenAddress:
-                  '0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb',
-              },
-            },
-          },
-        ],
-      },
-    ],
+    tokens: getPrivacyTokens(),
     exitWindow: {
       value: 'None',
       sentiment: 'bad',
@@ -157,4 +129,32 @@ export const strk20: BaseProject = {
       'upgradesAndGovernance',
     ),
   },
+}
+
+function getPrivacyTokens(): ProjectPrivacyToken[] {
+  return STRK20_TOKENS.map((token) => ({
+    token: {
+      ...token,
+      sinceTimestamp: STRK20_SINCE,
+    },
+    buckets: [
+      {
+        id: `strk20-${token.symbol}`,
+        type: 'pool',
+        label: `${token.symbol} pool`,
+        address: STRK20_POOL,
+        sinceTimestamp: STRK20_SINCE,
+        deposit: {
+          event: STRK20_DEPOSIT_EVENT,
+          extractor: 'strk20Deposit',
+          params: { tokenAddress: token.address },
+        },
+        withdrawal: {
+          event: STRK20_WITHDRAWAL_EVENT,
+          extractor: 'strk20Withdrawal',
+          params: { tokenAddress: token.address },
+        },
+      },
+    ],
+  }))
 }

--- a/packages/config/src/projects/strk20/strk20.ts
+++ b/packages/config/src/projects/strk20/strk20.ts
@@ -12,6 +12,9 @@ const STRK20_DEPOSIT_EVENT =
 const STRK20_WITHDRAWAL_EVENT =
   '0x2eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8'
 const STRK20_SINCE = UnixTime.fromDate(new Date('2026-06-17'))
+const STRK20_POOL_SINCE = UnixTime.fromDate(
+  new Date('2026-04-20T10:08:48Z'),
+)
 const STRK20_TOKENS = [
   {
     address:
@@ -57,6 +60,24 @@ const STRK20_TOKENS = [
     symbol: 'ETH',
     decimals: 18,
     priceId: 'ethereum',
+  },
+  {
+    address:
+      '0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a',
+    iconUrl:
+      'https://assets.coingecko.com/coins/images/54172/standard/logo200x200.png?1738561141',
+    symbol: 'XSTRK',
+    decimals: 18,
+    priceId: 'endur-fi-staked-strk',
+  },
+  {
+    address:
+      '0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8',
+    iconUrl:
+      'https://assets.coingecko.com/coins/images/325/large/Tether.png?1696501661',
+    decimals: 6,
+    symbol: 'USDT',
+    priceId: 'tether',
   },
 ] as const
 
@@ -143,7 +164,7 @@ function getPrivacyTokens(): ProjectPrivacyToken[] {
         type: 'pool',
         label: `${token.symbol} pool`,
         address: STRK20_POOL,
-        sinceTimestamp: STRK20_SINCE,
+        sinceTimestamp: STRK20_POOL_SINCE,
         deposit: {
           event: STRK20_DEPOSIT_EVENT,
           extractor: 'strk20Deposit',

--- a/packages/config/src/projects/strk20/strk20.ts
+++ b/packages/config/src/projects/strk20/strk20.ts
@@ -13,6 +13,7 @@ const STRK20_WITHDRAWAL_EVENT =
   '0x2eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8'
 const STRK20_SINCE = UnixTime.fromDate(new Date('2026-06-17'))
 const STRK20_POOL_SINCE = UnixTime.fromDate(new Date('2026-04-20T10:08:48Z'))
+const STRK20_STRKBTC_SINCE = UnixTime(1777893725)
 const STRK20_TOKENS = [
   {
     address:
@@ -22,6 +23,7 @@ const STRK20_TOKENS = [
     symbol: 'STRK',
     decimals: 18,
     priceId: 'starknet',
+    sinceTimestamp: STRK20_POOL_SINCE,
   },
   {
     address:
@@ -31,6 +33,7 @@ const STRK20_TOKENS = [
     symbol: 'USDC',
     decimals: 6,
     priceId: 'usd-coin',
+    sinceTimestamp: STRK20_POOL_SINCE,
   },
   {
     address:
@@ -40,6 +43,7 @@ const STRK20_TOKENS = [
     symbol: 'strkBTC',
     decimals: 8,
     priceId: 'strkbtc',
+    sinceTimestamp: STRK20_STRKBTC_SINCE,
   },
   {
     address:
@@ -49,6 +53,7 @@ const STRK20_TOKENS = [
     symbol: 'WBTC',
     decimals: 8,
     priceId: 'wrapped-bitcoin',
+    sinceTimestamp: STRK20_POOL_SINCE,
   },
   {
     address:
@@ -58,6 +63,7 @@ const STRK20_TOKENS = [
     symbol: 'ETH',
     decimals: 18,
     priceId: 'ethereum',
+    sinceTimestamp: STRK20_POOL_SINCE,
   },
   {
     address:
@@ -67,6 +73,7 @@ const STRK20_TOKENS = [
     symbol: 'XSTRK',
     decimals: 18,
     priceId: 'endur-fi-staked-strk',
+    sinceTimestamp: STRK20_POOL_SINCE,
   },
   {
     address:
@@ -76,6 +83,7 @@ const STRK20_TOKENS = [
     decimals: 6,
     symbol: 'USDT',
     priceId: 'tether',
+    sinceTimestamp: STRK20_POOL_SINCE,
   },
 ] as const
 
@@ -152,17 +160,14 @@ export const strk20: BaseProject = {
 
 function getPrivacyTokens(): ProjectPrivacyToken[] {
   return STRK20_TOKENS.map((token) => ({
-    token: {
-      ...token,
-      sinceTimestamp: STRK20_SINCE,
-    },
+    token,
     buckets: [
       {
         id: `strk20-${token.symbol}`,
         type: 'pool',
         label: `${token.symbol} pool`,
         address: STRK20_POOL,
-        sinceTimestamp: STRK20_POOL_SINCE,
+        sinceTimestamp: token.sinceTimestamp,
         deposit: {
           event: STRK20_DEPOSIT_EVENT,
           extractor: 'strk20Deposit',

--- a/packages/config/src/projects/strk20/strk20.ts
+++ b/packages/config/src/projects/strk20/strk20.ts
@@ -3,12 +3,22 @@ import { PRIVACY_ATTRIBUTES } from '../../common/privacyAttributes'
 import type { BaseProject } from '../../types'
 import { readProjectMarkdown } from '../../utils/readMarkdown'
 
+const STRK20_POOL = {
+  chain: 'starknet',
+  address: '0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a',
+}
+const STRK20_DEPOSIT_EVENT =
+  '0x9149d2123147c5f43d258257fef0b7b969db78269369ebcf5ebb9eef8592f2'
+const STRK20_WITHDRAWAL_EVENT =
+  '0x2eed7e29b3502a726faf503ac4316b7101f3da813654e8df02c13449e03da8'
+const STRK20_SINCE = UnixTime.fromDate(new Date('2026-06-17'))
+
 export const strk20: BaseProject = {
   id: ProjectId('strk20'),
   slug: 'strk20',
   name: 'STRK-20',
   shortName: undefined,
-  addedAt: UnixTime.fromDate(new Date('2026-06-17')),
+  addedAt: STRK20_SINCE,
   statuses: {
     yellowWarning:
       'The proven program is not made available so it is unknown what logic is verified by the smart contract. Furthermore, real-time monitoring for this project is not supported.',
@@ -34,7 +44,82 @@ export const strk20: BaseProject = {
     badges: [],
   },
   privacyInfo: {
-    tokens: [],
+    tokens: [
+      {
+        token: {
+          address:
+            '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
+          iconUrl:
+            'https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507',
+          symbol: 'STRK',
+          decimals: 18,
+          priceId: 'starknet',
+          sinceTimestamp: STRK20_SINCE,
+        },
+        buckets: [
+          {
+            id: 'strk20-STRK',
+            type: 'pool',
+            label: 'STRK pool',
+            address: STRK20_POOL,
+            sinceTimestamp: STRK20_SINCE,
+            deposit: {
+              event: STRK20_DEPOSIT_EVENT,
+              extractor: 'strk20Deposit',
+              params: {
+                tokenAddress:
+                  '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
+              },
+            },
+            withdrawal: {
+              event: STRK20_WITHDRAWAL_EVENT,
+              extractor: 'strk20Withdrawal',
+              params: {
+                tokenAddress:
+                  '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d',
+              },
+            },
+          },
+        ],
+      },
+      {
+        token: {
+          address:
+            '0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb',
+          iconUrl:
+            'https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696501661',
+          symbol: 'USDC',
+          decimals: 6,
+          priceId: 'usd-coin',
+          sinceTimestamp: STRK20_SINCE,
+        },
+        buckets: [
+          {
+            id: 'strk20-USDC',
+            type: 'pool',
+            label: 'USDC pool',
+            address: STRK20_POOL,
+            sinceTimestamp: STRK20_SINCE,
+            deposit: {
+              event: STRK20_DEPOSIT_EVENT,
+              extractor: 'strk20Deposit',
+              params: {
+                tokenAddress:
+                  '0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb',
+              },
+            },
+            withdrawal: {
+              event: STRK20_WITHDRAWAL_EVENT,
+              extractor: 'strk20Withdrawal',
+              params: {
+                tokenAddress:
+                  '0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb',
+              },
+            },
+          },
+        ],
+      },
+    ],
     exitWindow: {
       value: 'None',
       sentiment: 'bad',

--- a/packages/config/src/projects/strk20/tvs.json
+++ b/packages/config/src/projects/strk20/tvs.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "../tvs-config-schema.json",
+  "projectId": "strk20",
+  "tokens": [
+    {
+      "mode": "custom",
+      "id": "strk20-STRK",
+      "priceId": "starknet",
+      "symbol": "STRK",
+      "name": "Starknet Token",
+      "iconUrl": "https://assets.coingecko.com/coins/images/26433/large/starknet.png?1696525507",
+      "amount": {
+        "type": "starknetBalanceOf",
+        "address": "0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+        "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
+        "chain": "starknet",
+        "decimals": 18,
+        "sinceTimestamp": 1776679728
+      },
+      "category": "other",
+      "source": "canonical",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "strk20-USDC",
+      "priceId": "usd-coin",
+      "symbol": "USDC",
+      "name": "USD Coin",
+      "iconUrl": "https://assets.coingecko.com/coins/images/6319/large/usdc.png?1696501661",
+      "amount": {
+        "type": "starknetBalanceOf",
+        "address": "0x033068f6539f8e6e6b131e6b2b814e6c34a5224bc66947c47dab9dfee93b35fb",
+        "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
+        "chain": "starknet",
+        "decimals": 6,
+        "sinceTimestamp": 1776679728
+      },
+      "category": "stablecoin",
+      "source": "canonical",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "strk20-strkBTC",
+      "priceId": "strkbtc",
+      "symbol": "strkBTC",
+      "name": "strkBTC",
+      "iconUrl": "https://coin-images.coingecko.com/coins/images/102173511/large/strkBTC_Logo.png?1779888214",
+      "amount": {
+        "type": "starknetBalanceOf",
+        "address": "0x0787150e306e6eae6e3f79dea881770e8bbff2c1b8eb490f969669ee945b3135",
+        "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
+        "chain": "starknet",
+        "decimals": 8,
+        "sinceTimestamp": 1776679728
+      },
+      "category": "btc",
+      "source": "canonical",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "strk20-WBTC",
+      "priceId": "wrapped-bitcoin",
+      "symbol": "WBTC",
+      "name": "Wrapped Bitcoin",
+      "iconUrl": "https://assets.coingecko.com/coins/images/7598/large/wrapped_bitcoin_wbtc.png?1696507857",
+      "amount": {
+        "type": "starknetBalanceOf",
+        "address": "0x03fe2b97c1fd336e750087d68b9b867997fd64a2661ff3ca5a7c771641e8e7ac",
+        "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
+        "chain": "starknet",
+        "decimals": 8,
+        "sinceTimestamp": 1776679728
+      },
+      "category": "btc",
+      "source": "canonical",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "strk20-ETH",
+      "priceId": "ethereum",
+      "symbol": "ETH",
+      "name": "Ether",
+      "iconUrl": "https://assets.coingecko.com/coins/images/279/large/ethereum.png?1595348880",
+      "amount": {
+        "type": "starknetBalanceOf",
+        "address": "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7",
+        "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
+        "chain": "starknet",
+        "decimals": 18,
+        "sinceTimestamp": 1776679728
+      },
+      "category": "ether",
+      "source": "canonical",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "strk20-XSTRK",
+      "priceId": "endur-fi-staked-strk",
+      "symbol": "XSTRK",
+      "name": "Endur.Fi Staked STRK",
+      "iconUrl": "https://assets.coingecko.com/coins/images/54172/standard/logo200x200.png?1738561141",
+      "amount": {
+        "type": "starknetBalanceOf",
+        "address": "0x028d709c875c0ceac3dce7065bec5328186dc89fe254527084d1689910954b0a",
+        "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
+        "chain": "starknet",
+        "decimals": 18,
+        "sinceTimestamp": 1776679728
+      },
+      "category": "other",
+      "source": "canonical",
+      "isAssociated": false
+    },
+    {
+      "mode": "custom",
+      "id": "strk20-USDT",
+      "priceId": "tether",
+      "symbol": "USDT",
+      "name": "Tether USD",
+      "iconUrl": "https://assets.coingecko.com/coins/images/325/large/Tether.png?1696501661",
+      "amount": {
+        "type": "starknetBalanceOf",
+        "address": "0x068f5c6a61780768455de69077e07e89787839bf8166decfbf92b645209c0fb8",
+        "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
+        "chain": "starknet",
+        "decimals": 6,
+        "sinceTimestamp": 1776679728
+      },
+      "category": "stablecoin",
+      "source": "canonical",
+      "isAssociated": false
+    }
+  ]
+}

--- a/packages/config/src/projects/strk20/tvs.json
+++ b/packages/config/src/projects/strk20/tvs.json
@@ -53,7 +53,7 @@
         "escrowAddress": "0x040337b1af3c663e86e333bab5a4b28da8d4652a15a69beee2b677776ffe812a",
         "chain": "starknet",
         "decimals": 8,
-        "sinceTimestamp": 1776679728
+        "sinceTimestamp": 1777893725
       },
       "category": "btc",
       "source": "canonical",

--- a/packages/config/src/projects/tvs-config-schema.json
+++ b/packages/config/src/projects/tvs-config-schema.json
@@ -196,6 +196,40 @@
             }
           },
           "required": ["type", "chain", "sinceTimestamp", "address", "decimals"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "starknetBalanceOf"
+            },
+            "chain": {
+              "type": "string"
+            },
+            "sinceTimestamp": {
+              "type": "number"
+            },
+            "untilTimestamp": {
+              "type": "number"
+            },
+            "address": {
+              "type": "string"
+            },
+            "escrowAddress": {
+              "type": "string"
+            },
+            "decimals": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "type",
+            "chain",
+            "sinceTimestamp",
+            "address",
+            "escrowAddress",
+            "decimals"
+          ]
         }
       ]
     },
@@ -344,6 +378,40 @@
             }
           },
           "required": ["type", "chain", "sinceTimestamp", "address", "decimals"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "starknetBalanceOf"
+            },
+            "chain": {
+              "type": "string"
+            },
+            "sinceTimestamp": {
+              "type": "number"
+            },
+            "untilTimestamp": {
+              "type": "number"
+            },
+            "address": {
+              "type": "string"
+            },
+            "escrowAddress": {
+              "type": "string"
+            },
+            "decimals": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "type",
+            "chain",
+            "sinceTimestamp",
+            "address",
+            "escrowAddress",
+            "decimals"
+          ]
         }
       ]
     },
@@ -592,6 +660,40 @@
                       "chain",
                       "sinceTimestamp",
                       "address",
+                      "decimals"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "const": "starknetBalanceOf"
+                      },
+                      "chain": {
+                        "type": "string"
+                      },
+                      "sinceTimestamp": {
+                        "type": "number"
+                      },
+                      "untilTimestamp": {
+                        "type": "number"
+                      },
+                      "address": {
+                        "type": "string"
+                      },
+                      "escrowAddress": {
+                        "type": "string"
+                      },
+                      "decimals": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "type",
+                      "chain",
+                      "sinceTimestamp",
+                      "address",
+                      "escrowAddress",
                       "decimals"
                     ]
                   }

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -988,7 +988,7 @@ export interface PrivacyAttribute {
 
 export interface ProjectPrivacyToken {
   token: {
-    address: EthereumAddress
+    address: string
     iconUrl: string | undefined
     symbol: string
     decimals: number
@@ -1002,12 +1002,21 @@ export interface ProjectPrivacyBucket {
   id: string
   type: 'pool' | 'denomination'
   label: string
-  address: ChainSpecificAddress
+  address: PrivacyBucketAddress
   sinceTimestamp: UnixTime
   denomination?: string
   deposit: PrivacyFlowSource
   withdrawal: PrivacyFlowSource
 }
+
+/**
+ * Privacy pools can live on non-EVM chains. Keep EVM addresses in their
+ * existing ERC-3770 representation and use an explicit chain/address pair
+ * where an ERC-3770 address is not applicable.
+ */
+export type PrivacyBucketAddress =
+  | ChainSpecificAddress
+  | { chain: string; address: string }
 
 export type PrivacyFlowSource = {
   event: string
@@ -1044,6 +1053,18 @@ export type PrivacyFlowExtractorConfig =
       extractor: 'zamaUnwrap'
       params: {
         rate: string
+      }
+    }
+  | {
+      extractor: 'strk20Deposit'
+      params: {
+        tokenAddress: string
+      }
+    }
+  | {
+      extractor: 'strk20Withdrawal'
+      params: {
+        tokenAddress: string
       }
     }
 

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1623,6 +1623,19 @@ export const StarknetTotalSupplyAmountFormulaSchema = v.object({
   decimals: v.number(),
 })
 
+export type StarknetBalanceOfAmountFormula = v.infer<
+  typeof StarknetBalanceOfAmountFormulaSchema
+>
+export const StarknetBalanceOfAmountFormulaSchema = v.object({
+  type: v.literal('starknetBalanceOf'),
+  chain: v.string(),
+  sinceTimestamp: v.number(),
+  untilTimestamp: v.number().optional(),
+  address: v.string(),
+  escrowAddress: v.string(),
+  decimals: v.number(),
+})
+
 export type CirculatingSupplyAmountFormula = v.infer<
   typeof CirculatingSupplyAmountFormulaSchema
 >
@@ -1652,6 +1665,7 @@ export const AmountFormulaSchema = v.union([
   CirculatingSupplyAmountFormulaSchema,
   ConstAmountFormulaSchema,
   StarknetTotalSupplyAmountFormulaSchema,
+  StarknetBalanceOfAmountFormulaSchema,
 ])
 
 export type Formula = CalculationFormula | ValueFormula | AmountFormula
@@ -1663,6 +1677,7 @@ export type OnchainAmountFormula =
   | BalanceOfEscrowAmountFormula
   | TotalSupplyAmountFormula
   | StarknetTotalSupplyAmountFormula
+  | StarknetBalanceOfAmountFormula
 
 export function isOnchainAmountFormula(
   formula: Formula,
@@ -1670,7 +1685,8 @@ export function isOnchainAmountFormula(
   return (
     formula.type === 'totalSupply' ||
     formula.type === 'balanceOfEscrow' ||
-    formula.type === 'starknetTotalSupply'
+    formula.type === 'starknetTotalSupply' ||
+    formula.type === 'starknetBalanceOf'
   )
 }
 

--- a/packages/frontend/src/pages/scaling/project/tvs-breakdown/components/tables/FormulaSubRow.tsx
+++ b/packages/frontend/src/pages/scaling/project/tvs-breakdown/components/tables/FormulaSubRow.tsx
@@ -51,6 +51,7 @@ function Formula({
 }) {
   switch (formula.type) {
     case 'balanceOfEscrow':
+    case 'starknetBalanceOf':
       return <BalanceOfEscrow formula={formula} />
     case 'circulatingSupply':
       return <CirculatingSupply formula={formula} />
@@ -97,7 +98,7 @@ function BalanceOfEscrow({
 }: {
   formula: Extract<
     ProjectTvsBreakdownTokenEntry['formula'],
-    { type: 'balanceOfEscrow' }
+    { type: 'balanceOfEscrow' | 'starknetBalanceOf' }
   >
 }) {
   if (formula.addressMeta.address === 'native') {

--- a/packages/frontend/src/server/features/privacy/types.ts
+++ b/packages/frontend/src/server/features/privacy/types.ts
@@ -1,5 +1,4 @@
 import type { Project } from '@l2beat/config'
-import type { EthereumAddress } from '@l2beat/shared-pure'
 
 export type PrivacyProject = Project<
   'display' | 'privacyInfo' | 'statuses',
@@ -30,7 +29,7 @@ export interface PrivacyBucket {
 export interface PrivacyAsset {
   symbol: string
   iconUrl: string
-  address?: EthereumAddress
+  address?: string
   decimals: number
   bucketCount: number
   totalAmount: number

--- a/packages/frontend/src/server/features/scaling/tvs/breakdown/extractAddressesFromTokenConfig.test.ts
+++ b/packages/frontend/src/server/features/scaling/tvs/breakdown/extractAddressesFromTokenConfig.test.ts
@@ -106,6 +106,27 @@ describe(extractAddressesFromTokenConfig.name, () => {
     expect(result.escrows).toEqualUnsorted([{ address: add2, chain: '1' }])
   })
 
+  it('should handle a Starknet token balance', () => {
+    const tokenAddress = '0x123'
+    const poolAddress = '0x456'
+
+    const result = extractAddressesFromTokenConfig(
+      mockToken({
+        type: 'starknetBalanceOf',
+        address: tokenAddress,
+        escrowAddress: poolAddress,
+        chain: 'starknet',
+        sinceTimestamp: 0,
+        decimals: 18,
+      }),
+    )
+
+    expect(result).toEqual({
+      addresses: [{ address: tokenAddress, chain: 'starknet' }],
+      escrows: [{ address: poolAddress, chain: 'starknet' }],
+    })
+  })
+
   it('should return empty array for types with no addresses', () => {
     const token = mockToken({
       type: 'calculation',

--- a/packages/frontend/src/server/features/scaling/tvs/breakdown/extractAddressesFromTokenConfig.ts
+++ b/packages/frontend/src/server/features/scaling/tvs/breakdown/extractAddressesFromTokenConfig.ts
@@ -42,6 +42,7 @@ function collectAddressesFromFormula(
       })
       break
     case 'balanceOfEscrow':
+    case 'starknetBalanceOf':
       if (formula.address !== 'native') {
         addresses.push({
           address: formula.address,

--- a/packages/frontend/src/server/features/scaling/tvs/breakdown/getAllTokenEntries.ts
+++ b/packages/frontend/src/server/features/scaling/tvs/breakdown/getAllTokenEntries.ts
@@ -150,7 +150,7 @@ function getEntries(
 
 // Ik its ugly but it works and is type safe
 type FormulaWithMeta =
-  | (Extract<Formula, { type: 'balanceOfEscrow' }> & {
+  | (Extract<Formula, { type: 'balanceOfEscrow' | 'starknetBalanceOf' }> & {
       addressMeta: AddressData
       escrowAddressMeta: AddressData
     })
@@ -174,7 +174,8 @@ function withExplorerUrl(
   projectContracts: Record<string, ProjectContract[]> | undefined,
 ): FormulaWithMeta {
   switch (formula.type) {
-    case 'balanceOfEscrow': {
+    case 'balanceOfEscrow':
+    case 'starknetBalanceOf': {
       return {
         ...formula,
         escrowAddressMeta: processAddress(

--- a/packages/frontend/src/server/features/scaling/tvs/breakdown/getProjectTokensEntries.ts
+++ b/packages/frontend/src/server/features/scaling/tvs/breakdown/getProjectTokensEntries.ts
@@ -209,7 +209,7 @@ function getEntries(
 
 // Ik its ugly but it works and is type safe
 type FormulaWithMeta =
-  | (Extract<Formula, { type: 'balanceOfEscrow' }> & {
+  | (Extract<Formula, { type: 'balanceOfEscrow' | 'starknetBalanceOf' }> & {
       addressMeta: AddressData
       escrowAddressMeta: AddressData
     })
@@ -233,7 +233,8 @@ function withExplorerUrl(
   projectContracts: Record<string, ProjectContract[]> | undefined,
 ): FormulaWithMeta {
   switch (formula.type) {
-    case 'balanceOfEscrow': {
+    case 'balanceOfEscrow':
+    case 'starknetBalanceOf': {
       return {
         ...formula,
         escrowAddressMeta: processAddress(

--- a/packages/frontend/src/server/routers/InternalApiRouter/getInternalTokenBreakdown.ts
+++ b/packages/frontend/src/server/routers/InternalApiRouter/getInternalTokenBreakdown.ts
@@ -183,6 +183,7 @@ function collectAddressesFromFormula(
       })
       break
     case 'balanceOfEscrow':
+    case 'starknetBalanceOf':
       if (formula.address !== 'native') {
         addresses.push({
           address: formula.address,

--- a/packages/shared/src/clients/starknet/StarknetClient.test.ts
+++ b/packages/shared/src/clients/starknet/StarknetClient.test.ts
@@ -114,9 +114,7 @@ describe(StarknetClient.name, () => {
         .returnsOnce(
           mockStarknetGetEventsResponse([mockStarknetEvent(1)], 'next'),
         )
-        .returnsOnce(
-          mockStarknetGetEventsResponse([mockStarknetEvent(2)], null),
-        )
+        .returnsOnce(mockStarknetGetEventsResponse([mockStarknetEvent(2)]))
       client.query = query
 
       const result = await client.getEvents(10, 20, '0x1234', [
@@ -144,6 +142,20 @@ describe(StarknetClient.name, () => {
         },
       ])
       expect(result).toEqual([mockStarknetEvent(1), mockStarknetEvent(2)])
+    })
+
+    it('assigns a deterministic index when the RPC omits event_index', async () => {
+      const client = mockClient({})
+      client.query = mockFn().returnsOnce(
+        mockStarknetGetEventsResponse([
+          mockStarknetEventWithoutIndex('0xtx'),
+          mockStarknetEventWithoutIndex('0xtx'),
+        ]),
+      )
+
+      const result = await client.getEvents(10, 20, '0x1234', ['0x5678'])
+
+      expect(result.map((event) => event.event_index)).toEqual([0, 1])
     })
   })
 
@@ -239,16 +251,33 @@ function mockStarknetEvent(eventIndex: number): StarknetEvent {
 }
 
 function mockStarknetGetEventsResponse(
-  events: StarknetEvent[],
-  continuationToken: string | null,
+  events: StarknetRpcEvent[],
+  continuationToken?: string | null,
 ) {
   return {
     jsonrpc: '2.0' as const,
     id: 1,
     result: {
       events,
-      continuation_token: continuationToken,
+      ...(continuationToken === undefined
+        ? {}
+        : { continuation_token: continuationToken }),
     },
+  }
+}
+
+type StarknetRpcEvent = Omit<StarknetEvent, 'event_index'> & {
+  event_index?: number
+}
+
+function mockStarknetEventWithoutIndex(
+  transactionHash: string,
+): StarknetRpcEvent {
+  return {
+    block_number: 100,
+    transaction_hash: transactionHash,
+    keys: ['0x5678'],
+    data: ['0x9abc'],
   }
 }
 

--- a/packages/shared/src/clients/starknet/StarknetClient.test.ts
+++ b/packages/shared/src/clients/starknet/StarknetClient.test.ts
@@ -6,6 +6,7 @@ import { StarknetClient } from './StarknetClient'
 import type {
   StarknetCallParameters,
   StarknetErrorResponse,
+  StarknetEvent,
   StarknetGetBlockResponse,
   StarknetGetBlockWithTxsResponse,
 } from './types'
@@ -54,6 +55,27 @@ describe(StarknetClient.name, () => {
     })
   })
 
+  describe(StarknetClient.prototype.getBlockTimestamps.name, () => {
+    it('returns timestamps keyed by block number', async () => {
+      const client = mockClient({})
+      const getBlockWithTransactions = mockFn()
+        .returnsOnce({ number: 100, timestamp: 1_000 })
+        .returnsOnce({ number: 200, timestamp: 2_000 })
+      client.getBlockWithTransactions = getBlockWithTransactions
+
+      const result = await client.getBlockTimestamps([100, 200])
+
+      expect(getBlockWithTransactions).toHaveBeenNthCalledWith(1, 100)
+      expect(getBlockWithTransactions).toHaveBeenNthCalledWith(2, 200)
+      expect(result).toEqual(
+        new Map([
+          [100, 1_000],
+          [200, 2_000],
+        ]),
+      )
+    })
+  })
+
   describe(StarknetClient.prototype.call.name, () => {
     it('sends call request and parses response', async () => {
       const params: StarknetCallParameters = {
@@ -82,6 +104,46 @@ describe(StarknetClient.name, () => {
       ])
 
       expect(result).toEqual(rpcResult)
+    })
+  })
+
+  describe(StarknetClient.prototype.getEvents.name, () => {
+    it('fetches every response page', async () => {
+      const client = mockClient({})
+      const query = mockFn()
+        .returnsOnce(
+          mockStarknetGetEventsResponse([mockStarknetEvent(1)], 'next'),
+        )
+        .returnsOnce(
+          mockStarknetGetEventsResponse([mockStarknetEvent(2)], null),
+        )
+      client.query = query
+
+      const result = await client.getEvents(10, 20, '0x1234', [
+        '0x5678',
+        '0x9abc',
+      ])
+
+      expect(query).toHaveBeenNthCalledWith(1, 'starknet_getEvents', [
+        {
+          from_block: { block_number: 10 },
+          to_block: { block_number: 20 },
+          address: '0x1234',
+          keys: [['0x5678', '0x9abc']],
+          chunk_size: 1_000,
+        },
+      ])
+      expect(query).toHaveBeenNthCalledWith(2, 'starknet_getEvents', [
+        {
+          from_block: { block_number: 10 },
+          to_block: { block_number: 20 },
+          address: '0x1234',
+          keys: [['0x5678', '0x9abc']],
+          chunk_size: 1_000,
+          continuation_token: 'next',
+        },
+      ])
+      expect(result).toEqual([mockStarknetEvent(1), mockStarknetEvent(2)])
     })
   })
 
@@ -165,6 +227,30 @@ const mockStarknetGetBlockResponse = (
     transactions: [],
   },
 })
+
+function mockStarknetEvent(eventIndex: number): StarknetEvent {
+  return {
+    block_number: 100,
+    transaction_hash: '0x1234',
+    event_index: eventIndex,
+    keys: ['0x5678'],
+    data: ['0x9abc'],
+  }
+}
+
+function mockStarknetGetEventsResponse(
+  events: StarknetEvent[],
+  continuationToken: string | null,
+) {
+  return {
+    jsonrpc: '2.0' as const,
+    id: 1,
+    result: {
+      events,
+      continuation_token: continuationToken,
+    },
+  }
+}
 
 const mockStarknetGetBlockWithTxsResponse = (
   block: Block,

--- a/packages/shared/src/clients/starknet/StarknetClient.ts
+++ b/packages/shared/src/clients/starknet/StarknetClient.ts
@@ -113,7 +113,7 @@ export class StarknetClient extends ClientCore implements BlockClient {
     address: string,
     eventSelectors: string[],
   ): Promise<StarknetEvent[]> {
-    const events: StarknetEvent[] = []
+    const events: StarknetRpcEvent[] = []
     let continuationToken: string | undefined
 
     do {
@@ -139,7 +139,15 @@ export class StarknetClient extends ClientCore implements BlockClient {
       continuationToken = parsed.data.result.continuation_token ?? undefined
     } while (continuationToken)
 
-    return events
+    const lastEventIndexByTransaction = new Map<string, number>()
+    return events.map((event) => {
+      const previousEventIndex =
+        lastEventIndexByTransaction.get(event.transaction_hash) ?? -1
+      const eventIndex = event.event_index ?? previousEventIndex + 1
+      lastEventIndexByTransaction.set(event.transaction_hash, eventIndex)
+
+      return { ...event, event_index: eventIndex }
+    })
   }
 
   async query(method: string, params: unknown) {
@@ -177,4 +185,8 @@ export class StarknetClient extends ClientCore implements BlockClient {
   get chain() {
     return this.$.sourceName
   }
+}
+
+type StarknetRpcEvent = Omit<StarknetEvent, 'event_index'> & {
+  event_index?: number
 }

--- a/packages/shared/src/clients/starknet/StarknetClient.ts
+++ b/packages/shared/src/clients/starknet/StarknetClient.ts
@@ -6,10 +6,14 @@ import {
   type StarknetCallParameters,
   StarknetCallResponse,
   StarknetErrorResponse,
+  type StarknetEvent,
   StarknetGetBlockResponse,
   StarknetGetBlockWithTxsResponse,
+  StarknetGetEventsResponse,
   type StarknetTransaction,
 } from './types'
+
+export type { StarknetEvent } from './types'
 
 interface Dependencies extends ClientCoreDependencies {
   url: string
@@ -73,6 +77,17 @@ export class StarknetClient extends ClientCore implements BlockClient {
     }
   }
 
+  async getBlockTimestamps(
+    blockNumbers: number[],
+  ): Promise<Map<number, number>> {
+    const blocks = await Promise.all(
+      blockNumbers.map((blockNumber) =>
+        this.getBlockWithTransactions(blockNumber),
+      ),
+    )
+    return new Map(blocks.map((block) => [block.number, block.timestamp]))
+  }
+
   async call(
     callParams: StarknetCallParameters,
     blockNumber: number | 'latest',
@@ -90,6 +105,41 @@ export class StarknetClient extends ClientCore implements BlockClient {
     }
 
     return callResponse.data.result
+  }
+
+  async getEvents(
+    fromBlock: number,
+    toBlock: number,
+    address: string,
+    eventSelectors: string[],
+  ): Promise<StarknetEvent[]> {
+    const events: StarknetEvent[] = []
+    let continuationToken: string | undefined
+
+    do {
+      const response = await this.query('starknet_getEvents', [
+        {
+          from_block: { block_number: fromBlock },
+          to_block: { block_number: toBlock },
+          address,
+          keys: [eventSelectors],
+          chunk_size: 1_000,
+          ...(continuationToken
+            ? { continuation_token: continuationToken }
+            : {}),
+        },
+      ])
+      const parsed = StarknetGetEventsResponse.safeParse(response)
+
+      if (!parsed.success) {
+        throw new Error('Get events: Error during parsing')
+      }
+
+      events.push(...parsed.data.result.events)
+      continuationToken = parsed.data.result.continuation_token ?? undefined
+    } while (continuationToken)
+
+    return events
   }
 
   async query(method: string, params: unknown) {

--- a/packages/shared/src/clients/starknet/types.ts
+++ b/packages/shared/src/clients/starknet/types.ts
@@ -23,12 +23,12 @@ export const StarknetGetEventsResponse = v.object({
       v.object({
         block_number: v.number().check(Number.isInteger),
         transaction_hash: v.string(),
-        event_index: v.number().check(Number.isInteger),
+        event_index: v.number().check(Number.isInteger).optional(),
         keys: v.array(v.string().check((v) => HEX_REGEX.test(v))),
         data: v.array(v.string().check((v) => HEX_REGEX.test(v))),
       }),
     ),
-    continuation_token: v.union([v.string(), v.null()]),
+    continuation_token: v.union([v.string(), v.null()]).optional(),
   }),
 })
 

--- a/packages/shared/src/clients/starknet/types.ts
+++ b/packages/shared/src/clients/starknet/types.ts
@@ -7,6 +7,31 @@ export interface StarknetCallParameters {
   calldata: string[]
 }
 
+export interface StarknetEvent {
+  block_number: number
+  transaction_hash: string
+  event_index: number
+  keys: string[]
+  data: string[]
+}
+
+export const StarknetGetEventsResponse = v.object({
+  jsonrpc: v.literal('2.0'),
+  id: v.number().check(Number.isInteger),
+  result: v.object({
+    events: v.array(
+      v.object({
+        block_number: v.number().check(Number.isInteger),
+        transaction_hash: v.string(),
+        event_index: v.number().check(Number.isInteger),
+        keys: v.array(v.string().check((v) => HEX_REGEX.test(v))),
+        data: v.array(v.string().check((v) => HEX_REGEX.test(v))),
+      }),
+    ),
+    continuation_token: v.union([v.string(), v.null()]),
+  }),
+})
+
 export type StarknetGetBlockResponse = v.infer<typeof StarknetGetBlockResponse>
 export const StarknetGetBlockResponse = v.object({
   jsonrpc: v.literal('2.0'),

--- a/packages/shared/src/providers/balance/StarknetBalanceProvider.test.ts
+++ b/packages/shared/src/providers/balance/StarknetBalanceProvider.test.ts
@@ -1,0 +1,75 @@
+import { Logger } from '@l2beat/backend-tools'
+import { expect, mockFn, mockObject } from 'earl'
+import type { StarknetClient } from '../../clients'
+import {
+  STARKNET_BALANCE_OF_SELECTOR,
+  StarknetBalanceProvider,
+} from './StarknetBalanceProvider'
+
+describe(StarknetBalanceProvider.name, () => {
+  const BLOCK = 100
+  const CHAIN = 'starknet'
+  const BALANCES = [
+    { token: '0x123', holder: '0xabc' },
+    { token: '0x456', holder: '0xdef' },
+    { token: '0x789', holder: '0x012' },
+  ]
+
+  describe(StarknetBalanceProvider.prototype.getBalances.name, () => {
+    it('performs a balanceOf call for each token and decodes u256 values', async () => {
+      const client = mockObject<StarknetClient>({
+        call: mockFn()
+          .resolvesToOnce(['0x1'])
+          .resolvesToOnce(['0x2', '0x1'])
+          .rejectsWithOnce('error'),
+        chain: CHAIN,
+      })
+      const balanceProvider = new StarknetBalanceProvider(
+        [client, mockObject<StarknetClient>({ chain: 'random' })],
+        Logger.SILENT,
+      )
+
+      const result = await balanceProvider.getBalances(BALANCES, BLOCK, CHAIN)
+
+      expect(client.call).toHaveBeenNthCalledWith(
+        1,
+        {
+          contract_address: BALANCES[0].token,
+          entry_point_selector: STARKNET_BALANCE_OF_SELECTOR,
+          calldata: [BALANCES[0].holder],
+        },
+        BLOCK,
+      )
+      expect(client.call).toHaveBeenNthCalledWith(
+        2,
+        {
+          contract_address: BALANCES[1].token,
+          entry_point_selector: STARKNET_BALANCE_OF_SELECTOR,
+          calldata: [BALANCES[1].holder],
+        },
+        BLOCK,
+      )
+      expect(client.call).toHaveBeenNthCalledWith(
+        3,
+        {
+          contract_address: BALANCES[2].token,
+          entry_point_selector: STARKNET_BALANCE_OF_SELECTOR,
+          calldata: [BALANCES[2].holder],
+        },
+        BLOCK,
+      )
+      expect(result).toEqual([1n, 2n + (1n << 128n), 0n])
+    })
+
+    it('throws if there is no client for the chain', () => {
+      const balanceProvider = new StarknetBalanceProvider(
+        [mockObject<StarknetClient>({ chain: 'other-chain' })],
+        Logger.SILENT,
+      )
+
+      expect(() => balanceProvider.getBalances(BALANCES, BLOCK, CHAIN)).toThrow(
+        `Missing starknet client for ${CHAIN}`,
+      )
+    })
+  })
+})

--- a/packages/shared/src/providers/balance/StarknetBalanceProvider.ts
+++ b/packages/shared/src/providers/balance/StarknetBalanceProvider.ts
@@ -1,0 +1,57 @@
+import type { Logger } from '@l2beat/backend-tools'
+import type { StarknetClient } from '../../clients'
+
+export const STARKNET_BALANCE_OF_SELECTOR =
+  '0x035a73cd311a05d46deda634c5ee045db92f811b4e74bca4437fcb5302b7af33'
+
+export class StarknetBalanceProvider {
+  private logger: Logger
+
+  constructor(
+    private readonly starknetClients: StarknetClient[],
+    logger: Logger,
+  ) {
+    this.logger = logger.for(this)
+  }
+
+  getBalances(
+    balances: { token: string; holder: string }[],
+    blockNumber: number,
+    chain: string,
+  ): Promise<bigint[]> {
+    const client = this.starknetClients.find((r) => r.chain === chain)
+
+    if (!client) {
+      throw new Error(`Missing starknet client for ${chain}`)
+    }
+
+    return Promise.all(
+      balances.map(async ({ token, holder }) => {
+        try {
+          const result = await client.call(
+            {
+              contract_address: token,
+              entry_point_selector: STARKNET_BALANCE_OF_SELECTOR,
+              calldata: [holder],
+            },
+            blockNumber,
+          )
+          return decodeStarknetUint256(result)
+        } catch {
+          this.logger.tag({ chain }).warn('Issue with balanceOf fetching', {
+            token,
+            holder,
+            blockNumber,
+          })
+          return 0n
+        }
+      }),
+    )
+  }
+}
+
+export function decodeStarknetUint256(result: string[]): bigint {
+  const low = BigInt(result[0] ?? 0)
+  const high = BigInt(result[1] ?? 0)
+  return low + (high << 128n)
+}

--- a/packages/shared/src/providers/index.ts
+++ b/packages/shared/src/providers/index.ts
@@ -1,4 +1,5 @@
 export * from './balance/BalanceProvider'
+export * from './balance/StarknetBalanceProvider'
 export * from './block/AztecBlockProvider'
 export * from './block/BlockProvider'
 export * from './block/SvmBlockProvider'


### PR DESCRIPTION
## Summary

Adds end-to-end Starknet support for STRK-20 privacy-pool statistics and TVS.

- Introduces Starknet RPC client/event support and a Starknet privacy-flow indexer.
- Adds `starknetBalanceOf` TVS formula support, including Cairo `u256` balance decoding.
- Configures STRK-20 pool tokens, TVS balances, privacy flows, prices, and pool timestamps.
- Extends frontend TVS breakdowns to render the new balance formula with token and pool explorer links.
- Regenerates the TVS JSON schema.

## Reviewer focus

1. **Starknet event extraction**
   - Validate the STRK-20 deposit/withdrawal event selectors and token-address extraction.
   - Confirm pagination/range handling in `StarknetClient.getEvents()` and `StarknetPrivacyFlowIndexer`.

2. **TVS correctness**
   - `starknetBalanceOf` calls the token’s `balance_of(pool)` at the historical Starknet block.
   - Check Cairo `u256` decoding, especially the high limb.
   - Confirm provider failures follow the existing TVS behavior.

3. **Timestamp semantics**
   - Project `addedAt` remains Jun 17.
   - Pool tracking starts at Apr 20 deployment.
   - `strkBTC` starts May 4, when its token contract exists.
   - Privacy token price timestamps match their flow timestamps, so flow indexing cannot request a price before it is collected.

4. **Indexer dependencies**
   - Privacy flow indexing depends on privacy prices and Starknet block timestamps.
   - TVS token values depend on the Starknet amount indexer.

## Validation

- Config typecheck/build
- Backend typecheck and focused TVS/privacy tests
- Frontend typecheck and formula address-extraction test

<img width="1063" height="263" alt="image" src="https://github.com/user-attachments/assets/e86bb8f6-243c-4b97-87e7-f61fe61fb7e4" />
<img width="889" height="427" alt="image" src="https://github.com/user-attachments/assets/1e3a2b16-b1f8-4da9-ae4d-f82a4a880368" />
<img width="879" height="459" alt="image" src="https://github.com/user-attachments/assets/b6655a13-d50f-478d-82bd-d6f49b222454" />
<img width="885" height="543" alt="image" src="https://github.com/user-attachments/assets/38429e87-454e-407c-b46b-2751b98ded3c" />
