### PR TITLE
Public API - interop messages and transfers

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -65,8 +65,12 @@ export type {
 } from './repositories/InteropEventRepository'
 export type {
   InteropMessageDetailedStatsRecord,
+  InteropMessagePageCursor,
+  InteropMessagePageFilter,
+  InteropMessagePageOptions,
   InteropMessageRecord,
   InteropMessageStatsRecord,
+  InteropMessageTypeSummaryRecord,
   InteropMessageUniqueAppsRecord,
 } from './repositories/InteropMessageRepository'
 export type {
@@ -80,13 +84,17 @@ export {
   type InteropMissingTokenInfo,
   type InteropSuspiciousTransferRecord,
   type InteropTokenRouteRecord,
+  type InteropTransferCursor,
   type InteropTransferFinancialsFilter,
   type InteropTransferFinancialsStats,
+  type InteropTransferPageFilter,
+  type InteropTransferPageOptions,
   type InteropTransferRecord,
   type InteropTransfersDetailedStatsRecord,
   type InteropTransfersStatsRecord,
   type InteropTransferTimeRange,
   type InteropTransferTokenInfo,
+  type InteropTransferTypeSummaryRecord,
   type InteropTransferUpdate,
 } from './repositories/InteropTransferRepository'
 export type {

--- a/packages/database/src/repositories/InteropMessageRepository.test.ts
+++ b/packages/database/src/repositories/InteropMessageRepository.test.ts
@@ -248,4 +248,233 @@ describeDatabase(InteropMessageRepository.name, (database) => {
       expect(remaining[0]?.messageId).toEqual('msg3')
     })
   })
+
+  describe(InteropMessageRepository.prototype.getPage.name, () => {
+    const base = UnixTime(1_700_000_000)
+
+    beforeEach(async () => {
+      await repository.insertMany([
+        makeRecord(base, {
+          messageId: 'b',
+          timestamp: base,
+          plugin: 'across',
+          type: 'across.Message',
+        }),
+        // Same timestamp as 'b' - messageId decides the order.
+        makeRecord(base, {
+          messageId: 'a',
+          timestamp: base,
+          plugin: 'across',
+          type: 'across.Message',
+        }),
+        makeRecord(base, {
+          messageId: 'c',
+          timestamp: base + 100,
+          plugin: 'across',
+          type: 'across.Message',
+          app: 'other-app',
+          srcChain: 'base',
+          dstChain: 'optimism',
+        }),
+        makeRecord(base, {
+          messageId: 'd',
+          timestamp: base + 200,
+          plugin: 'cctp',
+          type: 'cctp.Message',
+        }),
+      ])
+    })
+
+    it('orders by timestamp then messageId, descending', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'desc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.messageId)).toEqual(['c', 'b', 'a'])
+    })
+
+    it('orders by timestamp then messageId, ascending', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'asc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.messageId)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('walks every row exactly once across pages, breaking timestamp ties', async () => {
+      const seen: string[] = []
+      let cursor: { timestamp: UnixTime; messageId: string } | undefined
+
+      for (let page = 0; page < 5; page++) {
+        const rows = await repository.getPage({
+          filter: { plugin: 'across' },
+          order: 'desc',
+          limit: 1,
+          cursor,
+        })
+        if (rows.length === 0) break
+
+        const last = rows[rows.length - 1]
+        assert(last)
+        seen.push(last.messageId)
+        cursor = { timestamp: last.timestamp, messageId: last.messageId }
+      }
+
+      expect(seen).toEqual(['c', 'b', 'a'])
+    })
+
+    it('resumes ascending walks from the cursor', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'asc',
+        limit: 10,
+        cursor: { timestamp: base, messageId: 'a' },
+      })
+
+      expect(result.map((r) => r.messageId)).toEqual(['b', 'c'])
+    })
+
+    it('respects the limit', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'desc',
+        limit: 2,
+      })
+
+      expect(result.map((r) => r.messageId)).toEqual(['c', 'b'])
+    })
+
+    it('scopes results to the plugin', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'cctp' },
+        order: 'desc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.messageId)).toEqual(['d'])
+    })
+
+    it('filters by type, app and chains', async () => {
+      expect(
+        (
+          await repository.getPage({
+            filter: { plugin: 'across', type: 'cctp.Message' },
+            order: 'desc',
+            limit: 10,
+          })
+        ).map((r) => r.messageId),
+      ).toEqual([])
+
+      expect(
+        (
+          await repository.getPage({
+            filter: { plugin: 'across', app: 'other-app' },
+            order: 'desc',
+            limit: 10,
+          })
+        ).map((r) => r.messageId),
+      ).toEqual(['c'])
+
+      expect(
+        (
+          await repository.getPage({
+            filter: {
+              plugin: 'across',
+              srcChain: 'base',
+              dstChain: 'optimism',
+            },
+            order: 'desc',
+            limit: 10,
+          })
+        ).map((r) => r.messageId),
+      ).toEqual(['c'])
+    })
+
+    it('treats from as inclusive and to as exclusive', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across', from: base, to: base + 100 },
+        order: 'asc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.messageId)).toEqual(['a', 'b'])
+    })
+
+    it('rejects a non-positive limit', async () => {
+      await expect(
+        repository.getPage({
+          filter: { plugin: 'across' },
+          order: 'desc',
+          limit: 0,
+        }),
+      ).toBeRejectedWith('limit must be a positive number')
+    })
+  })
+
+  describe(InteropMessageRepository.prototype.hasPlugin.name, () => {
+    it('distinguishes a plugin with data from one without', async () => {
+      await repository.insertMany([
+        makeRecord(UnixTime(1_700_000_000), {
+          messageId: 'msg1',
+          plugin: 'across',
+        }),
+      ])
+
+      expect(await repository.hasPlugin('across')).toEqual(true)
+      expect(await repository.hasPlugin('acros')).toEqual(false)
+    })
+  })
+
+  describe(InteropMessageRepository.prototype.getTypeSummary.name, () => {
+    it('returns counts and the retained timestamp span per plugin and type', async () => {
+      const base = UnixTime(1_700_000_000)
+      await repository.insertMany([
+        makeRecord(base, {
+          messageId: 'msg1',
+          plugin: 'across',
+          type: 'across.Message',
+          timestamp: base,
+        }),
+        makeRecord(base, {
+          messageId: 'msg2',
+          plugin: 'across',
+          type: 'across.Message',
+          timestamp: base + 500,
+        }),
+        makeRecord(base, {
+          messageId: 'msg3',
+          plugin: 'cctp',
+          type: 'cctp.Message',
+          timestamp: base + 700,
+        }),
+      ])
+
+      const result = await repository.getTypeSummary()
+
+      expect(result).toEqualUnsorted([
+        {
+          plugin: 'across',
+          type: 'across.Message',
+          count: 2,
+          oldestTimestamp: base,
+          newestTimestamp: base + 500,
+        },
+        {
+          plugin: 'cctp',
+          type: 'cctp.Message',
+          count: 1,
+          oldestTimestamp: base + 700,
+          newestTimestamp: base + 700,
+        },
+      ])
+    })
+
+    it('returns an empty array when there is no data', async () => {
+      expect(await repository.getTypeSummary()).toEqual([])
+    })
+  })
 })

--- a/packages/database/src/repositories/InteropMessageRepository.ts
+++ b/packages/database/src/repositories/InteropMessageRepository.ts
@@ -92,6 +92,42 @@ export interface InteropMessageUniqueAppsRecord {
   apps: string[]
 }
 
+/**
+ * Keyset pagination position. Rows are totally ordered by
+ * `(timestamp, messageId)`, so this identifies an exact position in the result.
+ */
+export interface InteropMessagePageCursor {
+  timestamp: UnixTime
+  messageId: string
+}
+
+export interface InteropMessagePageFilter {
+  plugin: string
+  type?: string
+  app?: string
+  srcChain?: string
+  dstChain?: string
+  /** Inclusive lower bound for the message timestamp. */
+  from?: UnixTime
+  /** Exclusive upper bound for the message timestamp. */
+  to?: UnixTime
+}
+
+export interface InteropMessagePageOptions {
+  filter: InteropMessagePageFilter
+  order: 'asc' | 'desc'
+  limit: number
+  cursor?: InteropMessagePageCursor
+}
+
+export interface InteropMessageTypeSummaryRecord {
+  plugin: string
+  type: string
+  count: number
+  oldestTimestamp: UnixTime
+  newestTimestamp: UnixTime
+}
+
 export class InteropMessageRepository extends BaseRepository {
   async insertMany(records: InteropMessageRecord[]): Promise<number> {
     if (records.length === 0) return 0
@@ -270,4 +306,105 @@ export class InteropMessageRepository extends BaseRepository {
       apps,
     }))
   }
+
+  // #region Public API
+
+  /**
+   * Returns a single keyset-paginated page ordered by `(timestamp, messageId)`.
+   * `plugin` is required to bound the result set, but no index leads with
+   * `plugin`, so the scan and sort cover the whole table - which stays small
+   * only because messages are retained for a single day.
+   */
+  async getPage(
+    options: InteropMessagePageOptions,
+  ): Promise<InteropMessageRecord[]> {
+    assert(options.limit > 0, 'limit must be a positive number')
+
+    const { filter, order, cursor } = options
+    let query = this.db
+      .selectFrom('InteropMessage')
+      .selectAll()
+      .where('plugin', '=', filter.plugin)
+
+    if (filter.type !== undefined) {
+      query = query.where('type', '=', filter.type)
+    }
+    if (filter.app !== undefined) {
+      query = query.where('app', '=', filter.app)
+    }
+    if (filter.srcChain !== undefined) {
+      query = query.where('srcChain', '=', filter.srcChain)
+    }
+    if (filter.dstChain !== undefined) {
+      query = query.where('dstChain', '=', filter.dstChain)
+    }
+    if (filter.from !== undefined) {
+      query = query.where('timestamp', '>=', UnixTime.toDate(filter.from))
+    }
+    if (filter.to !== undefined) {
+      query = query.where('timestamp', '<', UnixTime.toDate(filter.to))
+    }
+
+    if (cursor) {
+      const cursorDate = UnixTime.toDate(cursor.timestamp)
+      const comparison = order === 'desc' ? '<' : '>'
+      query = query.where((eb) =>
+        eb.or([
+          eb('timestamp', comparison, cursorDate),
+          eb.and([
+            eb('timestamp', '=', cursorDate),
+            eb('messageId', comparison, cursor.messageId),
+          ]),
+        ]),
+      )
+    }
+
+    const rows = await query
+      .orderBy('timestamp', order)
+      .orderBy('messageId', order)
+      .limit(options.limit)
+      .execute()
+
+    return rows.map(toRecord)
+  }
+
+  /** Returns true when the plugin has at least one retained message. */
+  async hasPlugin(plugin: string): Promise<boolean> {
+    const row = await this.db
+      .selectFrom('InteropMessage')
+      .select('messageId')
+      .where('plugin', '=', plugin)
+      .limit(1)
+      .executeTakeFirst()
+
+    return row !== undefined
+  }
+
+  /**
+   * Per `(plugin, type)` counts and the retained timestamp span. Full scan -
+   * callers are expected to cache the result.
+   */
+  async getTypeSummary(): Promise<InteropMessageTypeSummaryRecord[]> {
+    const rows = await this.db
+      .selectFrom('InteropMessage')
+      .select((eb) => [
+        'plugin',
+        'type',
+        eb.fn.countAll().as('count'),
+        eb.fn.min('timestamp').as('oldestTimestamp'),
+        eb.fn.max('timestamp').as('newestTimestamp'),
+      ])
+      .groupBy(['plugin', 'type'])
+      .execute()
+
+    return rows.map((row) => ({
+      plugin: row.plugin,
+      type: row.type,
+      count: Number(row.count),
+      oldestTimestamp: UnixTime.fromDate(row.oldestTimestamp),
+      newestTimestamp: UnixTime.fromDate(row.newestTimestamp),
+    }))
+  }
+
+  // #endregion
 }

--- a/packages/database/src/repositories/InteropTransferRepository.test.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.test.ts
@@ -1,10 +1,16 @@
-import { Address32, EthereumAddress, UnixTime } from '@l2beat/shared-pure'
+import {
+  Address32,
+  assert,
+  EthereumAddress,
+  UnixTime,
+} from '@l2beat/shared-pure'
 import { expect } from 'earl'
 import type { Selectable } from 'kysely'
 import type { InteropTransfer } from '../kysely/generated/types'
 import { describeDatabase } from '../test/database'
 import {
   hasAnyInteropTransferFinancialsFilter,
+  type InteropTransferCursor,
   type InteropTransferRecord,
   InteropTransferRepository,
   type InteropTransferUpdate,
@@ -1918,6 +1924,191 @@ describeDatabase(InteropTransferRepository.name, (db) => {
       })
     },
   )
+
+  describe(InteropTransferRepository.prototype.getPage.name, () => {
+    const base = UnixTime(1_700_000_000)
+
+    beforeEach(async () => {
+      await repository.insertMany([
+        transfer('across', 'b', 'across.Transfer', base),
+        // Same timestamp as 'b' - transferId decides the order.
+        transfer('across', 'a', 'across.Transfer', base),
+        transfer(
+          'across',
+          'c',
+          'across.Transfer',
+          base + 100,
+          'base',
+          'optimism',
+        ),
+        transfer('cctp', 'd', 'cctp.Transfer', base + 200),
+      ])
+    })
+
+    it('orders by timestamp then transferId, descending', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'desc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.transferId)).toEqual(['c', 'b', 'a'])
+    })
+
+    it('orders by timestamp then transferId, ascending', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'asc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.transferId)).toEqual(['a', 'b', 'c'])
+    })
+
+    it('walks every row exactly once across pages, breaking timestamp ties', async () => {
+      const seen: string[] = []
+      let cursor: InteropTransferCursor | undefined
+
+      for (let page = 0; page < 5; page++) {
+        const rows = await repository.getPage({
+          filter: { plugin: 'across' },
+          order: 'desc',
+          limit: 1,
+          cursor,
+        })
+        if (rows.length === 0) break
+
+        const last = rows[rows.length - 1]
+        assert(last)
+        seen.push(last.transferId)
+        cursor = { timestamp: last.timestamp, transferId: last.transferId }
+      }
+
+      expect(seen).toEqual(['c', 'b', 'a'])
+    })
+
+    it('resumes ascending walks from the cursor', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'asc',
+        limit: 10,
+        cursor: { timestamp: base, transferId: 'a' },
+      })
+
+      expect(result.map((r) => r.transferId)).toEqual(['b', 'c'])
+    })
+
+    it('respects the limit', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across' },
+        order: 'desc',
+        limit: 2,
+      })
+
+      expect(result.map((r) => r.transferId)).toEqual(['c', 'b'])
+    })
+
+    it('scopes results to the plugin', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'cctp' },
+        order: 'desc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.transferId)).toEqual(['d'])
+    })
+
+    it('filters by type and chains', async () => {
+      expect(
+        (
+          await repository.getPage({
+            filter: { plugin: 'across', type: 'cctp.Transfer' },
+            order: 'desc',
+            limit: 10,
+          })
+        ).map((r) => r.transferId),
+      ).toEqual([])
+
+      expect(
+        (
+          await repository.getPage({
+            filter: {
+              plugin: 'across',
+              srcChain: 'base',
+              dstChain: 'optimism',
+            },
+            order: 'desc',
+            limit: 10,
+          })
+        ).map((r) => r.transferId),
+      ).toEqual(['c'])
+    })
+
+    it('treats from as inclusive and to as exclusive', async () => {
+      const result = await repository.getPage({
+        filter: { plugin: 'across', from: base, to: base + 100 },
+        order: 'asc',
+        limit: 10,
+      })
+
+      expect(result.map((r) => r.transferId)).toEqual(['a', 'b'])
+    })
+
+    it('rejects a non-positive limit', async () => {
+      await expect(
+        repository.getPage({
+          filter: { plugin: 'across' },
+          order: 'desc',
+          limit: 0,
+        }),
+      ).toBeRejectedWith('limit must be a positive number')
+    })
+  })
+
+  describe(InteropTransferRepository.prototype.hasPlugin.name, () => {
+    it('distinguishes a plugin with data from one without', async () => {
+      await repository.insertMany([
+        transfer('across', 'msg1', 'across.Transfer', UnixTime(1_700_000_000)),
+      ])
+
+      expect(await repository.hasPlugin('across')).toEqual(true)
+      expect(await repository.hasPlugin('acros')).toEqual(false)
+    })
+  })
+
+  describe(InteropTransferRepository.prototype.getTypeSummary.name, () => {
+    it('returns counts and the retained timestamp span per plugin and type', async () => {
+      const base = UnixTime(1_700_000_000)
+      await repository.insertMany([
+        transfer('across', 'msg1', 'across.Transfer', base),
+        transfer('across', 'msg2', 'across.Transfer', base + 500),
+        transfer('cctp', 'msg3', 'cctp.Transfer', base + 700),
+      ])
+
+      const result = await repository.getTypeSummary()
+
+      expect(result).toEqualUnsorted([
+        {
+          plugin: 'across',
+          type: 'across.Transfer',
+          count: 2,
+          oldestTimestamp: base,
+          newestTimestamp: base + 500,
+        },
+        {
+          plugin: 'cctp',
+          type: 'cctp.Transfer',
+          count: 1,
+          oldestTimestamp: base + 700,
+          newestTimestamp: base + 700,
+        },
+      ])
+    })
+
+    it('returns an empty array when there is no data', async () => {
+      expect(await repository.getTypeSummary()).toEqual([])
+    })
+  })
 
   afterEach(async () => {
     await repository.deleteAll()

--- a/packages/database/src/repositories/InteropTransferRepository.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.ts
@@ -298,6 +298,32 @@ export interface InteropTransferCursor {
   transferId: string
 }
 
+export interface InteropTransferPageFilter {
+  plugin: string
+  type?: string
+  srcChain?: string
+  dstChain?: string
+  /** Inclusive lower bound for the transfer timestamp. */
+  from?: UnixTime
+  /** Exclusive upper bound for the transfer timestamp. */
+  to?: UnixTime
+}
+
+export interface InteropTransferPageOptions {
+  filter: InteropTransferPageFilter
+  order: 'asc' | 'desc'
+  limit: number
+  cursor?: InteropTransferCursor
+}
+
+export interface InteropTransferTypeSummaryRecord {
+  plugin: string
+  type: string
+  count: number
+  oldestTimestamp: UnixTime
+  newestTimestamp: UnixTime
+}
+
 export class InteropTransferRepository extends BaseRepository {
   async insertMany(records: InteropTransferRecord[]): Promise<number> {
     if (records.length === 0) return 0
@@ -1082,4 +1108,103 @@ export class InteropTransferRepository extends BaseRepository {
 
     return result
   }
+
+  // #region Public API
+
+  /**
+   * Returns a single keyset-paginated page ordered by `(timestamp, transferId)`.
+   * `plugin` is required so that the scan is bounded to one plugin's rows: the
+   * `(plugin, srcChain, dstChain, timestamp, transferId)` index provides the
+   * plugin prefix, but ordered output from it needs both chains bound too, so
+   * anything less is sorted per call.
+   */
+  async getPage(
+    options: InteropTransferPageOptions,
+  ): Promise<InteropTransferRecord[]> {
+    assert(options.limit > 0, 'limit must be a positive number')
+
+    const { filter, order, cursor } = options
+    let query = this.db
+      .selectFrom('InteropTransfer')
+      .selectAll()
+      .where('plugin', '=', filter.plugin)
+
+    if (filter.type !== undefined) {
+      query = query.where('type', '=', filter.type)
+    }
+    if (filter.srcChain !== undefined) {
+      query = query.where('srcChain', '=', filter.srcChain)
+    }
+    if (filter.dstChain !== undefined) {
+      query = query.where('dstChain', '=', filter.dstChain)
+    }
+    if (filter.from !== undefined) {
+      query = query.where('timestamp', '>=', UnixTime.toDate(filter.from))
+    }
+    if (filter.to !== undefined) {
+      query = query.where('timestamp', '<', UnixTime.toDate(filter.to))
+    }
+
+    if (cursor) {
+      const cursorDate = UnixTime.toDate(cursor.timestamp)
+      const comparison = order === 'desc' ? '<' : '>'
+      query = query.where((eb) =>
+        eb.or([
+          eb('timestamp', comparison, cursorDate),
+          eb.and([
+            eb('timestamp', '=', cursorDate),
+            eb('transferId', comparison, cursor.transferId),
+          ]),
+        ]),
+      )
+    }
+
+    const rows = await query
+      .orderBy('timestamp', order)
+      .orderBy('transferId', order)
+      .limit(options.limit)
+      .execute()
+
+    return rows.map(toRecord)
+  }
+
+  /** Returns true when the plugin has at least one retained transfer. */
+  async hasPlugin(plugin: string): Promise<boolean> {
+    const row = await this.db
+      .selectFrom('InteropTransfer')
+      .select('transferId')
+      .where('plugin', '=', plugin)
+      .limit(1)
+      .executeTakeFirst()
+
+    return row !== undefined
+  }
+
+  /**
+   * Per `(plugin, type)` counts and the retained timestamp span. Full scan -
+   * callers are expected to cache the result.
+   */
+  async getTypeSummary(): Promise<InteropTransferTypeSummaryRecord[]> {
+    const rows = await this.db
+      .selectFrom('InteropTransfer')
+      .select((eb) => [
+        'plugin',
+        'type',
+        eb.fn.countAll().as('count'),
+        eb.fn.min('timestamp').as('oldestTimestamp'),
+        eb.fn.max('timestamp').as('newestTimestamp'),
+      ])
+      .groupBy(['plugin', 'type'])
+      .execute()
+
+    return rows.map((row) => ({
+      plugin: row.plugin,
+      type: row.type,
+      count: Number(row.count),
+      oldestTimestamp: UnixTime.fromDate(row.oldestTimestamp),
+      newestTimestamp: UnixTime.fromDate(row.newestTimestamp),
+    }))
+  }
+
+  // #endregion
 }

--- a/packages/public-api/src/OpenApi.ts
+++ b/packages/public-api/src/OpenApi.ts
@@ -42,7 +42,7 @@ type OpenApiResponse = {
 
 type Tags = 'projects' | 'tvs' | 'activity' | 'interop'
 
-const BadRequestResponse = v
+export const BadRequestResponse = v
   .object({
     path: v.string(),
     message: v.string(),

--- a/packages/public-api/src/config/makeConfig.ts
+++ b/packages/public-api/src/config/makeConfig.ts
@@ -40,6 +40,7 @@ export function makeConfig(env: Env, options: MakeConfigOptions): Config {
             agglayer: env.string('API_KEY_AGGLAYER'),
             theElasticNetwork: env.string('API_KEY_THE_ELASTIC_NETWORK'),
             pulseKit: env.string('API_KEY_PULSEKIT'),
+            fcr: env.string('API_KEY_FCR'),
           },
         },
     openapi: {

--- a/packages/public-api/src/routes/interop/getInteropPlugins.test.ts
+++ b/packages/public-api/src/routes/interop/getInteropPlugins.test.ts
@@ -1,0 +1,98 @@
+import type { Database } from '@l2beat/database'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import { getInteropPluginsData } from './getInteropPlugins'
+
+const BASE = UnixTime(1_700_000_000)
+
+describe(getInteropPluginsData.name, () => {
+  it('groups types under their plugin, sorted by name', async () => {
+    const db = mockObject<Database>({
+      interopMessage: mockObject<Database['interopMessage']>({
+        getTypeSummary: mockFn().resolvesTo([
+          summary('cctp', 'cctp.Message'),
+          summary('across', 'across.Message'),
+        ]),
+      }),
+      interopTransfer: mockObject<Database['interopTransfer']>({
+        getTypeSummary: mockFn().resolvesTo([
+          summary('across', 'across.Transfer.b'),
+          summary('across', 'across.Transfer.a'),
+        ]),
+      }),
+    })
+
+    const result = await getInteropPluginsData(db)
+
+    expect(result).toEqual([
+      {
+        plugin: 'across',
+        messageTypes: [expectedSummary('across.Message')],
+        transferTypes: [
+          expectedSummary('across.Transfer.a'),
+          expectedSummary('across.Transfer.b'),
+        ],
+      },
+      {
+        plugin: 'cctp',
+        messageTypes: [expectedSummary('cctp.Message')],
+        transferTypes: [],
+      },
+    ])
+  })
+
+  it('lists a plugin that only has transfers', async () => {
+    const db = mockObject<Database>({
+      interopMessage: mockObject<Database['interopMessage']>({
+        getTypeSummary: mockFn().resolvesTo([]),
+      }),
+      interopTransfer: mockObject<Database['interopTransfer']>({
+        getTypeSummary: mockFn().resolvesTo([
+          summary('relay', 'relay.Transfer'),
+        ]),
+      }),
+    })
+
+    const result = await getInteropPluginsData(db)
+
+    expect(result).toEqual([
+      {
+        plugin: 'relay',
+        messageTypes: [],
+        transferTypes: [expectedSummary('relay.Transfer')],
+      },
+    ])
+  })
+
+  it('returns an empty list when nothing is retained', async () => {
+    const db = mockObject<Database>({
+      interopMessage: mockObject<Database['interopMessage']>({
+        getTypeSummary: mockFn().resolvesTo([]),
+      }),
+      interopTransfer: mockObject<Database['interopTransfer']>({
+        getTypeSummary: mockFn().resolvesTo([]),
+      }),
+    })
+
+    expect(await getInteropPluginsData(db)).toEqual([])
+  })
+})
+
+function summary(plugin: string, type: string) {
+  return {
+    plugin,
+    type,
+    count: 3,
+    oldestTimestamp: BASE,
+    newestTimestamp: BASE + 100,
+  }
+}
+
+function expectedSummary(type: string) {
+  return {
+    type,
+    count: 3,
+    oldestTimestamp: BASE,
+    newestTimestamp: BASE + 100,
+  }
+}

--- a/packages/public-api/src/routes/interop/getInteropPlugins.ts
+++ b/packages/public-api/src/routes/interop/getInteropPlugins.ts
@@ -1,0 +1,65 @@
+import type { Database } from '@l2beat/database'
+import type { InteropPlugin } from './types'
+
+interface TypeSummary {
+  plugin: string
+  type: string
+  count: number
+  oldestTimestamp: number
+  newestTimestamp: number
+}
+
+/**
+ * Lists every plugin that currently has retained data, with the types it emits
+ * and the timestamp span still available. The span is derived from the rows
+ * themselves so that the retention window is self-documenting.
+ */
+export async function getInteropPluginsData(
+  db: Database,
+): Promise<InteropPlugin[]> {
+  const [messageTypes, transferTypes] = await Promise.all([
+    db.interopMessage.getTypeSummary(),
+    db.interopTransfer.getTypeSummary(),
+  ])
+
+  const plugins = new Map<string, InteropPlugin>()
+  const get = (plugin: string) => {
+    const existing = plugins.get(plugin)
+    if (existing) return existing
+
+    const created: InteropPlugin = {
+      plugin,
+      messageTypes: [],
+      transferTypes: [],
+    }
+    plugins.set(plugin, created)
+    return created
+  }
+
+  for (const summary of messageTypes) {
+    get(summary.plugin).messageTypes.push(toTypeSummary(summary))
+  }
+  for (const summary of transferTypes) {
+    get(summary.plugin).transferTypes.push(toTypeSummary(summary))
+  }
+
+  const sortByType = (a: { type: string }, b: { type: string }) =>
+    a.type.localeCompare(b.type)
+
+  return Array.from(plugins.values())
+    .map((plugin) => ({
+      ...plugin,
+      messageTypes: plugin.messageTypes.sort(sortByType),
+      transferTypes: plugin.transferTypes.sort(sortByType),
+    }))
+    .sort((a, b) => a.plugin.localeCompare(b.plugin))
+}
+
+function toTypeSummary(summary: TypeSummary) {
+  return {
+    type: summary.type,
+    count: summary.count,
+    oldestTimestamp: summary.oldestTimestamp,
+    newestTimestamp: summary.newestTimestamp,
+  }
+}

--- a/packages/public-api/src/routes/interop/getInteropRows.test.ts
+++ b/packages/public-api/src/routes/interop/getInteropRows.test.ts
@@ -1,0 +1,416 @@
+import type {
+  Database,
+  InteropMessageRecord,
+  InteropTransferRecord,
+} from '@l2beat/database'
+import { assert, UnixTime } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import {
+  getInteropMessagesData,
+  getInteropTransfersData,
+  type InteropRowsParams,
+  interopRowsFingerprint,
+  normalizeInteropRowsQuery,
+} from './getInteropRows'
+import { decodeCursor } from './utils/cursor'
+
+const BASE = UnixTime(1_700_000_000)
+
+describe(normalizeInteropRowsQuery.name, () => {
+  it('converts numeric params and applies defaults', () => {
+    expect(
+      normalizeInteropRowsQuery({
+        plugin: 'across',
+        from: '1700000000',
+        to: '1700000100',
+        limit: '250',
+      }),
+    ).toEqual({
+      plugin: 'across',
+      type: undefined,
+      app: undefined,
+      srcChain: undefined,
+      dstChain: undefined,
+      from: 1_700_000_000,
+      to: 1_700_000_100,
+      order: 'desc',
+      limit: 250,
+    })
+  })
+
+  it('defaults order to desc and limit to 100', () => {
+    const params = normalizeInteropRowsQuery({ plugin: 'across' })
+
+    expect(params.order).toEqual('desc')
+    expect(params.limit).toEqual(100)
+  })
+})
+
+describe(getInteropMessagesData.name, () => {
+  it('requests one row beyond the page and trims it off', async () => {
+    const getPage = mockFn().resolvesTo([
+      message('m3', BASE + 200),
+      message('m2', BASE + 100),
+      message('m1', BASE),
+    ])
+    const db = messageDb(getPage)
+    const params = paramsOf({ limit: 2 })
+
+    const result = await getInteropMessagesData(db, params, undefined)
+
+    expect(getPage).toHaveBeenOnlyCalledWith({
+      filter: {
+        plugin: 'across',
+        type: undefined,
+        app: undefined,
+        srcChain: undefined,
+        dstChain: undefined,
+        from: undefined,
+        to: undefined,
+      },
+      order: 'desc',
+      limit: 3,
+      cursor: undefined,
+    })
+    expect(result.data.map((r) => r.messageId)).toEqual(['m3', 'm2'])
+  })
+
+  it('returns a cursor pointing at the last row of the page', async () => {
+    const db = messageDb(
+      mockFn().resolvesTo([
+        message('m3', BASE + 200),
+        message('m2', BASE + 100),
+        message('m1', BASE),
+      ]),
+    )
+    const params = paramsOf({ limit: 2 })
+
+    const result = await getInteropMessagesData(db, params, undefined)
+
+    assert(result.nextCursor !== null)
+    expect(
+      decodeCursor(
+        result.nextCursor,
+        interopRowsFingerprint('messages', params),
+      ),
+    ).toEqual({
+      ok: true,
+      cursor: { timestamp: BASE + 100, id: 'm2' },
+    })
+  })
+
+  it('returns a null cursor on the last page', async () => {
+    const db = messageDb(
+      mockFn().resolvesTo([message('m2', BASE + 100), message('m1', BASE)]),
+    )
+
+    const result = await getInteropMessagesData(
+      db,
+      paramsOf({ limit: 2 }),
+      undefined,
+    )
+
+    expect(result.data).toHaveLength(2)
+    expect(result.nextCursor).toEqual(null)
+  })
+
+  it('returns a null cursor for an empty page', async () => {
+    const db = messageDb(mockFn().resolvesTo([]))
+
+    const result = await getInteropMessagesData(db, paramsOf(), undefined)
+
+    expect(result).toEqual({ data: [], nextCursor: null })
+  })
+
+  it('forwards the cursor as a keyset position', async () => {
+    const getPage = mockFn().resolvesTo([])
+    const db = messageDb(getPage)
+
+    await getInteropMessagesData(db, paramsOf(), {
+      timestamp: BASE,
+      id: 'm1',
+    })
+
+    expect(getPage.calls[0]?.args[0]?.cursor).toEqual({
+      timestamp: BASE,
+      messageId: 'm1',
+    })
+  })
+
+  it('maps absent fields to null instead of dropping them', async () => {
+    const db = messageDb(
+      mockFn().resolvesTo([
+        {
+          ...message('m1', BASE),
+          duration: undefined,
+          srcChain: undefined,
+          srcTime: undefined,
+          srcTxHash: undefined,
+          srcLogIndex: undefined,
+          dstChain: undefined,
+          dstTime: undefined,
+          dstTxHash: undefined,
+          dstLogIndex: undefined,
+        },
+      ]),
+    )
+
+    const result = await getInteropMessagesData(db, paramsOf(), undefined)
+
+    expect(result.data[0]).toEqual({
+      plugin: 'across',
+      type: 'across.Message',
+      app: 'app',
+      messageId: 'm1',
+      timestamp: BASE,
+      duration: null,
+      srcChain: null,
+      srcTime: null,
+      srcTxHash: null,
+      srcLogIndex: null,
+      dstChain: null,
+      dstTime: null,
+      dstTxHash: null,
+      dstLogIndex: null,
+    })
+  })
+
+  it('does not expose internal event ids', async () => {
+    const db = messageDb(mockFn().resolvesTo([message('m1', BASE)]))
+
+    const result = await getInteropMessagesData(db, paramsOf(), undefined)
+
+    expect(Object.keys(result.data[0] ?? {})).not.toInclude('srcEventId')
+    expect(Object.keys(result.data[0] ?? {})).not.toInclude('dstEventId')
+  })
+})
+
+describe(getInteropTransfersData.name, () => {
+  it('passes filters through and trims the lookahead row', async () => {
+    const getPage = mockFn().resolvesTo([
+      transfer('t2', BASE + 100),
+      transfer('t1', BASE),
+    ])
+    const db = transferDb(getPage)
+
+    const result = await getInteropTransfersData(
+      db,
+      {
+        ...paramsOf({ limit: 1 }),
+        type: 'across.Transfer',
+        srcChain: 'ethereum',
+        dstChain: 'base',
+        from: BASE,
+        to: BASE + 500,
+        order: 'asc',
+      },
+      undefined,
+    )
+
+    expect(getPage).toHaveBeenOnlyCalledWith({
+      filter: {
+        plugin: 'across',
+        type: 'across.Transfer',
+        srcChain: 'ethereum',
+        dstChain: 'base',
+        from: BASE,
+        to: BASE + 500,
+      },
+      order: 'asc',
+      limit: 2,
+      cursor: undefined,
+    })
+    expect(result.data.map((r) => r.transferId)).toEqual(['t2'])
+    expect(result.nextCursor).not.toEqual(null)
+  })
+
+  it('serializes raw amounts as decimal strings', async () => {
+    const db = transferDb(
+      mockFn().resolvesTo([
+        {
+          ...transfer('t1', BASE),
+          srcRawAmount: 12345678901234567890n,
+          dstRawAmount: undefined,
+        },
+      ]),
+    )
+
+    const result = await getInteropTransfersData(db, paramsOf(), undefined)
+
+    expect(result.data[0]?.srcRawAmount).toEqual('12345678901234567890')
+    expect(result.data[0]?.dstRawAmount).toEqual(null)
+  })
+
+  it('keeps the declared bridge type when the plugin set one', async () => {
+    const db = transferDb(
+      mockFn().resolvesTo([
+        { ...transfer('t1', BASE), bridgeType: 'burnAndMint' as const },
+      ]),
+    )
+
+    const result = await getInteropTransfersData(db, paramsOf(), undefined)
+
+    expect(result.data[0]?.bridgeType).toEqual('burnAndMint')
+  })
+
+  it('derives the bridge type from the supply flags when undeclared', async () => {
+    const db = transferDb(
+      mockFn().resolvesTo([
+        {
+          ...transfer('t1', BASE),
+          bridgeType: undefined,
+          srcWasBurned: true,
+          dstWasMinted: false,
+        },
+        {
+          ...transfer('t2', BASE),
+          bridgeType: undefined,
+          srcWasBurned: undefined,
+          dstWasMinted: undefined,
+        },
+      ]),
+    )
+
+    const result = await getInteropTransfersData(db, paramsOf(), undefined)
+
+    expect(result.data.map((r) => r.bridgeType)).toEqual([
+      'lockAndMint',
+      'unknown',
+    ])
+  })
+
+  it('exposes isProcessed so pending pricing is not read as missing value', async () => {
+    const db = transferDb(
+      mockFn().resolvesTo([
+        {
+          ...transfer('t1', BASE),
+          isProcessed: false,
+          srcValueUsd: undefined,
+          dstValueUsd: undefined,
+        },
+      ]),
+    )
+
+    const result = await getInteropTransfersData(db, paramsOf(), undefined)
+
+    expect(result.data[0]?.isProcessed).toEqual(false)
+    expect(result.data[0]?.srcValueUsd).toEqual(null)
+    expect(result.data[0]?.dstValueUsd).toEqual(null)
+  })
+})
+
+describe(interopRowsFingerprint.name, () => {
+  it('separates messages from transfers', () => {
+    const params = paramsOf()
+
+    expect(interopRowsFingerprint('messages', params)).not.toEqual(
+      interopRowsFingerprint('transfers', params),
+    )
+  })
+
+  it('ignores the page size', () => {
+    expect(interopRowsFingerprint('messages', paramsOf({ limit: 10 }))).toEqual(
+      interopRowsFingerprint('messages', paramsOf({ limit: 500 })),
+    )
+  })
+
+  it('changes with the order', () => {
+    expect(interopRowsFingerprint('messages', paramsOf())).not.toEqual(
+      interopRowsFingerprint('messages', {
+        ...paramsOf(),
+        order: 'asc',
+      }),
+    )
+  })
+})
+
+function paramsOf(
+  overrides: Partial<InteropRowsParams> = {},
+): InteropRowsParams {
+  return {
+    plugin: 'across',
+    type: undefined,
+    app: undefined,
+    srcChain: undefined,
+    dstChain: undefined,
+    from: undefined,
+    to: undefined,
+    order: 'desc',
+    limit: 100,
+    ...overrides,
+  }
+}
+
+function messageDb(getPage: Database['interopMessage']['getPage']): Database {
+  return mockObject<Database>({
+    interopMessage: mockObject<Database['interopMessage']>({ getPage }),
+  })
+}
+
+function transferDb(getPage: Database['interopTransfer']['getPage']): Database {
+  return mockObject<Database>({
+    interopTransfer: mockObject<Database['interopTransfer']>({ getPage }),
+  })
+}
+
+function message(messageId: string, timestamp: UnixTime): InteropMessageRecord {
+  return {
+    plugin: 'across',
+    messageId,
+    type: 'across.Message',
+    app: 'app',
+    duration: 60,
+    timestamp,
+    srcTime: timestamp - 60,
+    srcChain: 'ethereum',
+    srcTxHash: `0x${messageId}src`,
+    srcLogIndex: 1,
+    srcEventId: 'src-event',
+    dstTime: timestamp,
+    dstChain: 'base',
+    dstTxHash: `0x${messageId}dst`,
+    dstLogIndex: 2,
+    dstEventId: 'dst-event',
+  }
+}
+
+function transfer(
+  transferId: string,
+  timestamp: UnixTime,
+): InteropTransferRecord {
+  return {
+    plugin: 'across',
+    transferId,
+    type: 'across.Transfer',
+    bridgeType: 'nonMinting',
+    duration: 60,
+    timestamp,
+    srcTime: timestamp - 60,
+    srcChain: 'ethereum',
+    srcTxHash: `0x${transferId}src`,
+    srcLogIndex: 1,
+    srcEventId: 'src-event',
+    srcTokenAddress: '0xtoken',
+    srcRawAmount: 1_000n,
+    srcWasBurned: false,
+    srcAbstractTokenId: 'eth',
+    srcSymbol: 'ETH',
+    srcAmount: 1,
+    srcPrice: 2000,
+    srcValueUsd: 2000,
+    dstTime: timestamp,
+    dstChain: 'base',
+    dstTxHash: `0x${transferId}dst`,
+    dstLogIndex: 2,
+    dstEventId: 'dst-event',
+    dstTokenAddress: '0xtoken2',
+    dstRawAmount: 1_000n,
+    dstWasMinted: false,
+    dstAbstractTokenId: 'eth',
+    dstSymbol: 'ETH',
+    dstAmount: 1,
+    dstPrice: 2000,
+    dstValueUsd: 2000,
+    isProcessed: true,
+  }
+}

--- a/packages/public-api/src/routes/interop/getInteropRows.ts
+++ b/packages/public-api/src/routes/interop/getInteropRows.ts
@@ -1,0 +1,201 @@
+import type {
+  Database,
+  InteropMessageRecord,
+  InteropTransferRecord,
+} from '@l2beat/database'
+import { inferInteropBridgeType } from '@l2beat/shared-pure'
+import {
+  INTEROP_ROWS_DEFAULT_LIMIT,
+  type InteropMessage,
+  type InteropMessagesResult,
+  type InteropTransfer,
+  type InteropTransfersResult,
+  parseIntegerParam,
+} from './types'
+import {
+  encodeCursor,
+  fingerprintFilters,
+  type PageCursor,
+} from './utils/cursor'
+
+/** A row query with query-string params already converted and defaulted. */
+export interface InteropRowsParams {
+  plugin: string
+  type: string | undefined
+  app: string | undefined
+  srcChain: string | undefined
+  dstChain: string | undefined
+  from: number | undefined
+  to: number | undefined
+  order: 'asc' | 'desc'
+  limit: number
+}
+
+export function normalizeInteropRowsQuery(query: {
+  plugin: string
+  type?: string
+  app?: string
+  srcChain?: string
+  dstChain?: string
+  from?: string
+  to?: string
+  order?: 'asc' | 'desc'
+  limit?: string
+}): InteropRowsParams {
+  return {
+    plugin: query.plugin,
+    type: query.type,
+    app: query.app,
+    srcChain: query.srcChain,
+    dstChain: query.dstChain,
+    from: parseIntegerParam(query.from),
+    to: parseIntegerParam(query.to),
+    order: query.order ?? 'desc',
+    limit: parseIntegerParam(query.limit) ?? INTEROP_ROWS_DEFAULT_LIMIT,
+  }
+}
+
+/**
+ * Everything that must stay fixed while walking a cursor. `limit` is
+ * deliberately excluded - changing page size mid-walk is harmless.
+ */
+export function interopRowsFingerprint(
+  kind: 'messages' | 'transfers',
+  params: InteropRowsParams,
+): string {
+  return fingerprintFilters({
+    kind,
+    plugin: params.plugin,
+    type: params.type,
+    app: params.app,
+    srcChain: params.srcChain,
+    dstChain: params.dstChain,
+    from: params.from,
+    to: params.to,
+    order: params.order,
+  })
+}
+
+export async function getInteropMessagesData(
+  db: Database,
+  params: InteropRowsParams,
+  cursor: PageCursor | undefined,
+): Promise<InteropMessagesResult> {
+  const rows = await db.interopMessage.getPage({
+    filter: {
+      plugin: params.plugin,
+      type: params.type,
+      app: params.app,
+      srcChain: params.srcChain,
+      dstChain: params.dstChain,
+      from: params.from,
+      to: params.to,
+    },
+    order: params.order,
+    // One extra row tells us whether a next page exists without a count query.
+    limit: params.limit + 1,
+    cursor: cursor && { timestamp: cursor.timestamp, messageId: cursor.id },
+  })
+
+  const page = rows.slice(0, params.limit)
+  const last = rows.length > params.limit ? page.at(-1) : undefined
+
+  return {
+    data: page.map(toInteropMessage),
+    nextCursor: last
+      ? encodeCursor(
+          { timestamp: last.timestamp, id: last.messageId },
+          interopRowsFingerprint('messages', params),
+        )
+      : null,
+  }
+}
+
+export async function getInteropTransfersData(
+  db: Database,
+  params: InteropRowsParams,
+  cursor: PageCursor | undefined,
+): Promise<InteropTransfersResult> {
+  const rows = await db.interopTransfer.getPage({
+    filter: {
+      plugin: params.plugin,
+      type: params.type,
+      srcChain: params.srcChain,
+      dstChain: params.dstChain,
+      from: params.from,
+      to: params.to,
+    },
+    order: params.order,
+    // One extra row tells us whether a next page exists without a count query.
+    limit: params.limit + 1,
+    cursor: cursor && { timestamp: cursor.timestamp, transferId: cursor.id },
+  })
+
+  const page = rows.slice(0, params.limit)
+  const last = rows.length > params.limit ? page.at(-1) : undefined
+
+  return {
+    data: page.map(toInteropTransfer),
+    nextCursor: last
+      ? encodeCursor(
+          { timestamp: last.timestamp, id: last.transferId },
+          interopRowsFingerprint('transfers', params),
+        )
+      : null,
+  }
+}
+
+function toInteropMessage(record: InteropMessageRecord): InteropMessage {
+  return {
+    plugin: record.plugin,
+    type: record.type,
+    app: record.app,
+    messageId: record.messageId,
+    timestamp: record.timestamp,
+    duration: record.duration ?? null,
+    srcChain: record.srcChain ?? null,
+    srcTime: record.srcTime ?? null,
+    srcTxHash: record.srcTxHash ?? null,
+    srcLogIndex: record.srcLogIndex ?? null,
+    dstChain: record.dstChain ?? null,
+    dstTime: record.dstTime ?? null,
+    dstTxHash: record.dstTxHash ?? null,
+    dstLogIndex: record.dstLogIndex ?? null,
+  }
+}
+
+function toInteropTransfer(record: InteropTransferRecord): InteropTransfer {
+  return {
+    plugin: record.plugin,
+    type: record.type,
+    transferId: record.transferId,
+    bridgeType: record.bridgeType ?? inferInteropBridgeType(record),
+    timestamp: record.timestamp,
+    duration: record.duration ?? null,
+    srcChain: record.srcChain,
+    srcTime: record.srcTime ?? null,
+    srcTxHash: record.srcTxHash ?? null,
+    srcLogIndex: record.srcLogIndex ?? null,
+    srcTokenAddress: record.srcTokenAddress ?? null,
+    srcAbstractTokenId: record.srcAbstractTokenId ?? null,
+    srcSymbol: record.srcSymbol ?? null,
+    srcRawAmount: record.srcRawAmount?.toString() ?? null,
+    srcAmount: record.srcAmount ?? null,
+    srcPrice: record.srcPrice ?? null,
+    srcValueUsd: record.srcValueUsd ?? null,
+    srcWasBurned: record.srcWasBurned ?? null,
+    dstChain: record.dstChain,
+    dstTime: record.dstTime ?? null,
+    dstTxHash: record.dstTxHash ?? null,
+    dstLogIndex: record.dstLogIndex ?? null,
+    dstTokenAddress: record.dstTokenAddress ?? null,
+    dstAbstractTokenId: record.dstAbstractTokenId ?? null,
+    dstSymbol: record.dstSymbol ?? null,
+    dstRawAmount: record.dstRawAmount?.toString() ?? null,
+    dstAmount: record.dstAmount ?? null,
+    dstPrice: record.dstPrice ?? null,
+    dstValueUsd: record.dstValueUsd ?? null,
+    dstWasMinted: record.dstWasMinted ?? null,
+    isProcessed: record.isProcessed,
+  }
+}

--- a/packages/public-api/src/routes/interop/routes.ts
+++ b/packages/public-api/src/routes/interop/routes.ts
@@ -1,12 +1,30 @@
 import type { ProjectService } from '@l2beat/config'
 import type { Database } from '@l2beat/database'
 import { type InMemoryCache, UnixTime } from '@l2beat/shared-pure'
-import type { OpenApi } from '../../OpenApi'
+import { BadRequestResponse, type OpenApi } from '../../OpenApi'
 import { getInteropChainsData, getInteropProtocolsData } from './getInteropData'
+import { getInteropPluginsData } from './getInteropPlugins'
+import {
+  getInteropMessagesData,
+  getInteropTransfersData,
+  interopRowsFingerprint,
+  normalizeInteropRowsQuery,
+} from './getInteropRows'
 import {
   InteropChainsResultSchema,
+  InteropMessagesQuerySchema,
+  InteropMessagesResultSchema,
+  InteropPluginsResultSchema,
   InteropProtocolsResultSchema,
+  InteropTransfersQuerySchema,
+  InteropTransfersResultSchema,
 } from './types'
+import { decodeCursor, type PageCursor } from './utils/cursor'
+
+const RETENTION_NOTE =
+  'Rows are retained for a limited window only - see oldestTimestamp in /v1/interop/plugins - and are deleted afterwards. ' +
+  'To accumulate history, poll with overlapping windows and de-duplicate on the row id. ' +
+  'A row can also be inserted with an older timestamp than rows already returned, because it is only written once both sides are matched.'
 
 export function addInteropRoutes(
   openapi: OpenApi,
@@ -55,4 +73,140 @@ export function addInteropRoutes(
       res.json(data)
     },
   )
+
+  openapi.get(
+    '/v1/interop/plugins',
+    {
+      summary:
+        'List interop plugins with the message and transfer types they emit.',
+      description:
+        'Use this to discover valid `plugin` and `type` values for /v1/interop/messages and /v1/interop/transfers, ' +
+        'and to see how much data is currently retained for each of them. Counts and timestamps are cached for up to 15 minutes.',
+      tags: ['interop'],
+      result: InteropPluginsResultSchema,
+    },
+    async (_, res) => {
+      const data = await cache.get(
+        {
+          key: ['interop', 'plugins'],
+          ttl: 15 * UnixTime.MINUTE,
+          staleWhileRevalidate: 15 * UnixTime.MINUTE,
+        },
+        () => getInteropPluginsData(db),
+      )
+
+      res.json(data)
+    },
+  )
+
+  openapi.get(
+    '/v1/interop/messages',
+    {
+      summary: 'List individual cross-chain messages for a plugin.',
+      description: `Keyset-paginated, ordered by (timestamp, messageId). ${RETENTION_NOTE}`,
+      tags: ['interop'],
+      query: InteropMessagesQuerySchema,
+      result: InteropMessagesResultSchema,
+      errors: {
+        400: BadRequestResponse,
+      },
+    },
+    async (req, res) => {
+      const params = normalizeInteropRowsQuery(req.query)
+      const cursor = readCursor(
+        req.query.cursor,
+        interopRowsFingerprint('messages', params),
+      )
+      if ('error' in cursor) {
+        res.status(400).json({ path: '.query.cursor', message: cursor.error })
+        return
+      }
+
+      const data = await getInteropMessagesData(db, params, cursor.value)
+
+      if (
+        data.data.length === 0 &&
+        req.query.cursor === undefined &&
+        !(await db.interopMessage.hasPlugin(params.plugin))
+      ) {
+        res.status(400).json(unknownPluginError(params.plugin))
+        return
+      }
+
+      res.json(data)
+    },
+  )
+
+  openapi.get(
+    '/v1/interop/transfers',
+    {
+      summary: 'List individual cross-chain transfers for a plugin.',
+      description:
+        `Keyset-paginated, ordered by (timestamp, transferId). ${RETENTION_NOTE} ` +
+        'Transfer rows are additionally updated in place once token resolution and pricing complete - see isProcessed.',
+      tags: ['interop'],
+      query: InteropTransfersQuerySchema,
+      result: InteropTransfersResultSchema,
+      errors: {
+        400: BadRequestResponse,
+      },
+    },
+    async (req, res) => {
+      const params = normalizeInteropRowsQuery(req.query)
+      const cursor = readCursor(
+        req.query.cursor,
+        interopRowsFingerprint('transfers', params),
+      )
+      if ('error' in cursor) {
+        res.status(400).json({ path: '.query.cursor', message: cursor.error })
+        return
+      }
+
+      const data = await getInteropTransfersData(db, params, cursor.value)
+
+      if (
+        data.data.length === 0 &&
+        req.query.cursor === undefined &&
+        !(await db.interopTransfer.hasPlugin(params.plugin))
+      ) {
+        res.status(400).json(unknownPluginError(params.plugin))
+        return
+      }
+
+      res.json(data)
+    },
+  )
+}
+
+/**
+ * Only reachable when the plugin has no retained rows at all, so a client
+ * polling a live plugin with an empty `from`/`to` window still gets a 200 with
+ * an empty page. A typo, on the other hand, never looks like "no new data".
+ */
+function unknownPluginError(plugin: string) {
+  return {
+    path: '.query.plugin',
+    message: `No data is retained for plugin "${plugin}". See /v1/interop/plugins for the plugins that currently have data.`,
+  }
+}
+
+function readCursor(
+  raw: string | undefined,
+  fingerprint: string,
+): { value: PageCursor | undefined } | { error: string } {
+  if (raw === undefined) {
+    return { value: undefined }
+  }
+
+  const decoded = decodeCursor(raw, fingerprint)
+  if (decoded.ok) {
+    return { value: decoded.cursor }
+  }
+
+  return {
+    error:
+      decoded.reason === 'malformed'
+        ? 'Malformed cursor. Pass back the nextCursor value from a previous response verbatim.'
+        : 'This cursor was issued for a different filter set or order. Restart pagination without a cursor after changing filters.',
+  }
 }

--- a/packages/public-api/src/routes/interop/types.ts
+++ b/packages/public-api/src/routes/interop/types.ts
@@ -1,4 +1,5 @@
-import { v } from '@l2beat/validate'
+import { InteropBridgeTypeValues } from '@l2beat/shared-pure'
+import { type Validator, v } from '@l2beat/validate'
 
 const SplitAverageTransferTimeSchema = v.object({
   label: v.string(),
@@ -70,3 +71,196 @@ export const InteropChainSchema = v
 
 export type InteropChain = v.infer<typeof InteropChainSchema>
 export const InteropChainsResultSchema = v.array(InteropChainSchema)
+
+const nullable = <T>(validator: Validator<T>) => v.union([validator, v.null()])
+
+const MAX_UNIX_TIME = 4102444800 // 2100-01-01
+
+/**
+ * Query params always arrive as strings. They are validated here and converted
+ * by `parseIntegerParam` at the call site, which keeps the query schema a
+ * `Validator` - `transform` would downgrade it to a bare `Parser`.
+ */
+const integerParam = (name: string, min: number, max: number) =>
+  v
+    .string()
+    .check((raw) => {
+      const value = Number(raw)
+      return Number.isInteger(value) && value >= min && value <= max
+    }, `${name} must be an integer between ${min} and ${max}`)
+    .meta({ format: 'integer' })
+
+export function parseIntegerParam(raw: string | undefined): number | undefined {
+  return raw === undefined ? undefined : Number(raw)
+}
+
+export const INTEROP_ROWS_MAX_LIMIT = 1000
+export const INTEROP_ROWS_DEFAULT_LIMIT = 100
+
+const InteropRowsQueryBase = {
+  plugin: v.string().meta({
+    description:
+      'Plugin id. Required - it bounds every query to a single plugin. Discoverable via /v1/interop/plugins.',
+  }),
+  type: v.string().optional().meta({
+    description: 'Exact message/transfer type, e.g. "across.Transfer".',
+  }),
+  srcChain: v.string().optional(),
+  dstChain: v.string().optional(),
+  from: integerParam('from', 0, MAX_UNIX_TIME).optional().meta({
+    description: 'Inclusive lower bound on timestamp, unix seconds.',
+  }),
+  to: integerParam('to', 0, MAX_UNIX_TIME).optional().meta({
+    description: 'Exclusive upper bound on timestamp, unix seconds.',
+  }),
+  order: v.enum(['asc', 'desc']).optional().meta({
+    description: 'Order by (timestamp, id). Defaults to desc.',
+  }),
+  limit: integerParam('limit', 1, INTEROP_ROWS_MAX_LIMIT)
+    .optional()
+    .meta({
+      description: `Rows per page, 1-${INTEROP_ROWS_MAX_LIMIT}. Defaults to ${INTEROP_ROWS_DEFAULT_LIMIT}.`,
+    }),
+  cursor: v.string().optional().meta({
+    description:
+      'Opaque cursor from a previous response. Only valid for the filter set and order that produced it.',
+  }),
+}
+
+export const InteropMessagesQuerySchema = v.object({
+  ...InteropRowsQueryBase,
+  app: v.string().optional().meta({
+    description: 'Exact app name attributed to the message.',
+  }),
+})
+export type InteropMessagesQuery = v.infer<typeof InteropMessagesQuerySchema>
+
+export const InteropTransfersQuerySchema = v.object(InteropRowsQueryBase)
+export type InteropTransfersQuery = v.infer<typeof InteropTransfersQuerySchema>
+
+export const InteropMessageSchema = v
+  .object({
+    plugin: v.string(),
+    type: v.string(),
+    app: v.string(),
+    messageId: v.string(),
+    timestamp: v.number().meta({
+      description:
+        'max(srcTime, dstTime) in unix seconds - the sort key of this endpoint.',
+    }),
+    duration: nullable(v.number()).meta({
+      description: 'dstTime - srcTime in seconds.',
+    }),
+    srcChain: nullable(v.string()),
+    srcTime: nullable(v.number()),
+    srcTxHash: nullable(v.string()),
+    srcLogIndex: nullable(v.number()),
+    dstChain: nullable(v.string()),
+    dstTime: nullable(v.number()),
+    dstTxHash: nullable(v.string()),
+    dstLogIndex: nullable(v.number()),
+  })
+  .describe('InteropMessage')
+
+export type InteropMessage = v.infer<typeof InteropMessageSchema>
+
+export const InteropMessagesResultSchema = v
+  .object({
+    data: v.array(InteropMessageSchema),
+    nextCursor: nullable(v.string()).meta({
+      description:
+        'Pass back as `cursor` to fetch the next page. Null on the last page.',
+    }),
+  })
+  .describe('InteropMessagesResult')
+
+export type InteropMessagesResult = v.infer<typeof InteropMessagesResultSchema>
+
+export const InteropTransferSchema = v
+  .object({
+    plugin: v.string(),
+    type: v.string(),
+    transferId: v.string(),
+    bridgeType: v.enum(InteropBridgeTypeValues).meta({
+      description:
+        'Plugin-declared bridge type, or one derived from srcWasBurned/dstWasMinted when the plugin did not declare it.',
+    }),
+    timestamp: v.number().meta({
+      description:
+        'max(srcTime, dstTime) in unix seconds - the sort key of this endpoint.',
+    }),
+    duration: nullable(v.number()).meta({
+      description: 'dstTime - srcTime in seconds.',
+    }),
+    srcChain: v.string(),
+    srcTime: nullable(v.number()),
+    srcTxHash: nullable(v.string()),
+    srcLogIndex: nullable(v.number()),
+    srcTokenAddress: nullable(v.string()),
+    srcAbstractTokenId: nullable(v.string()),
+    srcSymbol: nullable(v.string()),
+    srcRawAmount: nullable(v.string()).meta({
+      description:
+        'Exact on-chain amount as a decimal string. Prefer this over srcAmount, which is a single-precision float.',
+    }),
+    srcAmount: nullable(v.number()),
+    srcPrice: nullable(v.number()),
+    srcValueUsd: nullable(v.number()),
+    srcWasBurned: nullable(v.boolean()),
+    dstChain: v.string(),
+    dstTime: nullable(v.number()),
+    dstTxHash: nullable(v.string()),
+    dstLogIndex: nullable(v.number()),
+    dstTokenAddress: nullable(v.string()),
+    dstAbstractTokenId: nullable(v.string()),
+    dstSymbol: nullable(v.string()),
+    dstRawAmount: nullable(v.string()).meta({
+      description:
+        'Exact on-chain amount as a decimal string. Prefer this over dstAmount, which is a single-precision float.',
+    }),
+    dstAmount: nullable(v.number()),
+    dstPrice: nullable(v.number()),
+    dstValueUsd: nullable(v.number()),
+    dstWasMinted: nullable(v.boolean()),
+    isProcessed: v.boolean().meta({
+      description:
+        'False while token resolution and pricing are still pending, in which case symbol/amount/price/valueUsd fields are not yet populated. Rows are updated in place after insertion.',
+    }),
+  })
+  .describe('InteropTransfer')
+
+export type InteropTransfer = v.infer<typeof InteropTransferSchema>
+
+export const InteropTransfersResultSchema = v
+  .object({
+    data: v.array(InteropTransferSchema),
+    nextCursor: nullable(v.string()).meta({
+      description:
+        'Pass back as `cursor` to fetch the next page. Null on the last page.',
+    }),
+  })
+  .describe('InteropTransfersResult')
+
+export type InteropTransfersResult = v.infer<
+  typeof InteropTransfersResultSchema
+>
+
+const InteropTypeSummarySchema = v
+  .object({
+    type: v.string(),
+    count: v.number(),
+    oldestTimestamp: v.number(),
+    newestTimestamp: v.number(),
+  })
+  .describe('InteropTypeSummary')
+
+export const InteropPluginSchema = v
+  .object({
+    plugin: v.string(),
+    messageTypes: v.array(InteropTypeSummarySchema),
+    transferTypes: v.array(InteropTypeSummarySchema),
+  })
+  .describe('InteropPlugin')
+
+export type InteropPlugin = v.infer<typeof InteropPluginSchema>
+export const InteropPluginsResultSchema = v.array(InteropPluginSchema)

--- a/packages/public-api/src/routes/interop/utils/cursor.test.ts
+++ b/packages/public-api/src/routes/interop/utils/cursor.test.ts
@@ -1,0 +1,103 @@
+import { expect } from 'earl'
+import { decodeCursor, encodeCursor, fingerprintFilters } from './cursor'
+
+describe('interop cursor', () => {
+  describe(fingerprintFilters.name, () => {
+    it('ignores key order and undefined values', () => {
+      expect(
+        fingerprintFilters({
+          plugin: 'across',
+          type: undefined,
+          order: 'desc',
+        }),
+      ).toEqual(fingerprintFilters({ order: 'desc', plugin: 'across' }))
+    })
+
+    it('changes when a filter value changes', () => {
+      expect(fingerprintFilters({ plugin: 'across' })).not.toEqual(
+        fingerprintFilters({ plugin: 'cctp' }),
+      )
+    })
+
+    it('distinguishes a set value from an absent one', () => {
+      expect(fingerprintFilters({ plugin: 'a', srcChain: 'base' })).not.toEqual(
+        fingerprintFilters({ plugin: 'a' }),
+      )
+    })
+  })
+
+  describe(decodeCursor.name, () => {
+    const fingerprint = fingerprintFilters({ plugin: 'across' })
+
+    it('round-trips a cursor', () => {
+      const encoded = encodeCursor({ timestamp: 1700, id: 'T123' }, fingerprint)
+
+      expect(decodeCursor(encoded, fingerprint)).toEqual({
+        ok: true,
+        cursor: { timestamp: 1700, id: 'T123' },
+      })
+    })
+
+    it('rejects a cursor issued for different filters', () => {
+      const encoded = encodeCursor({ timestamp: 1700, id: 'T123' }, fingerprint)
+
+      expect(
+        decodeCursor(encoded, fingerprintFilters({ plugin: 'cctp' })),
+      ).toEqual({ ok: false, reason: 'filtersChanged' })
+    })
+
+    it('rejects garbage', () => {
+      expect(decodeCursor('not-a-cursor', fingerprint)).toEqual({
+        ok: false,
+        reason: 'malformed',
+      })
+    })
+
+    it('rejects a payload that is not an object', () => {
+      const encoded = Buffer.from('"nope"', 'utf8').toString('base64url')
+
+      expect(decodeCursor(encoded, fingerprint)).toEqual({
+        ok: false,
+        reason: 'malformed',
+      })
+    })
+
+    it('rejects a payload with wrongly typed fields', () => {
+      const encoded = Buffer.from(
+        JSON.stringify({ t: '1700', i: 'T123', f: fingerprint }),
+        'utf8',
+      ).toString('base64url')
+
+      expect(decodeCursor(encoded, fingerprint)).toEqual({
+        ok: false,
+        reason: 'malformed',
+      })
+    })
+
+    it('rejects a payload with a missing field', () => {
+      const encoded = Buffer.from(
+        JSON.stringify({ t: 1700, i: 'T123' }),
+        'utf8',
+      ).toString('base64url')
+
+      expect(decodeCursor(encoded, fingerprint)).toEqual({
+        ok: false,
+        reason: 'malformed',
+      })
+    })
+
+    it('rejects a timestamp that is not a safe integer', () => {
+      for (const t of [1.5, 1e300]) {
+        const encoded = Buffer.from(
+          JSON.stringify({ t, i: 'T123', f: fingerprint }),
+          'utf8',
+        ).toString('base64url')
+
+        expect(decodeCursor(encoded, fingerprint)).toEqual({
+          ok: false,
+          reason: 'malformed',
+        })
+      }
+    })
+  })
+})

--- a/packages/public-api/src/routes/interop/utils/cursor.ts
+++ b/packages/public-api/src/routes/interop/utils/cursor.ts
@@ -1,0 +1,67 @@
+import { createHash } from 'node:crypto'
+import { v } from '@l2beat/validate'
+
+export interface PageCursor {
+  timestamp: number
+  id: string
+}
+
+/**
+ * Keyset cursors are only meaningful for the exact filter set that produced
+ * them - reusing one with different filters would silently interleave two
+ * result sets. The fingerprint lets us reject that with a 400 instead.
+ */
+export function fingerprintFilters(
+  filters: Record<string, string | number | undefined>,
+): string {
+  const canonical = Object.entries(filters)
+    .filter(([, value]) => value !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('&')
+
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 12)
+}
+
+export function encodeCursor(cursor: PageCursor, fingerprint: string): string {
+  const payload = JSON.stringify({
+    t: cursor.timestamp,
+    i: cursor.id,
+    f: fingerprint,
+  })
+
+  return Buffer.from(payload, 'utf8').toString('base64url')
+}
+
+export type DecodeCursorResult =
+  | { ok: true; cursor: PageCursor }
+  | { ok: false; reason: 'malformed' | 'filtersChanged' }
+
+const CursorPayload = v.object({
+  t: v.number().check(Number.isSafeInteger),
+  i: v.string(),
+  f: v.string(),
+})
+
+export function decodeCursor(
+  raw: string,
+  fingerprint: string,
+): DecodeCursorResult {
+  let decoded: unknown
+  try {
+    decoded = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'))
+  } catch {
+    return { ok: false, reason: 'malformed' }
+  }
+
+  const payload = CursorPayload.safeParse(decoded)
+  if (!payload.success) {
+    return { ok: false, reason: 'malformed' }
+  }
+
+  if (payload.data.f !== fingerprint) {
+    return { ok: false, reason: 'filtersChanged' }
+  }
+
+  return { ok: true, cursor: { timestamp: payload.data.t, id: payload.data.i } }
+}

--- a/packages/shared-pure/src/types/InteropBridgeType.ts
+++ b/packages/shared-pure/src/types/InteropBridgeType.ts
@@ -16,3 +16,26 @@ export const KnownInteropBridgeTypeValues = [
 ] as const
 export const KnownInteropBridgeType = v.enum(KnownInteropBridgeTypeValues)
 export type KnownInteropBridgeType = v.infer<typeof KnownInteropBridgeType>
+
+/**
+ * Derives the bridge type from the observed supply-change flags. Used when a
+ * transfer has no plugin-declared `bridgeType`.
+ */
+export function inferInteropBridgeType(transfer: {
+  srcWasBurned: boolean | undefined
+  dstWasMinted: boolean | undefined
+}): InteropBridgeType {
+  if (
+    (transfer.srcWasBurned === false && transfer.dstWasMinted === true) ||
+    (transfer.srcWasBurned === true && transfer.dstWasMinted === false)
+  ) {
+    return 'lockAndMint'
+  }
+  if (transfer.srcWasBurned === true && transfer.dstWasMinted === true) {
+    return 'burnAndMint'
+  }
+  if (transfer.srcWasBurned === false && transfer.dstWasMinted === false) {
+    return 'nonMinting'
+  }
+  return 'unknown'
+}

--- a/packages/shared/src/tools/InteropTransferClassifier.ts
+++ b/packages/shared/src/tools/InteropTransferClassifier.ts
@@ -1,6 +1,7 @@
-import type {
-  InteropBridgeType,
-  KnownInteropBridgeType,
+import {
+  type InteropBridgeType,
+  inferInteropBridgeType,
+  type KnownInteropBridgeType,
 } from '@l2beat/shared-pure'
 
 export interface InteropTransferForClassification {
@@ -149,19 +150,7 @@ export class InteropTransferClassifier {
       'srcWasBurned' | 'dstWasMinted'
     >,
   ): InteropBridgeType {
-    if (
-      (transfer.srcWasBurned === false && transfer.dstWasMinted === true) ||
-      (transfer.srcWasBurned === true && transfer.dstWasMinted === false)
-    ) {
-      return 'lockAndMint'
-    }
-    if (transfer.srcWasBurned === true && transfer.dstWasMinted === true) {
-      return 'burnAndMint'
-    }
-    if (transfer.srcWasBurned === false && transfer.dstWasMinted === false) {
-      return 'nonMinting'
-    }
-    return 'unknown'
+    return inferInteropBridgeType(transfer)
   }
 
   /**


### PR DESCRIPTION
@codex review

## Endpoints

| Endpoint | Purpose |
| --- | --- |
| `GET /v1/interop/plugins` | Discovery: which plugins and types exist, and how much data is retained for each |
| `GET /v1/interop/messages` | Individual messages for one plugin |
| `GET /v1/interop/transfers` | Individual transfers for one plugin |

Row endpoints take `plugin` (**required**), plus optional `type`, `srcChain`, `dstChain`,
`app` (messages only), `from`, `to`, `order`, `limit`, `cursor`. They return
`{ data, nextCursor }`.

## Context for review

**Retention shapes everything.** `InteropCleanerLoop` keeps messages 1 day and transfers
7 days, so this is a rolling window, not an archive. Extending retention was out of scope.
The endpoints are built for incremental polling instead, and `/v1/interop/plugins` reports
the retained span per type so the window is self-documenting.

**Keyset pagination on `(timestamp, id)`.** Offset would duplicate and skip rows as new ones
land mid-walk. The repository fetches `limit + 1` so `nextCursor` is exact. Cursors carry a
hash of the filter set, so replaying one after changing filters is a `400` rather than two
interleaved result sets. Because a late-matched row can be inserted behind a cursor already
passed, the documented approach for accumulating history is overlapping `from`/`to` windows
de-duplicated on the row id.

**`plugin` is required** — it bounds every query to one plugin instead of scanning the whole
table. A typo returns `400` pointing at `/v1/interop/plugins`; a live plugin with an empty
time window still returns `200` with an empty page.

**Fields differ from the dashboard on purpose:** internal `srcEventId`/`dstEventId` dropped;
`srcTime`/`dstTime` added (the actual latency measurement); raw amounts added as exact decimal
strings because `srcAmount`/`srcValueUsd` are single-precision `@db.Real`; `isProcessed` added
because transfer rows are re-priced in place after insertion, so pending values would
otherwise look absent. Absent values are `null`, not omitted keys.

**`inferBridgeType` moved to `shared-pure`** so the API can match the dashboard's fallback
without `public-api` depending on `@l2beat/shared`. The static method now delegates — no
behavior change for existing callers.

Repository methods live under a `// #region Public API` block in both repositories.

## Risks

- **No index was added** (deliberate). Neither table has an index leading with
  `(plugin, timestamp)`, so these queries sort per call. Bounded by retention and a 1000-row
  cap, but heavy polling will show in DB load. `(plugin, timestamp DESC, id DESC)` is the fix
  if needed.
- **No per-key scoping or rate limiting** exists in this package, so all key holders can read
  these endpoints. Accepted.

