### PR TITLE
Distinguish DB connection errors from invalid SINCE in db-restore

### DIFF
--- a/packages/database/scripts/db-restore/db-restore.sh
+++ b/packages/database/scripts/db-restore/db-restore.sh
@@ -154,9 +154,15 @@ fi
 TABLES=(${FEATURES_TABLES[$FEATURE_INDEX]})
 
 # Fail on an invalid cutoff before any local data is wiped
-if [ -n "$SINCE" ] && ! psql "$DEV_LOCAL_DB_URL" -tAc "SELECT '$SINCE'::timestamp" > /dev/null 2>&1; then
-  echo "Error: SINCE value '$SINCE' is not a valid timestamp."
-  exit 1
+if [ -n "$SINCE" ]; then
+  if ! psql "$DEV_LOCAL_DB_URL" -tAc "SELECT 1" > /dev/null 2>&1; then
+    echo "Error: cannot connect to the local database (DEV_LOCAL_DB_URL). Is it running?"
+    exit 1
+  fi
+  if ! psql "$DEV_LOCAL_DB_URL" -tAc "SELECT '$SINCE'::timestamp" > /dev/null 2>&1; then
+    echo "Error: SINCE value '$SINCE' is not a valid timestamp."
+    exit 1
+  fi
 fi
 
 clear_tables "${TABLES[@]}"


### PR DESCRIPTION
## Problem

`db-restore.sh <feature> <since>` validates the `SINCE` cutoff by asking the local database to cast it (`SELECT '$SINCE'::timestamp`) with all output redirected to `/dev/null`. Any psql failure — including the local Postgres simply not running — was therefore reported as:

```
Error: SINCE value '2026-07-15' is not a valid timestamp.
```

## Fix

Split the check in two:

1. `SELECT 1` against `DEV_LOCAL_DB_URL` — failure now reports "cannot connect to the local database... Is it running?"
2. Only then attempt the `::timestamp` cast — failure there genuinely means an invalid value.

Verified both paths: with Postgres down the script reports the connection error; `tvs not-a-date` still reports the invalid-timestamp error and exits before wiping any data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)