### PR TITLE
Filter out marlin token regardless of sinceTimestamp

### DIFF
--- a/packages/backend/src/config/features/tvs.ts
+++ b/packages/backend/src/config/features/tvs.ts
@@ -32,19 +32,17 @@ export async function getTvsConfig(
 
   let projects = enabledProjects.map((p) => ({
     projectId: p.id,
-    tokens: p.tvsConfig,
+    // Temporary filter for Marlin token
+    // Coingecko started returning wrong response just for this token
+    // which results in halting all TVS sync. We should investigate this issue and remove this filter once it's fixed.
+    tokens: p.tvsConfig.filter((t) => t.priceId !== 'marlin'),
   }))
 
   // sinceTimestamp override for local development
   if (sinceTimestamp) {
     projects = projects.map((p) => ({
       projectId: p.projectId,
-      // Temporary filter for Marlin token
-      // Coingecko started returning wrong response just for this token
-      // which results in halting all TVS sync. We should investigate this issue and remove this filter once it's fixed.
-      tokens: getEffectiveConfig(p.tokens, sinceTimestamp).filter(
-        (p) => p.priceId !== 'marlin',
-      ),
+      tokens: getEffectiveConfig(p.tokens, sinceTimestamp),
     }))
   }
 


### PR DESCRIPTION
## Summary

- Move the temporary Marlin token filter out of the `sinceTimestamp` branch so it applies to all TVS configs, not just local development runs
- Coingecko returns a wrong response for this token, which halts the whole TVS sync; the filter stays until that is fixed

## Testing

- Not run — config-only change