### PR TITLE
Add Ethereum line to the activity chart of L2s on home page

### DIFF
--- a/packages/frontend/src/pages/home/components/HomeScalingCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeScalingCard.tsx
@@ -49,16 +49,20 @@ export function HomeScalingCard({ charts, scalingCategoryCounts }: Props) {
     [tvsChartData],
   )
 
-  const activityChartData = useMemo(
+  const activityChartData = useMemo<HomeChartDataPoint[]>(
     () =>
-      charts.activity.chart.map(([timestamp, rollupsUops, vAndOUops]) => {
-        const hasAny = rollupsUops !== null || vAndOUops !== null
-        const sum = (rollupsUops ?? 0) + (vAndOUops ?? 0)
-        return {
-          timestamp,
-          value: hasAny ? sum / UnixTime.DAY : null,
-        }
-      }),
+      charts.activity.chart.map(
+        ([timestamp, rollupsUops, vAndOUops, ethereumUops]) => {
+          const hasAny = rollupsUops !== null || vAndOUops !== null
+          const sum = (rollupsUops ?? 0) + (vAndOUops ?? 0)
+          return {
+            timestamp,
+            value: hasAny ? sum / UnixTime.DAY : null,
+            ethereum:
+              ethereumUops !== null ? ethereumUops / UnixTime.DAY : null,
+          }
+        },
+      ),
     [charts.activity.chart],
   )
 
@@ -117,11 +121,12 @@ export function HomeScalingCard({ charts, scalingCategoryCounts }: Props) {
             data={activityChartData}
             isLoading={false}
             color="pink"
-            tooltipLabel="UOPS"
+            tooltipLabel="Layer 2s"
             formatValue={(value) => formatActivityCount(value)}
             yAxisUnit=" UOPS"
             syncedUntil={charts.activity.syncedUntil}
             tooltipDayRange
+            withEthereum
           />
         </HomeChartSection>
       </div>

--- a/packages/frontend/src/pages/home/components/charts/HomeChart.tsx
+++ b/packages/frontend/src/pages/home/components/charts/HomeChart.tsx
@@ -23,6 +23,7 @@ export type HomeChartColor = 'pink' | 'ethereum'
 export interface HomeChartDataPoint {
   timestamp: number
   value: number | null
+  ethereum?: number | null
   tvsBreakdown?: {
     rollups: number | null
     validiumsAndOptimiums: number | null
@@ -38,6 +39,7 @@ interface Props {
   yAxisUnit?: string
   syncedUntil?: number
   tooltipDayRange?: boolean
+  withEthereum?: boolean
 }
 
 const STROKE_COLOR: Record<HomeChartColor, string> = {
@@ -71,8 +73,10 @@ export function HomeChart({
   yAxisUnit,
   syncedUntil,
   tooltipDayRange,
+  withEthereum,
 }: Props) {
   const fillId = useId()
+  const ethereumFillId = useId()
 
   const stroke = STROKE_COLOR[color]
   const meta = useMemo<ChartMeta>(
@@ -82,8 +86,17 @@ export function HomeChart({
         color: stroke,
         indicatorType: { shape: 'line' },
       },
+      ...(withEthereum
+        ? {
+            ethereum: {
+              label: 'Ethereum',
+              color: STROKE_COLOR.ethereum,
+              indicatorType: { shape: 'line' as const },
+            },
+          }
+        : {}),
     }),
-    [stroke, tooltipLabel],
+    [stroke, tooltipLabel, withEthereum],
   )
 
   return (
@@ -103,6 +116,7 @@ export function HomeChart({
             <defs>
               {color === 'pink' && <PinkFillGradientDef id={fillId} />}
               {color === 'ethereum' && <EthereumFillGradientDef id={fillId} />}
+              {withEthereum && <EthereumFillGradientDef id={ethereumFillId} />}
             </defs>
             <Area
               dataKey="value"
@@ -121,6 +135,25 @@ export function HomeChart({
                 fill: stroke,
               }}
             />
+            {withEthereum && (
+              <Area
+                dataKey="ethereum"
+                type="monotone"
+                stroke={STROKE_COLOR.ethereum}
+                strokeWidth={1.75}
+                fill={`url(#${ethereumFillId})`}
+                fillOpacity={1}
+                dot={false}
+                isAnimationActive={false}
+                connectNulls={false}
+                activeDot={{
+                  r: 3,
+                  stroke: '#fff',
+                  strokeWidth: 1,
+                  fill: STROKE_COLOR.ethereum,
+                }}
+              />
+            )}
             <ChartCommonComponents
               data={data}
               isLoading={isLoading}
@@ -155,11 +188,15 @@ function HomeChartTooltip({
 }) {
   const { meta } = useChart()
   if (!payload || typeof label !== 'number') return null
-  const entry = payload[0]
-  if (!entry || entry.name === undefined) return null
-  const config = meta[entry.name]
-  if (!config) return null
-  const row = entry.payload as HomeChartDataPoint | undefined
+  const entries = payload.flatMap((entry) => {
+    if (entry.name === undefined) return []
+    const config = meta[entry.name]
+    if (!config) return []
+    return { entry, config }
+  })
+  const firstEntry = entries[0]
+  if (!firstEntry) return null
+  const row = firstEntry.entry.payload as HomeChartDataPoint | undefined
   const breakdown = row?.tvsBreakdown
   return (
     <ChartTooltipWrapper>
@@ -170,22 +207,27 @@ function HomeChartTooltip({
             : formatTimestamp(label, { longMonthName: true })}
         </div>
         <div className="flex flex-col gap-2">
-          <div className="flex w-full items-center justify-between gap-2">
-            <div className="flex items-center gap-1">
-              <ChartDataIndicator
-                backgroundColor={config.color}
-                type={config.indicatorType}
-              />
-              <span className="w-20 font-medium text-label-value-14 sm:w-fit">
-                {config.label}
+          {entries.map(({ entry, config }) => (
+            <div
+              key={entry.name}
+              className="flex w-full items-center justify-between gap-2"
+            >
+              <div className="flex items-center gap-1">
+                <ChartDataIndicator
+                  backgroundColor={config.color}
+                  type={config.indicatorType}
+                />
+                <span className="w-20 font-medium text-label-value-14 sm:w-fit">
+                  {config.label}
+                </span>
+              </div>
+              <span className="whitespace-nowrap font-medium text-label-value-15 tabular-nums">
+                {entry.value !== null && entry.value !== undefined
+                  ? formatValue(entry.value)
+                  : 'No data'}
               </span>
             </div>
-            <span className="whitespace-nowrap font-medium text-label-value-15 tabular-nums">
-              {entry.value !== null && entry.value !== undefined
-                ? formatValue(entry.value)
-                : 'No data'}
-            </span>
-          </div>
+          ))}
           {breakdown !== undefined && (
             <>
               <HorizontalSeparator />

--- a/packages/frontend/src/server/features/home/getHomeScalingCharts.ts
+++ b/packages/frontend/src/server/features/home/getHomeScalingCharts.ts
@@ -1,4 +1,4 @@
-import { UnixTime } from '@l2beat/shared-pure'
+import { ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
@@ -17,7 +17,8 @@ export interface HomeScalingCharts {
     change: number | undefined
   }
   activity: {
-    chart: [number, number | null, number | null][]
+    /** [timestamp, rollupsUops, validiumsAndOptimiumsUops, ethereumUops] */
+    chart: [number, number | null, number | null, number | null][]
     syncedUntil: number
     change: number | undefined
   }
@@ -93,25 +94,42 @@ async function getHomeActivityChart(
     .map((p) => p.id)
 
   const adjustedRange = await getFullySyncedActivityRange(range)
-  const [rollupEntries, validiumAndOptimiumEntries] = await Promise.all([
-    db.activity.getSummedByTimestamp(rollups, adjustedRange),
-    db.activity.getSummedByTimestamp(validiumsAndOptimiums, adjustedRange),
-  ])
+  const [rollupEntries, validiumAndOptimiumEntries, ethereumRecords] =
+    await Promise.all([
+      db.activity.getSummedByTimestamp(rollups, adjustedRange),
+      db.activity.getSummedByTimestamp(validiumsAndOptimiums, adjustedRange),
+      db.activity.getByProjectsAndTimeRange(
+        [ProjectId.ETHEREUM],
+        adjustedRange,
+      ),
+    ])
 
   const toSeries = (entries: { timestamp: number; uopsCount: number }[]) =>
     entries.map((entry) => ({
       timestamp: entry.timestamp,
       value: entry.uopsCount,
     }))
-  const chart = mergeSeriesByTimestamp(
+  const l2Chart = mergeSeriesByTimestamp(
     toSeries(rollupEntries),
     toSeries(validiumAndOptimiumEntries),
+  )
+
+  const ethereumByTimestamp = new Map<number, number>(
+    ethereumRecords.map((r) => [r.timestamp, r.uopsCount ?? r.count]),
+  )
+  const chart: HomeScalingCharts['activity']['chart'] = l2Chart.map(
+    ([timestamp, rollupsUops, vAndOUops]) => [
+      timestamp,
+      rollupsUops,
+      vAndOUops,
+      ethereumByTimestamp.get(timestamp) ?? null,
+    ],
   )
 
   return {
     chart,
     syncedUntil: adjustedRange[1],
-    change: computeSummedSeriesChange(chart),
+    change: computeSummedSeriesChange(l2Chart),
   }
 }
 
@@ -157,7 +175,7 @@ function getMockHomeScalingCharts(range: ChartRange): HomeScalingCharts {
       change: 0,
     },
     activity: {
-      chart: timestamps.map((timestamp) => [+timestamp, 14000, 10000]),
+      chart: timestamps.map((timestamp) => [+timestamp, 14000, 10000, 8000]),
       syncedUntil: adjustedRange[1],
       change: 0,
     },


### PR DESCRIPTION
Resolves L2B-14561

For the activity chart in the Layer 2s card on the home page, the first impression was that Ethereum processes more UOPS than L2s. This adds the Ethereum blue line to that chart to give perspective and visually connect it with the Ethereum card next to it.

## Changes

- `getHomeScalingCharts.ts`: the home activity chart tuple gains a fourth slot — `[timestamp, rollupsUops, vAndOUops, ethereumUops]`. Ethereum is fetched the same way as in the Ethereum card sparkline (`getByProjectsAndTimeRange` with `uopsCount ?? count`) over the same fully-synced range. The 1-year change stat still measures the L2 sum only.
- `HomeChart.tsx`: new optional `withEthereum` prop renders a second area with the standard `--chart-ethereum` stroke and fill gradient; the tooltip now renders a row per visible series instead of only the first one.
- `HomeScalingCard.tsx`: maps the new tuple slot and enables the Ethereum line; tooltip rows read "Layer 2s" / "Ethereum".

## Testing

- Typecheck, biome, and the frontend mocha suite pass.
- Verified in the running app (`CLIENT_SIDE_HOME_PAGE=true MOCK=true pnpm dev`): the chart renders both curves and the tooltip shows both values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)