### PR TITLE
Support highlighting multiple rows in tables

### DIFF
--- a/packages/frontend/src/components/table/BasicTable.tsx
+++ b/packages/frontend/src/components/table/BasicTable.tsx
@@ -226,14 +226,14 @@ export function BasicTableRow<T extends BasicTableRow>({
   className,
   ...props
 }: BasicTableProps<T> & { row: Row<T>; className?: string }) {
-  const { highlightedId } = useHighlightedTableRowContext()
+  const { highlightedIds } = useHighlightedTableRowContext()
   const { cells, denominator } = prepareBasicTableVisibleCells(row)
 
   const cellDataMap = new Map<number, BasicTableCellData>()
 
   const highlightId = props.getHighlightId?.(row.original) ?? row.original.slug
   const isHighlighted =
-    highlightId !== undefined && highlightedId === highlightId
+    highlightId !== undefined && highlightedIds.includes(highlightId)
 
   const shouldRenderSubComponentRow =
     row.getIsExpanded() && !!props.renderSubComponent

--- a/packages/frontend/src/components/table/HighlightedTableRowContext.tsx
+++ b/packages/frontend/src/components/table/HighlightedTableRowContext.tsx
@@ -1,41 +1,33 @@
 import {
   createContext,
   type ReactNode,
-  useCallback,
   useContext,
   useEffect,
   useState,
 } from 'react'
+import { parseHighlightedIds } from './utils/parseHighlightedIds'
 
 interface HighlightedTableRowContextType {
-  highlightedId: string | undefined
+  highlightedIds: string[]
 }
 
 const HighlightedTableRowContext = createContext<
   HighlightedTableRowContextType | undefined
 >(undefined)
 
-interface HighlightedTableRowProviderProps {
-  children: ReactNode
-  defaultValue?: string
-}
-
 export function HighlightedTableRowProvider({
   children,
-  defaultValue,
-}: HighlightedTableRowProviderProps) {
-  const [highlightedId, setHighlightedId] = useState(defaultValue)
+}: {
+  children: ReactNode
+}) {
+  const [highlightedIds, setHighlightedIds] = useState<string[]>([])
 
-  const handleHighlightChange = useCallback(() => {
-    const params = new URLSearchParams(window.location.search)
-    const highlight = params.get('highlight')
-    setHighlightedId(highlight ?? undefined)
+  useEffect(() => {
+    setHighlightedIds(parseHighlightedIds(window.location.search))
   }, [])
 
-  useEffect(handleHighlightChange, [])
-
   return (
-    <HighlightedTableRowContext.Provider value={{ highlightedId }}>
+    <HighlightedTableRowContext.Provider value={{ highlightedIds }}>
       {children}
     </HighlightedTableRowContext.Provider>
   )

--- a/packages/frontend/src/components/table/HighlightedTableRowContext.tsx
+++ b/packages/frontend/src/components/table/HighlightedTableRowContext.tsx
@@ -1,10 +1,5 @@
-import {
-  createContext,
-  type ReactNode,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import { createContext, type ReactNode, useContext, useMemo } from 'react'
+import { useQueryParam } from '~/hooks/useQueryParam'
 import { parseHighlightedIds } from './utils/parseHighlightedIds'
 
 interface HighlightedTableRowContextType {
@@ -20,14 +15,14 @@ export function HighlightedTableRowProvider({
 }: {
   children: ReactNode
 }) {
-  const [highlightedIds, setHighlightedIds] = useState<string[]>([])
-
-  useEffect(() => {
-    setHighlightedIds(parseHighlightedIds(window.location.search))
-  }, [])
+  const [highlight] = useQueryParam('highlight', '')
+  const value = useMemo(
+    () => ({ highlightedIds: parseHighlightedIds(highlight) }),
+    [highlight],
+  )
 
   return (
-    <HighlightedTableRowContext.Provider value={{ highlightedIds }}>
+    <HighlightedTableRowContext.Provider value={value}>
       {children}
     </HighlightedTableRowContext.Provider>
   )

--- a/packages/frontend/src/components/table/Table.tsx
+++ b/packages/frontend/src/components/table/Table.tsx
@@ -72,8 +72,12 @@ const TableRow = ({
 }: React.HTMLAttributes<HTMLTableRowElement> & {
   highlightId: string | undefined
 }) => {
-  const { highlightedId } = useHighlightedTableRowContext()
-  const isSelected = highlightedId && highlightedId === highlightId
+  const { highlightedIds } = useHighlightedTableRowContext()
+  const isSelected =
+    highlightId !== undefined && highlightedIds.includes(highlightId)
+  // With multiple highlighted rows, scroll only to the first one so the
+  // rows don't fight over the viewport.
+  const isScrollTarget = isSelected && highlightId === highlightedIds[0]
   return (
     <tr
       className={cn(
@@ -82,7 +86,7 @@ const TableRow = ({
         className,
       )}
       ref={(node) => {
-        if (node && isSelected) {
+        if (node && isScrollTarget) {
           node.scrollIntoView({ block: 'center' })
         }
       }}

--- a/packages/frontend/src/components/table/cells/ProofSystemCell.tsx
+++ b/packages/frontend/src/components/table/cells/ProofSystemCell.tsx
@@ -29,17 +29,14 @@ export function ProofSystemCell({
       : proofSystem?.name && !hideType
         ? proofSystem.name
         : undefined
-  // A single ZK Catalog project can be highlighted directly; multi-proof
-  // systems link to the project's state validation section, which lists all
-  // of them.
   const zkCatalogIds = proofSystem?.zkCatalogIds ?? []
   return (
     <TableLink
       href={
         !proofSystem?.type
           ? undefined
-          : zkCatalogIds.length === 1
-            ? `/zk-catalog?highlight=${zkCatalogIds[0]}`
+          : zkCatalogIds.length > 0
+            ? `/zk-catalog?highlight=${zkCatalogIds.join(',')}`
             : `/scaling/projects/${slug}#state-validation`
       }
     >

--- a/packages/frontend/src/components/table/utils/parseHighlightedIds.test.ts
+++ b/packages/frontend/src/components/table/utils/parseHighlightedIds.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'earl'
+import { parseHighlightedIds } from './parseHighlightedIds'
+
+describe(parseHighlightedIds.name, () => {
+  it('returns no ids when the param is absent', () => {
+    expect(parseHighlightedIds('?foo=bar')).toEqual([])
+  })
+
+  it('parses a single id', () => {
+    expect(parseHighlightedIds('?highlight=risc0')).toEqual(['risc0'])
+  })
+
+  it('parses comma-separated ids', () => {
+    expect(parseHighlightedIds('?highlight=sp1hypercube,risc0')).toEqual([
+      'sp1hypercube',
+      'risc0',
+    ])
+  })
+
+  it('parses repeated params', () => {
+    expect(
+      parseHighlightedIds('?highlight=sp1hypercube&highlight=risc0'),
+    ).toEqual(['sp1hypercube', 'risc0'])
+  })
+
+  it('ignores empty values', () => {
+    expect(parseHighlightedIds('?highlight=,risc0,&highlight=')).toEqual([
+      'risc0',
+    ])
+  })
+})

--- a/packages/frontend/src/components/table/utils/parseHighlightedIds.test.ts
+++ b/packages/frontend/src/components/table/utils/parseHighlightedIds.test.ts
@@ -2,30 +2,22 @@ import { expect } from 'earl'
 import { parseHighlightedIds } from './parseHighlightedIds'
 
 describe(parseHighlightedIds.name, () => {
-  it('returns no ids when the param is absent', () => {
-    expect(parseHighlightedIds('?foo=bar')).toEqual([])
+  it('returns no ids for an empty value', () => {
+    expect(parseHighlightedIds('')).toEqual([])
   })
 
   it('parses a single id', () => {
-    expect(parseHighlightedIds('?highlight=risc0')).toEqual(['risc0'])
+    expect(parseHighlightedIds('risc0')).toEqual(['risc0'])
   })
 
   it('parses comma-separated ids', () => {
-    expect(parseHighlightedIds('?highlight=sp1hypercube,risc0')).toEqual([
+    expect(parseHighlightedIds('sp1hypercube,risc0')).toEqual([
       'sp1hypercube',
       'risc0',
     ])
   })
 
-  it('parses repeated params', () => {
-    expect(
-      parseHighlightedIds('?highlight=sp1hypercube&highlight=risc0'),
-    ).toEqual(['sp1hypercube', 'risc0'])
-  })
-
-  it('ignores empty values', () => {
-    expect(parseHighlightedIds('?highlight=,risc0,&highlight=')).toEqual([
-      'risc0',
-    ])
+  it('ignores empty segments', () => {
+    expect(parseHighlightedIds(',risc0,')).toEqual(['risc0'])
   })
 })

--- a/packages/frontend/src/components/table/utils/parseHighlightedIds.ts
+++ b/packages/frontend/src/components/table/utils/parseHighlightedIds.ts
@@ -1,11 +1,7 @@
 /**
- * Parses the `highlight` search params into row ids to highlight.
- * Supports both comma-separated values (`?highlight=a,b`) and repeated
- * params (`?highlight=a&highlight=b`).
+ * Parses the `highlight` query param value into row ids to highlight,
+ * e.g. `sp1hypercube,risc0`.
  */
-export function parseHighlightedIds(search: string): string[] {
-  return new URLSearchParams(search)
-    .getAll('highlight')
-    .flatMap((value) => value.split(','))
-    .filter((id) => id.length > 0)
+export function parseHighlightedIds(value: string): string[] {
+  return value.split(',').filter((id) => id.length > 0)
 }

--- a/packages/frontend/src/components/table/utils/parseHighlightedIds.ts
+++ b/packages/frontend/src/components/table/utils/parseHighlightedIds.ts
@@ -1,0 +1,11 @@
+/**
+ * Parses the `highlight` search params into row ids to highlight.
+ * Supports both comma-separated values (`?highlight=a,b`) and repeated
+ * params (`?highlight=a&highlight=b`).
+ */
+export function parseHighlightedIds(search: string): string[] {
+  return new URLSearchParams(search)
+    .getAll('highlight')
+    .flatMap((value) => value.split(','))
+    .filter((id) => id.length > 0)
+}

--- a/packages/frontend/src/pages/scaling/risk/state-validation/components/table/OptimisticProofSystemCell.tsx
+++ b/packages/frontend/src/pages/scaling/risk/state-validation/components/table/OptimisticProofSystemCell.tsx
@@ -36,13 +36,7 @@ export function OptimisticProofSystemCell({
           {zkCatalog && (
             <Tooltip>
               <TooltipTrigger>
-                <a
-                  href={
-                    zkCatalog.ids.length === 1
-                      ? `/zk-catalog?highlight=${zkCatalog.ids[0]}`
-                      : '/zk-catalog'
-                  }
-                >
+                <a href={`/zk-catalog?highlight=${zkCatalog.ids.join(',')}`}>
                   <Badge
                     type={
                       isMixed || hasNotVerified


### PR DESCRIPTION
Stacked on #12457.

The `highlight` search param on table pages now accepts multiple comma-separated ids (`?highlight=sp1hypercube,risc0`). All matching rows get the highlight animation; the page scrolls to the first one so multiple rows don't fight over the viewport. The param is read through the canonical `useQueryParam` hook, so the value is SSR-safe on first render and stays in sync on popstate.

With that in place, multi-proof systems link to the ZK Catalog with all of their catalog projects highlighted:

- `ProofSystemCell` links `/zk-catalog?highlight=<id1>,<id2>` whenever the proof system references any catalog projects (previously it fell back to the project's state validation section for multi-proof systems).
- `OptimisticProofSystemCell` does the same for the verified-prover badge.

The param parsing lives in `parseHighlightedIds` with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)