### PR TITLE
Fix clipped descenders on home page widget labels

### DIFF
--- a/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeAnomaliesTile.tsx
@@ -33,7 +33,7 @@ export function HomeAnomaliesTile({
             <span className="lg:hidden">Ongoing major anomalies</span>
             <span className="max-lg:hidden">Ongoing anomalies</span>
           </span>
-          <span className="mt-0.5 flex min-w-0 items-center gap-1.5 font-medium text-label-value-12 text-secondary lg:hidden">
+          <span className="mt-0.5 flex min-w-0 items-center gap-1.5 font-medium text-label-value-12 text-secondary leading-tight lg:hidden">
             {isOngoing && first ? (
               <>
                 <img

--- a/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeInteropCard.tsx
@@ -269,10 +269,10 @@ function StatTile({
             )}
           >
             {icon}
-            <span className="min-w-0 truncate">{primary}</span>
+            <span className="min-w-0 truncate leading-tight">{primary}</span>
           </ValueWrapper>
           {secondary !== undefined && (
-            <span className="truncate font-medium text-label-value-12 text-secondary">
+            <span className="truncate font-medium text-label-value-12 text-secondary leading-tight">
               {secondary}
             </span>
           )}

--- a/packages/frontend/src/pages/home/components/HomeInteropSelectedPath.tsx
+++ b/packages/frontend/src/pages/home/components/HomeInteropSelectedPath.tsx
@@ -87,7 +87,7 @@ export function HomeInteropSelectedPath({
         <span className="shrink-0 font-bold text-label-value-15">
           Selected path
         </span>
-        <span className="min-w-0 truncate font-medium text-label-value-12 text-secondary">
+        <span className="min-w-0 truncate font-medium text-label-value-12 text-secondary leading-tight">
           {chainA.name} ↔ {subtitle}
         </span>
       </div>
@@ -159,7 +159,7 @@ export function HomeInteropSelectedPath({
 
 function Row({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <div className="flex items-center justify-between gap-2 text-label-value-12">
+    <div className="flex items-center justify-between gap-2 text-label-value-12 leading-tight">
       <span className="shrink-0 font-medium text-secondary">{label}</span>
       <span className="min-w-0 truncate text-right">{children}</span>
     </div>

--- a/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentChangesTile.tsx
@@ -56,7 +56,7 @@ export function HomeRecentChangesTile({
             </span>
           </span>
 
-          <span className="mt-0.5 truncate font-medium text-label-value-12 text-secondary">
+          <span className="mt-0.5 truncate font-medium text-label-value-12 text-secondary leading-tight">
             <span className="lg:hidden">
               {disabled
                 ? 'No project changes handled this week'

--- a/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeRecentProjectsCard.tsx
@@ -52,10 +52,10 @@ function RecentProjectCard({ project }: { project: HomeRecentProject }) {
         className="size-7 shrink-0 rounded-full"
       />
       <div className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate font-bold text-label-value-14">
+        <span className="truncate font-bold text-label-value-14 leading-tight">
           {project.name}
         </span>
-        <span className="flex items-center gap-1 truncate font-medium text-label-value-12 text-secondary">
+        <span className="flex items-center gap-1 truncate font-medium text-label-value-12 text-secondary leading-tight">
           {subtitle}
         </span>
       </div>

--- a/packages/frontend/src/pages/home/components/RecentChangesDialog.tsx
+++ b/packages/frontend/src/pages/home/components/RecentChangesDialog.tsx
@@ -112,7 +112,7 @@ function RecentChangesBody({
                 alt={group.name}
                 className="size-5 shrink-0 rounded-full"
               />
-              <h3 className="truncate font-bold text-base text-primary leading-none">
+              <h3 className="truncate font-bold text-base text-primary leading-tight">
                 {group.name}
               </h3>
             </span>


### PR DESCRIPTION
Resolves L2B-14638

The `text-label-value-*` typography tokens use 100% line-height. Combined with `truncate` (which sets `overflow: hidden`), this clipped glyph descenders — e.g. the "g" in "ZK Catalog" or the "j" in "projects" — on several home page widgets.

Fix: add `leading-tight` (125%) to the truncating labels, the same pattern the tile titles already use. 125% fits Roboto's natural glyph box (~117%), so descenders render fully while the layout shifts by only ~3px per line.

Touched labels:
- Anomalies tile subtitle
- Recent changes tile subtitle
- Recently added projects: name + category
- Interop card stat tile value + secondary label
- Interop selected path subtitle + stat rows
- Recent changes dialog project heading (had `leading-none`)

Verified in the dev app (MOCK + CLIENT_SIDE_HOME_PAGE) that the affected labels now compute 15px/17.5px line-height instead of 12px/14px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)