### PR TITLE
Add project logo to privacy project TVL chart

### DIFF
--- a/packages/frontend/src/components/projects/sections/privacy/PrivacyTvlSection.tsx
+++ b/packages/frontend/src/components/projects/sections/privacy/PrivacyTvlSection.tsx
@@ -54,6 +54,7 @@ export function PrivacyTvlSection({
         data={chartData}
         syncedUntil={data?.syncedUntil}
         isLoading={isLoading}
+        project={project}
       />
     </ProjectSection>
   )

--- a/packages/frontend/src/pages/privacy/summary/components/PrivacyTvlChart.tsx
+++ b/packages/frontend/src/pages/privacy/summary/components/PrivacyTvlChart.tsx
@@ -1,6 +1,7 @@
 import { Area, AreaChart } from 'recharts'
 import type {
   ChartMeta,
+  ChartProject,
   CustomChartTooltipProps,
 } from '~/components/core/chart/Chart'
 import {
@@ -30,6 +31,7 @@ interface Props {
   data: PrivacyTvlChartDataPoint[] | undefined
   syncedUntil: number | undefined
   isLoading: boolean
+  project?: ChartProject
 }
 
 const chartMeta = {
@@ -40,9 +42,19 @@ const chartMeta = {
   },
 } satisfies ChartMeta
 
-export function PrivacyTvlChart({ data, syncedUntil, isLoading }: Props) {
+export function PrivacyTvlChart({
+  data,
+  syncedUntil,
+  isLoading,
+  project,
+}: Props) {
   return (
-    <ChartContainer data={data} meta={chartMeta} isLoading={isLoading}>
+    <ChartContainer
+      data={data}
+      meta={chartMeta}
+      isLoading={isLoading}
+      project={project}
+    >
       <AreaChart responsive data={data} margin={{ top: 20 }}>
         <defs>
           <PinkFillGradientDef id="privacy-tvl-fill" />


### PR DESCRIPTION
Resolves L2B-14593

The TVL chart on privacy project detail pages was missing the project logo watermark in the bottom-left corner. `PrivacyTvlChart` never passed a `project` to `ChartContainer`, which is what renders the logo.

Added an optional `project` prop to `PrivacyTvlChart` (mirroring the existing pattern in `PrivacyFlowChart` on the same page) and passed it through from `PrivacyTvlSection`. The privacy summary page keeps using the chart without a logo, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)