### PR TITLE
Rewrite Token UI graph from SVG to canvas (for speed)

### DIFF
--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
@@ -144,6 +144,16 @@ export function TokenRelationsGraph({
     }
     requestDrawRef.current = requestDraw
 
+    function eventPoint(event: Event): [number, number] {
+      // d3.pointer reads clientX/clientY, which a TouchEvent itself lacks —
+      // it expects the individual Touch, as d3-zoom passes internally.
+      const source =
+        'changedTouches' in event
+          ? (event as TouchEvent).changedTouches[0]
+          : event
+      return d3.pointer(source, canvas)
+    }
+
     function toWorld(pointer: [number, number]): [number, number] {
       return cameraTransform.invert(pointer)
     }
@@ -227,7 +237,9 @@ export function TokenRelationsGraph({
         if (event.type !== 'mousedown' && event.type !== 'touchstart') {
           return allowed
         }
-        return allowed && pickNode(d3.pointer(event, canvas)) === undefined
+        // No pan while a node drag is active (a later touch joining it) or
+        // when the gesture itself grabs a node (the primary pointer).
+        return allowed && !drag && pickNode(eventPoint(event)) === undefined
       })
       .on('start', (event: d3.D3ZoomEvent<HTMLCanvasElement, unknown>) => {
         if (event.sourceEvent && !hovered) canvas.style.cursor = 'grabbing'
@@ -237,7 +249,7 @@ export function TokenRelationsGraph({
         // The world moves under a stationary pointer, so what is hovered can
         // change without a pointer event.
         if (event.sourceEvent instanceof Event) {
-          refreshHover(d3.pointer(event.sourceEvent, canvas))
+          refreshHover(eventPoint(event.sourceEvent))
         }
         requestDraw()
       })
@@ -249,9 +261,9 @@ export function TokenRelationsGraph({
       .on('pointerdown.graph', (event: PointerEvent) => {
         suppressNextClick = false
         if (!event.isPrimary || event.button !== 0) return
-        const node = pickNode(d3.pointer(event, canvas))
+        const node = pickNode(eventPoint(event))
         if (node === undefined) return
-        const [x, y] = toWorld(d3.pointer(event, canvas))
+        const [x, y] = toWorld(eventPoint(event))
         drag = { node, offsetX: node.x - x, offsetY: node.y - y, moved: false }
         canvas.setPointerCapture(event.pointerId)
         // Also stops the compatibility mousedown, so d3-zoom cannot start a
@@ -260,7 +272,7 @@ export function TokenRelationsGraph({
         updateCursor()
       })
       .on('pointermove.graph', (event: PointerEvent) => {
-        const pointer = d3.pointer(event, canvas)
+        const pointer = eventPoint(event)
         if (drag) {
           drag.moved = true
           const [x, y] = toWorld(pointer)
@@ -278,7 +290,7 @@ export function TokenRelationsGraph({
         suppressNextClick = drag.moved && event.type === 'pointerup'
         drag = undefined
         updateCursor()
-        refreshHover(d3.pointer(event, canvas))
+        refreshHover(eventPoint(event))
       })
       .on('pointerleave.graph', () => {
         if (!drag) clearHover()
@@ -288,7 +300,7 @@ export function TokenRelationsGraph({
           suppressNextClick = false
           return
         }
-        const pointer = d3.pointer(event, canvas)
+        const pointer = eventPoint(event)
         const node = pickNode(pointer)
         if (node !== undefined) {
           onSelectionChangeRef.current({ type: 'node', id: node.data.id })

--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
@@ -1,52 +1,52 @@
 import * as d3 from 'd3'
-import { type RefObject, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { cn } from '~/utils/cn'
 import {
-  type LayoutLink,
-  type LayoutNode,
-  layoutRelationGraph,
-} from './relationGraphLayout'
+  drawRelationGraph,
+  NODE_RING_RADIUS,
+  nodeVisualScreenScale,
+  type RelationGraphTheme,
+} from './relationGraphCanvas'
 import {
-  getClusterLabelStyle,
-  getNodeVisualScale,
   getRelationGraphFocus,
-  getRelationLabelStyle,
-  mostCommonDeployedSymbol,
-  nodeColor,
-  nodeLabel,
-  RELATION_COLORS,
   type RelationGraph,
-  type RelationGraphFocus,
-  type RelationGraphRelation,
   type RelationGraphSelection,
-  relationColor,
   relationDirectionLabel,
-  relationId,
   relationIsDirectional,
   relationTypeLabel,
-  sourceId,
-  targetId,
-  unorderedPairKey,
 } from './relationGraphModel'
+import {
+  buildRelationGraphScene,
+  findLinkAt,
+  findNodeAt,
+  type SceneLink,
+  type SceneNode,
+} from './relationGraphScene'
 
-type NodeDatum = RelationGraph['nodes'][number] & LayoutNode
-type VisualLink = LayoutLink<NodeDatum> & {
-  relation: RelationGraphRelation
-  curve: number
-}
-
-type HoveredItem = RelationGraphSelection | undefined
+/**
+ * Renders the relations graph onto a canvas (see relationGraphCanvas.ts for
+ * why not SVG) and owns all interaction: the d3-zoom camera, node dragging,
+ * hover, clicks, and the tooltip. Rendering state lives in refs and every
+ * change just schedules a redraw — React re-renders only for the tooltip.
+ */
 
 const SEARCH_ZOOM_SCALE = 2
 const SEARCH_ZOOM_DURATION_MS = 300
 const DETAILS_PANEL_MAX_WIDTH = 440
 const DETAILS_PANEL_WIDTH_RATIO = 0.92
-const RELATION_ARROW_POSITION = 0.65
+const MAX_ZOOM_SCALE = 8
+const FIT_VIEW_PADDING = 32
+/** Pointer slack: how far from a link a click still selects it, screen px. */
+const LINK_HIT_TOLERANCE = 7
+/** Tiny nodes stay clickable when zoomed far out. */
+const MIN_NODE_HIT_RADIUS = 8
 
-interface GraphStyleState {
-  focus: RelationGraphFocus | undefined
-  highlightAnomalies: boolean
-  hovered: HoveredItem
-  selection: RelationGraphSelection | undefined
+interface NodeDrag {
+  node: SceneNode
+  /** World-space offset from the pointer to the node center at grab time. */
+  offsetX: number
+  offsetY: number
+  moved: boolean
 }
 
 export function TokenRelationsGraph({
@@ -64,327 +64,325 @@ export function TokenRelationsGraph({
   deletedRelationIds: ReadonlySet<string>
   onSelectionChange: (selection: RelationGraphSelection | undefined) => void
 }) {
-  const containerRef = useRef<HTMLDivElement>(null)
-  const svgRef = useRef<SVGSVGElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const requestDrawRef = useRef<(() => void) | undefined>(undefined)
   const zoomToNodeRef = useRef<((nodeId: string) => void) | undefined>(
     undefined,
   )
-  const zoomScaleRef = useRef(1)
   const onSelectionChangeRef = useRef(onSelectionChange)
-  const [hovered, setHovered] = useState<HoveredItem>()
-  const size = useElementSize(containerRef)
-  // Hover styling touches every SVG node and edge. Build the selected
-  // neighborhood only when the selection changes so that pass stays linear.
+  const [tooltip, setTooltip] = useState<string>()
+
   const focus = useMemo(
     () => getRelationGraphFocus(graph, selection, deletedRelationIds),
     [graph, selection, deletedRelationIds],
   )
-  // Read by the rebuild effect through a ref: a deletion must not re-run the
-  // layout (see the removal effect below), but a rebuild that happens later
-  // for its own reasons (e.g. a resize) must not resurrect deleted edges.
-  const deletedRelationIdsRef = useRef(deletedRelationIds)
-  deletedRelationIdsRef.current = deletedRelationIds
-  const styleStateRef = useRef<GraphStyleState>({
+  // The draw loop reads the latest style inputs through a ref so that the
+  // canvas lifecycle effect does not have to re-run on every style change.
+  const styleStateRef = useRef({
+    deletedRelationIds,
     focus,
     highlightAnomalies,
-    hovered,
     selection,
   })
-  styleStateRef.current = {
-    focus,
-    highlightAnomalies,
-    hovered,
-    selection,
-  }
 
   useEffect(() => {
     onSelectionChangeRef.current = onSelectionChange
   }, [onSelectionChange])
 
   useEffect(() => {
-    const svgElement = svgRef.current
-    if (!svgElement || size.width === 0 || size.height === 0) return
-
-    const nodes = graph.nodes.map((node): NodeDatum => ({ ...node }))
-    const nodeById = new Map(nodes.map((node) => [node.id, node]))
-    const relations = graph.relations.filter(
-      (relation) => !deletedRelationIdsRef.current.has(relationId(relation)),
-    )
-    const visualLinks = buildVisualLinks(relations, nodeById)
-    const layout = layoutRelationGraph(nodes, buildSimulationLinks(visualLinks))
-    const clusterLabelData = layout.clusters.flatMap((cluster) => {
-      const text = mostCommonDeployedSymbol(cluster.nodes)
-      return text === undefined ? [] : [{ nodes: cluster.nodes, text }]
-    })
-
-    const svg = d3.select(svgElement)
-    svg.selectAll('*').remove()
-    svg.attr('viewBox', `0 0 ${size.width} ${size.height}`)
-
-    const arrowMarkers = appendArrowMarkers(svg)
-
-    const background = svg
-      .append('rect')
-      .attr('width', size.width)
-      .attr('height', size.height)
-      .attr('fill', 'transparent')
-      .attr('cursor', 'grab')
-      .on('click', () => onSelectionChangeRef.current(undefined))
-
-    const layer = svg.append('g')
-    const linksLayer = layer.append('g')
-    const relationLabelsLayer = layer
-      .append('g')
-      .attr('class', 'relation-labels-layer')
-    const nodesLayer = layer.append('g')
-    const clusterLabelsLayer = layer.append('g')
-
-    const links = linksLayer
-      .selectAll<SVGPathElement, VisualLink>('path.relation-link')
-      .data(visualLinks, (link) => relationId(link.relation))
-      .join('path')
-      .attr('class', 'relation-link')
-      .attr('fill', 'none')
-      .attr('stroke', (link) => relationColor(link.relation))
-      .attr('stroke-linecap', 'round')
-      .attr('stroke-width', 1.4)
-      .attr('vector-effect', 'non-scaling-stroke')
-      .attr('opacity', 0.55)
-      .attr('marker-mid', (link) => markerUrl(link.relation, false))
-
-    links.append('title').text((link) => {
-      const relation = link.relation
-      const arrow = relationIsDirectional(relation) ? '->' : '<->'
-      return `${sourceId(relation)} ${arrow} ${targetId(relation)}\n${relationTypeLabel(relation)} via ${relation.plugin}\n${relationDirectionLabel(relation)}`
-    })
-
-    const linkHits = linksLayer
-      .selectAll<SVGPathElement, VisualLink>('path.relation-hit')
-      .data(visualLinks, (link) => relationId(link.relation))
-      .join('path')
-      .attr('class', 'relation-hit')
-      .attr('fill', 'none')
-      .attr('stroke', 'transparent')
-      .attr('stroke-width', 14)
-      .attr('vector-effect', 'non-scaling-stroke')
-      .attr('pointer-events', 'stroke')
-      .attr('cursor', 'pointer')
-      .on('mouseenter', (_, link) =>
-        setHovered({ type: 'relation', id: relationId(link.relation) }),
-      )
-      .on('mouseleave', () => setHovered(undefined))
-      .on('click', (event, link) => {
-        event.stopPropagation()
-        onSelectionChangeRef.current({
-          type: 'relation',
-          id: relationId(link.relation),
-        })
-      })
-
-    const relationLabels = relationLabelsLayer
-      .selectAll<SVGTextElement, VisualLink>('text.relation-label')
-      .data(visualLinks, (link) => relationId(link.relation))
-      .join('text')
-      .attr('class', 'relation-label')
-      .attr('text-anchor', 'middle')
-      .attr('dominant-baseline', 'central')
-      .attr('paint-order', 'stroke')
-      .attr('stroke', 'var(--background)')
-      .attr('fill', (link) => relationColor(link.relation))
-      .attr('font-weight', 600)
-      .attr('pointer-events', 'none')
-      .attr('opacity', 0)
-      .attr('x', (link) => linkLabelPosition(link).x)
-      .attr('y', (link) => linkLabelPosition(link).y)
-      .text((link) => link.relation.plugin)
-
-    const clusterLabels = clusterLabelsLayer
-      .selectAll<SVGTextElement, (typeof clusterLabelData)[number]>('text')
-      .data(clusterLabelData)
-      .join('text')
-      .attr('text-anchor', 'middle')
-      .attr('dominant-baseline', 'central')
-      .attr('paint-order', 'stroke')
-      .attr('stroke', 'var(--background)')
-      .attr('fill', 'var(--foreground)')
-      .attr('font-weight', 700)
-      .attr('letter-spacing', '0.08em')
-      .attr('pointer-events', 'none')
-      .text((label) => label.text)
-
-    const node = nodesLayer
-      .selectAll<SVGGElement, NodeDatum>('g.relation-node')
-      .data(nodes, (node) => node.id)
-      .join('g')
-      .attr('class', 'relation-node')
-      .attr('cursor', 'pointer')
-      .on('mouseenter', (_, node) => setHovered({ type: 'node', id: node.id }))
-      .on('mouseleave', () => setHovered(undefined))
-      .on('click', (event, node) => {
-        event.stopPropagation()
-        onSelectionChangeRef.current({ type: 'node', id: node.id })
-      })
-
-    const nodeVisual = node.append('g').attr('class', 'node-visual')
-
-    nodeVisual
-      .append('circle')
-      .attr('class', 'node-ring')
-      .attr('r', nodeRadius() + 5)
-      .attr('fill', 'none')
-      .attr('stroke', (node) => nodeColor(node))
-      .attr('stroke-width', 2.5)
-      .attr('opacity', 0)
-
-    nodeVisual
-      .append('circle')
-      .attr('class', 'node-core')
-      .attr('r', nodeRadius())
-      .attr('fill', (node) => nodeColor(node))
-      .attr('stroke', 'var(--background)')
-      .attr('stroke-width', 2)
-
-    nodeVisual
-      .append('text')
-      .attr('class', 'node-label')
-      .attr('x', 0)
-      .attr('y', -12)
-      .attr('text-anchor', 'middle')
-      .attr('paint-order', 'stroke')
-      .attr('stroke', 'var(--background)')
-      .attr('stroke-width', 3)
-      .attr('fill', 'var(--foreground)')
-      .attr('font-size', 11)
-      .attr('font-weight', 600)
-      .attr('pointer-events', 'none')
-      .text(nodeLabel)
-
-    node
-      .append('title')
-      .text(
-        (node) =>
-          `${nodeLabel(node)} on ${node.chain}\n${node.chain}:${node.address}\n${node.isDeployed ? 'Deployed token exists' : 'Missing deployed token'}`,
-      )
-
-    function redrawRelations() {
-      links.attr('d', linkPath)
-      linkHits.attr('d', linkPath)
-      relationLabels
-        .attr('x', (link) => linkLabelPosition(link).x)
-        .attr('y', (link) => linkLabelPosition(link).y)
+    styleStateRef.current = {
+      deletedRelationIds,
+      focus,
+      highlightAnomalies,
+      selection,
     }
+    requestDrawRef.current?.()
+  }, [deletedRelationIds, focus, highlightAnomalies, selection])
 
-    function redraw() {
-      redrawRelations()
-      node.attr('transform', (node) => `translate(${node.x},${node.y})`)
-      clusterLabels
-        .attr('x', (label) => clusterCenter(label.nodes).x)
-        .attr('y', (label) => clusterCenter(label.nodes).y)
-    }
-    redraw()
-
-    const fitScale = Math.min(
-      (size.width - 32) / layout.width,
-      (size.height - 32) / layout.height,
-      1,
-    )
-    let previousScale: number | undefined
-    const zoom = d3
-      .zoom<SVGSVGElement, unknown>()
-      .scaleExtent([Math.min(fitScale / 2, 0.1), 8])
-      .on('start', () => background.attr('cursor', 'grabbing'))
-      .on('zoom', (event) => {
-        const scale = event.transform.k
-        zoomScaleRef.current = scale
-        layer.attr('transform', event.transform.toString())
-
-        // D3 also emits zoom events while panning. The graph's scale-dependent
-        // styles do not change then, so avoid touching every SVG element.
-        if (scale === previousScale) return
-
-        nodeVisual.attr('transform', `scale(${getNodeVisualScale(scale)})`)
-        updateClusterLabelScale(clusterLabels, scale)
-        updateRelationLabelScale(relationLabelsLayer, scale)
-        const markerSize = 6 / Math.max(scale, 1)
-        arrowMarkers
-          .attr('markerWidth', markerSize)
-          .attr('markerHeight', markerSize)
-        previousScale = scale
-      })
-      .on('end', () => background.attr('cursor', 'grab'))
-    svg.call(zoom)
-
-    const initialTransform = d3.zoomIdentity
-      .translate(
-        (size.width - layout.width * fitScale) / 2,
-        (size.height - layout.height * fitScale) / 2,
-      )
-      .scale(fitScale)
-    svg.call(zoom.transform, initialTransform)
-
-    zoomToNodeRef.current = (nodeId) => {
-      const target = nodeById.get(nodeId)
-      if (target === undefined) {
-        throw new Error(`Cannot zoom to missing graph node ${nodeId}`)
-      }
-      if (target.x === undefined || target.y === undefined) {
-        throw new Error(`Graph node ${nodeId} has no layout position`)
-      }
-
-      const detailsPanelWidth = Math.min(
-        size.width * DETAILS_PANEL_WIDTH_RATIO,
-        DETAILS_PANEL_MAX_WIDTH,
-      )
-      const visibleCenterX = (size.width - detailsPanelWidth) / 2
-      const transform = d3.zoomIdentity
-        .translate(
-          visibleCenterX - target.x * SEARCH_ZOOM_SCALE,
-          size.height / 2 - target.y * SEARCH_ZOOM_SCALE,
-        )
-        .scale(SEARCH_ZOOM_SCALE)
-      svg
-        .transition()
-        .duration(SEARCH_ZOOM_DURATION_MS)
-        .call(zoom.transform, transform)
-    }
-
-    node.call(
-      d3
-        .drag<SVGGElement, NodeDatum>()
-        .on('start', (event) => {
-          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'grabbing')
-        })
-        .on('drag', (event, node) => {
-          node.x = event.x
-          node.y = event.y
-          redraw()
-        })
-        .on('end', (event) => {
-          d3.select(event.sourceEvent.currentTarget).attr('cursor', 'pointer')
-        }),
-    )
-    updateGraphStyles(svgElement, styleStateRef.current)
-    return () => {
-      svg.interrupt()
-      zoomScaleRef.current = 1
-      zoomToNodeRef.current = undefined
-    }
-  }, [graph, size.height, size.width])
-
-  // A deleted relation only disappears from the drawing. Deliberately no
-  // re-layout: removing an edge can split a cluster, and re-running the
-  // simulation would move every node under the user. Refreshing the page is
-  // how one sees the re-clustered graph.
   useEffect(() => {
-    const svgElement = svgRef.current
-    if (!svgElement || deletedRelationIds.size === 0) return
-    d3.select(svgElement)
-      .selectAll<SVGElement, VisualLink>(
-        '.relation-link, .relation-hit, .relation-label',
+    // Rebound consts so the narrowed types carry into the closures below.
+    const canvasElement = canvasRef.current
+    const contextOrNull = canvasElement?.getContext('2d')
+    if (!canvasElement) return
+    if (!contextOrNull) throw new Error('Canvas 2d rendering is unavailable')
+    const canvas = canvasElement
+    const context = contextOrNull
+
+    const scene = buildRelationGraphScene(graph)
+    const theme = resolveTheme(canvas)
+    let cameraTransform = d3.zoomIdentity
+    let cameraInitialized = false
+    let hovered: RelationGraphSelection | undefined
+    let drag: NodeDrag | undefined
+    let suppressNextClick = false
+    let width = 0
+    let height = 0
+    let pixelRatio = 1
+    let frame: number | undefined
+    canvas.style.cursor = 'grab'
+
+    function draw() {
+      if (width === 0 || height === 0) return
+      context.setTransform(pixelRatio, 0, 0, pixelRatio, 0, 0)
+      drawRelationGraph(context, scene, {
+        width,
+        height,
+        camera: cameraTransform,
+        hovered,
+        theme,
+        ...styleStateRef.current,
+      })
+    }
+
+    function requestDraw() {
+      if (frame !== undefined) return
+      frame = requestAnimationFrame(() => {
+        frame = undefined
+        draw()
+      })
+    }
+    requestDrawRef.current = requestDraw
+
+    function toWorld(pointer: [number, number]): [number, number] {
+      return cameraTransform.invert(pointer)
+    }
+
+    function pickNode(pointer: [number, number]) {
+      const [x, y] = toWorld(pointer)
+      const scale = cameraTransform.k
+      const radius = Math.max(
+        NODE_RING_RADIUS * nodeVisualScreenScale(scale),
+        MIN_NODE_HIT_RADIUS,
       )
-      .filter((link) => deletedRelationIds.has(relationId(link.relation)))
-      .remove()
-  }, [deletedRelationIds])
+      return findNodeAt(scene, x, y, radius / scale)
+    }
+
+    function pickLink(pointer: [number, number]) {
+      const [x, y] = toWorld(pointer)
+      const scale = cameraTransform.k
+      return findLinkAt(
+        scene,
+        x,
+        y,
+        LINK_HIT_TOLERANCE / scale,
+        styleStateRef.current.deletedRelationIds,
+      )
+    }
+
+    function updateCursor() {
+      canvas.style.cursor = drag ? 'grabbing' : hovered ? 'pointer' : 'grab'
+    }
+
+    function positionTooltip(pointer: [number, number]) {
+      const element = tooltipRef.current
+      if (!element) return
+      const flipX = pointer[0] > width * 0.6
+      const flipY = pointer[1] > height * 0.7
+      const x = pointer[0] + (flipX ? -14 : 14)
+      const y = pointer[1] + (flipY ? -14 : 14)
+      element.style.transform =
+        `translate(${x}px, ${y}px)` +
+        ` translate(${flipX ? '-100%' : '0px'}, ${flipY ? '-100%' : '0px'})`
+    }
+
+    function setHovered(next: RelationGraphSelection | undefined) {
+      if (hovered?.type === next?.type && hovered?.id === next?.id) return
+      hovered = next
+      updateCursor()
+      requestDraw()
+    }
+
+    function refreshHover(pointer: [number, number]) {
+      positionTooltip(pointer)
+      if (drag) return
+      const node = pickNode(pointer)
+      const link = node === undefined ? pickLink(pointer) : undefined
+      setHovered(
+        node
+          ? { type: 'node', id: node.data.id }
+          : link
+            ? { type: 'relation', id: link.id }
+            : undefined,
+      )
+      setTooltip(
+        node ? nodeTooltip(node) : link ? linkTooltip(link) : undefined,
+      )
+    }
+
+    function clearHover() {
+      setHovered(undefined)
+      setTooltip(undefined)
+    }
+
+    const zoom = d3
+      .zoom<HTMLCanvasElement, unknown>()
+      .scaleExtent([0.1, MAX_ZOOM_SCALE])
+      // Reject pan gestures that grab a node — those are node drags. Wheel
+      // and double-click zooming stay untouched.
+      .filter((event: MouseEvent | TouchEvent) => {
+        const allowed =
+          (!event.ctrlKey || event.type === 'wheel') &&
+          !('button' in event && event.button)
+        if (event.type !== 'mousedown' && event.type !== 'touchstart') {
+          return allowed
+        }
+        return allowed && pickNode(d3.pointer(event, canvas)) === undefined
+      })
+      .on('start', (event: d3.D3ZoomEvent<HTMLCanvasElement, unknown>) => {
+        if (event.sourceEvent && !hovered) canvas.style.cursor = 'grabbing'
+      })
+      .on('zoom', (event: d3.D3ZoomEvent<HTMLCanvasElement, unknown>) => {
+        cameraTransform = event.transform
+        // The world moves under a stationary pointer, so what is hovered can
+        // change without a pointer event.
+        if (event.sourceEvent instanceof Event) {
+          refreshHover(d3.pointer(event.sourceEvent, canvas))
+        }
+        requestDraw()
+      })
+      .on('end', () => updateCursor())
+
+    const canvasSelection = d3.select(canvas)
+    canvasSelection
+      .call(zoom)
+      .on('pointerdown.graph', (event: PointerEvent) => {
+        suppressNextClick = false
+        if (!event.isPrimary || event.button !== 0) return
+        const node = pickNode(d3.pointer(event, canvas))
+        if (node === undefined) return
+        const [x, y] = toWorld(d3.pointer(event, canvas))
+        drag = { node, offsetX: node.x - x, offsetY: node.y - y, moved: false }
+        canvas.setPointerCapture(event.pointerId)
+        // Also stops the compatibility mousedown, so d3-zoom cannot start a
+        // competing pan on mouse devices; the zoom filter covers touch.
+        event.preventDefault()
+        updateCursor()
+      })
+      .on('pointermove.graph', (event: PointerEvent) => {
+        const pointer = d3.pointer(event, canvas)
+        if (drag) {
+          drag.moved = true
+          const [x, y] = toWorld(pointer)
+          drag.node.x = x + drag.offsetX
+          drag.node.y = y + drag.offsetY
+          positionTooltip(pointer)
+          requestDraw()
+          return
+        }
+        refreshHover(pointer)
+      })
+      .on('pointerup.graph pointercancel.graph', (event: PointerEvent) => {
+        if (!drag) return
+        // A canceled gesture emits no click, so it must not arm suppression.
+        suppressNextClick = drag.moved && event.type === 'pointerup'
+        drag = undefined
+        updateCursor()
+        refreshHover(d3.pointer(event, canvas))
+      })
+      .on('pointerleave.graph', () => {
+        if (!drag) clearHover()
+      })
+      .on('click.graph', (event: MouseEvent) => {
+        if (suppressNextClick) {
+          suppressNextClick = false
+          return
+        }
+        const pointer = d3.pointer(event, canvas)
+        const node = pickNode(pointer)
+        if (node !== undefined) {
+          onSelectionChangeRef.current({ type: 'node', id: node.data.id })
+          return
+        }
+        const link = pickLink(pointer)
+        onSelectionChangeRef.current(
+          link ? { type: 'relation', id: link.id } : undefined,
+        )
+      })
+
+    function resize(nextWidth: number, nextHeight: number) {
+      width = nextWidth
+      height = nextHeight
+      pixelRatio = window.devicePixelRatio || 1
+      canvas.width = Math.max(1, Math.round(width * pixelRatio))
+      canvas.height = Math.max(1, Math.round(height * pixelRatio))
+      if (width === 0 || height === 0) return
+      if (cameraInitialized) {
+        // Synchronous, not scheduled: ResizeObserver runs before paint, so
+        // drawing now avoids a blank frame while the container is resized.
+        draw()
+      } else {
+        cameraInitialized = true
+        initializeCamera()
+      }
+    }
+
+    // Runs once, at the first real size: fits the whole graph into view and
+    // enables programmatic zooming. Later resizes keep the camera in place.
+    function initializeCamera() {
+      const fitScale = Math.max(
+        Math.min(
+          (width - FIT_VIEW_PADDING) / scene.width,
+          (height - FIT_VIEW_PADDING) / scene.height,
+          1,
+        ),
+        0.05,
+      )
+      zoom.scaleExtent([Math.min(fitScale / 2, 0.1), MAX_ZOOM_SCALE])
+      canvasSelection.call(
+        zoom.transform,
+        d3.zoomIdentity
+          .translate(
+            (width - scene.width * fitScale) / 2,
+            (height - scene.height * fitScale) / 2,
+          )
+          .scale(fitScale),
+      )
+
+      zoomToNodeRef.current = (nodeId) => {
+        const node = scene.nodeById.get(nodeId)
+        if (node === undefined) {
+          throw new Error(`Cannot zoom to missing graph node ${nodeId}`)
+        }
+        // Center within the part of the viewport the details panel leaves
+        // visible — selecting a search result always opens the panel.
+        const detailsPanelWidth = Math.min(
+          width * DETAILS_PANEL_WIDTH_RATIO,
+          DETAILS_PANEL_MAX_WIDTH,
+        )
+        clearHover()
+        canvasSelection
+          .transition()
+          .duration(SEARCH_ZOOM_DURATION_MS)
+          .call(
+            zoom.transform,
+            d3.zoomIdentity
+              .translate(
+                (width - detailsPanelWidth) / 2 - node.x * SEARCH_ZOOM_SCALE,
+                height / 2 - node.y * SEARCH_ZOOM_SCALE,
+              )
+              .scale(SEARCH_ZOOM_SCALE),
+          )
+      }
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      resize(entry.contentRect.width, entry.contentRect.height)
+    })
+    observer.observe(canvas)
+
+    return () => {
+      if (frame !== undefined) cancelAnimationFrame(frame)
+      observer.disconnect()
+      canvasSelection.interrupt()
+      canvasSelection.on('.zoom', null).on('.graph', null)
+      requestDrawRef.current = undefined
+      zoomToNodeRef.current = undefined
+      setTooltip(undefined)
+    }
+  }, [graph])
 
   useEffect(() => {
     if (zoomTarget === undefined) return
@@ -395,389 +393,57 @@ export function TokenRelationsGraph({
     zoomToNode(zoomTarget.nodeId)
   }, [zoomTarget])
 
-  useEffect(() => {
-    const svgElement = svgRef.current
-    if (!svgElement) return
-    updateGraphStyles(svgElement, {
-      focus,
-      highlightAnomalies,
-      hovered,
-      selection,
-    })
-  }, [focus, highlightAnomalies, hovered, selection])
-
   return (
-    <div ref={containerRef} className="h-full w-full">
-      <svg ref={svgRef} className="h-full w-full" />
+    <div className="relative h-full w-full overflow-hidden">
+      <canvas
+        ref={canvasRef}
+        className="block h-full w-full touch-none bg-background text-foreground"
+      />
+      <div
+        ref={tooltipRef}
+        className={cn(
+          'pointer-events-none absolute top-0 left-0 z-10 w-max max-w-72',
+          'whitespace-pre-line rounded-md border bg-background px-2.5 py-1.5 text-xs shadow-md',
+          tooltip === undefined && 'hidden',
+        )}
+      >
+        {tooltip}
+      </div>
     </div>
   )
 }
 
-function updateGraphStyles(svgElement: SVGSVGElement, state: GraphStyleState) {
-  const { focus, highlightAnomalies, hovered, selection } = state
-  const svg = d3.select(svgElement)
-  const links = svg.selectAll<SVGPathElement, VisualLink>('.relation-link')
-  const nodes = svg.selectAll<SVGGElement, NodeDatum>('.relation-node')
-
-  links
-    .attr('stroke', (link) =>
-      displayedRelationColor(link.relation, highlightAnomalies),
-    )
-    .attr('marker-mid', (link) => markerUrl(link.relation, highlightAnomalies))
-    .attr('opacity', (link) => linkOpacity(link, state))
-    .attr('stroke-width', (link) => {
-      if (isLinkActive(link, hovered)) return 3
-      if (focus?.relationIds.has(relationId(link.relation))) return 2.8
-      if (highlightAnomalies && link.relation.isConflict) return 2.2
-      return 1.4
-    })
-
-  updateRelationLabelStyles(svgElement, state)
-
-  nodes
-    .attr('opacity', (node) =>
-      focus === undefined || focus.nodeIds.has(node.id) ? 1 : 0.12,
-    )
-    .select<SVGCircleElement>('.node-ring')
-    .attr('opacity', (node) => {
-      if (hovered?.type === 'node' && hovered.id === node.id) return 0.8
-      if (selection?.type === 'node' && selection.id === node.id) return 1
-      if (selection?.type === 'relation' && focus?.nodeIds.has(node.id)) {
-        return 0.7
-      }
-      return 0
-    })
-    .attr('stroke-width', (node) =>
-      selection?.type === 'node' && selection.id === node.id ? 3.5 : 2.5,
-    )
-
-  nodes
-    .select<SVGCircleElement>('.node-core')
-    .attr('r', (node) =>
-      hovered?.type === 'node' && hovered.id === node.id
-        ? nodeRadius() + 1.5
-        : nodeRadius(),
-    )
-}
-
-function updateRelationLabelStyles(
-  svgElement: SVGSVGElement,
-  state: GraphStyleState,
-) {
-  d3.select(svgElement)
-    .selectAll<SVGTextElement, VisualLink>('.relation-label')
-    .attr('fill', (link) =>
-      displayedRelationColor(link.relation, state.highlightAnomalies),
-    )
-    .attr('opacity', (link) => Math.min(linkOpacity(link, state), 0.8))
-}
-
-function displayedRelationColor(
-  relation: RelationGraphRelation,
-  highlightAnomalies: boolean,
-) {
-  if (!highlightAnomalies) return relationColor(relation)
-  return relation.isConflict ? RELATION_COLORS.conflict : RELATION_COLORS.muted
-}
-
-function linkOpacity(link: VisualLink, state: GraphStyleState) {
-  const { focus, highlightAnomalies, hovered } = state
-  const isHovered = isLinkActive(link, hovered)
-  const isSelected = focus?.relationIds.has(relationId(link.relation))
-  if (isHovered || isSelected) return 0.95
-  if (focus !== undefined) return 0.08
-  if (highlightAnomalies) {
-    return link.relation.isConflict ? 0.95 : 0.22
-  }
-  return 0.55
-}
-
-function appendArrowMarkers(
-  svg: d3.Selection<SVGSVGElement, unknown, null, undefined>,
-) {
-  const markers = [
-    { id: 'relation-arrow-lock-and-mint', color: RELATION_COLORS.lockAndMint },
-    { id: 'relation-arrow-conflict', color: RELATION_COLORS.conflict },
-    { id: 'relation-arrow-muted', color: RELATION_COLORS.muted },
-  ]
-
-  const selection = svg
-    .append('defs')
-    .selectAll('marker')
-    .data(markers)
-    .join('marker')
-    .attr('id', (marker) => marker.id)
-    .attr('markerUnits', 'userSpaceOnUse')
-    .attr('viewBox', '0 0 10 10')
-    .attr('refX', 8)
-    .attr('refY', 5)
-    .attr('markerWidth', 6)
-    .attr('markerHeight', 6)
-    .attr('orient', 'auto')
-
-  selection
-    .append('path')
-    .attr('d', 'M 0 0 L 10 5 L 0 10 z')
-    .attr('fill', (marker) => marker.color)
-
-  return selection
-}
-
-function markerUrl(
-  relation: RelationGraphRelation,
-  highlightAnomalies: boolean,
-) {
-  if (!relationIsDirectional(relation)) return null
-  if (highlightAnomalies) {
-    return relation.isConflict
-      ? 'url(#relation-arrow-conflict)'
-      : 'url(#relation-arrow-muted)'
-  }
-  switch (relation.bridgeType) {
-    case 'lockAndMint':
-      return 'url(#relation-arrow-lock-and-mint)'
-    case 'burnAndMint':
-      throw new Error('Burn & Mint relation unexpectedly requested an arrow')
-    default:
-      throw new Error(
-        `Unexpected bridge type in relations graph: ${relation.bridgeType}`,
-      )
-  }
-}
-
-function updateClusterLabelScale(
-  labels: d3.Selection<
-    SVGTextElement,
-    { nodes: NodeDatum[]; text: string },
-    SVGGElement,
-    unknown
-  >,
-  scale: number,
-) {
-  const style = getClusterLabelStyle(scale)
-  labels
-    .attr('font-size', style.fontSize)
-    .attr('stroke-width', style.strokeWidth)
-    .attr('opacity', style.opacity)
-}
-
-function updateRelationLabelScale(
-  labelsLayer: d3.Selection<SVGGElement, unknown, null, undefined>,
-  scale: number,
-) {
-  const style = getRelationLabelStyle(scale)
-  labelsLayer
-    .attr('visibility', style.visible ? 'visible' : 'hidden')
-    .attr('font-size', style.fontSize)
-    .attr('stroke-width', style.strokeWidth)
-    .attr('transform', `translate(0,${style.offset})`)
-}
-
-function clusterCenter(nodes: NodeDatum[]) {
+/**
+ * The canvas cannot use CSS variables, so the theme is read off the canvas
+ * element (which carries the background/foreground classes) once per mount.
+ */
+function resolveTheme(canvas: HTMLCanvasElement): RelationGraphTheme {
+  const style = getComputedStyle(canvas)
   return {
-    x: d3.mean(nodes, (node) => node.x ?? 0) ?? 0,
-    y: d3.mean(nodes, (node) => node.y ?? 0) ?? 0,
+    background: style.backgroundColor,
+    foreground: style.color,
+    fontFamily: style.fontFamily,
   }
 }
 
-function useElementSize<T extends HTMLElement>(ref: RefObject<T | null>) {
-  const [size, setSize] = useState({ width: 0, height: 0 })
-
-  useEffect(() => {
-    if (!ref.current) return
-
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0]
-      if (!entry) return
-
-      setSize({
-        width: entry.contentRect.width,
-        height: entry.contentRect.height,
-      })
-    })
-    observer.observe(ref.current)
-
-    return () => observer.disconnect()
-  }, [ref])
-
-  return size
+function nodeTooltip(node: SceneNode) {
+  const { data } = node
+  return [
+    `${node.label} on ${data.chain}`,
+    `${data.chain}:${data.address}`,
+    data.isDeployed ? 'Deployed token exists' : 'Missing deployed token',
+  ].join('\n')
 }
 
-function buildVisualLinks(
-  relations: RelationGraphRelation[],
-  nodeById: Map<string, NodeDatum>,
-): VisualLink[] {
-  const relationGroups = new Map<string, RelationGraphRelation[]>()
-  for (const relation of relations) {
-    const key = unorderedPairKey(sourceId(relation), targetId(relation))
-    const group = relationGroups.get(key)
-    if (group === undefined) {
-      relationGroups.set(key, [relation])
-    } else {
-      group.push(relation)
-    }
-  }
-
-  return relations.map((relation) => {
-    const source = nodeById.get(sourceId(relation))
-    const target = nodeById.get(targetId(relation))
-    if (source === undefined || target === undefined) {
-      throw new Error('Relation graph contains an unknown endpoint')
-    }
-
-    const group = relationGroups.get(
-      unorderedPairKey(sourceId(relation), targetId(relation)),
-    )
-    if (group === undefined) {
-      throw new Error('Relation graph contains an ungrouped relation')
-    }
-    const index = group.findIndex(
-      (entry) => relationId(entry) === relationId(relation),
-    )
-    if (index === -1) {
-      throw new Error('Relation graph group does not contain relation')
-    }
-    const direction = source.id < target.id ? 1 : -1
-    const curve = (index - (group.length - 1) / 2) * 16 * direction
-
-    return { source, target, relation, curve }
-  })
+function linkTooltip(link: SceneLink) {
+  const arrow = relationIsDirectional(link.relation) ? '→' : '↔'
+  return [
+    `${endpointName(link.source)} ${arrow} ${endpointName(link.target)}`,
+    `${relationTypeLabel(link.relation)} via ${link.relation.plugin}`,
+    relationDirectionLabel(link.relation),
+  ].join('\n')
 }
 
-function buildSimulationLinks(visualLinks: VisualLink[]) {
-  const links = new Map<string, LayoutLink<NodeDatum>>()
-  for (const link of visualLinks) {
-    links.set(unorderedPairKey(link.source.id, link.target.id), {
-      source: link.source,
-      target: link.target,
-    })
-  }
-  return [...links.values()]
-}
-
-interface LinkGeometry {
-  source: { x: number; y: number }
-  target: { x: number; y: number }
-  control: { x: number; y: number } | undefined
-}
-
-function linkGeometry(link: VisualLink): LinkGeometry {
-  const sourceX = link.source.x
-  const sourceY = link.source.y
-  const targetX = link.target.x
-  const targetY = link.target.y
-  if (
-    sourceX === undefined ||
-    sourceY === undefined ||
-    targetX === undefined ||
-    targetY === undefined
-  ) {
-    throw new Error('Relation graph link has an endpoint without a position')
-  }
-
-  const dx = targetX - sourceX
-  const dy = targetY - sourceY
-  const distance = Math.sqrt(dx * dx + dy * dy)
-  if (distance === 0) {
-    return {
-      source: { x: sourceX, y: sourceY },
-      target: { x: targetX, y: targetY },
-      control: undefined,
-    }
-  }
-
-  const ux = dx / distance
-  const uy = dy / distance
-  const source = {
-    x: sourceX,
-    y: sourceY,
-  }
-  const target = {
-    x: targetX,
-    y: targetY,
-  }
-
-  if (link.curve === 0) {
-    return { source, target, control: undefined }
-  }
-
-  const nx = -uy
-  const ny = ux
-  const control = {
-    x: (source.x + target.x) / 2 + nx * link.curve,
-    y: (source.y + target.y) / 2 + ny * link.curve,
-  }
-  return { source, target, control }
-}
-
-function linkPath(link: VisualLink) {
-  const { source, target, control } = linkGeometry(link)
-  if (control === undefined) {
-    if (relationIsDirectional(link.relation)) {
-      const arrow = interpolatePoint(source, target, RELATION_ARROW_POSITION)
-      return `M${source.x},${source.y} L${arrow.x},${arrow.y} L${target.x},${target.y}`
-    }
-    return `M${source.x},${source.y} L${target.x},${target.y}`
-  }
-  if (relationIsDirectional(link.relation)) {
-    const firstControl = interpolatePoint(
-      source,
-      control,
-      RELATION_ARROW_POSITION,
-    )
-    const secondControl = interpolatePoint(
-      control,
-      target,
-      RELATION_ARROW_POSITION,
-    )
-    const arrow = interpolatePoint(
-      firstControl,
-      secondControl,
-      RELATION_ARROW_POSITION,
-    )
-    return `M${source.x},${source.y} Q${firstControl.x},${firstControl.y} ${arrow.x},${arrow.y} Q${secondControl.x},${secondControl.y} ${target.x},${target.y}`
-  }
-  return `M${source.x},${source.y} Q${control.x},${control.y} ${target.x},${target.y}`
-}
-
-function linkLabelPosition(link: VisualLink) {
-  const { source, target, control } = linkGeometry(link)
-  if (control === undefined) {
-    return {
-      x: (source.x + target.x) / 2,
-      y: (source.y + target.y) / 2,
-    }
-  }
-  return {
-    x: source.x * 0.25 + control.x * 0.5 + target.x * 0.25,
-    y: source.y * 0.25 + control.y * 0.5 + target.y * 0.25,
-  }
-}
-
-function interpolatePoint(
-  from: { x: number; y: number },
-  to: { x: number; y: number },
-  position: number,
-) {
-  return {
-    x: from.x + (to.x - from.x) * position,
-    y: from.y + (to.y - from.y) * position,
-  }
-}
-
-function nodeRadius() {
-  return 7
-}
-
-function isLinkActive(
-  link: VisualLink,
-  selection: RelationGraphSelection | undefined,
-) {
-  if (selection?.type === 'relation') {
-    return relationId(link.relation) === selection.id
-  }
-  if (selection?.type === 'node') {
-    return link.source.id === selection.id || link.target.id === selection.id
-  }
-  return false
+function endpointName(node: SceneNode) {
+  return `${node.label} (${node.data.chain})`
 }

--- a/packages/token-ui/src/pages/tokens/relationGraphCanvas.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphCanvas.test.ts
@@ -1,0 +1,169 @@
+import { expect } from 'earl'
+import {
+  getLinkStyle,
+  getNodeRingOpacity,
+  nodeVisualScreenScale,
+} from './relationGraphCanvas'
+import {
+  RELATION_COLORS,
+  type RelationGraphFocus,
+  type RelationGraphNode,
+  type RelationGraphRelation,
+  type RelationGraphSelection,
+  relationId,
+  tokenId,
+} from './relationGraphModel'
+import type { SceneLink, SceneNode } from './relationGraphScene'
+
+describe(getLinkStyle.name, () => {
+  const link = sceneLink('lockAndMint', false)
+
+  it('draws unremarkable links thin and semi-transparent', () => {
+    expect(getLinkStyle(link, styleInputs({}))).toEqual({
+      color: RELATION_COLORS.lockAndMint,
+      opacity: 0.55,
+      width: 1.4,
+    })
+  })
+
+  it('emphasizes the hovered link and links of a hovered node', () => {
+    const hoveredDirectly = getLinkStyle(
+      link,
+      styleInputs({ hovered: { type: 'relation', id: link.id } }),
+    )
+    const hoveredViaEndpoint = getLinkStyle(
+      link,
+      styleInputs({ hovered: { type: 'node', id: link.source.data.id } }),
+    )
+
+    for (const style of [hoveredDirectly, hoveredViaEndpoint]) {
+      expect(style.opacity).toEqual(0.95)
+      expect(style.width).toEqual(3)
+    }
+  })
+
+  it('emphasizes focused links and fades everything else', () => {
+    const focus: RelationGraphFocus = {
+      nodeIds: new Set(),
+      relationIds: new Set([link.id]),
+    }
+
+    expect(getLinkStyle(link, styleInputs({ focus }))).toEqual({
+      color: RELATION_COLORS.lockAndMint,
+      opacity: 0.95,
+      width: 2.8,
+    })
+    expect(
+      getLinkStyle(
+        link,
+        styleInputs({ focus: { nodeIds: new Set(), relationIds: new Set() } }),
+      ).opacity,
+    ).toEqual(0.08)
+  })
+
+  it('recolors links by conflict state when anomalies are highlighted', () => {
+    expect(
+      getLinkStyle(
+        sceneLink('lockAndMint', true),
+        styleInputs({ highlightAnomalies: true }),
+      ),
+    ).toEqual({ color: RELATION_COLORS.conflict, opacity: 0.95, width: 2.2 })
+    expect(
+      getLinkStyle(link, styleInputs({ highlightAnomalies: true })),
+    ).toEqual({ color: RELATION_COLORS.muted, opacity: 0.22, width: 1.4 })
+  })
+})
+
+describe(getNodeRingOpacity.name, () => {
+  const node = sceneNode('ethereum', '0xaaa')
+
+  it('shows the ring for hovered and selected nodes', () => {
+    expect(
+      getNodeRingOpacity(
+        node,
+        styleInputs({ hovered: { type: 'node', id: node.data.id } }),
+      ),
+    ).toEqual(0.8)
+    expect(
+      getNodeRingOpacity(
+        node,
+        styleInputs({ selection: { type: 'node', id: node.data.id } }),
+      ),
+    ).toEqual(1)
+  })
+
+  it('shows a softer ring on the endpoints of a selected relation', () => {
+    expect(
+      getNodeRingOpacity(
+        node,
+        styleInputs({
+          selection: { type: 'relation', id: 'some:relation' },
+          focus: {
+            nodeIds: new Set([node.data.id]),
+            relationIds: new Set(['some:relation']),
+          },
+        }),
+      ),
+    ).toEqual(0.7)
+  })
+
+  it('hides the ring otherwise', () => {
+    expect(getNodeRingOpacity(node, styleInputs({}))).toEqual(0)
+  })
+})
+
+describe(nodeVisualScreenScale.name, () => {
+  it('scales nodes with the world until they reach constant screen size', () => {
+    expect(nodeVisualScreenScale(0.5)).toEqual(0.5)
+    expect(nodeVisualScreenScale(1.2)).toEqual(1.2)
+    expect(nodeVisualScreenScale(4)).toEqual(1.2)
+  })
+})
+
+function styleInputs(overrides: {
+  hovered?: RelationGraphSelection
+  selection?: RelationGraphSelection
+  focus?: RelationGraphFocus
+  highlightAnomalies?: boolean
+}) {
+  return {
+    hovered: overrides.hovered,
+    selection: overrides.selection,
+    focus: overrides.focus,
+    highlightAnomalies: overrides.highlightAnomalies ?? false,
+  }
+}
+
+function sceneNode(chain: string, address: string): SceneNode {
+  const data: RelationGraphNode = {
+    id: tokenId(chain, address),
+    chain,
+    address,
+    symbol: 'TOKEN',
+    isDeployed: true,
+  }
+  return { data, label: 'TOKEN', x: 0, y: 0 }
+}
+
+function sceneLink(
+  bridgeType: RelationGraphRelation['bridgeType'],
+  isConflict: boolean,
+): SceneLink {
+  const relation: RelationGraphRelation = {
+    tokenAChain: 'ethereum',
+    tokenAAddress: '0xaaa',
+    tokenBChain: 'base',
+    tokenBAddress: '0xbbb',
+    plugin: 'plugin',
+    bridgeType,
+    lockedToken: 'A',
+    isConflict,
+  }
+  return {
+    relation,
+    id: relationId(relation),
+    source: sceneNode('ethereum', '0xaaa'),
+    target: sceneNode('base', '0xbbb'),
+    curve: 0,
+  }
+}

--- a/packages/token-ui/src/pages/tokens/relationGraphCanvas.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphCanvas.ts
@@ -77,6 +77,19 @@ const RELATION_LABEL_MIN_SCALE = 2.5
 const RELATION_LABEL_FONT_SIZE = 10
 const RELATION_LABEL_OFFSET_Y = -5
 const CLUSTER_LABEL_FONT_SIZE = 16
+/**
+ * Zoomed in past this scale the cluster label grows with the world, so it
+ * keeps reading as a heading over the cluster instead of blending in with the
+ * node labels, which max out at a smaller constant size.
+ */
+const CLUSTER_LABEL_GROWTH_START_SCALE = 0.7
+const CLUSTER_LABEL_MAX_GROWTH = 3
+/**
+ * Screen distance from the topmost node's center up to the cluster label.
+ * Scaled like node geometry, it clears the node disc and its label (which
+ * both scale the same way) at every zoom level.
+ */
+const CLUSTER_LABEL_CLEARANCE = 34
 /** Where along a directional link its arrow sits. */
 const ARROW_POSITION = 0.65
 const ARROW_LENGTH = 6
@@ -286,23 +299,32 @@ function drawClusterLabels(
   const opacity = getClusterLabelOpacity(camera.k)
   if (opacity === 0) return
 
-  ctx.font = `700 ${CLUSTER_LABEL_FONT_SIZE}px ${theme.fontFamily}`
+  const clearance = CLUSTER_LABEL_CLEARANCE * nodeVisualScreenScale(camera.k)
+  const fontSize =
+    CLUSTER_LABEL_FONT_SIZE *
+    Math.min(
+      Math.max(camera.k / CLUSTER_LABEL_GROWTH_START_SCALE, 1),
+      CLUSTER_LABEL_MAX_GROWTH,
+    )
+  ctx.font = `700 ${fontSize}px ${theme.fontFamily}`
   ctx.textAlign = 'center'
-  ctx.textBaseline = 'middle'
+  ctx.textBaseline = 'bottom'
   ctx.lineJoin = 'round'
-  ctx.lineWidth = 4
+  ctx.lineWidth = fontSize / 4
   ctx.strokeStyle = theme.background
   ctx.fillStyle = theme.foreground
   ctx.globalAlpha = opacity
   for (const label of scene.clusterLabels) {
+    // The label hangs above the cluster — horizontally centered, just clear
+    // of the topmost node — so it never covers what it names.
     let sumX = 0
-    let sumY = 0
+    let topY = Number.POSITIVE_INFINITY
     for (const node of label.nodes) {
       sumX += node.x
-      sumY += node.y
+      topY = Math.min(topY, node.y)
     }
     const x = (sumX / label.nodes.length) * camera.k + camera.x
-    const y = (sumY / label.nodes.length) * camera.k + camera.y
+    const y = topY * camera.k + camera.y - clearance
     if (isPointOutsideViewport(x, y, view)) continue
 
     ctx.strokeText(label.text, x, y)

--- a/packages/token-ui/src/pages/tokens/relationGraphCanvas.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphCanvas.ts
@@ -1,0 +1,432 @@
+import {
+  getClusterLabelOpacity,
+  getNodeVisualScale,
+  nodeColor,
+  RELATION_COLORS,
+  type RelationGraphFocus,
+  type RelationGraphRelation,
+  type RelationGraphSelection,
+  relationColor,
+  relationIsDirectional,
+} from './relationGraphModel'
+import {
+  type LinkGeometry,
+  linkGeometry,
+  linkTangent,
+  pointOnLink,
+  type RelationGraphScene,
+  type SceneLink,
+  type SceneNode,
+} from './relationGraphScene'
+
+/**
+ * Immediate-mode renderer for the relations graph. Every frame redraws the
+ * scene from scratch onto a canvas, which is what keeps zooming fluid: the
+ * cost of a frame is a few thousand cheap draw calls on the visible elements,
+ * not a re-rasterization of a retained SVG tree.
+ *
+ * Two rules keep frames cheap at any camera position:
+ * - viewport culling: elements outside the screen (plus a margin for labels)
+ *   are skipped entirely;
+ * - zoom thresholds: text and arrows are only drawn at zoom levels where they
+ *   are legible, so a zoomed-out view is just dots and lines.
+ *
+ * Everything is drawn in screen space with sizes in CSS pixels, so strokes
+ * and text stay crisp and constant-size across zoom levels by construction.
+ */
+export interface RelationGraphViewState {
+  /** Viewport size in CSS pixels. */
+  width: number
+  height: number
+  camera: RelationGraphCamera
+  hovered: RelationGraphSelection | undefined
+  selection: RelationGraphSelection | undefined
+  focus: RelationGraphFocus | undefined
+  highlightAnomalies: boolean
+  deletedRelationIds: ReadonlySet<string>
+  theme: RelationGraphTheme
+}
+
+/** world * k + offset = screen. Structurally satisfied by d3.ZoomTransform. */
+export interface RelationGraphCamera {
+  x: number
+  y: number
+  k: number
+}
+
+/** Colors resolved to concrete values — canvas cannot read CSS variables. */
+export interface RelationGraphTheme {
+  background: string
+  foreground: string
+  fontFamily: string
+}
+
+type StyleInputs = Pick<
+  RelationGraphViewState,
+  'focus' | 'highlightAnomalies' | 'hovered' | 'selection'
+>
+
+const NODE_RADIUS = 7
+const NODE_HOVER_RADIUS = 8.5
+export const NODE_RING_RADIUS = 12
+const NODE_LABEL_FONT_SIZE = 11
+const NODE_LABEL_OFFSET_Y = -12
+/** Below this on-screen font size node labels are illegible — skip them. */
+const NODE_LABEL_MIN_FONT_SIZE = 8
+const RELATION_LABEL_MIN_SCALE = 2.5
+const RELATION_LABEL_FONT_SIZE = 10
+const RELATION_LABEL_OFFSET_Y = -5
+const CLUSTER_LABEL_FONT_SIZE = 16
+/** Where along a directional link its arrow sits. */
+const ARROW_POSITION = 0.65
+const ARROW_LENGTH = 6
+/** Below this zoom an arrow would be under ~2px on screen — skip it. */
+const ARROW_MIN_SCALE = 0.35
+/**
+ * Extra screen pixels around the viewport that still draw, so labels hanging
+ * off a just-offscreen element do not pop in and out at the edges.
+ */
+const CULL_MARGIN = 80
+
+export function drawRelationGraph(
+  ctx: CanvasRenderingContext2D,
+  scene: RelationGraphScene,
+  view: RelationGraphViewState,
+): void {
+  ctx.clearRect(0, 0, view.width, view.height)
+  drawLinks(ctx, scene, view)
+  if (view.camera.k > RELATION_LABEL_MIN_SCALE) {
+    drawRelationLabels(ctx, scene, view)
+  }
+  drawNodes(ctx, scene, view)
+  drawNodeLabels(ctx, scene, view)
+  drawClusterLabels(ctx, scene, view)
+  ctx.globalAlpha = 1
+}
+
+function drawLinks(
+  ctx: CanvasRenderingContext2D,
+  scene: RelationGraphScene,
+  view: RelationGraphViewState,
+) {
+  const { camera } = view
+  const drawArrows = camera.k >= ARROW_MIN_SCALE
+  const arrowLength = ARROW_LENGTH * Math.min(camera.k, 1)
+  ctx.lineCap = 'round'
+  for (const link of scene.links) {
+    if (view.deletedRelationIds.has(link.id)) continue
+    const geometry = screenLinkGeometry(link, camera)
+    if (isOutsideViewport(geometry, view)) continue
+
+    const style = getLinkStyle(link, view)
+    ctx.globalAlpha = style.opacity
+    ctx.strokeStyle = style.color
+    ctx.lineWidth = style.width
+    ctx.beginPath()
+    ctx.moveTo(geometry.sx, geometry.sy)
+    ctx.quadraticCurveTo(geometry.cx, geometry.cy, geometry.tx, geometry.ty)
+    ctx.stroke()
+
+    if (drawArrows && relationIsDirectional(link.relation)) {
+      drawArrow(ctx, geometry, arrowLength, style.color)
+    }
+  }
+  ctx.globalAlpha = 1
+}
+
+function drawArrow(
+  ctx: CanvasRenderingContext2D,
+  geometry: LinkGeometry,
+  length: number,
+  color: string,
+) {
+  const point = pointOnLink(geometry, ARROW_POSITION)
+  const direction = linkTangent(geometry, ARROW_POSITION)
+  // The anchor point sits 80% along the arrow, like the SVG marker this
+  // replaces, so the visible triangle straddles the line the same way.
+  const tipX = point.x + direction.x * length * 0.2
+  const tipY = point.y + direction.y * length * 0.2
+  const backX = point.x - direction.x * length * 0.8
+  const backY = point.y - direction.y * length * 0.8
+  const halfWidth = length / 2
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.moveTo(tipX, tipY)
+  ctx.lineTo(backX - direction.y * halfWidth, backY + direction.x * halfWidth)
+  ctx.lineTo(backX + direction.y * halfWidth, backY - direction.x * halfWidth)
+  ctx.closePath()
+  ctx.fill()
+}
+
+function drawRelationLabels(
+  ctx: CanvasRenderingContext2D,
+  scene: RelationGraphScene,
+  view: RelationGraphViewState,
+) {
+  const { theme } = view
+  ctx.font = `600 ${RELATION_LABEL_FONT_SIZE}px ${theme.fontFamily}`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.lineJoin = 'round'
+  ctx.lineWidth = 3
+  ctx.strokeStyle = theme.background
+  for (const link of scene.links) {
+    if (view.deletedRelationIds.has(link.id)) continue
+    const geometry = screenLinkGeometry(link, view.camera)
+    if (isOutsideViewport(geometry, view)) continue
+
+    const style = getLinkStyle(link, view)
+    const anchor = pointOnLink(geometry, 0.5)
+    ctx.globalAlpha = Math.min(style.opacity, 0.8)
+    ctx.fillStyle = style.color
+    ctx.strokeText(
+      link.relation.plugin,
+      anchor.x,
+      anchor.y + RELATION_LABEL_OFFSET_Y,
+    )
+    ctx.fillText(
+      link.relation.plugin,
+      anchor.x,
+      anchor.y + RELATION_LABEL_OFFSET_Y,
+    )
+  }
+  ctx.globalAlpha = 1
+}
+
+function drawNodes(
+  ctx: CanvasRenderingContext2D,
+  scene: RelationGraphScene,
+  view: RelationGraphViewState,
+) {
+  const { camera, focus, hovered, selection, theme } = view
+  const visualScale = nodeVisualScreenScale(camera.k)
+  for (const node of scene.nodes) {
+    const x = node.x * camera.k + camera.x
+    const y = node.y * camera.k + camera.y
+    if (isPointOutsideViewport(x, y, view)) continue
+
+    const id = node.data.id
+    const groupAlpha = focus === undefined || focus.nodeIds.has(id) ? 1 : 0.12
+    const isHovered = hovered?.type === 'node' && hovered.id === id
+    const isSelected = selection?.type === 'node' && selection.id === id
+    const color = nodeColor(node.data)
+
+    const ringOpacity = getNodeRingOpacity(node, view)
+    if (ringOpacity > 0) {
+      ctx.globalAlpha = groupAlpha * ringOpacity
+      ctx.strokeStyle = color
+      ctx.lineWidth = (isSelected ? 3.5 : 2.5) * visualScale
+      ctx.beginPath()
+      ctx.arc(x, y, NODE_RING_RADIUS * visualScale, 0, 2 * Math.PI)
+      ctx.stroke()
+    }
+
+    ctx.globalAlpha = groupAlpha
+    ctx.fillStyle = color
+    ctx.beginPath()
+    ctx.arc(
+      x,
+      y,
+      (isHovered ? NODE_HOVER_RADIUS : NODE_RADIUS) * visualScale,
+      0,
+      2 * Math.PI,
+    )
+    ctx.fill()
+    ctx.strokeStyle = theme.background
+    ctx.lineWidth = 2 * visualScale
+    ctx.stroke()
+  }
+  ctx.globalAlpha = 1
+}
+
+function drawNodeLabels(
+  ctx: CanvasRenderingContext2D,
+  scene: RelationGraphScene,
+  view: RelationGraphViewState,
+) {
+  const { camera, focus, hovered, theme } = view
+  const visualScale = nodeVisualScreenScale(camera.k)
+  const fontSize = NODE_LABEL_FONT_SIZE * visualScale
+  // Zoomed out, labels are only kept for the hovered and focused nodes — a
+  // handful — clamped up to stay legible; cluster labels carry that view.
+  const showAll = fontSize >= NODE_LABEL_MIN_FONT_SIZE
+  if (!showAll && hovered === undefined && focus === undefined) return
+
+  ctx.font = `600 ${Math.max(fontSize, NODE_LABEL_MIN_FONT_SIZE)}px ${theme.fontFamily}`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'alphabetic'
+  ctx.lineJoin = 'round'
+  ctx.lineWidth = Math.max(3 * visualScale, 2)
+  ctx.strokeStyle = theme.background
+  ctx.fillStyle = theme.foreground
+  for (const node of scene.nodes) {
+    const id = node.data.id
+    const emphasized =
+      (hovered?.type === 'node' && hovered.id === id) ||
+      focus?.nodeIds.has(id) === true
+    if (!showAll && !emphasized) continue
+    const x = node.x * camera.k + camera.x
+    const y = node.y * camera.k + camera.y
+    if (isPointOutsideViewport(x, y, view)) continue
+
+    ctx.globalAlpha = focus === undefined || focus.nodeIds.has(id) ? 1 : 0.12
+    const labelY = y + NODE_LABEL_OFFSET_Y * visualScale
+    ctx.strokeText(node.label, x, labelY)
+    ctx.fillText(node.label, x, labelY)
+  }
+  ctx.globalAlpha = 1
+}
+
+function drawClusterLabels(
+  ctx: CanvasRenderingContext2D,
+  scene: RelationGraphScene,
+  view: RelationGraphViewState,
+) {
+  const { camera, theme } = view
+  const opacity = getClusterLabelOpacity(camera.k)
+  if (opacity === 0) return
+
+  ctx.font = `700 ${CLUSTER_LABEL_FONT_SIZE}px ${theme.fontFamily}`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.lineJoin = 'round'
+  ctx.lineWidth = 4
+  ctx.strokeStyle = theme.background
+  ctx.fillStyle = theme.foreground
+  ctx.globalAlpha = opacity
+  for (const label of scene.clusterLabels) {
+    let sumX = 0
+    let sumY = 0
+    for (const node of label.nodes) {
+      sumX += node.x
+      sumY += node.y
+    }
+    const x = (sumX / label.nodes.length) * camera.k + camera.x
+    const y = (sumY / label.nodes.length) * camera.k + camera.y
+    if (isPointOutsideViewport(x, y, view)) continue
+
+    ctx.strokeText(label.text, x, y)
+    ctx.fillText(label.text, x, y)
+  }
+  ctx.globalAlpha = 1
+}
+
+export interface LinkStyle {
+  color: string
+  opacity: number
+  width: number
+}
+
+export function getLinkStyle(link: SceneLink, view: StyleInputs): LinkStyle {
+  const { focus, highlightAnomalies } = view
+  const isHovered = isLinkHovered(link, view.hovered)
+  const inFocus = focus?.relationIds.has(link.id) === true
+  return {
+    color: displayedRelationColor(link.relation, highlightAnomalies),
+    opacity: getLinkOpacity(link, view, isHovered, inFocus),
+    width: isHovered
+      ? 3
+      : inFocus
+        ? 2.8
+        : highlightAnomalies && link.relation.isConflict
+          ? 2.2
+          : 1.4,
+  }
+}
+
+function getLinkOpacity(
+  link: SceneLink,
+  view: StyleInputs,
+  isHovered: boolean,
+  inFocus: boolean,
+) {
+  if (isHovered || inFocus) return 0.95
+  if (view.focus !== undefined) return 0.08
+  if (view.highlightAnomalies) {
+    return link.relation.isConflict ? 0.95 : 0.22
+  }
+  return 0.55
+}
+
+/** Hovering a node lights up its incident links as well. */
+function isLinkHovered(
+  link: SceneLink,
+  hovered: RelationGraphSelection | undefined,
+) {
+  if (hovered?.type === 'relation') return link.id === hovered.id
+  if (hovered?.type === 'node') {
+    return (
+      link.source.data.id === hovered.id || link.target.data.id === hovered.id
+    )
+  }
+  return false
+}
+
+function displayedRelationColor(
+  relation: RelationGraphRelation,
+  highlightAnomalies: boolean,
+) {
+  if (!highlightAnomalies) return relationColor(relation)
+  return relation.isConflict ? RELATION_COLORS.conflict : RELATION_COLORS.muted
+}
+
+export function getNodeRingOpacity(node: SceneNode, view: StyleInputs): number {
+  const id = node.data.id
+  const { focus, hovered, selection } = view
+  if (hovered?.type === 'node' && hovered.id === id) return 0.8
+  if (selection?.type === 'node' && selection.id === id) return 1
+  if (selection?.type === 'relation' && focus?.nodeIds.has(id) === true) {
+    return 0.7
+  }
+  return 0
+}
+
+/**
+ * On-screen size multiplier for node geometry: nodes scale with the world
+ * until 1.2x zoom and keep a constant screen size beyond it.
+ */
+export function nodeVisualScreenScale(scale: number) {
+  return scale * getNodeVisualScale(scale)
+}
+
+function screenLinkGeometry(
+  link: SceneLink,
+  camera: RelationGraphCamera,
+): LinkGeometry {
+  const geometry = linkGeometry(link)
+  const { x, y, k } = camera
+  return {
+    sx: geometry.sx * k + x,
+    sy: geometry.sy * k + y,
+    cx: geometry.cx * k + x,
+    cy: geometry.cy * k + y,
+    tx: geometry.tx * k + x,
+    ty: geometry.ty * k + y,
+  }
+}
+
+function isOutsideViewport(
+  geometry: LinkGeometry,
+  view: RelationGraphViewState,
+) {
+  return (
+    Math.max(geometry.sx, geometry.cx, geometry.tx) < -CULL_MARGIN ||
+    Math.min(geometry.sx, geometry.cx, geometry.tx) >
+      view.width + CULL_MARGIN ||
+    Math.max(geometry.sy, geometry.cy, geometry.ty) < -CULL_MARGIN ||
+    Math.min(geometry.sy, geometry.cy, geometry.ty) > view.height + CULL_MARGIN
+  )
+}
+
+function isPointOutsideViewport(
+  x: number,
+  y: number,
+  view: RelationGraphViewState,
+) {
+  return (
+    x < -CULL_MARGIN ||
+    x > view.width + CULL_MARGIN ||
+    y < -CULL_MARGIN ||
+    y > view.height + CULL_MARGIN
+  )
+}

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
@@ -47,14 +47,16 @@ describe(mostCommonDeployedSymbol.name, () => {
 })
 
 describe(getClusterLabelOpacity.name, () => {
-  it('shows labels only in the zoomed-out overview range', () => {
+  it('keeps labels visible at overview and zoomed-in scales', () => {
     expect(getClusterLabelOpacity(0.3)).toEqual(0.8)
-    expect(getClusterLabelOpacity(1)).toEqual(0)
-    expect(getClusterLabelOpacity(2)).toEqual(0)
+    expect(getClusterLabelOpacity(1)).toEqual(0.8)
+    expect(getClusterLabelOpacity(2)).toEqual(0.8)
   })
 
-  it('hides labels at extreme zoom-out', () => {
-    expect(getClusterLabelOpacity(0.05)).toEqual(0)
+  it('fades labels away at extreme zoom-out', () => {
+    // The exact fade thresholds are tuning knobs; the contract is only that
+    // labels are gone once the zoom-out is extreme enough.
+    expect(getClusterLabelOpacity(0.01)).toEqual(0)
   })
 
   it('rejects invalid scales', () => {

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.test.ts
@@ -1,10 +1,9 @@
 import { expect } from 'earl'
 import {
-  getClusterLabelStyle,
+  getClusterLabelOpacity,
   getExistingRelationGraphSelection,
   getNodeVisualScale,
   getRelationGraphFocus,
-  getRelationLabelStyle,
   mostCommonDeployedSymbol,
   type RelationGraph,
   type RelationGraphFocus,
@@ -47,20 +46,19 @@ describe(mostCommonDeployedSymbol.name, () => {
   })
 })
 
-describe(getClusterLabelStyle.name, () => {
-  it('stops increasing labels below the minimum scale', () => {
-    expect(getClusterLabelStyle(1).fontSize).toEqual(18)
-    expect(getClusterLabelStyle(1).strokeWidth).toEqual(4)
-    expect(getClusterLabelStyle(0.1).fontSize).toEqual(18)
-    expect(getClusterLabelStyle(0.1).strokeWidth).toEqual(4)
+describe(getClusterLabelOpacity.name, () => {
+  it('shows labels only in the zoomed-out overview range', () => {
+    expect(getClusterLabelOpacity(0.3)).toEqual(0.8)
+    expect(getClusterLabelOpacity(1)).toEqual(0)
+    expect(getClusterLabelOpacity(2)).toEqual(0)
   })
 
   it('hides labels at extreme zoom-out', () => {
-    expect(getClusterLabelStyle(0.05).opacity).toEqual(0)
+    expect(getClusterLabelOpacity(0.05)).toEqual(0)
   })
 
   it('rejects invalid scales', () => {
-    expect(() => getClusterLabelStyle(0)).toThrow(
+    expect(() => getClusterLabelOpacity(0)).toThrow(
       'Graph scale must be a positive finite number',
     )
   })
@@ -71,16 +69,6 @@ describe(getNodeVisualScale.name, () => {
     expect(getNodeVisualScale(0.5)).toEqual(1)
     expect(getNodeVisualScale(1.2)).toEqual(1)
     expect(getNodeVisualScale(2.4)).toEqual(0.5)
-  })
-})
-
-describe(getRelationLabelStyle.name, () => {
-  it('shows constant-size labels above 2.5x zoom', () => {
-    expect(getRelationLabelStyle(2.5).visible).toEqual(false)
-    const style = getRelationLabelStyle(4)
-    expect(style.visible).toEqual(true)
-    expect(style.fontSize * 4).toEqual(10)
-    expect(style.strokeWidth * 4).toEqual(3)
   })
 })
 

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.ts
@@ -25,7 +25,13 @@ export const NODE_COLORS = {
   missing: '#f97316',
 } as const
 
-const CLUSTER_LABEL_FADE_OUT_SCALE = 0.05
+/** Zoomed out to this scale or further, cluster labels are gone entirely. */
+const CLUSTER_LABEL_FADE_OUT_SCALE = 0.15
+/**
+ * At this scale and closer, cluster labels are fully shown; between the two
+ * scales they fade linearly. Raise both to make labels vanish sooner when
+ * zooming out.
+ */
 const CLUSTER_LABEL_FULL_OPACITY_SCALE = 0.2
 const CLUSTER_LABEL_MAX_OPACITY = 0.8
 const SEARCH_RESULT_LIMIT = 5
@@ -167,10 +173,10 @@ export function mostCommonDeployedSymbol(nodes: RelationGraphNode[]) {
 }
 
 /**
- * Cluster labels take over when the graph is zoomed out too far for node
- * labels: invisible when zoomed in past 1x, fully visible in the overview
- * range, and fading away again at extreme zoom-out where even clusters are
- * specks.
+ * Cluster labels hang above their cluster, so they never cover nodes and can
+ * stay visible at any zoom-in level. They only fade away at extreme zoom-out,
+ * where clusters shrink to specks and neighboring labels would pile up into
+ * unreadable overlap.
  */
 export function getClusterLabelOpacity(scale: number) {
   assertGraphScale(scale)
@@ -183,9 +189,7 @@ export function getClusterLabelOpacity(scale: number) {
       ((scale - CLUSTER_LABEL_FADE_OUT_SCALE) / fadeRange)
     )
   }
-  if (scale <= 0.6) return CLUSTER_LABEL_MAX_OPACITY
-  if (scale >= 1) return 0
-  return CLUSTER_LABEL_MAX_OPACITY * ((1 - scale) / 0.4)
+  return CLUSTER_LABEL_MAX_OPACITY
 }
 
 export function getNodeVisualScale(scale: number) {

--- a/packages/token-ui/src/pages/tokens/relationGraphModel.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphModel.ts
@@ -25,13 +25,11 @@ export const NODE_COLORS = {
   missing: '#f97316',
 } as const
 
-const CLUSTER_LABEL_MIN_SCALE = 1
 const CLUSTER_LABEL_FADE_OUT_SCALE = 0.05
 const CLUSTER_LABEL_FULL_OPACITY_SCALE = 0.2
 const CLUSTER_LABEL_MAX_OPACITY = 0.8
 const SEARCH_RESULT_LIMIT = 5
 const NODE_VISUAL_MAX_SCALE = 1.2
-const RELATION_LABEL_MIN_SCALE = 2.5
 
 export function relationId(relation: RelationGraphRelation) {
   return [
@@ -168,30 +166,31 @@ export function mostCommonDeployedSymbol(nodes: RelationGraphNode[]) {
     .at(0)?.[0]
 }
 
-export function getClusterLabelStyle(scale: number) {
+/**
+ * Cluster labels take over when the graph is zoomed out too far for node
+ * labels: invisible when zoomed in past 1x, fully visible in the overview
+ * range, and fading away again at extreme zoom-out where even clusters are
+ * specks.
+ */
+export function getClusterLabelOpacity(scale: number) {
   assertGraphScale(scale)
-
-  const clampedScale = Math.max(scale, CLUSTER_LABEL_MIN_SCALE)
-  return {
-    fontSize: 18 / clampedScale,
-    strokeWidth: 4 / clampedScale,
-    opacity: clusterLabelOpacity(scale),
+  if (scale <= CLUSTER_LABEL_FADE_OUT_SCALE) return 0
+  if (scale < CLUSTER_LABEL_FULL_OPACITY_SCALE) {
+    const fadeRange =
+      CLUSTER_LABEL_FULL_OPACITY_SCALE - CLUSTER_LABEL_FADE_OUT_SCALE
+    return (
+      CLUSTER_LABEL_MAX_OPACITY *
+      ((scale - CLUSTER_LABEL_FADE_OUT_SCALE) / fadeRange)
+    )
   }
+  if (scale <= 0.6) return CLUSTER_LABEL_MAX_OPACITY
+  if (scale >= 1) return 0
+  return CLUSTER_LABEL_MAX_OPACITY * ((1 - scale) / 0.4)
 }
 
 export function getNodeVisualScale(scale: number) {
   assertGraphScale(scale)
   return Math.min(1, NODE_VISUAL_MAX_SCALE / scale)
-}
-
-export function getRelationLabelStyle(scale: number) {
-  assertGraphScale(scale)
-  return {
-    visible: scale > RELATION_LABEL_MIN_SCALE,
-    fontSize: 10 / scale,
-    strokeWidth: 3 / scale,
-    offset: -5 / scale,
-  }
 }
 
 export function getExistingRelationGraphSelection(
@@ -253,21 +252,6 @@ function assertGraphScale(scale: number) {
   if (!Number.isFinite(scale) || scale <= 0) {
     throw new Error('Graph scale must be a positive finite number')
   }
-}
-
-function clusterLabelOpacity(scale: number) {
-  if (scale <= CLUSTER_LABEL_FADE_OUT_SCALE) return 0
-  if (scale < CLUSTER_LABEL_FULL_OPACITY_SCALE) {
-    const fadeRange =
-      CLUSTER_LABEL_FULL_OPACITY_SCALE - CLUSTER_LABEL_FADE_OUT_SCALE
-    return (
-      CLUSTER_LABEL_MAX_OPACITY *
-      ((scale - CLUSTER_LABEL_FADE_OUT_SCALE) / fadeRange)
-    )
-  }
-  if (scale <= 0.6) return CLUSTER_LABEL_MAX_OPACITY
-  if (scale >= 1) return 0
-  return CLUSTER_LABEL_MAX_OPACITY * ((1 - scale) / 0.4)
 }
 
 export function getRelationGraphFocus(

--- a/packages/token-ui/src/pages/tokens/relationGraphScene.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphScene.test.ts
@@ -1,0 +1,209 @@
+import { expect } from 'earl'
+import {
+  type RelationGraph,
+  type RelationGraphNode,
+  type RelationGraphRelation,
+  relationId,
+  tokenId,
+} from './relationGraphModel'
+import {
+  buildRelationGraphScene,
+  distanceToLink,
+  findLinkAt,
+  findNodeAt,
+  linkGeometry,
+  type RelationGraphScene,
+  type SceneLink,
+  type SceneNode,
+} from './relationGraphScene'
+
+describe(buildRelationGraphScene.name, () => {
+  const graph: RelationGraph = {
+    nodes: [
+      graphNode('ethereum', '0xaaa', 'USDC'),
+      graphNode('base', '0xbbb', 'USDC'),
+      graphNode('optimism', '0xccc', 'USDT'),
+    ],
+    relations: [
+      relation('ethereum', '0xaaa', 'base', '0xbbb', 'first'),
+      relation('ethereum', '0xaaa', 'base', '0xbbb', 'second'),
+      relation('ethereum', '0xaaa', 'optimism', '0xccc', 'third'),
+    ],
+  }
+
+  it('positions every node and connects links to the shared node objects', () => {
+    const scene = buildRelationGraphScene(graph)
+
+    expect(scene.nodes.length).toEqual(3)
+    for (const node of scene.nodes) {
+      expect(Number.isFinite(node.x)).toEqual(true)
+      expect(Number.isFinite(node.y)).toEqual(true)
+    }
+    for (const link of scene.links) {
+      // Reference equality matters: dragging a node must move its links.
+      expect(found(scene.nodeById.get(link.source.data.id))).toExactlyEqual(
+        link.source,
+      )
+      expect(found(scene.nodeById.get(link.target.data.id))).toExactlyEqual(
+        link.target,
+      )
+    }
+  })
+
+  it('curves parallel relations apart and keeps single relations straight', () => {
+    const scene = buildRelationGraphScene(graph)
+
+    const parallel = scene.links.filter(
+      (link) => link.target.data.id === tokenId('base', '0xbbb'),
+    )
+    expect(parallel.map((link) => link.curve).sort((a, b) => a - b)).toEqual([
+      -8, 8,
+    ])
+    const single = scene.links.find(
+      (link) => link.target.data.id === tokenId('optimism', '0xccc'),
+    )
+    expect(single?.curve).toEqual(0)
+  })
+
+  it('labels the cluster with its most common deployed symbol', () => {
+    const scene = buildRelationGraphScene(graph)
+
+    expect(scene.clusterLabels.map((label) => label.text)).toEqual(['USDC'])
+    expect(scene.clusterLabels[0]?.nodes.length).toEqual(3)
+  })
+})
+
+describe(findNodeAt.name, () => {
+  const near = sceneNode('ethereum', '0xaaa', 0, 0)
+  const far = sceneNode('base', '0xbbb', 10, 0)
+  const scene = sceneWith([near, far], [])
+
+  it('returns the nearest node within the radius', () => {
+    expect(found(findNodeAt(scene, 2, 1, 5))).toExactlyEqual(near)
+    expect(found(findNodeAt(scene, 7, 0, 5))).toExactlyEqual(far)
+  })
+
+  it('returns undefined when every node is out of reach', () => {
+    expect(findNodeAt(scene, 2, 1, 1)).toEqual(undefined)
+  })
+})
+
+describe(findLinkAt.name, () => {
+  const source = sceneNode('ethereum', '0xaaa', 0, 0)
+  const target = sceneNode('base', '0xbbb', 100, 0)
+  const straight = sceneLink(source, target, 'straight', 0)
+  const curved = sceneLink(source, target, 'curved', 16)
+  const scene = sceneWith([source, target], [straight, curved])
+
+  it('picks the closest link within the tolerance', () => {
+    // The curved link's control point sits 16 world units off the straight
+    // line, which puts its midpoint 8 units off it.
+    expect(found(findLinkAt(scene, 50, 0, 2))).toExactlyEqual(straight)
+    expect(found(findLinkAt(scene, 50, 8, 2))).toExactlyEqual(curved)
+    expect(findLinkAt(scene, 50, 20, 5)).toEqual(undefined)
+  })
+
+  it('ignores excluded links', () => {
+    // Tolerance 10 reaches both links from the query point; exclusion is
+    // what removes them, not distance.
+    expect(found(findLinkAt(scene, 50, 0, 10))).toExactlyEqual(straight)
+    expect(
+      found(findLinkAt(scene, 50, 0, 10, new Set([straight.id]))),
+    ).toExactlyEqual(curved)
+    expect(
+      findLinkAt(scene, 50, 0, 10, new Set([straight.id, curved.id])),
+    ).toEqual(undefined)
+  })
+})
+
+describe(distanceToLink.name, () => {
+  it('is exact for straight links', () => {
+    const link = sceneLink(
+      sceneNode('ethereum', '0xaaa', 0, 0),
+      sceneNode('base', '0xbbb', 100, 0),
+      'straight',
+      0,
+    )
+    expect(distanceToLink(linkGeometry(link), 50, 7)).toEqual(7)
+    expect(distanceToLink(linkGeometry(link), -3, 0)).toEqual(3)
+  })
+})
+
+function found<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error('Expected the hit test to hit')
+  return value
+}
+
+function graphNode(
+  chain: string,
+  address: string,
+  symbol: string,
+): RelationGraphNode {
+  return {
+    id: tokenId(chain, address),
+    chain,
+    address,
+    symbol,
+    isDeployed: true,
+  }
+}
+
+function relation(
+  tokenAChain: string,
+  tokenAAddress: string,
+  tokenBChain: string,
+  tokenBAddress: string,
+  plugin: string,
+): RelationGraphRelation {
+  return {
+    tokenAChain,
+    tokenAAddress,
+    tokenBChain,
+    tokenBAddress,
+    plugin,
+    bridgeType: 'lockAndMint',
+    lockedToken: 'A',
+    isConflict: false,
+  }
+}
+
+function sceneNode(
+  chain: string,
+  address: string,
+  x: number,
+  y: number,
+): SceneNode {
+  return {
+    data: graphNode(chain, address, 'TOKEN'),
+    label: 'TOKEN',
+    x,
+    y,
+  }
+}
+
+function sceneLink(
+  source: SceneNode,
+  target: SceneNode,
+  plugin: string,
+  curve: number,
+): SceneLink {
+  const link = relation(
+    source.data.chain,
+    source.data.address,
+    target.data.chain,
+    target.data.address,
+    plugin,
+  )
+  return { relation: link, id: relationId(link), source, target, curve }
+}
+
+function sceneWith(nodes: SceneNode[], links: SceneLink[]): RelationGraphScene {
+  return {
+    nodes,
+    links,
+    clusterLabels: [],
+    nodeById: new Map(nodes.map((node) => [node.data.id, node])),
+    width: 0,
+    height: 0,
+  }
+}

--- a/packages/token-ui/src/pages/tokens/relationGraphScene.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphScene.ts
@@ -61,7 +61,8 @@ export interface SceneLink {
 
 export interface SceneClusterLabel {
   readonly text: string
-  /** The label sits at the live centroid of these nodes, so it follows drags. */
+  /** The label is anchored to the live positions of these nodes each frame,
+   * so it follows drags. */
   readonly nodes: SceneNode[]
 }
 

--- a/packages/token-ui/src/pages/tokens/relationGraphScene.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphScene.ts
@@ -1,0 +1,348 @@
+import {
+  type LayoutLink,
+  type LayoutNode,
+  layoutRelationGraph,
+} from './relationGraphLayout'
+import {
+  mostCommonDeployedSymbol,
+  nodeLabel,
+  type RelationGraph,
+  type RelationGraphNode,
+  type RelationGraphRelation,
+  relationId,
+  sourceId,
+  targetId,
+  unorderedPairKey,
+} from './relationGraphModel'
+
+/**
+ * The scene is the drawable form of the relations graph: every node placed by
+ * the force layout, every relation resolved to its endpoints and curve shape.
+ * It is built once per graph payload and then only read — except node
+ * positions, which dragging mutates in place. Links hold references to the
+ * shared node objects, so moving a node moves its links.
+ *
+ * Deleted relations are deliberately not the scene's concern: deleting must
+ * not re-run the layout, so the renderer and the hit tests skip deleted links
+ * at read time instead.
+ */
+export interface RelationGraphScene {
+  nodes: SceneNode[]
+  links: SceneLink[]
+  clusterLabels: SceneClusterLabel[]
+  nodeById: Map<string, SceneNode>
+  /** Layout bounds, used to fit the initial camera. */
+  width: number
+  height: number
+}
+
+export interface SceneNode {
+  /** The graph payload behind this node; geometry lives beside it, not in it. */
+  readonly data: RelationGraphNode
+  /** Displayed name, precomputed because it is drawn every frame. */
+  readonly label: string
+  x: number
+  y: number
+}
+
+export interface SceneLink {
+  readonly relation: RelationGraphRelation
+  /** Precomputed relationId — compared against sets every frame. */
+  readonly id: string
+  readonly source: SceneNode
+  readonly target: SceneNode
+  /**
+   * Sideways offset of the curve's control point in world units, so parallel
+   * relations between the same two tokens stay distinguishable. Zero means a
+   * straight line.
+   */
+  readonly curve: number
+}
+
+export interface SceneClusterLabel {
+  readonly text: string
+  /** The label sits at the live centroid of these nodes, so it follows drags. */
+  readonly nodes: SceneNode[]
+}
+
+/** How far apart the curved duplicates of a same-pair relation sit, world units. */
+const PARALLEL_RELATION_SPACING = 16
+
+export function buildRelationGraphScene(
+  graph: RelationGraph,
+): RelationGraphScene {
+  type WorkingNode = LayoutNode & { data: RelationGraphNode }
+  const workingNodes = graph.nodes.map(
+    (node): WorkingNode => ({ id: node.id, data: node }),
+  )
+  const workingById = new Map(workingNodes.map((node) => [node.id, node]))
+  const layout = layoutRelationGraph(
+    workingNodes,
+    buildSimulationLinks(graph.relations, workingById),
+  )
+
+  const nodes = workingNodes.map((node): SceneNode => {
+    if (node.x === undefined || node.y === undefined) {
+      throw new Error(`Graph layout left node ${node.id} without a position`)
+    }
+    return {
+      data: node.data,
+      label: nodeLabel(node.data),
+      x: node.x,
+      y: node.y,
+    }
+  })
+  const nodeById = new Map(nodes.map((node) => [node.data.id, node]))
+  const sceneNodeOf = (working: WorkingNode) => {
+    const node = nodeById.get(working.id)
+    if (node === undefined) {
+      throw new Error(`Graph layout returned unknown node ${working.id}`)
+    }
+    return node
+  }
+
+  return {
+    nodes,
+    links: buildSceneLinks(graph.relations, nodeById),
+    clusterLabels: layout.clusters.flatMap((cluster) => {
+      const text = mostCommonDeployedSymbol(cluster.nodes.map((n) => n.data))
+      if (text === undefined) return []
+      return [{ text, nodes: cluster.nodes.map(sceneNodeOf) }]
+    }),
+    nodeById,
+    width: layout.width,
+    height: layout.height,
+  }
+}
+
+/**
+ * The force simulation must see one spring per node pair, not one per
+ * relation, or pairs with many parallel relations would be pulled unnaturally
+ * close together.
+ */
+function buildSimulationLinks<Node extends LayoutNode>(
+  relations: RelationGraphRelation[],
+  nodeById: Map<string, Node>,
+): LayoutLink<Node>[] {
+  const byPair = new Map<string, LayoutLink<Node>>()
+  for (const relation of relations) {
+    const source = requireNode(nodeById, sourceId(relation))
+    const target = requireNode(nodeById, targetId(relation))
+    byPair.set(unorderedPairKey(source.id, target.id), { source, target })
+  }
+  return [...byPair.values()]
+}
+
+function buildSceneLinks(
+  relations: RelationGraphRelation[],
+  nodeById: Map<string, SceneNode>,
+): SceneLink[] {
+  const groups = new Map<string, RelationGraphRelation[]>()
+  for (const relation of relations) {
+    const key = unorderedPairKey(sourceId(relation), targetId(relation))
+    const group = groups.get(key)
+    if (group === undefined) {
+      groups.set(key, [relation])
+    } else {
+      group.push(relation)
+    }
+  }
+
+  return relations.map((relation): SceneLink => {
+    const source = requireNode(nodeById, sourceId(relation))
+    const target = requireNode(nodeById, targetId(relation))
+    const group = groups.get(
+      unorderedPairKey(sourceId(relation), targetId(relation)),
+    )
+    if (group === undefined) {
+      throw new Error('Relation graph contains an ungrouped relation')
+    }
+    // Spread the group symmetrically around the straight line. The sign flips
+    // with the endpoint order so that the same relation always bends to the
+    // same side no matter which endpoint is the locked one.
+    const direction = source.data.id < target.data.id ? 1 : -1
+    const curve =
+      (group.indexOf(relation) - (group.length - 1) / 2) *
+      PARALLEL_RELATION_SPACING *
+      direction
+
+    return { relation, id: relationId(relation), source, target, curve }
+  })
+}
+
+function requireNode<Node>(nodeById: Map<string, Node>, id: string): Node {
+  const node = nodeById.get(id)
+  if (node === undefined) {
+    throw new Error(`Relation graph contains unknown endpoint ${id}`)
+  }
+  return node
+}
+
+/**
+ * A link is always a quadratic curve; a straight link is the degenerate curve
+ * whose control point is the midpoint. One shape means one code path for
+ * drawing, arrows, labels, and distance checks.
+ *
+ * The geometry is space-agnostic: built from world coordinates here, and still
+ * valid after an affine screen transform of all three points.
+ */
+export interface LinkGeometry {
+  sx: number
+  sy: number
+  cx: number
+  cy: number
+  tx: number
+  ty: number
+}
+
+export function linkGeometry(link: SceneLink): LinkGeometry {
+  const { source, target, curve } = link
+  const cx = (source.x + target.x) / 2
+  const cy = (source.y + target.y) / 2
+  const base = {
+    sx: source.x,
+    sy: source.y,
+    cx,
+    cy,
+    tx: target.x,
+    ty: target.y,
+  }
+  if (curve === 0) return base
+
+  const dx = target.x - source.x
+  const dy = target.y - source.y
+  const length = Math.hypot(dx, dy)
+  // Coincident endpoints have no sideways direction to offset into.
+  if (length === 0) return base
+
+  return {
+    ...base,
+    cx: cx + (-dy / length) * curve,
+    cy: cy + (dx / length) * curve,
+  }
+}
+
+export function pointOnLink(geometry: LinkGeometry, t: number) {
+  const u = 1 - t
+  return {
+    x: u * u * geometry.sx + 2 * u * t * geometry.cx + t * t * geometry.tx,
+    y: u * u * geometry.sy + 2 * u * t * geometry.cy + t * t * geometry.ty,
+  }
+}
+
+/** Normalized direction of travel at `t`, for orienting arrows. */
+export function linkTangent(geometry: LinkGeometry, t: number) {
+  const u = 1 - t
+  const x =
+    2 * u * (geometry.cx - geometry.sx) + 2 * t * (geometry.tx - geometry.cx)
+  const y =
+    2 * u * (geometry.cy - geometry.sy) + 2 * t * (geometry.ty - geometry.cy)
+  const length = Math.hypot(x, y)
+  if (length === 0) return { x: 1, y: 0 }
+  return { x: x / length, y: y / length }
+}
+
+const LINK_DISTANCE_SAMPLES = 16
+
+/**
+ * Distance from a point to the curve, approximated by sampling. Exact for
+ * straight links; for curved ones the error is far below the pointer
+ * tolerances used for hit testing.
+ */
+export function distanceToLink(
+  geometry: LinkGeometry,
+  x: number,
+  y: number,
+): number {
+  let previousX = geometry.sx
+  let previousY = geometry.sy
+  let best = Number.POSITIVE_INFINITY
+  for (let i = 1; i <= LINK_DISTANCE_SAMPLES; i++) {
+    const point = pointOnLink(geometry, i / LINK_DISTANCE_SAMPLES)
+    best = Math.min(
+      best,
+      distanceToSegment(x, y, previousX, previousY, point.x, point.y),
+    )
+    previousX = point.x
+    previousY = point.y
+  }
+  return best
+}
+
+/**
+ * Nearest node whose center is within `radius` of the point, or undefined.
+ *
+ * Both hit tests scan linearly. At the graph's scale (thousands of elements,
+ * one scan per pointer event) this is well under a millisecond, and unlike a
+ * spatial index it cannot go stale while nodes are dragged.
+ */
+export function findNodeAt(
+  scene: RelationGraphScene,
+  x: number,
+  y: number,
+  radius: number,
+): SceneNode | undefined {
+  let best: SceneNode | undefined
+  let bestDistance = radius
+  for (const node of scene.nodes) {
+    const distance = Math.hypot(node.x - x, node.y - y)
+    if (distance <= bestDistance) {
+      best = node
+      bestDistance = distance
+    }
+  }
+  return best
+}
+
+/** Nearest link within `tolerance` of the point, or undefined. */
+export function findLinkAt(
+  scene: RelationGraphScene,
+  x: number,
+  y: number,
+  tolerance: number,
+  excludedIds?: ReadonlySet<string>,
+): SceneLink | undefined {
+  let best: SceneLink | undefined
+  let bestDistance = tolerance
+  for (const link of scene.links) {
+    if (excludedIds?.has(link.id)) continue
+    const geometry = linkGeometry(link)
+    // The curve never leaves the triangle of its three points, so a box check
+    // around them rejects most links before the sampled distance runs.
+    if (
+      x < Math.min(geometry.sx, geometry.cx, geometry.tx) - tolerance ||
+      x > Math.max(geometry.sx, geometry.cx, geometry.tx) + tolerance ||
+      y < Math.min(geometry.sy, geometry.cy, geometry.ty) - tolerance ||
+      y > Math.max(geometry.sy, geometry.cy, geometry.ty) + tolerance
+    ) {
+      continue
+    }
+    const distance = distanceToLink(geometry, x, y)
+    if (distance <= bestDistance) {
+      best = link
+      bestDistance = distance
+    }
+  }
+  return best
+}
+
+function distanceToSegment(
+  x: number,
+  y: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  const abx = bx - ax
+  const aby = by - ay
+  const lengthSquared = abx * abx + aby * aby
+  const t =
+    lengthSquared === 0
+      ? 0
+      : Math.max(
+          0,
+          Math.min(1, ((x - ax) * abx + (y - ay) * aby) / lengthSquared),
+        )
+  return Math.hypot(x - (ax + abx * t), y - (ay + aby * t))
+}


### PR DESCRIPTION
Part of L2B-14586

SVG display was too slow. Switching to canvas rendering. All functionality stays the same.