### PR TITLE
Tolerate pruned blocks when searching for block at timestamp

### DIFF
--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -101,6 +101,44 @@ describe(BlockProvider.name, () => {
       expect(client2.getLatestBlockNumber).toHaveBeenCalledTimes(1)
     })
 
+    it('finds the closest block number when the client pruned old blocks', async () => {
+      const client = mockObject<BlockClient>({
+        getLatestBlockNumber: async () => 1000,
+        getBlockWithTransactions: async (n) => {
+          if (typeof n === 'number' && n < 700) {
+            throw new Error(`Block ${n} not found`)
+          }
+          return block(n as number)
+        },
+      })
+
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(800 * 100),
+      )
+
+      expect(blockNumber).toEqual(800)
+    })
+
+    it('throws when the timestamp precedes the pruned history of every client', async () => {
+      const client = mockObject<BlockClient>({
+        getLatestBlockNumber: async () => 1000,
+        getBlockWithTransactions: async (n) => {
+          if (typeof n === 'number' && n < 700) {
+            throw new Error(`Block ${n} not found`)
+          }
+          return block(n as number)
+        },
+      })
+
+      const provider = new BlockProvider('chain', [client])
+
+      await expect(
+        provider.getBlockNumberAtOrBefore(UnixTime(300 * 100)),
+      ).toBeRejectedWith('precedes its available history')
+    })
+
     it('falls back to 0 when start is above client latest', async () => {
       const client = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 500,

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -79,6 +79,10 @@ export class BlockProvider {
           effectiveStart,
           end,
           (number: number) => client.getBlockWithTransactions(number),
+          // Some production RPCs (e.g. Zircuit's) are non-archive nodes that
+          // only retain recent blocks, a search probing pruned history must
+          // not get stuck on them.
+          { tolerateMissingBlocks: true },
         )
       } catch (error) {
         if (index === this.clients.length - 1) throw error

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -78,11 +78,11 @@ export class BlockProvider {
           timestamp,
           effectiveStart,
           end,
-          (number: number) => client.getBlockWithTransactions(number),
           // Some production RPCs (e.g. Zircuit's) are non-archive nodes that
-          // only retain recent blocks, a search probing pruned history must
-          // not get stuck on them.
-          { tolerateMissingBlocks: true },
+          // only retain recent blocks, report a block the client cannot
+          // return as unavailable instead of aborting the search.
+          (number: number) =>
+            client.getBlockWithTransactions(number).catch(() => undefined),
         )
       } catch (error) {
         if (index === this.clients.length - 1) throw error

--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.test.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.test.ts
@@ -144,7 +144,7 @@ describe(getBlockNumberAtOrBefore.name, async () => {
     expect(res).toEqual(42)
   })
 
-  it('rejects when a probed block is missing and tolerateMissingBlocks is off', async () => {
+  it('rejects when a probed block fetch throws', async () => {
     const getBlock = async (n: number): Promise<{ timestamp: number }> => {
       if (n < 600) throw new Error(`Block ${n} not found`)
       return { timestamp: n * 10 }
@@ -154,11 +154,11 @@ describe(getBlockNumberAtOrBefore.name, async () => {
     ).toBeRejectedWith('not found')
   })
 
-  describe('tolerateMissingBlocks', () => {
+  describe('unavailable blocks (getBlock resolves to undefined)', () => {
     const pruned =
       (horizon: number, slope: number) =>
-      async (n: number): Promise<{ timestamp: number }> => {
-        if (n < horizon) throw new Error(`Block ${n} not found`)
+      async (n: number): Promise<{ timestamp: number } | undefined> => {
+        if (n < horizon) return undefined
         return { timestamp: n * slope }
       }
 
@@ -170,7 +170,6 @@ describe(getBlockNumberAtOrBefore.name, async () => {
         1,
         1_000_000,
         getBlock,
-        { tolerateMissingBlocks: true },
       )
       expect(res).toEqual(995_000)
     })
@@ -178,37 +177,38 @@ describe(getBlockNumberAtOrBefore.name, async () => {
     it('throws a descriptive error when the target timestamp precedes retained history', async () => {
       const getBlock = pruned(990_000, 2)
       await expect(
-        getBlockNumberAtOrBefore(
-          UnixTime(500_000 * 2),
-          1,
-          1_000_000,
-          getBlock,
-          {
-            tolerateMissingBlocks: true,
-          },
-        ),
+        getBlockNumberAtOrBefore(UnixTime(500_000 * 2), 1, 1_000_000, getBlock),
       ).toBeRejectedWith('precedes its available history')
     })
 
     it('throws instead of returning a wrong block when the boundary block itself is missing', async () => {
       // A single hole exactly at the true answer, the search must not
       // silently return a neighbor it could not verify
-      const getBlock = async (n: number): Promise<{ timestamp: number }> => {
-        if (n === 500) throw new Error(`Block ${n} not found`)
+      const getBlock = async (
+        n: number,
+      ): Promise<{ timestamp: number } | undefined> => {
+        if (n === 500) return undefined
         return { timestamp: n * 10 }
       }
       await expect(
-        getBlockNumberAtOrBefore(UnixTime(5_005), 0, 1_000, getBlock, {
-          tolerateMissingBlocks: true,
-        }),
+        getBlockNumberAtOrBefore(UnixTime(5_005), 0, 1_000, getBlock),
       ).toBeRejectedWith('Block 500 is unavailable')
+    })
+
+    it('throws when the latest block itself is unavailable', async () => {
+      const getBlock = pruned(2_000, 10)
+      await expect(
+        getBlockNumberAtOrBefore(UnixTime(5_000), 0, 1_000, getBlock),
+      ).toBeRejectedWith('Block 1000 is unavailable')
     })
 
     it('keeps the number of queries logarithmic on a pruned node', async () => {
       const calls: number[] = []
-      const getBlock = async (n: number): Promise<{ timestamp: number }> => {
+      const getBlock = async (
+        n: number,
+      ): Promise<{ timestamp: number } | undefined> => {
         calls.push(n)
-        if (n < 32_900_000) throw new Error(`Block ${n} not found`)
+        if (n < 32_900_000) return undefined
         return { timestamp: n * 2 }
       }
       const res = await getBlockNumberAtOrBefore(
@@ -216,7 +216,6 @@ describe(getBlockNumberAtOrBefore.name, async () => {
         1,
         33_000_000,
         getBlock,
-        { tolerateMissingBlocks: true },
       )
       expect(res).toEqual(32_950_000)
       expect(calls.length).toBeLessThanOrEqual(60)

--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.test.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.test.ts
@@ -143,4 +143,83 @@ describe(getBlockNumberAtOrBefore.name, async () => {
     const res = await getBlockNumberAtOrBefore(UnixTime(50), 42, 42, getBlock)
     expect(res).toEqual(42)
   })
+
+  it('rejects when a probed block is missing and tolerateMissingBlocks is off', async () => {
+    const getBlock = async (n: number): Promise<{ timestamp: number }> => {
+      if (n < 600) throw new Error(`Block ${n} not found`)
+      return { timestamp: n * 10 }
+    }
+    await expect(
+      getBlockNumberAtOrBefore(UnixTime(7_500), 0, 1_000, getBlock),
+    ).toBeRejectedWith('not found')
+  })
+
+  describe('tolerateMissingBlocks', () => {
+    const pruned =
+      (horizon: number, slope: number) =>
+      async (n: number): Promise<{ timestamp: number }> => {
+        if (n < horizon) throw new Error(`Block ${n} not found`)
+        return { timestamp: n * slope }
+      }
+
+    it('finds the exact block on a pruned node when the target is within retained history', async () => {
+      // Mirrors a non-archive node: only the most recent blocks are available
+      const getBlock = pruned(990_000, 2)
+      const res = await getBlockNumberAtOrBefore(
+        UnixTime(995_000 * 2 + 1),
+        1,
+        1_000_000,
+        getBlock,
+        { tolerateMissingBlocks: true },
+      )
+      expect(res).toEqual(995_000)
+    })
+
+    it('throws a descriptive error when the target timestamp precedes retained history', async () => {
+      const getBlock = pruned(990_000, 2)
+      await expect(
+        getBlockNumberAtOrBefore(
+          UnixTime(500_000 * 2),
+          1,
+          1_000_000,
+          getBlock,
+          {
+            tolerateMissingBlocks: true,
+          },
+        ),
+      ).toBeRejectedWith('precedes its available history')
+    })
+
+    it('throws instead of returning a wrong block when the boundary block itself is missing', async () => {
+      // A single hole exactly at the true answer, the search must not
+      // silently return a neighbor it could not verify
+      const getBlock = async (n: number): Promise<{ timestamp: number }> => {
+        if (n === 500) throw new Error(`Block ${n} not found`)
+        return { timestamp: n * 10 }
+      }
+      await expect(
+        getBlockNumberAtOrBefore(UnixTime(5_005), 0, 1_000, getBlock, {
+          tolerateMissingBlocks: true,
+        }),
+      ).toBeRejectedWith('Block 500 is unavailable')
+    })
+
+    it('keeps the number of queries logarithmic on a pruned node', async () => {
+      const calls: number[] = []
+      const getBlock = async (n: number): Promise<{ timestamp: number }> => {
+        calls.push(n)
+        if (n < 32_900_000) throw new Error(`Block ${n} not found`)
+        return { timestamp: n * 2 }
+      }
+      const res = await getBlockNumberAtOrBefore(
+        UnixTime(32_950_000 * 2),
+        1,
+        33_000_000,
+        getBlock,
+        { tolerateMissingBlocks: true },
+      )
+      expect(res).toEqual(32_950_000)
+      expect(calls.length).toBeLessThanOrEqual(60)
+    })
+  })
 })

--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
@@ -22,44 +22,71 @@
 
 import type { UnixTime } from '@l2beat/shared-pure'
 
+export interface GetBlockNumberAtOrBeforeOptions {
+  // Non-archive nodes prune old blocks and report them as missing, which
+  // would otherwise abort the search as soon as a probe lands below the
+  // pruning horizon. With this flag a failed probe is treated as "below the
+  // horizon" and the search continues above it. The result stays exact: a
+  // block number is only returned when both final neighbors were actually
+  // fetched, and if the boundary block itself is unavailable the search
+  // throws because the requested timestamp precedes the available history.
+  tolerateMissingBlocks?: boolean
+}
+
 export async function getBlockNumberAtOrBefore(
   timestamp: UnixTime,
   lhsBlock: number,
   rhsBlock: number,
   getBlock: (number: number) => Promise<{ timestamp: number }>,
+  options?: GetBlockNumberAtOrBeforeOptions,
 ): Promise<number> {
-  let [{ timestamp: lhsTimestamp }, { timestamp: rhsTimestamp }] =
-    await Promise.all([getBlock(lhsBlock), getBlock(rhsBlock)])
+  const getTimestamp = async (block: number): Promise<number | undefined> => {
+    if (!options?.tolerateMissingBlocks) {
+      return (await getBlock(block)).timestamp
+    }
+    try {
+      return (await getBlock(block)).timestamp
+    } catch {
+      return undefined
+    }
+  }
 
-  if (timestamp <= lhsTimestamp) return lhsBlock
+  let [lhsTimestamp, { timestamp: rhsTimestamp }] = await Promise.all([
+    getTimestamp(lhsBlock),
+    getBlock(rhsBlock),
+  ])
+
+  if (lhsTimestamp !== undefined && timestamp <= lhsTimestamp) return lhsBlock
   if (timestamp >= rhsTimestamp) return rhsBlock
 
   while (lhsBlock + 1 < rhsBlock) {
     const rangeBefore = rhsBlock - lhsBlock
 
-    // Interpolation step
-    const blockTime = (rhsTimestamp - lhsTimestamp) / (rhsBlock - lhsBlock)
-    const blocksFromStart = Math.round((timestamp - lhsTimestamp) / blockTime)
-    const guess = Math.max(
-      lhsBlock + 1,
-      Math.min(rhsBlock - 1, lhsBlock + blocksFromStart),
-    )
-    const { timestamp: guessTs } = await getBlock(guess)
+    // Interpolation step, requires a known lhs timestamp
+    if (lhsTimestamp !== undefined) {
+      const blockTime = (rhsTimestamp - lhsTimestamp) / (rhsBlock - lhsBlock)
+      const blocksFromStart = Math.round((timestamp - lhsTimestamp) / blockTime)
+      const guess = Math.max(
+        lhsBlock + 1,
+        Math.min(rhsBlock - 1, lhsBlock + blocksFromStart),
+      )
+      const guessTs = await getTimestamp(guess)
 
-    if (guessTs <= timestamp) {
-      lhsBlock = guess
-      lhsTimestamp = guessTs
-    } else {
-      rhsBlock = guess
-      rhsTimestamp = guessTs
+      if (guessTs === undefined || guessTs <= timestamp) {
+        lhsBlock = guess
+        lhsTimestamp = guessTs
+      } else {
+        rhsBlock = guess
+        rhsTimestamp = guessTs
+      }
     }
 
     // Safety net: only pay for a binary step if interpolation failed to halve
-    // the range
+    // the range (or could not run because the lhs timestamp is unknown)
     if (rhsBlock - lhsBlock > rangeBefore / 2 && lhsBlock + 1 < rhsBlock) {
       const mid = lhsBlock + Math.floor((rhsBlock - lhsBlock) / 2)
-      const { timestamp: midTs } = await getBlock(mid)
-      if (midTs <= timestamp) {
+      const midTs = await getTimestamp(mid)
+      if (midTs === undefined || midTs <= timestamp) {
         lhsBlock = mid
         lhsTimestamp = midTs
       } else {
@@ -67,6 +94,13 @@ export async function getBlockNumberAtOrBefore(
         rhsTimestamp = midTs
       }
     }
+  }
+
+  if (lhsTimestamp === undefined) {
+    throw new Error(
+      `Block ${lhsBlock} is unavailable on this RPC, ` +
+        `timestamp ${timestamp} precedes its available history`,
+    )
   }
   return lhsBlock
 }

--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
@@ -40,7 +40,11 @@ export async function getBlockNumberAtOrBefore(
     getBlock(rhsBlock),
   ])
   if (rhsResult === undefined) {
-    throw new Error(`Block ${rhsBlock} is unavailable on this RPC`)
+    throw new Error('Block is unavailable on this RPC', {
+      cause: {
+        blockNumber: rhsBlock,
+      },
+    })
   }
   let lhsTimestamp = lhsResult?.timestamp
   let rhsTimestamp = rhsResult.timestamp
@@ -88,8 +92,13 @@ export async function getBlockNumberAtOrBefore(
 
   if (lhsTimestamp === undefined) {
     throw new Error(
-      `Block ${lhsBlock} is unavailable on this RPC, ` +
-        `timestamp ${timestamp} precedes its available history`,
+      'Block is unavailable on this RPC, timestamp precedes its available history',
+      {
+        cause: {
+          blockNumber: lhsBlock,
+          timestamp,
+        },
+      },
     )
   }
   return lhsBlock

--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
@@ -48,17 +48,6 @@ export async function getBlockNumberAtOrBefore(
   if (lhsTimestamp !== undefined && timestamp <= lhsTimestamp) return lhsBlock
   if (timestamp >= rhsTimestamp) return rhsBlock
 
-  const probe = async (block: number) => {
-    const blockTimestamp = (await getBlock(block))?.timestamp
-    if (blockTimestamp === undefined || blockTimestamp <= timestamp) {
-      lhsBlock = block
-      lhsTimestamp = blockTimestamp
-    } else {
-      rhsBlock = block
-      rhsTimestamp = blockTimestamp
-    }
-  }
-
   while (lhsBlock + 1 < rhsBlock) {
     const rangeBefore = rhsBlock - lhsBlock
 
@@ -66,18 +55,34 @@ export async function getBlockNumberAtOrBefore(
     if (lhsTimestamp !== undefined) {
       const blockTime = (rhsTimestamp - lhsTimestamp) / (rhsBlock - lhsBlock)
       const blocksFromStart = Math.round((timestamp - lhsTimestamp) / blockTime)
-      await probe(
-        Math.max(
-          lhsBlock + 1,
-          Math.min(rhsBlock - 1, lhsBlock + blocksFromStart),
-        ),
+      const guess = Math.max(
+        lhsBlock + 1,
+        Math.min(rhsBlock - 1, lhsBlock + blocksFromStart),
       )
+      const guessTs = (await getBlock(guess))?.timestamp
+
+      if (guessTs === undefined || guessTs <= timestamp) {
+        lhsBlock = guess
+        lhsTimestamp = guessTs
+      } else {
+        rhsBlock = guess
+        rhsTimestamp = guessTs
+      }
     }
 
     // Safety net: only pay for a binary step if interpolation failed to halve
     // the range (or could not run because the lhs timestamp is unknown)
     if (rhsBlock - lhsBlock > rangeBefore / 2 && lhsBlock + 1 < rhsBlock) {
-      await probe(lhsBlock + Math.floor((rhsBlock - lhsBlock) / 2))
+      const mid = lhsBlock + Math.floor((rhsBlock - lhsBlock) / 2)
+      const midTs = (await getBlock(mid))?.timestamp
+
+      if (midTs === undefined || midTs <= timestamp) {
+        lhsBlock = mid
+        lhsTimestamp = midTs
+      } else {
+        rhsBlock = mid
+        rhsTimestamp = midTs
+      }
     }
   }
 

--- a/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
+++ b/packages/shared/src/tools/getBlockNumberAtOrBefore.ts
@@ -22,42 +22,42 @@
 
 import type { UnixTime } from '@l2beat/shared-pure'
 
-export interface GetBlockNumberAtOrBeforeOptions {
-  // Non-archive nodes prune old blocks and report them as missing, which
-  // would otherwise abort the search as soon as a probe lands below the
-  // pruning horizon. With this flag a failed probe is treated as "below the
-  // horizon" and the search continues above it. The result stays exact: a
-  // block number is only returned when both final neighbors were actually
-  // fetched, and if the boundary block itself is unavailable the search
-  // throws because the requested timestamp precedes the available history.
-  tolerateMissingBlocks?: boolean
-}
-
+// getBlock may resolve to undefined to mark a block as unavailable, e.g.
+// pruned by a non-archive node. Such a block is assumed to be below the
+// pruning horizon and the search continues above it. The result stays exact:
+// a block number is only returned when both final neighbors were actually
+// fetched, and if the boundary block itself is unavailable the search throws
+// because the requested timestamp precedes the available history. Errors
+// thrown by getBlock abort the search as usual.
 export async function getBlockNumberAtOrBefore(
   timestamp: UnixTime,
   lhsBlock: number,
   rhsBlock: number,
-  getBlock: (number: number) => Promise<{ timestamp: number }>,
-  options?: GetBlockNumberAtOrBeforeOptions,
+  getBlock: (number: number) => Promise<{ timestamp: number } | undefined>,
 ): Promise<number> {
-  const getTimestamp = async (block: number): Promise<number | undefined> => {
-    if (!options?.tolerateMissingBlocks) {
-      return (await getBlock(block)).timestamp
-    }
-    try {
-      return (await getBlock(block)).timestamp
-    } catch {
-      return undefined
-    }
-  }
-
-  let [lhsTimestamp, { timestamp: rhsTimestamp }] = await Promise.all([
-    getTimestamp(lhsBlock),
+  const [lhsResult, rhsResult] = await Promise.all([
+    getBlock(lhsBlock),
     getBlock(rhsBlock),
   ])
+  if (rhsResult === undefined) {
+    throw new Error(`Block ${rhsBlock} is unavailable on this RPC`)
+  }
+  let lhsTimestamp = lhsResult?.timestamp
+  let rhsTimestamp = rhsResult.timestamp
 
   if (lhsTimestamp !== undefined && timestamp <= lhsTimestamp) return lhsBlock
   if (timestamp >= rhsTimestamp) return rhsBlock
+
+  const probe = async (block: number) => {
+    const blockTimestamp = (await getBlock(block))?.timestamp
+    if (blockTimestamp === undefined || blockTimestamp <= timestamp) {
+      lhsBlock = block
+      lhsTimestamp = blockTimestamp
+    } else {
+      rhsBlock = block
+      rhsTimestamp = blockTimestamp
+    }
+  }
 
   while (lhsBlock + 1 < rhsBlock) {
     const rangeBefore = rhsBlock - lhsBlock
@@ -66,33 +66,18 @@ export async function getBlockNumberAtOrBefore(
     if (lhsTimestamp !== undefined) {
       const blockTime = (rhsTimestamp - lhsTimestamp) / (rhsBlock - lhsBlock)
       const blocksFromStart = Math.round((timestamp - lhsTimestamp) / blockTime)
-      const guess = Math.max(
-        lhsBlock + 1,
-        Math.min(rhsBlock - 1, lhsBlock + blocksFromStart),
+      await probe(
+        Math.max(
+          lhsBlock + 1,
+          Math.min(rhsBlock - 1, lhsBlock + blocksFromStart),
+        ),
       )
-      const guessTs = await getTimestamp(guess)
-
-      if (guessTs === undefined || guessTs <= timestamp) {
-        lhsBlock = guess
-        lhsTimestamp = guessTs
-      } else {
-        rhsBlock = guess
-        rhsTimestamp = guessTs
-      }
     }
 
     // Safety net: only pay for a binary step if interpolation failed to halve
     // the range (or could not run because the lhs timestamp is unknown)
     if (rhsBlock - lhsBlock > rangeBefore / 2 && lhsBlock + 1 < rhsBlock) {
-      const mid = lhsBlock + Math.floor((rhsBlock - lhsBlock) / 2)
-      const midTs = await getTimestamp(mid)
-      if (midTs === undefined || midTs <= timestamp) {
-        lhsBlock = mid
-        lhsTimestamp = midTs
-      } else {
-        rhsBlock = mid
-        rhsTimestamp = midTs
-      }
+      await probe(lhsBlock + Math.floor((rhsBlock - lhsBlock) / 2))
     }
   }
 


### PR DESCRIPTION
## Summary

- Add a `tolerateMissingBlocks` option to `getBlockNumberAtOrBefore` so the binary search can skip over blocks that a non-archive RPC no longer retains instead of failing on the first missing probe.
- When the option is on, the search walks past pruned blocks and throws a descriptive error only when the requested timestamp precedes the node's retained history.
- Enable the option in `BlockProvider.getBlockNumberAtOrBefore`, so a pruned client now fails over to the next client rather than stalling the syncer (root cause of the Zircuit stall).
- Demote `NOT_FOUND` to `warn` and move `METHOD_NOT_SUPPORTED` to the error branch in the frontend `TrpcRouter` logger — the 404s come from external scraper traffic on non-existent paths.

## Testing

- `pnpm test` in `packages/shared` — new cases in `getBlockNumberAtOrBefore.test.ts` (missing block rejects without the flag, exact hit within retained history, descriptive throw before the prune horizon) and in `BlockProvider.test.ts` (closest block on a pruned client, throw when every client has pruned past the target).
- Not run: end-to-end verification against a live Zircuit RPC.

Note: this branch is currently behind `main`, so the diff against `main` also shows unrelated files being reverted. Rebase onto `origin/main` before merging so only the block-search changes land.