### PR TITLE
Home page layout changes

### DIFF
--- a/packages/frontend/src/components/LiveIndicator.tsx
+++ b/packages/frontend/src/components/LiveIndicator.tsx
@@ -4,7 +4,7 @@ export function LiveIndicator({
   size = 'sm',
   disabled,
 }: {
-  size?: 'sm' | 'md'
+  size?: 'sm' | 'md' | 'xl'
   disabled?: boolean
 }) {
   return (
@@ -13,6 +13,7 @@ export function LiveIndicator({
         'relative flex',
         size === 'sm' && 'ml-0.5 size-2',
         size === 'md' && 'ml-[3px] size-3',
+        size === 'xl' && 'ml-1 size-6',
       )}
     >
       <span
@@ -27,6 +28,7 @@ export function LiveIndicator({
           disabled && 'bg-secondary',
           size === 'sm' && 'size-2',
           size === 'md' && 'size-3',
+          size === 'xl' && 'size-6',
         )}
       />
     </span>

--- a/packages/frontend/src/components/LiveIndicator.tsx
+++ b/packages/frontend/src/components/LiveIndicator.tsx
@@ -4,7 +4,7 @@ export function LiveIndicator({
   size = 'sm',
   disabled,
 }: {
-  size?: 'sm' | 'md' | 'xl'
+  size?: 'sm' | 'md'
   disabled?: boolean
 }) {
   return (
@@ -13,7 +13,6 @@ export function LiveIndicator({
         'relative flex',
         size === 'sm' && 'ml-0.5 size-2',
         size === 'md' && 'ml-[3px] size-3',
-        size === 'xl' && 'ml-1 size-6',
       )}
     >
       <span
@@ -28,7 +27,6 @@ export function LiveIndicator({
           disabled && 'bg-secondary',
           size === 'sm' && 'size-2',
           size === 'md' && 'size-3',
-          size === 'xl' && 'size-6',
         )}
       />
     </span>

--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -82,75 +82,57 @@ export function HomePage({
         >
           <MainPageHeader>Home</MainPageHeader>
           <div className="flex flex-col md:gap-4 xl:gap-6 [&_.primary-card]:max-md:rounded-none [&_.primary-card]:max-md:border-divider [&_.primary-card]:max-md:border-b">
-            <div className="grid grid-cols-1 items-stretch md:gap-4 xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)] xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
-              <div className="flex h-full min-w-0 flex-col md:gap-4 lg:max-xl:hidden">
-                <HomeStatsStrip counts={projectCounts} className="lg:hidden" />
+            <div className="grid grid-cols-1 md:gap-4 xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)] xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
+              <HomeStatsStrip counts={projectCounts} className="lg:hidden" />
+              <div className="flex min-w-0 flex-col gap-4 max-xl:hidden">
                 <HomeRecentProjectsCard
-                  className="hidden h-auto xl:flex"
+                  className="h-auto"
                   projects={recentProjects}
                 />
                 <HomeWhatsNewCard
                   item={whatsNewItem}
-                  className="min-h-0 xl:flex-1"
+                  className="min-h-0 flex-1"
                 />
-                <HomeAnomaliesTile
-                  ongoingAnomalies={ongoingAnomalies}
-                  className="max-xl:hidden"
-                />
-                <HomeRecentChangesTile
-                  recentChangesCount={recentChangesCount}
-                  recentChangesProjects={recentChangesProjects}
-                  className="max-xl:hidden"
-                />
-              </div>
-              <div className="flex h-full min-h-0 min-w-0 flex-col 2xl:hidden">
-                <HomeInteropCard
-                  interopChains={interopChains}
-                  interopProtocols={interopProtocols}
-                  defaultSelectedFlowChains={defaultSelectedFlowChains}
-                />
-              </div>
-              <div className="flex h-full min-h-0 min-w-0 flex-col md:grid md:grid-cols-2 md:gap-4 xl:gap-6 xl:max-2xl:col-span-full 2xl:flex 2xl:flex-col">
-                <div className="flex min-h-0 min-w-0 flex-col xl:flex-1">
-                  <HomeScalingCard
-                    charts={scalingCharts}
-                    scalingCategoryCounts={scalingCategoryCounts}
-                  />
-                </div>
-                <div className="flex min-h-0 min-w-0 flex-col xl:flex-1">
-                  <HomeEthereumCard
-                    charts={ethereumCharts}
-                    economicSecurity={ethereumEconomicSecurity}
-                  />
-                </div>
-              </div>
-              <div className="flex h-full min-h-0 min-w-0 flex-col max-2xl:hidden">
-                <HomeInteropCard
-                  interopChains={interopChains}
-                  interopProtocols={interopProtocols}
-                  defaultSelectedFlowChains={defaultSelectedFlowChains}
-                />
-              </div>
-            </div>
-            <div className="grid grid-cols-1 gap-4 max-md:contents xl:hidden">
-              <div className="grid gap-4 sm:grid-cols-2">
                 <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
                 <HomeRecentChangesTile
                   recentChangesCount={recentChangesCount}
                   recentChangesProjects={recentChangesProjects}
                 />
               </div>
-              <HomeWhatsNewCard
-                item={whatsNewItem}
-                className="h-full flex-1 xl:hidden"
-              />
-              <HomeRecentProjectsCard
-                className="xl:hidden"
-                projects={recentProjects}
-              />
+              <div className="flex min-h-0 min-w-0 flex-col 2xl:order-last">
+                <HomeInteropCard
+                  interopChains={interopChains}
+                  interopProtocols={interopProtocols}
+                  defaultSelectedFlowChains={defaultSelectedFlowChains}
+                />
+              </div>
+              <div className="flex min-h-0 min-w-0 flex-col md:grid md:grid-cols-2 md:gap-4 xl:gap-6 xl:max-2xl:col-span-full 2xl:flex">
+                <div className="flex min-h-0 min-w-0 flex-col 2xl:flex-1">
+                  <HomeScalingCard
+                    charts={scalingCharts}
+                    scalingCategoryCounts={scalingCategoryCounts}
+                  />
+                </div>
+                <div className="flex min-h-0 min-w-0 flex-col 2xl:flex-1">
+                  <HomeEthereumCard
+                    charts={ethereumCharts}
+                    economicSecurity={ethereumEconomicSecurity}
+                  />
+                </div>
+              </div>
             </div>
-
-            <div className="grid grid-cols-1 items-stretch md:gap-4 lg:grid-cols-2 xl:gap-6">
+            <div className="grid grid-cols-1 gap-4 max-md:contents xl:hidden">
+              <div className="grid gap-4 max-md:contents md:grid-cols-2">
+                <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
+                <HomeRecentChangesTile
+                  recentChangesCount={recentChangesCount}
+                  recentChangesProjects={recentChangesProjects}
+                />
+              </div>
+              <HomeWhatsNewCard item={whatsNewItem} />
+              <HomeRecentProjectsCard projects={recentProjects} />
+            </div>
+            <div className="grid grid-cols-1 md:gap-4 lg:grid-cols-2 xl:gap-6">
               <HomeTopInteropProtocolsCard
                 interopChains={interopChains}
                 defaultSelectedFlowChains={defaultSelectedFlowChains}

--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -49,7 +49,7 @@ interface Props extends AppLayoutProps {
   recentChangesCount: number
   recentChangesProjects: HomeRecentChangesProject[]
   ongoingAnomalies: OngoingAnomaliesOverview
-  whatsNewItems: HomeWhatsNewItem[]
+  whatsNewItem: HomeWhatsNewItem | undefined
 }
 
 export function HomePage({
@@ -70,7 +70,7 @@ export function HomePage({
   recentChangesCount,
   recentChangesProjects,
   ongoingAnomalies,
-  whatsNewItems,
+  whatsNewItem,
   ...props
 }: Props) {
   return (
@@ -83,17 +83,14 @@ export function HomePage({
           <MainPageHeader>Home</MainPageHeader>
           <div className="flex flex-col md:gap-4 xl:gap-6 [&_.primary-card]:max-md:rounded-none [&_.primary-card]:max-md:border-divider [&_.primary-card]:max-md:border-b">
             <div className="grid grid-cols-1 items-stretch md:gap-4 xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)] xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
-              {/* Between lg and xl the What's new card is this column's only
-                  visible child, so the whole column has to go when dismissed —
-                  otherwise it leaves an empty grid row above the interop card. */}
-              <div className="flex h-full min-w-0 flex-col md:gap-4 [[data-whats-new-dismissed]_&]:lg:max-xl:hidden">
+              <div className="flex h-full min-w-0 flex-col md:gap-4 lg:max-xl:hidden">
                 <HomeStatsStrip counts={projectCounts} className="lg:hidden" />
                 <HomeRecentProjectsCard
                   className="hidden h-auto xl:flex"
                   projects={recentProjects}
                 />
                 <HomeWhatsNewCard
-                  items={whatsNewItems}
+                  item={whatsNewItem}
                   className="min-h-0 xl:flex-1"
                 />
                 <HomeAnomaliesTile
@@ -135,17 +132,24 @@ export function HomePage({
                 />
               </div>
             </div>
-            <div className="grid grid-cols-1 gap-4 max-md:contents sm:grid-cols-2 xl:hidden xl:gap-6">
-              <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
-              <HomeRecentChangesTile
-                recentChangesCount={recentChangesCount}
-                recentChangesProjects={recentChangesProjects}
+            <div className="grid grid-cols-1 gap-4 max-md:contents xl:hidden">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
+                <HomeRecentChangesTile
+                  recentChangesCount={recentChangesCount}
+                  recentChangesProjects={recentChangesProjects}
+                />
+              </div>
+              <HomeWhatsNewCard
+                item={whatsNewItem}
+                className="h-full flex-1 xl:hidden"
+              />
+              <HomeRecentProjectsCard
+                className="xl:hidden"
+                projects={recentProjects}
               />
             </div>
-            <HomeRecentProjectsCard
-              className="xl:hidden"
-              projects={recentProjects}
-            />
+
             <div className="grid grid-cols-1 items-stretch md:gap-4 lg:grid-cols-2 xl:gap-6">
               <HomeTopInteropProtocolsCard
                 interopChains={interopChains}

--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -122,13 +122,11 @@ export function HomePage({
               </div>
             </div>
             <div className="grid grid-cols-1 gap-4 max-md:contents lg:hidden">
-              <div className="grid gap-4 max-md:contents md:grid-cols-2">
-                <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
-                <HomeRecentChangesTile
-                  recentChangesCount={recentChangesCount}
-                  recentChangesProjects={recentChangesProjects}
-                />
-              </div>
+              <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
+              <HomeRecentChangesTile
+                recentChangesCount={recentChangesCount}
+                recentChangesProjects={recentChangesProjects}
+              />
               <HomeWhatsNewCard item={whatsNewItem} />
               <HomeRecentProjectsCard projects={recentProjects} />
             </div>

--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -81,10 +81,10 @@ export function HomePage({
           childrenWrapperClassName="max-md:bg-surface-primary"
         >
           <MainPageHeader>Home</MainPageHeader>
-          <div className="flex flex-col md:gap-6 [&_.primary-card]:max-md:rounded-none [&_.primary-card]:max-md:border-divider [&_.primary-card]:max-md:border-b">
-            <div className="grid grid-cols-1 items-stretch md:gap-4 xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
-              <div className="flex h-full min-w-0 flex-col md:gap-4 xl:grid xl:grid-cols-3 xl:gap-6 2xl:flex">
-                <HomeStatsStrip counts={projectCounts} />
+          <div className="flex flex-col md:gap-4 xl:gap-6 [&_.primary-card]:max-md:rounded-none [&_.primary-card]:max-md:border-divider [&_.primary-card]:max-md:border-b">
+            <div className="grid grid-cols-1 items-stretch md:gap-4 xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)] xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
+              <div className="flex h-full min-w-0 flex-col md:gap-4">
+                <HomeStatsStrip counts={projectCounts} className="lg:hidden" />
                 <HomeRecentProjectsCard
                   className="hidden h-auto xl:flex"
                   projects={recentProjects}
@@ -93,8 +93,24 @@ export function HomePage({
                   items={whatsNewItems}
                   className="min-h-0 xl:flex-1"
                 />
+                <HomeAnomaliesTile
+                  ongoingAnomalies={ongoingAnomalies}
+                  className="max-xl:hidden"
+                />
+                <HomeRecentChangesTile
+                  recentChangesCount={recentChangesCount}
+                  recentChangesProjects={recentChangesProjects}
+                  className="max-xl:hidden"
+                />
               </div>
-              <div className="flex h-full min-h-0 min-w-0 flex-col md:grid md:grid-cols-2 md:gap-4 xl:gap-6 2xl:flex 2xl:flex-col">
+              <div className="flex h-full min-h-0 min-w-0 flex-col 2xl:hidden">
+                <HomeInteropCard
+                  interopChains={interopChains}
+                  interopProtocols={interopProtocols}
+                  defaultSelectedFlowChains={defaultSelectedFlowChains}
+                />
+              </div>
+              <div className="flex h-full min-h-0 min-w-0 flex-col md:grid md:grid-cols-2 md:gap-4 xl:gap-6 xl:max-2xl:col-span-full 2xl:flex 2xl:flex-col">
                 <div className="flex min-h-0 min-w-0 flex-col xl:flex-1">
                   <HomeScalingCard
                     charts={scalingCharts}
@@ -108,7 +124,7 @@ export function HomePage({
                   />
                 </div>
               </div>
-              <div className="flex h-full min-h-0 min-w-0 flex-col">
+              <div className="flex h-full min-h-0 min-w-0 flex-col max-2xl:hidden">
                 <HomeInteropCard
                   interopChains={interopChains}
                   interopProtocols={interopProtocols}
@@ -116,7 +132,7 @@ export function HomePage({
                 />
               </div>
             </div>
-            <div className="grid grid-cols-1 gap-4 max-md:contents sm:grid-cols-2 xl:gap-6">
+            <div className="grid grid-cols-1 gap-4 max-md:contents sm:grid-cols-2 xl:hidden xl:gap-6">
               <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
               <HomeRecentChangesTile
                 recentChangesCount={recentChangesCount}

--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -83,7 +83,10 @@ export function HomePage({
           <MainPageHeader>Home</MainPageHeader>
           <div className="flex flex-col md:gap-4 xl:gap-6 [&_.primary-card]:max-md:rounded-none [&_.primary-card]:max-md:border-divider [&_.primary-card]:max-md:border-b">
             <div className="grid grid-cols-1 items-stretch md:gap-4 xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)] xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
-              <div className="flex h-full min-w-0 flex-col md:gap-4">
+              {/* Between lg and xl the What's new card is this column's only
+                  visible child, so the whole column has to go when dismissed —
+                  otherwise it leaves an empty grid row above the interop card. */}
+              <div className="flex h-full min-w-0 flex-col md:gap-4 [[data-whats-new-dismissed]_&]:lg:max-xl:hidden">
                 <HomeStatsStrip counts={projectCounts} className="lg:hidden" />
                 <HomeRecentProjectsCard
                   className="hidden h-auto xl:flex"

--- a/packages/frontend/src/pages/home/HomePage.tsx
+++ b/packages/frontend/src/pages/home/HomePage.tsx
@@ -82,9 +82,9 @@ export function HomePage({
         >
           <MainPageHeader>Home</MainPageHeader>
           <div className="flex flex-col md:gap-4 xl:gap-6 [&_.primary-card]:max-md:rounded-none [&_.primary-card]:max-md:border-divider [&_.primary-card]:max-md:border-b">
-            <div className="grid grid-cols-1 md:gap-4 xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)] xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
+            <div className="grid grid-cols-1 md:gap-4 lg:grid-cols-[minmax(260px,280px)_minmax(280px,1fr)] xl:gap-6 2xl:grid-cols-[minmax(260px,340px)_minmax(340px,1fr)_minmax(400px,1.35fr)]">
               <HomeStatsStrip counts={projectCounts} className="lg:hidden" />
-              <div className="flex min-w-0 flex-col gap-4 max-xl:hidden">
+              <div className="flex min-w-0 flex-col gap-4 max-lg:hidden">
                 <HomeRecentProjectsCard
                   className="h-auto"
                   projects={recentProjects}
@@ -106,7 +106,7 @@ export function HomePage({
                   defaultSelectedFlowChains={defaultSelectedFlowChains}
                 />
               </div>
-              <div className="flex min-h-0 min-w-0 flex-col md:grid md:grid-cols-2 md:gap-4 xl:gap-6 xl:max-2xl:col-span-full 2xl:flex">
+              <div className="flex min-h-0 min-w-0 flex-col md:grid md:grid-cols-2 md:gap-4 lg:max-2xl:col-span-full xl:gap-6 2xl:flex">
                 <div className="flex min-h-0 min-w-0 flex-col 2xl:flex-1">
                   <HomeScalingCard
                     charts={scalingCharts}
@@ -121,7 +121,7 @@ export function HomePage({
                 </div>
               </div>
             </div>
-            <div className="grid grid-cols-1 gap-4 max-md:contents xl:hidden">
+            <div className="grid grid-cols-1 gap-4 max-md:contents lg:hidden">
               <div className="grid gap-4 max-md:contents md:grid-cols-2">
                 <HomeAnomaliesTile ongoingAnomalies={ongoingAnomalies} />
                 <HomeRecentChangesTile

--- a/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
@@ -19,23 +19,19 @@ export function HomeAnomaliesTile({
   const first = items[0]
 
   return (
-    <HomeCard className={cn('relative overflow-hidden p-0 md:p-1', className)}>
+    <HomeCard className={cn('overflow-hidden p-0 md:p-1', className)}>
       <a
         href="/scaling/liveness"
         className="group flex items-center gap-3 px-4 py-3 transition-colors hover:bg-surface-secondary/50 md:rounded-lg md:px-7 md:py-5"
       >
-        {isOngoing && (
-          <div className="-translate-y-1/4 absolute top-0 right-0 hidden translate-x-1/4 lg:block">
-            <LiveIndicator size="xl" />
-          </div>
-        )}
         <div className="lg:hidden">
           <LiveIndicator size="md" disabled={!isOngoing} />
         </div>
 
         <div className="flex min-w-0 flex-1 flex-col">
           <span className="truncate font-bold text-label-value-14 leading-tight transition-colors group-hover:text-link">
-            Ongoing major anomalies
+            <span className="lg:hidden">Ongoing major anomalies</span>
+            <span className="max-lg:hidden">Ongoing anomalies</span>
           </span>
           <span className="mt-0.5 flex min-w-0 items-center gap-1.5 font-medium text-label-value-12 text-secondary lg:hidden">
             {isOngoing && first ? (
@@ -60,6 +56,9 @@ export function HomeAnomaliesTile({
               </span>
             )}
           </span>
+        </div>
+        <div className="max-lg:hidden">
+          <LiveIndicator size="md" disabled={!isOngoing} />
         </div>
         <span className="shrink-0 font-bold text-heading-20 tabular-nums leading-none">
           {formatInteger(count)}

--- a/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
@@ -3,20 +3,23 @@ import { LiveIndicator } from '~/components/LiveIndicator'
 import { ChevronIcon } from '~/icons/Chevron'
 import { anomalySubtypeToLabel } from '~/pages/scaling/liveness/components/AnomalyIndicator'
 import type { OngoingAnomaliesOverview } from '~/server/features/scaling/liveness/getOngoingAnomaliesOverview'
+import { cn } from '~/utils/cn'
 import { formatInteger } from '~/utils/number-format/formatInteger'
 import { HomeCard } from './HomeCard'
 
 export function HomeAnomaliesTile({
   ongoingAnomalies,
+  className,
 }: {
   ongoingAnomalies: OngoingAnomaliesOverview
+  className?: string
 }) {
   const { count, items } = ongoingAnomalies
   const isOngoing = count > 0
   const first = items[0]
 
   return (
-    <HomeCard className="p-0 md:p-1">
+    <HomeCard className={cn('p-0 md:p-1', className)}>
       <a
         href="/scaling/liveness"
         className="group flex items-center gap-3 px-4 py-3 transition-colors hover:bg-surface-secondary/50 md:rounded-lg md:px-7 md:py-5"
@@ -26,7 +29,7 @@ export function HomeAnomaliesTile({
           <span className="truncate font-bold text-label-value-14 leading-tight transition-colors group-hover:text-link">
             Ongoing major anomalies
           </span>
-          <span className="mt-0.5 flex min-w-0 items-center gap-1.5 font-medium text-label-value-12 text-secondary">
+          <span className="mt-0.5 flex min-w-0 items-center gap-1.5 font-medium text-label-value-12 text-secondary xl:hidden">
             {isOngoing && first ? (
               <>
                 <img

--- a/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
@@ -19,17 +19,25 @@ export function HomeAnomaliesTile({
   const first = items[0]
 
   return (
-    <HomeCard className={cn('p-0 md:p-1', className)}>
+    <HomeCard className={cn('relative overflow-hidden p-0 md:p-1', className)}>
       <a
         href="/scaling/liveness"
         className="group flex items-center gap-3 px-4 py-3 transition-colors hover:bg-surface-secondary/50 md:rounded-lg md:px-7 md:py-5"
       >
-        <LiveIndicator size="md" disabled={!isOngoing} />
+        {isOngoing && (
+          <div className="-translate-y-1/4 absolute top-0 right-0 hidden translate-x-1/4 lg:block">
+            <LiveIndicator size="xl" />
+          </div>
+        )}
+        <div className="lg:hidden">
+          <LiveIndicator size="md" disabled={!isOngoing} />
+        </div>
+
         <div className="flex min-w-0 flex-1 flex-col">
           <span className="truncate font-bold text-label-value-14 leading-tight transition-colors group-hover:text-link">
             Ongoing major anomalies
           </span>
-          <span className="mt-0.5 flex min-w-0 items-center gap-1.5 font-medium text-label-value-12 text-secondary xl:hidden">
+          <span className="mt-0.5 flex min-w-0 items-center gap-1.5 font-medium text-label-value-12 text-secondary lg:hidden">
             {isOngoing && first ? (
               <>
                 <img

--- a/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
@@ -117,12 +117,7 @@ function HomeInteropCardContent({
         href="/interop/summary"
         timeframe="Last 24h"
       />
-      {/* On wide cards (the full-width card below lg) the compact tile row is
-          replaced by the same General stats panel the interop summary page
-          shows, placed left of the graph. */}
       <div className="@min-[800px]:mt-4 flex @min-[800px]:grid min-h-0 flex-1 @min-[800px]:grid-cols-[minmax(0,1fr)_240px] flex-col @min-[800px]:gap-4 max-sm:flex-col-reverse">
-        {/* Four across as soon as the card can hold them - a 2x2 block steals
-            too much height from the graph in the narrow lg column. */}
         <div className="mt-2.5 grid @min-[800px]:hidden grid-cols-2 gap-2 sm:@min-[460px]:grid-cols-4">
           <StatTile
             title="Volume"
@@ -204,8 +199,7 @@ function HomeInteropCardContent({
             }
           />
         </div>
-        <div className="@min-[800px]:mt-0 mt-6 flex min-h-0 flex-1 flex-col">
-          {/* Static preview: interactions happen on the interop page */}
+        <div className="@min-[800px]:order-1 @min-[800px]:mt-0 mt-6 flex min-h-0 flex-1 flex-col">
           <div className="-mx-2 pointer-events-none flex min-h-0 min-w-0 flex-1 flex-col overflow-x-clip">
             <FlowsGraphPanel
               activeChains={activeChains}
@@ -214,10 +208,11 @@ function HomeInteropCardContent({
               hasEnoughProtocols={hasEnoughProtocols}
               isLoading={isLoading}
               className="pb-2"
+              maxSizeClassName="lg:max-w-[min(70svh,calc(100svh-20rem))] xl:max-w-[min(75svh,calc(100svh-4rem))]"
             />
           </div>
         </div>
-        <div className="@min-[800px]:block hidden h-full">
+        <div className="@min-[800px]:order-3 @min-[800px]:block hidden h-full">
           <FlowsGeneralStats title="" description="" linkTopRouteToSummary />
         </div>
       </div>

--- a/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
@@ -120,7 +120,7 @@ function HomeInteropCardContent({
       {/* On wide cards (full-width row between lg and xl) the compact tile
           row is replaced by the same General stats panel the interop
           summary page shows, placed left of the graph. */}
-      <div className="@min-[800px]:mt-4 flex @min-[800px]:grid min-h-0 flex-1 @min-[800px]:grid-cols-[240px_minmax(0,1fr)] flex-col @min-[800px]:gap-4">
+      <div className="@min-[800px]:mt-4 flex @min-[800px]:grid min-h-0 flex-1 @min-[800px]:grid-cols-[minmax(0,1fr)_240px] flex-col @min-[800px]:gap-4 max-sm:flex-col-reverse">
         <div className="mt-2.5 grid @min-[800px]:hidden @min-[550px]:grid-cols-4 grid-cols-2 gap-2">
           <StatTile
             title="Volume"
@@ -202,9 +202,6 @@ function HomeInteropCardContent({
             }
           />
         </div>
-        <div className="@min-[800px]:block hidden h-full">
-          <FlowsGeneralStats title="" description="" linkTopRouteToSummary />
-        </div>
         <div className="@min-[800px]:mt-0 mt-6 flex min-h-0 flex-1 flex-col">
           {/* Static preview: interactions happen on the interop page */}
           <div className="-mx-2 pointer-events-none flex min-h-0 min-w-0 flex-1 flex-col overflow-x-clip">
@@ -217,6 +214,9 @@ function HomeInteropCardContent({
               className="pb-2"
             />
           </div>
+        </div>
+        <div className="@min-[800px]:block hidden h-full">
+          <FlowsGeneralStats title="" description="" linkTopRouteToSummary />
         </div>
       </div>
     </HomeCard>

--- a/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
@@ -117,11 +117,13 @@ function HomeInteropCardContent({
         href="/interop/summary"
         timeframe="Last 24h"
       />
-      {/* On wide cards (full-width row between lg and xl) the compact tile
-          row is replaced by the same General stats panel the interop
-          summary page shows, placed left of the graph. */}
+      {/* On wide cards (the full-width card below lg) the compact tile row is
+          replaced by the same General stats panel the interop summary page
+          shows, placed left of the graph. */}
       <div className="@min-[800px]:mt-4 flex @min-[800px]:grid min-h-0 flex-1 @min-[800px]:grid-cols-[minmax(0,1fr)_240px] flex-col @min-[800px]:gap-4 max-sm:flex-col-reverse">
-        <div className="mt-2.5 grid @min-[800px]:hidden @min-[550px]:grid-cols-4 grid-cols-2 gap-2">
+        {/* Four across as soon as the card can hold them - a 2x2 block steals
+            too much height from the graph in the narrow lg column. */}
+        <div className="mt-2.5 grid @min-[800px]:hidden grid-cols-2 gap-2 sm:@min-[460px]:grid-cols-4">
           <StatTile
             title="Volume"
             isLoading={statsLoading}
@@ -247,6 +249,9 @@ function StatTile({
     <div
       className={cn(
         'flex flex-col items-center gap-1 rounded-lg border border-divider bg-surface-primary px-3 py-2 text-center',
+        // Four tiles in a row on a ~460-620px card leaves ~90px of text per
+        // tile, so trade side padding for value width before it truncates.
+        'sm:@min-[460px]:@max-[620px]:px-2',
         className,
       )}
     >

--- a/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
@@ -208,7 +208,7 @@ function HomeInteropCardContent({
               hasEnoughProtocols={hasEnoughProtocols}
               isLoading={isLoading}
               className="pb-2"
-              maxSizeClassName="lg:max-w-[min(70svh,calc(100svh-20rem))] xl:max-w-[min(75svh,calc(100svh-4rem))]"
+              maxSizeClassName="lg:max-w-[min(70dvh,calc(100dvh-20rem))] xl:max-w-[min(75dvh,calc(100dvh-4rem))]"
             />
           </div>
         </div>

--- a/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
@@ -44,23 +44,25 @@ export function HomeRecentChangesTile({
         <div className="flex min-w-0 flex-1 flex-col">
           <span
             className={cn(
-              'font-bold text-label-value-14 leading-tight transition-colors xl:truncate',
+              'font-bold text-label-value-14 leading-tight transition-colors lg:truncate',
               !disabled && 'group-hover:text-link',
             )}
           >
-            Recent changes{' '}
-            <span className="font-medium text-secondary xl:hidden">
+            <span className="max-xl:hidden">Recent changes</span>
+            <span className="hidden lg:max-xl:inline">Updates</span>
+            <span className="font-medium text-secondary lg:hidden">
+              {' '}
               (last 7 days)
             </span>
           </span>
 
           <span className="mt-0.5 truncate font-medium text-label-value-12 text-secondary">
-            <span className="xl:hidden">
+            <span className="lg:hidden">
               {disabled
                 ? 'No project changes handled this week'
                 : `${recentChangesCount} project ${recentChangesCount === 1 ? 'change' : 'changes'} handled by the L2BEAT team`}
             </span>
-            <span className="max-xl:hidden">Last 7 days</span>
+            <span className="max-lg:hidden">Last 7 days</span>
           </span>
         </div>
         {!disabled && (

--- a/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
@@ -48,8 +48,7 @@ export function HomeRecentChangesTile({
               !disabled && 'group-hover:text-link',
             )}
           >
-            <span className="max-xl:hidden">Recent changes</span>
-            <span className="hidden lg:max-xl:inline">Updates</span>
+            <span className="hidden lg:inline">Updates</span>
             <span className="font-medium text-secondary lg:hidden">
               {' '}
               (last 7 days)

--- a/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
@@ -48,7 +48,8 @@ export function HomeRecentChangesTile({
               !disabled && 'group-hover:text-link',
             )}
           >
-            <span className="hidden lg:inline">Updates</span>
+            <span className="lg:hidden">Recent changes</span>
+            <span className="max-lg:hidden">Updates</span>
             <span className="font-medium text-secondary lg:hidden">
               {' '}
               (last 7 days)

--- a/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
@@ -14,9 +14,11 @@ export interface HomeRecentChangesProject {
 export function HomeRecentChangesTile({
   recentChangesCount,
   recentChangesProjects,
+  className,
 }: {
   recentChangesCount: number
   recentChangesProjects: HomeRecentChangesProject[]
+  className?: string
 }) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const disabled = recentChangesCount === 0
@@ -28,7 +30,7 @@ export function HomeRecentChangesTile({
   const restCount = recentChangesProjects.length - visibleProjects.length
 
   return (
-    <HomeCard className="p-0 md:p-1">
+    <HomeCard className={cn('p-0 md:p-1', className)}>
       <button
         type="button"
         onClick={() => setDialogOpen(true)}
@@ -42,17 +44,23 @@ export function HomeRecentChangesTile({
         <div className="flex min-w-0 flex-1 flex-col">
           <span
             className={cn(
-              'truncate font-bold text-label-value-14 leading-tight transition-colors',
+              'font-bold text-label-value-14 leading-tight transition-colors xl:truncate',
               !disabled && 'group-hover:text-link',
             )}
           >
             Recent changes{' '}
-            <span className="font-medium text-secondary">(past 7 days)</span>
+            <span className="font-medium text-secondary xl:hidden">
+              (last 7 days)
+            </span>
           </span>
+
           <span className="mt-0.5 truncate font-medium text-label-value-12 text-secondary">
-            {disabled
-              ? 'No project changes handled this week'
-              : `${recentChangesCount} project ${recentChangesCount === 1 ? 'change' : 'changes'} handled by the L2BEAT team`}
+            <span className="xl:hidden">
+              {disabled
+                ? 'No project changes handled this week'
+                : `${recentChangesCount} project ${recentChangesCount === 1 ? 'change' : 'changes'} handled by the L2BEAT team`}
+            </span>
+            <span className="max-xl:hidden">Last 7 days</span>
           </span>
         </div>
         {!disabled && (

--- a/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
@@ -22,9 +22,9 @@ export function HomeRecentProjectsCard({ projects, className }: Props) {
   return (
     <HomeCard className={cn('flex h-full flex-col', className)}>
       <h2 className="font-bold text-xl">Recently added projects</h2>
-      <ul className="mt-2 grid grid-cols-1 gap-1.5 md:grid-cols-3 xl:grid-cols-1">
+      <ul className="mt-2 grid grid-cols-1 gap-1.5 md:grid-cols-3 lg:grid-cols-1">
         {projects.map((project) => (
-          <li key={project.id}>
+          <li key={project.id} className="lg:max-xl:nth-[n+5]:hidden">
             <RecentProjectCard project={project} />
           </li>
         ))}

--- a/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
@@ -24,7 +24,7 @@ export function HomeRecentProjectsCard({ projects, className }: Props) {
       <h2 className="font-bold text-xl">Recently added projects</h2>
       <ul className="mt-2 grid grid-cols-1 gap-1.5 md:grid-cols-3 lg:grid-cols-1">
         {projects.map((project) => (
-          <li key={project.id} className="lg:max-xl:nth-[n+5]:hidden">
+          <li key={project.id} className="lg:max-xl:nth-[n+4]:hidden">
             <RecentProjectCard project={project} />
           </li>
         ))}

--- a/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
@@ -3,8 +3,6 @@ import { cn } from '~/utils/cn'
 import type { HomeRecentProject } from '../getHomeData'
 import { HomeCard } from './HomeCard'
 
-const VISIBLE_RECENT_PROJECTS_COUNT = 5
-
 const CATEGORY_LABEL: Record<HomeRecentProject['category'], string> = {
   scaling: 'Scaling project',
   da: 'Data Availability',
@@ -18,16 +16,14 @@ interface Props {
 }
 
 export function HomeRecentProjectsCard({ projects, className }: Props) {
-  const visibleProjects = projects.slice(0, VISIBLE_RECENT_PROJECTS_COUNT)
-
-  if (visibleProjects.length === 0) {
+  if (projects.length === 0) {
     return null
   }
   return (
     <HomeCard className={cn('flex h-full flex-col', className)}>
       <h2 className="font-bold text-xl">Recently added projects</h2>
       <ul className="mt-2 grid grid-cols-1 gap-1.5 md:grid-cols-3 xl:grid-cols-1">
-        {visibleProjects.map((project) => (
+        {projects.map((project) => (
           <li key={project.id}>
             <RecentProjectCard project={project} />
           </li>

--- a/packages/frontend/src/pages/home/components/HomeStatsStrip.tsx
+++ b/packages/frontend/src/pages/home/components/HomeStatsStrip.tsx
@@ -24,7 +24,13 @@ interface Tile {
   iconBgClassName: string
 }
 
-export function HomeStatsStrip({ counts }: { counts: HomeProjectCounts }) {
+export function HomeStatsStrip({
+  counts,
+  className,
+}: {
+  counts: HomeProjectCounts
+  className?: string
+}) {
   const tiles: Tile[] = [
     {
       label: 'Layer 2s',
@@ -72,7 +78,7 @@ export function HomeStatsStrip({ counts }: { counts: HomeProjectCounts }) {
   ]
 
   return (
-    <HomeCard>
+    <HomeCard className={className}>
       <ul className="grid grid-cols-2 gap-2 md:grid-cols-3 xl:grid-cols-1 xl:gap-0 xl:divide-y xl:divide-divider">
         {tiles.map((tile) => (
           <li key={tile.label}>

--- a/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
@@ -31,12 +31,12 @@ export function HomeWhatsNewCard({
       />
       <HomeCard
         className={cn(
-          'flex flex-col gap-3 overflow-hidden p-0 xl:gap-0 xl:p-0',
-          '[[data-whats-new-dismissed]_&]:max-xl:hidden',
+          'flex flex-col gap-3 overflow-hidden p-0 lg:gap-0 lg:p-0',
+          '[[data-whats-new-dismissed]_&]:max-lg:hidden',
           className,
         )}
       >
-        <h2 className="sr-only font-bold text-xl md:not-sr-only xl:sr-only">
+        <h2 className="sr-only font-bold text-xl md:not-sr-only lg:sr-only">
           What's new
         </h2>
         <div className="relative flex flex-1">
@@ -68,9 +68,9 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
       <a
         href={item.href}
         onClick={() => setWidgetClosed(true)}
-        className="group relative block flex-1 overflow-hidden md:flex md:flex-row md:rounded-lg md:border-2 md:border-divider xl:block xl:min-h-40 xl:rounded-none xl:border-0"
+        className="group relative block flex-1 overflow-hidden md:flex md:flex-row md:rounded-lg md:border-2 md:border-divider lg:block lg:min-h-40 lg:rounded-none lg:border-0"
       >
-        <div className="relative aspect-video w-full overflow-hidden [container-type:size] md:aspect-auto md:min-h-[5.5rem] md:w-32 md:shrink-0 xl:absolute xl:inset-0 xl:min-h-0 xl:w-full">
+        <div className="relative aspect-video w-full overflow-hidden [container-type:size] md:aspect-auto md:min-h-[5.5rem] md:w-32 md:shrink-0 lg:absolute lg:inset-0 lg:min-h-0 lg:w-full">
           <img
             src={item.imageSrc}
             alt={item.imageAlt}
@@ -89,22 +89,22 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
             />
           )}
         </div>
-        <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 md:pr-8 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12 xl:pr-4">
+        <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 md:pr-8 lg:absolute lg:inset-x-0 lg:bottom-0 lg:bg-linear-to-t lg:p-4 lg:pt-12 lg:pr-4">
           <span
             aria-hidden
-            className="font-bold text-white/70 text-xs uppercase tracking-wide md:hidden xl:block"
+            className="font-bold text-white/70 text-xs uppercase tracking-wide md:hidden lg:block"
           >
             What's new
           </span>
-          <span className="font-bold text-label-value-14 text-pure-white leading-tight md:text-heading-16 md:text-primary xl:text-pure-white">
+          <span className="font-bold text-label-value-14 text-pure-white leading-tight md:text-heading-16 md:text-primary lg:text-pure-white">
             {item.title}
           </span>
           {item.description && (
-            <p className="line-clamp-2 text-label-value-12 text-white/80 leading-snug md:text-label-value-13 md:text-secondary xl:text-white/80">
+            <p className="line-clamp-2 text-label-value-12 text-white/80 leading-snug md:text-label-value-13 md:text-secondary lg:text-white/80">
               {item.description}
             </p>
           )}
-          <span className="mt-0.5 flex items-center gap-1 font-bold text-[#66b2ff] text-xs md:text-link xl:text-[#66b2ff]">
+          <span className="mt-0.5 flex items-center gap-1 font-bold text-[#66b2ff] text-xs md:text-link lg:text-[#66b2ff]">
             Explore
             <ArrowRightIcon className="size-3 fill-current transition-transform group-hover:translate-x-0.5" />
           </span>
@@ -114,7 +114,7 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
         type="button"
         aria-label="Dismiss"
         onClick={dismiss}
-        className="absolute top-2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-black/40 transition-colors hover:bg-black/60 md:bg-transparent md:hover:bg-surface-tertiary xl:hidden"
+        className="absolute top-2 right-2 z-10 flex size-6 cursor-pointer items-center justify-center rounded-full bg-black/40 transition-colors hover:bg-black/60 md:bg-transparent md:hover:bg-surface-tertiary lg:hidden"
       >
         <CloseIcon className="size-[10px] fill-white md:fill-secondary" />
       </button>

--- a/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
@@ -15,19 +15,20 @@ export interface HomeWhatsNewItem {
 }
 
 export function HomeWhatsNewCard({
-  items,
+  item,
   className,
 }: {
-  items: HomeWhatsNewItem[]
+  item: HomeWhatsNewItem | undefined
   className?: string
 }) {
-  if (items.length === 0) {
+  if (!item) {
     return null
   }
+  console.log(item)
   return (
     <>
       <script
-        dangerouslySetInnerHTML={{ __html: getDismissedCheckScript(items) }}
+        dangerouslySetInnerHTML={{ __html: getDismissedCheckScript(item) }}
       />
       <HomeCard
         className={cn(
@@ -39,13 +40,9 @@ export function HomeWhatsNewCard({
         <h2 className="sr-only font-bold text-xl md:not-sr-only xl:sr-only">
           What's new
         </h2>
-        <ul className="flex flex-1 flex-col gap-2 xl:gap-0">
-          {items.map((item) => (
-            <li key={item.id} className="relative flex flex-1">
-              <WhatsNewItemCard item={item} />
-            </li>
-          ))}
-        </ul>
+        <div className="relative flex flex-1">
+          <WhatsNewItemCard item={item} />
+        </div>
       </HomeCard>
     </>
   )
@@ -56,9 +53,9 @@ export function HomeWhatsNewCard({
  * already dismissed the card never see it flash on small screens. The attribute
  * lives on <html> (outside the React root) to keep hydration untouched.
  */
-function getDismissedCheckScript(items: HomeWhatsNewItem[]): string {
-  const keys = JSON.stringify(items.map((item) => `whats-new-${item.id}`))
-  return `try{if(${keys}.every(function(k){return localStorage.getItem(k)==='true'}))document.documentElement.dataset.whatsNewDismissed='true'}catch{}`
+function getDismissedCheckScript(item: HomeWhatsNewItem): string {
+  const key = JSON.stringify(`whats-new-${item.id}`)
+  return `try{if(localStorage.getItem(${key})==='true')document.documentElement.dataset.whatsNewDismissed='true'}catch{}`
 }
 
 function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
@@ -74,19 +71,24 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
         onClick={() => setWidgetClosed(true)}
         className="group relative block flex-1 overflow-hidden md:flex md:flex-row md:rounded-lg md:border-2 md:border-divider xl:block xl:min-h-40 xl:rounded-none xl:border-0"
       >
-        <div className="relative aspect-video w-full overflow-hidden md:aspect-auto md:w-32 md:shrink-0 xl:absolute xl:inset-0 xl:w-full">
-          <picture className="contents">
-            <source
-              media="(min-width: 1440px)"
-              srcSet={item.verticalImageSrc ?? item.imageSrc}
-            />
+        <div className="relative aspect-video w-full overflow-hidden [container-type:size] md:aspect-auto md:min-h-[5.5rem] md:w-32 md:shrink-0 xl:absolute xl:inset-0 xl:min-h-0 xl:w-full">
+          <img
+            src={item.imageSrc}
+            alt={item.imageAlt}
+            loading="lazy"
+            className={cn(
+              'size-full object-cover object-top-left transition-transform duration-300 group-hover:scale-[1.02]',
+              item.verticalImageSrc && '[@container_(aspect-ratio<1)]:hidden',
+            )}
+          />
+          {item.verticalImageSrc && (
             <img
-              src={item.imageSrc}
+              src={item.verticalImageSrc}
               alt={item.imageAlt}
               loading="lazy"
-              className="size-full object-cover object-top-left transition-transform duration-300 group-hover:scale-[1.02] md:min-h-[5.5rem] xl:min-h-0"
+              className="size-full object-cover object-top transition-transform duration-300 group-hover:scale-[1.02] [@container_(aspect-ratio>=1)]:hidden"
             />
-          </picture>
+          )}
         </div>
         <div className="absolute inset-x-0 bottom-0 flex min-w-0 flex-col gap-0.5 bg-linear-to-t from-black/85 via-black/60 to-transparent p-2.5 pt-8 md:static md:flex-1 md:justify-center md:gap-1 md:bg-none md:p-3 md:pr-8 xl:absolute xl:inset-x-0 xl:bottom-0 xl:bg-linear-to-t xl:p-4 xl:pt-12 xl:pr-4">
           <span

--- a/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
@@ -24,7 +24,6 @@ export function HomeWhatsNewCard({
   if (!item) {
     return null
   }
-  console.log(item)
   return (
     <>
       <script

--- a/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeWhatsNewCard.tsx
@@ -68,7 +68,7 @@ function WhatsNewItemCard({ item }: { item: HomeWhatsNewItem }) {
       <a
         href={item.href}
         onClick={() => setWidgetClosed(true)}
-        className="group relative block flex-1 overflow-hidden md:flex md:flex-row md:rounded-lg md:border-2 md:border-divider lg:block lg:min-h-40 lg:rounded-none lg:border-0"
+        className="group relative block flex-1 overflow-hidden md:flex md:flex-row md:rounded-lg md:border-2 md:border-divider lg:block lg:min-h-52 lg:rounded-none lg:border-0"
       >
         <div className="relative aspect-video w-full overflow-hidden [container-type:size] md:aspect-auto md:min-h-[5.5rem] md:w-32 md:shrink-0 lg:absolute lg:inset-0 lg:min-h-0 lg:w-full">
           <img

--- a/packages/frontend/src/pages/home/getHomeData.ts
+++ b/packages/frontend/src/pages/home/getHomeData.ts
@@ -204,7 +204,7 @@ async function getCachedData(manifest: Manifest) {
       iconUrl: group.iconUrl,
     })),
     ongoingAnomalies,
-    whatsNewItems: getHomeWhatsNewItems(),
+    whatsNewItem: getHomeWhatsNewItem(),
   }
 }
 
@@ -237,7 +237,7 @@ async function getEthereumEconomicSecurity(): Promise<number | undefined> {
   )
 }
 
-function getHomeWhatsNewItems(): HomeWhatsNewItem[] {
+function getHomeWhatsNewItem(): HomeWhatsNewItem | undefined {
   // The card is a permanent part of the desktop layout, so unlike the
   // floating widget it falls back to the most recent entry when no
   // campaign is currently active.
@@ -246,19 +246,17 @@ function getHomeWhatsNewItems(): HomeWhatsNewItem[] {
     selectActiveWhatsNewEntry(entries, new Date()) ??
     entries.find((entry) => entry.whatsNew)
   if (!entry?.whatsNew) {
-    return []
+    return undefined
   }
-  return [
-    {
-      id: `changelog-${entry.id}`,
-      title: entry.title,
-      description: entry.summary,
-      href: entry.whatsNew.href ?? `/changelog#${entry.id}`,
-      imageSrc: entry.whatsNew.image,
-      verticalImageSrc: entry.whatsNew.verticalImage,
-      imageAlt: entry.whatsNew.alt,
-    },
-  ]
+  return {
+    id: `changelog-${entry.id}`,
+    title: entry.title,
+    description: entry.summary,
+    href: entry.whatsNew.href ?? `/changelog#${entry.id}`,
+    imageSrc: entry.whatsNew.image,
+    verticalImageSrc: entry.whatsNew.verticalImage,
+    imageAlt: entry.whatsNew.alt,
+  }
 }
 
 export interface HomeRecentProject {

--- a/packages/frontend/src/pages/home/getHomeData.ts
+++ b/packages/frontend/src/pages/home/getHomeData.ts
@@ -37,7 +37,7 @@ import { HOME_CHART_RANGE } from './homeChartRanges'
 const TOP_CHAINS_COUNT = 5
 const TOP_PRIVACY_PROTOCOLS_COUNT = 5
 const TOP_ZK_PROVERS_COUNT = 5
-const RECENT_PROJECTS_COUNT = 5
+const RECENT_PROJECTS_COUNT = 6
 
 export async function getHomeData(
   req: Request,

--- a/packages/frontend/src/pages/interop/components/flows/graph/FlowsGraphPanel.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/graph/FlowsGraphPanel.tsx
@@ -19,6 +19,7 @@ interface FlowsGraphPanelProps {
   baseDollarsPerParticle?: number
   topChainId?: string
   className?: string
+  maxSizeClassName?: string
 }
 
 export function FlowsGraphPanel({
@@ -30,6 +31,7 @@ export function FlowsGraphPanel({
   baseDollarsPerParticle,
   topChainId,
   className,
+  maxSizeClassName = 'max-w-[min(70svh,calc(100svh-20rem))]',
 }: FlowsGraphPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const { width, height } = useResizeObserver({ ref: containerRef })
@@ -48,7 +50,10 @@ export function FlowsGraphPanel({
       <div className="flex min-h-0 w-full min-w-0 flex-1 items-center justify-center">
         <div
           id="flows-graph"
-          className="flex aspect-square max-h-full min-h-0 w-full min-w-0 max-w-[min(70svh,calc(100svh-20rem))] items-center justify-center"
+          className={cn(
+            'flex aspect-square max-h-full min-h-0 w-full min-w-0 items-center justify-center',
+            maxSizeClassName,
+          )}
           ref={containerRef}
         >
           {!size ? (


### PR DESCRIPTION
## Summary

- Rework the home page grid so the layout works between `lg` and `xl`: interop card gets its own column below `2xl`, scaling/other cards span the full row, and the anomalies + recent changes tiles move into the left column on `xl`+ (the standalone tile row is now `xl:hidden`).
- Hide the left column entirely between `lg` and `xl` when What's new is dismissed, so it doesn't leave an empty grid row above the interop card.
- Show a single What's new item instead of a list: `HomeWhatsNewCard` now takes one `item`, `getHomeData` returns `whatsNewItem`, and the dismissed-check inline script reads a single localStorage key.
- Interop card: move the General stats panel to the right of the graph on wide cards, and reverse the stacking order on small screens.
- Anomalies / recent changes tiles: accept a `className`, and use shorter copy on `xl`+ where the tiles are narrow.
- Recently added projects: show 6 projects, with the count controlled by `RECENT_PROJECTS_COUNT` in `getHomeData` instead of a second slice in the card.
- `HomeStatsStrip` accepts a `className` and is hidden from `lg` up.

## Testing

- Not run — visual-only change; verify the home page at `sm`, `md`, `lg`, `xl` and `2xl` widths, with What's new both present and dismissed.