### PR TITLE
Fetch only the needed calldata prefix for tracked txs

### DIFF
--- a/packages/backend/src/modules/tracked-txs/TrackedTxsClient.test.ts
+++ b/packages/backend/src/modules/tracked-txs/TrackedTxsClient.test.ts
@@ -99,7 +99,7 @@ describe(TrackedTxsClient.name, () => {
       expect(duneQueryService.query).not.toHaveBeenCalled()
     })
 
-    it('requests full input for grouped liveness calls', async () => {
+    it('requests a calldata prefix for grouped liveness calls', async () => {
       const duneQueryService = getMockDuneQueryService([[]])
       const trackedTxsClient = new TrackedTxsClient(
         duneQueryService,
@@ -135,7 +135,8 @@ describe(TrackedTxsClient.name, () => {
           [
             {
               ...config.properties.params,
-              getFullInput: true,
+              // 4 selector bytes + the first member of the static tuple
+              inputBytes: 36,
             },
           ],
           FROM,
@@ -401,9 +402,11 @@ const FUNCTIONS_SQL = getFunctionCallQuery(
   ).map((c) => ({
     address: c.properties.params.address,
     selector: c.properties.params.selector,
-    getFullInput:
+    inputBytes:
       c.properties.params.formula === 'sharpSubmission' ||
-      c.properties.params.formula === 'sharedBridge',
+      c.properties.params.formula === 'sharedBridge'
+        ? ('full' as const)
+        : 4,
   })),
   FROM,
   TO,

--- a/packages/backend/src/modules/tracked-txs/TrackedTxsClient.ts
+++ b/packages/backend/src/modules/tracked-txs/TrackedTxsClient.ts
@@ -17,6 +17,7 @@ import {
   type TrackedTxResult,
   type TrackedTxTransferResult,
 } from './types/model'
+import { getFunctionCallParameterPrefix } from './utils/functionCallParameter'
 import { hasLivenessGrouping } from './utils/getLivenessGroupingKey'
 import { getFunctionCallQuery, getTransferQuery } from './utils/sql'
 import { transformFunctionCallsQueryResult } from './utils/transformFunctionCallsQueryResult'
@@ -175,13 +176,26 @@ function combineCalls(
   sharpSubmissionsConfig: TrackedTxSharpSubmissionConfig[],
   sharedBridgesConfig: TrackedTxSharedBridgeConfig[],
 ) {
-  // TODO: unique
   return [
     ...functionCallsConfig.map((c) => ({
       ...c.properties.params,
-      getFullInput: hasLivenessGrouping(c.properties),
+      // Grouped liveness reads a single parameter from the input, so fetch
+      // only the calldata prefix containing it whenever its position is
+      // statically known. Everything else needs just the selector.
+      inputBytes: hasLivenessGrouping(c.properties)
+        ? (getFunctionCallParameterPrefix(
+            c.properties.params.signature,
+            c.properties.groupBy.path,
+          ) ?? ('full' as const))
+        : SELECTOR_BYTES,
     })),
-    ...sharpSubmissionsConfig.map((c) => ({ ...c, getFullInput: true })),
-    ...sharedBridgesConfig.map((c) => ({ ...c, getFullInput: true })),
+    // These formulas filter by decoding the input, so they need all of it.
+    ...sharpSubmissionsConfig.map((c) => ({
+      ...c,
+      inputBytes: 'full' as const,
+    })),
+    ...sharedBridgesConfig.map((c) => ({ ...c, inputBytes: 'full' as const })),
   ]
 }
+
+const SELECTOR_BYTES = 4

--- a/packages/backend/src/modules/tracked-txs/utils/functionCallParameter.test.ts
+++ b/packages/backend/src/modules/tracked-txs/utils/functionCallParameter.test.ts
@@ -1,0 +1,211 @@
+import { EthereumAddress } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { utils } from 'ethers'
+import {
+  extractFunctionCallParameter,
+  getFunctionCallParameterPrefix,
+} from './functionCallParameter'
+
+// Aztec Rollup.submitEpochRootProof, the motivating case: ~66 KB of calldata
+// of which liveness grouping needs only the first tuple member.
+const AZTEC_SIGNATURE =
+  'function submitEpochRootProof((uint256,uint256,(bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))' as const
+
+const PROVER = EthereumAddress.random().toString()
+
+function hex32(value: number): string {
+  return utils.hexZeroPad(`0x${value.toString(16)}`, 32)
+}
+
+function checkpoint(i: number) {
+  return [
+    hex32(1000 + i),
+    hex32(2000 + i),
+    hex32(3000 + i),
+    hex32(4000 + i),
+    hex32(5000 + i),
+    6000 + i,
+    7000 + i,
+    PROVER,
+    hex32(8000 + i),
+    [1, 2],
+    9000 + i,
+    10000 + i,
+  ]
+}
+
+const AZTEC_ARGS = [
+  [
+    24308,
+    24339,
+    [hex32(1), hex32(2), hex32(3), PROVER],
+    [checkpoint(0), checkpoint(1), checkpoint(2)],
+    [`0x${'aa'.repeat(100)}`, `0x${'bb'.repeat(7)}`],
+    `0x${'cc'.repeat(1234)}`,
+    `0x${'dd'.repeat(5)}`,
+  ],
+]
+
+const AZTEC_INTERFACE = new utils.Interface([AZTEC_SIGNATURE])
+const AZTEC_INPUT = AZTEC_INTERFACE.encodeFunctionData(
+  'submitEpochRootProof',
+  AZTEC_ARGS,
+)
+
+/** The pre-optimization implementation: full decode, walk the result. */
+function decodeByPath(input: string, path: number[]): string {
+  let value: unknown = AZTEC_INTERFACE.decodeFunctionData(
+    'submitEpochRootProof',
+    input,
+  )
+  for (const index of path) {
+    value = (value as unknown[])[index]
+  }
+  return String(value)
+}
+
+function prefixOf(input: string, bytes: number): string {
+  return input.slice(0, 2 + bytes * 2)
+}
+
+describe(extractFunctionCallParameter.name, () => {
+  it('extracts a head-word parameter from the full input', () => {
+    expect(
+      extractFunctionCallParameter(AZTEC_SIGNATURE, AZTEC_INPUT, [0, 0]),
+    ).toEqual('24308')
+    expect(
+      extractFunctionCallParameter(AZTEC_SIGNATURE, AZTEC_INPUT, [0, 1]),
+    ).toEqual('24339')
+  })
+
+  it('extracts the same value from just the calldata prefix', () => {
+    const prefix = getFunctionCallParameterPrefix(AZTEC_SIGNATURE, [0, 0])
+    expect(prefix).toEqual(68)
+    expect(
+      extractFunctionCallParameter(
+        AZTEC_SIGNATURE,
+        prefixOf(AZTEC_INPUT, 68),
+        [0, 0],
+      ),
+    ).toEqual('24308')
+  })
+
+  it('extracts an address from an inlined static tuple', () => {
+    const path = [0, 2, 3]
+    const value = extractFunctionCallParameter(
+      AZTEC_SIGNATURE,
+      AZTEC_INPUT,
+      path,
+    )
+    expect(value).toEqual(decodeByPath(AZTEC_INPUT, path))
+    expect(value).toEqual(PROVER)
+
+    const prefix = getFunctionCallParameterPrefix(AZTEC_SIGNATURE, path)
+    expect(prefix).toEqual(4 + 32 + 2 * 32 + 3 * 32 + 32)
+    expect(
+      extractFunctionCallParameter(
+        AZTEC_SIGNATURE,
+        prefixOf(AZTEC_INPUT, prefix ?? 0),
+        path,
+      ),
+    ).toEqual(value)
+  })
+
+  it('extracts a member of a dynamic array element', () => {
+    const path = [0, 3, 1, 5]
+    const value = extractFunctionCallParameter(
+      AZTEC_SIGNATURE,
+      AZTEC_INPUT,
+      path,
+    )
+    expect(value).toEqual(decodeByPath(AZTEC_INPUT, path))
+    expect(value).toEqual('6001')
+
+    // tuple offset word + tuple head (10 words) + array length word
+    // + 1 full element (13 words) + 5 head words into the second element
+    const prefix = getFunctionCallParameterPrefix(AZTEC_SIGNATURE, path)
+    expect(prefix).toEqual(4 + (1 + 10 + 1 + 13 + 5) * 32 + 32)
+    expect(
+      extractFunctionCallParameter(
+        AZTEC_SIGNATURE,
+        prefixOf(AZTEC_INPUT, prefix ?? 0),
+        path,
+      ),
+    ).toEqual(value)
+  })
+
+  it('extracts dynamic bytes when given the full input', () => {
+    const path = [0, 4, 0]
+    expect(
+      extractFunctionCallParameter(AZTEC_SIGNATURE, AZTEC_INPUT, path),
+    ).toEqual(`0x${'aa'.repeat(100)}`)
+  })
+
+  it('rejects input with a mismatched selector', () => {
+    const other = new utils.Interface(['function foo(uint256)'])
+    expect(() =>
+      extractFunctionCallParameter(
+        AZTEC_SIGNATURE,
+        other.encodeFunctionData('foo', [1]),
+        [0, 0],
+      ),
+    ).toThrow('Input does not match the function selector')
+  })
+
+  it('rejects input truncated below the target', () => {
+    expect(() =>
+      extractFunctionCallParameter(
+        AZTEC_SIGNATURE,
+        prefixOf(AZTEC_INPUT, 67),
+        [0, 0],
+      ),
+    ).toThrow('Unexpected end of function call input')
+  })
+
+  it('rejects a path ending at a tuple', () => {
+    expect(() =>
+      extractFunctionCallParameter(AZTEC_SIGNATURE, AZTEC_INPUT, [0]),
+    ).toThrow('Grouping parameter must be a scalar')
+  })
+
+  it('rejects a path outside the parameters', () => {
+    expect(() =>
+      extractFunctionCallParameter(AZTEC_SIGNATURE, AZTEC_INPUT, [0, 7]),
+    ).toThrow('Parameter path does not exist')
+    expect(() =>
+      extractFunctionCallParameter(AZTEC_SIGNATURE, AZTEC_INPUT, [0, 3, 3, 0]),
+    ).toThrow('Parameter path does not exist')
+  })
+})
+
+describe(getFunctionCallParameterPrefix.name, () => {
+  it('is undefined when the target position is data-dependent', () => {
+    // (bytes,bytes) is not the first dynamic member of the tuple, so its
+    // offset depends on the size of the checkpoint array before it.
+    expect(getFunctionCallParameterPrefix(AZTEC_SIGNATURE, [0, 4, 0])).toEqual(
+      undefined,
+    )
+    // Dynamic bytes need their data-dependent length even at a static offset.
+    expect(getFunctionCallParameterPrefix('function foo(bytes)', [0])).toEqual(
+      undefined,
+    )
+  })
+
+  it('is undefined for an invalid path', () => {
+    expect(getFunctionCallParameterPrefix(AZTEC_SIGNATURE, [0])).toEqual(
+      undefined,
+    )
+    expect(getFunctionCallParameterPrefix(AZTEC_SIGNATURE, [5])).toEqual(
+      undefined,
+    )
+  })
+
+  it('covers a fully static parameter list', () => {
+    expect(
+      getFunctionCallParameterPrefix(
+        'function foo(uint256,(uint256,address))',
+        [1, 1],
+      ),
+    ).toEqual(4 + 2 * 32 + 32)
+  })
+})

--- a/packages/backend/src/modules/tracked-txs/utils/functionCallParameter.ts
+++ b/packages/backend/src/modules/tracked-txs/utils/functionCallParameter.ts
@@ -1,0 +1,238 @@
+import { assert } from '@l2beat/shared-pure'
+import { utils } from 'ethers'
+
+const SELECTOR_BYTES = 4
+const WORD_BYTES = 32
+
+// The cache is bounded by the static tracked-tx configurations.
+const signatures = new Map<
+  `function ${string}`,
+  { inputs: utils.ParamType[]; sighash: string }
+>()
+
+function parseSignature(signature: `function ${string}`) {
+  let parsed = signatures.get(signature)
+  if (parsed === undefined) {
+    const iface = new utils.Interface([signature])
+    const fragment = Object.values(iface.functions)[0]
+    assert(fragment !== undefined, 'Invalid function signature')
+    parsed = { inputs: fragment.inputs, sighash: iface.getSighash(fragment) }
+    signatures.set(signature, parsed)
+  }
+  return parsed
+}
+
+/**
+ * Extracts a single parameter from function call input by walking the ABI head
+ * layout instead of running a full decode. Unlike a full decode this works on
+ * a calldata prefix (see getFunctionCallParameterPrefix), as long as the
+ * offsets on the path to the target and the target itself fit in the data.
+ */
+export function extractFunctionCallParameter(
+  signature: `function ${string}`,
+  input: string,
+  path: readonly number[],
+): string {
+  const { inputs, sighash } = parseSignature(signature)
+  assert(
+    input.toLowerCase().startsWith(sighash),
+    'Input does not match the function selector',
+  )
+  const data = Buffer.from(input.slice(2 + SELECTOR_BYTES * 2), 'hex')
+  const target = locate(inputs, path, {
+    blockOffset: (slot) => readPointer(data, slot),
+    arrayElementOffset: (slot) => readPointer(data, slot),
+    arrayLength: (position) => readPointer(data, position),
+  })
+
+  if (target.type.baseType === 'bytes' || target.type.baseType === 'string') {
+    const length = readPointer(data, target.position)
+    const bytes = readBytes(data, target.position + WORD_BYTES, length)
+    return target.type.baseType === 'string'
+      ? bytes.toString('utf8')
+      : `0x${bytes.toString('hex')}`
+  }
+
+  const word = readBytes(data, target.position, WORD_BYTES)
+  const value: unknown = utils.defaultAbiCoder.decode(
+    [target.type.type],
+    word,
+  )[0]
+  return String(value)
+}
+
+/**
+ * The number of calldata bytes sufficient to extract the parameter at `path`,
+ * assuming canonical ABI encoding (minimal offsets, which is what every
+ * standard encoder emits). Returns undefined when the target's position is
+ * data-dependent and the full input is required.
+ */
+export function getFunctionCallParameterPrefix(
+  signature: `function ${string}`,
+  path: readonly number[],
+): number | undefined {
+  try {
+    const { inputs } = parseSignature(signature)
+    const target = locate(inputs, path, CANONICAL_RESOLVER)
+    if (staticSize(target.type) === undefined) return undefined
+    return SELECTOR_BYTES + target.position + WORD_BYTES
+  } catch {
+    return undefined
+  }
+}
+
+interface TailResolver {
+  /** Offset stored in a block's head slot, relative to the block start. */
+  blockOffset(
+    slot: number,
+    components: utils.ParamType[],
+    index: number,
+  ): number
+  /** Offset stored in an array's element slot, relative to the elements start. */
+  arrayElementOffset(slot: number): number
+  /** Length of a dynamic array; undefined skips bounds checking. */
+  arrayLength(position: number): number | undefined
+}
+
+const CANONICAL_RESOLVER: TailResolver = {
+  blockOffset: (_slot, components, index) => {
+    // Only the first tail's location is data-independent: canonical encoders
+    // place it right after the block's head.
+    for (let i = 0; i < index; i++) {
+      if (staticSize(components[i]) === undefined) {
+        throw new Error('Offset is data-dependent')
+      }
+    }
+    return components.reduce((sum, c) => sum + headSize(c), 0)
+  },
+  arrayElementOffset: () => {
+    // Element offsets follow the data-dependent array length.
+    throw new Error('Offset is data-dependent')
+  },
+  arrayLength: () => undefined,
+}
+
+type Node =
+  | { kind: 'block'; components: utils.ParamType[]; start: number }
+  | {
+      kind: 'array'
+      element: utils.ParamType
+      start: number
+      length: number | undefined
+    }
+  | { kind: 'value'; type: utils.ParamType; position: number }
+
+function locate(
+  inputs: utils.ParamType[],
+  path: readonly number[],
+  resolver: TailResolver,
+): { type: utils.ParamType; position: number } {
+  let node: Node = { kind: 'block', components: inputs, start: 0 }
+  for (const index of path) {
+    assert(Number.isInteger(index) && index >= 0, 'Invalid parameter path')
+    assert(node.kind !== 'value', 'Parameter path does not exist')
+    node = stepInto(node, index, resolver)
+  }
+  assert(node.kind === 'value', 'Grouping parameter must be a scalar')
+  return node
+}
+
+function stepInto(
+  node: Exclude<Node, { kind: 'value' }>,
+  index: number,
+  resolver: TailResolver,
+): Node {
+  let type: utils.ParamType
+  let slot: number
+  if (node.kind === 'block') {
+    assert(index < node.components.length, 'Parameter path does not exist')
+    type = node.components[index]
+    slot = node.start
+    for (let i = 0; i < index; i++) {
+      slot += headSize(node.components[i])
+    }
+  } else {
+    assert(
+      node.length === undefined || index < node.length,
+      'Parameter path does not exist',
+    )
+    type = node.element
+    slot = node.start + index * headSize(type)
+  }
+
+  // A static type is inlined in the head, a dynamic one's head slot points
+  // into the tail, relative to the enclosing block.
+  const start =
+    staticSize(type) !== undefined
+      ? slot
+      : node.start +
+        (node.kind === 'block'
+          ? resolver.blockOffset(slot, node.components, index)
+          : resolver.arrayElementOffset(slot))
+
+  if (type.baseType === 'tuple') {
+    return { kind: 'block', components: type.components, start }
+  }
+  if (type.baseType === 'array') {
+    if (type.arrayLength !== -1) {
+      // Fixed-size arrays have no length word.
+      return {
+        kind: 'array',
+        element: type.arrayChildren,
+        start,
+        length: type.arrayLength,
+      }
+    }
+    return {
+      kind: 'array',
+      element: type.arrayChildren,
+      start: start + WORD_BYTES,
+      length: resolver.arrayLength(start),
+    }
+  }
+  return { kind: 'value', type, position: start }
+}
+
+function staticSize(type: utils.ParamType): number | undefined {
+  switch (type.baseType) {
+    case 'array': {
+      if (type.arrayLength === -1) return undefined
+      const element = staticSize(type.arrayChildren)
+      return element === undefined ? undefined : type.arrayLength * element
+    }
+    case 'tuple': {
+      let sum = 0
+      for (const component of type.components) {
+        const size = staticSize(component)
+        if (size === undefined) return undefined
+        sum += size
+      }
+      return sum
+    }
+    case 'bytes':
+    case 'string':
+      return undefined
+    default:
+      return WORD_BYTES
+  }
+}
+
+function headSize(type: utils.ParamType): number {
+  return staticSize(type) ?? WORD_BYTES
+}
+
+function readBytes(data: Buffer, position: number, length: number): Buffer {
+  assert(
+    position + length <= data.length,
+    'Unexpected end of function call input',
+  )
+  return data.subarray(position, position + length)
+}
+
+function readPointer(data: Buffer, position: number): number {
+  const value = BigInt(
+    `0x${readBytes(data, position, WORD_BYTES).toString('hex')}`,
+  )
+  assert(value <= BigInt(Number.MAX_SAFE_INTEGER), 'Pointer value out of range')
+  return Number(value)
+}

--- a/packages/backend/src/modules/tracked-txs/utils/getLivenessGroupingKey.ts
+++ b/packages/backend/src/modules/tracked-txs/utils/getLivenessGroupingKey.ts
@@ -5,7 +5,7 @@ import type {
   TrackedTxFunctionCallLivenessConfig,
 } from '@l2beat/shared'
 import { assert } from '@l2beat/shared-pure'
-import { decodeFunctionCallInput } from './decodeFunctionCallInput'
+import { extractFunctionCallParameter } from './functionCallParameter'
 
 export type GroupedLivenessConfig = TrackedTxFunctionCallLivenessConfig & {
   groupBy: TrackedTxFunctionCallGrouping
@@ -26,18 +26,11 @@ export function getLivenessGroupingKey(
   config: TrackedTxFunctionCallConfig,
   grouping: TrackedTxFunctionCallGrouping,
 ): string {
-  let value: unknown = decodeFunctionCallInput(config.signature, input)
-
-  for (const index of grouping.path) {
-    assert(Number.isInteger(index) && index >= 0, 'Invalid parameter path')
-    assert(Array.isArray(value), 'Parameter path does not exist')
-    value = value[index]
-  }
-
-  assert(value !== undefined && value !== null, 'Parameter path does not exist')
-  assert(!Array.isArray(value), 'Grouping parameter must be a scalar')
-
-  const key = String(value)
+  const key = extractFunctionCallParameter(
+    config.signature,
+    input,
+    grouping.path,
+  )
   // Keep in sync with the groupingKey columns.
   assert(key.length <= 255, 'Liveness grouping key exceeds 255 characters')
   return key

--- a/packages/backend/src/modules/tracked-txs/utils/sql/getFunctionCallQuery.test.ts
+++ b/packages/backend/src/modules/tracked-txs/utils/sql/getFunctionCallQuery.test.ts
@@ -13,32 +13,25 @@ const CONFIGURATIONS = [
   {
     address: ADDRESS_1,
     selector: SELECTOR_1,
-    getFullInput: false,
+    inputBytes: 4,
   },
   {
     address: ADDRESS_2,
     selector: SELECTOR_2,
-    getFullInput: true,
+    inputBytes: 'full' as const,
   },
 ]
 
-describe(getFunctionCallQuery.name, () => {
-  it('returns valid SQL', () => {
-    const query = getFunctionCallQuery(CONFIGURATIONS, FROM, TO)
-    expect(query).toEqual(`
+const EXPECTED_SQL = `
     WITH
       params AS (
         SELECT
           from_iso8601_timestamp('2021-01-01T00:00:00.000Z') AS t_start,
           from_iso8601_timestamp('2021-01-02T00:00:00.000Z') AS t_end
       ),
-      allowed_calls(to_addr, selector) AS (
+      allowed_calls(to_addr, selector, input_bytes) AS (
         VALUES
-          (0x67e002f3a410029501eae397b63ec5f2b1f9fc96, 0xaaaaaaaa),(0xe82a80c31a78f25c5dbe7ad7d035801f518653e6, 0xbbbbbbbb)
-      ),
-      full_input_to(to_addr) AS (
-        VALUES
-          (0xe82a80c31a78f25c5dbe7ad7d035801f518653e6)
+          (0x67e002f3a410029501eae397b63ec5f2b1f9fc96, 0xaaaaaaaa, 4),(0xe82a80c31a78f25c5dbe7ad7d035801f518653e6, 0xbbbbbbbb, NULL)
       ),
       traces_filtered AS (
         SELECT
@@ -55,7 +48,7 @@ describe(getFunctionCallQuery.name, () => {
           AND tr.block_time <=  p.t_end
       ),
       traces_allowed AS (
-        SELECT tr.*
+        SELECT tr.*, ac.input_bytes
         FROM traces_filtered tr
         JOIN allowed_calls ac
           ON tr.to = ac.to_addr
@@ -87,13 +80,18 @@ describe(getFunctionCallQuery.name, () => {
       length(tx.data) AS data_length,
       length(replace(regexp_replace(to_hex(tx.data), '([0-9A-Fa-f]{2})', '$1x'), '00x', '')) / 3 AS non_zero_bytes,
       CASE
-        WHEN tr.to IN (SELECT to_addr FROM full_input_to) THEN tr.input
-        ELSE tr.selector
+        WHEN tr.input_bytes IS NULL THEN tr.input
+        ELSE substr(tr.input, 1, tr.input_bytes)
       END AS input
     FROM txs_filtered tx
     JOIN traces_allowed tr
       ON tx.hash = tr.tx_hash;
-  `)
+  `
+
+describe(getFunctionCallQuery.name, () => {
+  it('returns valid SQL', () => {
+    const query = getFunctionCallQuery(CONFIGURATIONS, FROM, TO)
+    expect(query).toEqual(EXPECTED_SQL)
   })
 
   it('returns valid SQL with duplicate configurations', () => {
@@ -103,75 +101,39 @@ describe(getFunctionCallQuery.name, () => {
       TO,
     )
 
-    expect(query).toEqual(`
-    WITH
-      params AS (
-        SELECT
-          from_iso8601_timestamp('2021-01-01T00:00:00.000Z') AS t_start,
-          from_iso8601_timestamp('2021-01-02T00:00:00.000Z') AS t_end
-      ),
-      allowed_calls(to_addr, selector) AS (
-        VALUES
-          (0x67e002f3a410029501eae397b63ec5f2b1f9fc96, 0xaaaaaaaa),(0xe82a80c31a78f25c5dbe7ad7d035801f518653e6, 0xbbbbbbbb)
-      ),
-      full_input_to(to_addr) AS (
-        VALUES
-          (0xe82a80c31a78f25c5dbe7ad7d035801f518653e6)
-      ),
-      traces_filtered AS (
-        SELECT
-          tr.tx_hash,
-          tr.to,
-          tr.block_time,
-          tr.input,
-          substr(tr.input, 1, 4) AS selector
-        FROM ethereum.traces tr
-        CROSS JOIN params p
-        WHERE tr.call_type = 'call'
-          AND tr.success = true
-          AND tr.block_time >= p.t_start
-          AND tr.block_time <=  p.t_end
-      ),
-      traces_allowed AS (
-        SELECT tr.*
-        FROM traces_filtered tr
-        JOIN allowed_calls ac
-          ON tr.to = ac.to_addr
-        AND tr.selector = ac.selector
-      ),
-      txs_filtered AS (
-        SELECT
-          tx.hash,
-          tx.block_number,
-          tx.block_time,
-          tx.gas_used,
-          tx.gas_price,
-          tx.blob_versioned_hashes,
-          tx.data
-        FROM ethereum.transactions tx
-        CROSS JOIN params p
-        WHERE tx.block_time >= p.t_start
-          AND tx.block_time <=  p.t_end
-      )
+    expect(query).toEqual(EXPECTED_SQL)
+  })
 
-    SELECT DISTINCT
-      tx.hash,
-      tr.to,
-      tx.block_number,
-      tx.block_time,
-      tx.gas_used,
-      tx.gas_price,
-      tx.blob_versioned_hashes,
-      length(tx.data) AS data_length,
-      length(replace(regexp_replace(to_hex(tx.data), '([0-9A-Fa-f]{2})', '$1x'), '00x', '')) / 3 AS non_zero_bytes,
-      CASE
-        WHEN tr.to IN (SELECT to_addr FROM full_input_to) THEN tr.input
-        ELSE tr.selector
-      END AS input
-    FROM txs_filtered tx
-    JOIN traces_allowed tr
-      ON tx.hash = tr.tx_hash;
-  `)
+  it('merges duplicates to the widest input request', () => {
+    const query = getFunctionCallQuery(
+      [
+        { address: ADDRESS_1, selector: SELECTOR_1, inputBytes: 4 },
+        { address: ADDRESS_1, selector: SELECTOR_1, inputBytes: 68 },
+        {
+          address: ADDRESS_2,
+          selector: SELECTOR_2,
+          inputBytes: 'full' as const,
+        },
+        { address: ADDRESS_2, selector: SELECTOR_2, inputBytes: 4 },
+      ],
+      FROM,
+      TO,
+    )
+
+    expect(query).toEqual(
+      getFunctionCallQuery(
+        [
+          { address: ADDRESS_1, selector: SELECTOR_1, inputBytes: 68 },
+          {
+            address: ADDRESS_2,
+            selector: SELECTOR_2,
+            inputBytes: 'full' as const,
+          },
+        ],
+        FROM,
+        TO,
+      ),
+    )
   })
 
   it('handles empty helper tables', () => {
@@ -184,13 +146,9 @@ describe(getFunctionCallQuery.name, () => {
           from_iso8601_timestamp('2021-01-01T00:00:00.000Z') AS t_start,
           from_iso8601_timestamp('2021-01-02T00:00:00.000Z') AS t_end
       ),
-      allowed_calls(to_addr, selector) AS (
+      allowed_calls(to_addr, selector, input_bytes) AS (
         VALUES
-          (NULL, NULL)
-      ),
-      full_input_to(to_addr) AS (
-        VALUES
-          (NULL)
+          (NULL, NULL, NULL)
       ),
       traces_filtered AS (
         SELECT
@@ -207,7 +165,7 @@ describe(getFunctionCallQuery.name, () => {
           AND tr.block_time <=  p.t_end
       ),
       traces_allowed AS (
-        SELECT tr.*
+        SELECT tr.*, ac.input_bytes
         FROM traces_filtered tr
         JOIN allowed_calls ac
           ON tr.to = ac.to_addr
@@ -239,8 +197,8 @@ describe(getFunctionCallQuery.name, () => {
       length(tx.data) AS data_length,
       length(replace(regexp_replace(to_hex(tx.data), '([0-9A-Fa-f]{2})', '$1x'), '00x', '')) / 3 AS non_zero_bytes,
       CASE
-        WHEN tr.to IN (SELECT to_addr FROM full_input_to) THEN tr.input
-        ELSE tr.selector
+        WHEN tr.input_bytes IS NULL THEN tr.input
+        ELSE substr(tr.input, 1, tr.input_bytes)
       END AS input
     FROM txs_filtered tx
     JOIN traces_allowed tr

--- a/packages/backend/src/modules/tracked-txs/utils/sql/getFunctionCallQuery.ts
+++ b/packages/backend/src/modules/tracked-txs/utils/sql/getFunctionCallQuery.ts
@@ -1,23 +1,43 @@
-import { type EthereumAddress, UnixTime, unique } from '@l2beat/shared-pure'
+import { assert, type EthereumAddress, UnixTime } from '@l2beat/shared-pure'
 
 export function getFunctionCallQuery(
   configs: {
     address: EthereumAddress
     selector: string
-    getFullInput: boolean
+    /** How many bytes of the input to fetch, or all of them. */
+    inputBytes: number | 'full'
   }[],
   from: UnixTime,
   to: UnixTime,
 ): string {
-  const fullInputAddresses = unique(
-    configs.filter((c) => c.getFullInput).map((c) => c.address.toLowerCase()),
-  )
   const fromDate = UnixTime.toDate(from).toISOString()
   const toDate = UnixTime.toDate(to).toISOString()
-  const uniqueConfigs = unique(
-    configs,
-    (c) => `${c.address.toLowerCase()}-${c.selector.toLowerCase()}`,
-  )
+  const uniqueConfigs = new Map<
+    string,
+    { address: string; selector: string; inputBytes: number | 'full' }
+  >()
+  for (const config of configs) {
+    assert(
+      config.inputBytes === 'full' ||
+        (Number.isInteger(config.inputBytes) && config.inputBytes >= 4),
+      'inputBytes must cover at least the selector',
+    )
+    const address = config.address.toLowerCase()
+    const selector = config.selector.toLowerCase()
+    const existing = uniqueConfigs.get(`${address}-${selector}`)
+    if (existing === undefined) {
+      uniqueConfigs.set(`${address}-${selector}`, {
+        address,
+        selector,
+        inputBytes: config.inputBytes,
+      })
+    } else if (existing.inputBytes !== 'full') {
+      existing.inputBytes =
+        config.inputBytes === 'full'
+          ? 'full'
+          : Math.max(existing.inputBytes, config.inputBytes)
+    }
+  }
 
   // To calculate the non-zero bytes we are grouping bytes by adding 'x' sign between each byte
   // and then removing all '00x' sequences. Next step is to divide length of result by 3 as this is length of '00x' sequence.
@@ -28,25 +48,18 @@ export function getFunctionCallQuery(
           from_iso8601_timestamp('${fromDate}') AS t_start,
           from_iso8601_timestamp('${toDate}') AS t_end
       ),
-      allowed_calls(to_addr, selector) AS (
+      allowed_calls(to_addr, selector, input_bytes) AS (
         VALUES
           ${
-            uniqueConfigs.length > 0
-              ? uniqueConfigs
+            uniqueConfigs.size > 0
+              ? [...uniqueConfigs.values()]
+                  // NULL input_bytes selects the full input in the CASE below.
                   .map(
                     (c) =>
-                      `(${c.address.toLowerCase()}, ${c.selector.toLowerCase()})`,
+                      `(${c.address}, ${c.selector}, ${c.inputBytes === 'full' ? 'NULL' : c.inputBytes})`,
                   )
                   .join(',')
-              : '(NULL, NULL)'
-          }
-      ),
-      full_input_to(to_addr) AS (
-        VALUES
-          ${
-            fullInputAddresses.length > 0
-              ? fullInputAddresses.map((a) => `(${a})`).join(',')
-              : '(NULL)'
+              : '(NULL, NULL, NULL)'
           }
       ),
       traces_filtered AS (
@@ -64,7 +77,7 @@ export function getFunctionCallQuery(
           AND tr.block_time <=  p.t_end
       ),
       traces_allowed AS (
-        SELECT tr.*
+        SELECT tr.*, ac.input_bytes
         FROM traces_filtered tr
         JOIN allowed_calls ac
           ON tr.to = ac.to_addr
@@ -96,8 +109,8 @@ export function getFunctionCallQuery(
       length(tx.data) AS data_length,
       length(replace(regexp_replace(to_hex(tx.data), '([0-9A-Fa-f]{2})', '$1x'), '00x', '')) / 3 AS non_zero_bytes,
       CASE
-        WHEN tr.to IN (SELECT to_addr FROM full_input_to) THEN tr.input
-        ELSE tr.selector
+        WHEN tr.input_bytes IS NULL THEN tr.input
+        ELSE substr(tr.input, 1, tr.input_bytes)
       END AS input
     FROM txs_filtered tx
     JOIN traces_allowed tr

--- a/packages/config/src/processing/getProjects.test.ts
+++ b/packages/config/src/processing/getProjects.test.ts
@@ -556,23 +556,22 @@ describe('getProjects', () => {
   })
 
   describe('Tracked transactions', () => {
-    // Temporarily disabled together with Aztec state update tracking.
-    // it('groups only Aztec liveness state updates', () => {
-    //   const aztec = projects.find((project) => project.id === 'aztecnetwork')
-    //   const stateUpdates = aztec?.trackedTxsConfig?.filter(
-    //     (config) => config.subtype === 'stateUpdates',
-    //   )
+    it('groups only Aztec liveness state updates', () => {
+      const aztec = projects.find((project) => project.id === 'aztecnetwork')
+      const stateUpdates = aztec?.trackedTxsConfig?.filter(
+        (config) => config.subtype === 'stateUpdates',
+      )
 
-    //   const liveness = stateUpdates?.find(
-    //     (config) => config.type === 'liveness',
-    //   )
+      const liveness = stateUpdates?.find(
+        (config) => config.type === 'liveness',
+      )
 
-    //   assert(liveness !== undefined)
-    //   expect(liveness.groupBy).toEqual({
-    //     type: 'functionCallParameter',
-    //     path: [0, 0],
-    //   })
-    // })
+      assert(liveness !== undefined)
+      expect(liveness.groupBy).toEqual({
+        type: 'functionCallParameter',
+        path: [0, 0],
+      })
+    })
 
     it('every TrackedTxId is unique', () => {
       const ids = new Set<string>()

--- a/packages/config/src/projects/aztecnetwork/aztecnetwork.ts
+++ b/packages/config/src/projects/aztecnetwork/aztecnetwork.ts
@@ -375,26 +375,26 @@ export const aztecnetwork: ScalingProject = {
           sinceTimestamp: v5ActivationTimestamp,
         },
       },
-      // {
-      //   uses: [
-      //     {
-      //       type: 'liveness',
-      //       subtype: 'stateUpdates',
-      //       // All proof submissions targeting an epoch share its first
-      //       // checkpoint as `args.start`.
-      //       groupBy: { type: 'functionCallParameter', path: [0, 0] },
-      //     },
-      //     { type: 'l2costs', subtype: 'stateUpdates' },
-      //   ],
-      //   query: {
-      //     formula: 'functionCall',
-      //     address: rollupAddress,
-      //     selector: '0x069d1525',
-      //     functionSignature:
-      //       'function submitEpochRootProof((uint256,uint256,(bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))',
-      //     sinceTimestamp: v5ActivationTimestamp,
-      //   },
-      // },
+      {
+        uses: [
+          {
+            type: 'liveness',
+            subtype: 'stateUpdates',
+            // All proof submissions targeting an epoch share its first
+            // checkpoint as `args.start`.
+            groupBy: { type: 'functionCallParameter', path: [0, 0] },
+          },
+          { type: 'l2costs', subtype: 'stateUpdates' },
+        ],
+        query: {
+          formula: 'functionCall',
+          address: rollupAddress,
+          selector: '0x069d1525',
+          functionSignature:
+            'function submitEpochRootProof((uint256,uint256,(bytes32,bytes32,bytes32,address),(bytes32,bytes32,bytes32,bytes32,bytes32,uint256,uint256,address,bytes32,(uint128,uint128),uint256,uint256)[],(bytes,bytes),bytes,bytes))',
+          sinceTimestamp: v5ActivationTimestamp,
+        },
+      },
     ],
   },
   chainConfig: {


### PR DESCRIPTION
## Summary

- Replace the per-address `getFullInput` flag in the Dune function call query with a per-config `inputBytes` request (`number | 'full'`), so each tracked call fetches only the calldata it needs instead of the whole input
- Duplicate address/selector configs are now merged to the widest requested prefix; `NULL` means full input, otherwise `substr(tr.input, 1, input_bytes)`
- Add `functionCallParameter.ts`: walks the ABI head layout to extract a single parameter from (possibly truncated) calldata, plus `getFunctionCallParameterPrefix` computing the minimal prefix when the target's position is statically known
- `getLivenessGroupingKey` uses the new extractor instead of a full `decodeFunctionCallInput`
- Non-grouped function calls now request only the 4 selector bytes; `sharpSubmission` / `sharedBridge` still need the full input to decode filters
- Motivating case: Aztec `submitEpochRootProof` drops from ~66 KB of calldata per row to 68 bytes

## Testing

- `pnpm test` in `packages/backend` for the new `functionCallParameter` suite, `TrackedTxsClient` and `getFunctionCallQuery`
- New unit tests cross-check prefix extraction against a full `ethers` decode for head words, inlined static tuples, dynamic array elements, and dynamic bytes, and assert `undefined` prefixes for data-dependent positions
- Generated SQL asserted against snapshots for the prefix, full-input, duplicate-merge and empty-config cases
- Not run: end-to-end verification against live Dune data