### PR TITLE
Move Privacy above Data Availability in side nav

### DIFF
--- a/packages/frontend/src/consts/navGroups.tsx
+++ b/packages/frontend/src/consts/navGroups.tsx
@@ -106,6 +106,15 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
     ],
   },
   {
+    type: 'single',
+    title: 'Privacy',
+    match: 'privacy',
+    href: '/privacy',
+    icon: (
+      <PrivacyIcon className="transition-colors duration-300 group-data-[active=true]:stroke-brand" />
+    ),
+  },
+  {
     type: 'multiple',
     title: 'Data Availability',
     match: 'data-availability',
@@ -147,15 +156,6 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
     href: '/zk-catalog',
     icon: (
       <ZkCatalogIcon className="transition-colors duration-300 group-data-[active=true]:stroke-brand" />
-    ),
-  },
-  {
-    type: 'single',
-    title: 'Privacy',
-    match: 'privacy',
-    href: '/privacy',
-    icon: (
-      <PrivacyIcon className="transition-colors duration-300 group-data-[active=true]:stroke-brand" />
     ),
   },
   {


### PR DESCRIPTION
## Summary

- Reorder `navGroups` so the Privacy entry sits above Data Availability
- No content changes — same title, match, href, and icon; only position changed

## Testing

- Not run — presentation-only reordering of a static nav config; verify visually that the side nav lists Privacy above Data Availability