### PR TITLE
Demote METHOD_NOT_SUPPORTED tRPC errors to warn

### DIFF
--- a/packages/frontend/src/server/routers/TrpcRouter.ts
+++ b/packages/frontend/src/server/routers/TrpcRouter.ts
@@ -89,8 +89,8 @@ function getLogFn(error: TRPCError) {
   switch (error.code) {
     case 'UNAUTHORIZED':
     case 'BAD_REQUEST':
-    // We had plenty of 404s for some reason, so I demoted it to warn
     case 'NOT_FOUND':
+    case 'METHOD_NOT_SUPPORTED':
       return logger.warn
     case 'PARSE_ERROR':
     case 'INTERNAL_SERVER_ERROR':
@@ -100,7 +100,6 @@ function getLogFn(error: TRPCError) {
     case 'GATEWAY_TIMEOUT':
     case 'PAYMENT_REQUIRED':
     case 'FORBIDDEN':
-    case 'METHOD_NOT_SUPPORTED':
     case 'TIMEOUT':
     case 'CONFLICT':
     case 'PRECONDITION_FAILED':

--- a/packages/token-backend/src/server/routers/TrpcRouter.ts
+++ b/packages/token-backend/src/server/routers/TrpcRouter.ts
@@ -69,6 +69,7 @@ function getLogFn(error: TRPCError) {
   switch (error.code) {
     case 'UNAUTHORIZED':
     case 'BAD_REQUEST':
+    case 'METHOD_NOT_SUPPORTED':
       return logger.warn
     case 'PARSE_ERROR':
     case 'INTERNAL_SERVER_ERROR':
@@ -79,7 +80,6 @@ function getLogFn(error: TRPCError) {
     case 'PAYMENT_REQUIRED':
     case 'FORBIDDEN':
     case 'NOT_FOUND':
-    case 'METHOD_NOT_SUPPORTED':
     case 'TIMEOUT':
     case 'CONFLICT':
     case 'PRECONDITION_FAILED':


### PR DESCRIPTION
## Summary

- Log `METHOD_NOT_SUPPORTED` tRPC errors at `warn` instead of `error` in both the frontend and token-backend routers
- These come from external/bot traffic hitting valid paths with the wrong HTTP verb, so they were adding noise to error dashboards
- Drops the now-stale inline comment about 404s in the frontend router (`NOT_FOUND` stays at `warn`)

## Testing

- Not run — switch-case log-level change only, no behavior change beyond log severity