### PR TITLE
Add indexed view mode to scaling compare charts

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/components/CompareMetricLineChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareMetricLineChart.tsx
@@ -1,0 +1,241 @@
+import type { ReactNode } from 'react'
+import { useMemo } from 'react'
+import { Line, LineChart } from 'recharts'
+import type { ChartScale } from '~/components/chart/types'
+import type {
+  ChartMeta,
+  CustomChartTooltipProps,
+} from '~/components/core/chart/Chart'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipWrapper,
+  useChart,
+} from '~/components/core/chart/Chart'
+import { ChartCommonComponents } from '~/components/core/chart/ChartCommonComponents'
+import { ChartDataIndicator } from '~/components/core/chart/ChartDataIndicator'
+import { ChartLegendToggleAll } from '~/components/core/chart/ChartLegendToggleAll'
+import { ChartTimeRange } from '~/components/core/chart/ChartTimeRange'
+import { useChartDataKeys } from '~/components/core/chart/hooks/useChartDataKeys'
+import { getChartTimeRangeFromData } from '~/components/core/chart/utils/getChartTimeRangeFromData'
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import { generateAccessibleColors } from '~/utils/generateColors'
+import { formatNumber } from '~/utils/number-format/formatNumber'
+import type { CompareViewMode } from '../utils/compareChartState'
+import {
+  type CompareChartPoint,
+  toIndexedChartData,
+} from '../utils/toIndexedChartData'
+
+interface Props {
+  projects: CompareProjectEntry[]
+  data: CompareChartPoint[] | undefined
+  isLoading: boolean
+  syncedUntil: number | undefined
+  scale: ChartScale
+  mode: CompareViewMode
+  /** Absolute-mode formatters; indexed mode shows unitless index values. */
+  formatYAxisLabel: (value: number) => string
+  formatTooltipValue: (value: number) => string
+  renderTooltipTimestamp: (label: number) => ReactNode
+}
+
+/**
+ * The shared compare chart renderer: legend, lines, axes and tooltip for any
+ * registry metric. Also the single place implementing the indexed view mode -
+ * every series is rebased to 100 client-side, so metrics only supply data and
+ * absolute-value formatting.
+ */
+export function CompareMetricLineChart({
+  projects,
+  data,
+  isLoading,
+  syncedUntil,
+  scale,
+  mode,
+  formatYAxisLabel,
+  formatTooltipValue,
+  renderTooltipTimestamp,
+}: Props) {
+  const chartMeta = useMemo<ChartMeta>(() => {
+    const colors = generateAccessibleColors(projects.length)
+    return projects.reduce<ChartMeta>((acc, project, index) => {
+      acc[project.id] = {
+        label: (
+          <span className="inline-flex items-center gap-1">
+            <img
+              src={project.iconUrl}
+              alt=""
+              width={14}
+              height={14}
+              className="size-3.5 rounded-full"
+            />
+            {project.name}
+          </span>
+        ),
+        legendLabel: project.shortName ?? project.name,
+        color: colors[index] ?? 'var(--secondary)',
+        indicatorType: { shape: 'line' },
+      }
+      return acc
+    }, {})
+  }, [projects])
+
+  const { dataKeys, toggleDataKey, toggleAllDataKeys, showAllSelected } =
+    useChartDataKeys(chartMeta)
+
+  const indexed = mode === 'indexed'
+  const { chartData, rebasedMidRange } = useMemo(() => {
+    if (!data || !indexed) {
+      return { chartData: data, rebasedMidRange: {} }
+    }
+    const result = toIndexedChartData(
+      data,
+      projects.map((project) => project.id),
+    )
+    return { chartData: result.data, rebasedMidRange: result.rebasedMidRange }
+  }, [data, indexed, projects])
+
+  const timeRange = useMemo(
+    () => getChartTimeRangeFromData(chartData),
+    [chartData],
+  )
+
+  return (
+    <div className="flex flex-col">
+      <div className="mt-1 mb-2">
+        <ChartTimeRange timeRange={timeRange} />
+      </div>
+      <ChartContainer
+        data={chartData}
+        meta={chartMeta}
+        isLoading={isLoading}
+        interactiveLegend={{
+          dataKeys,
+          onItemClick: toggleDataKey,
+        }}
+      >
+        {/* Without right:1 the chart last point is not hoverable for some reason */}
+        <LineChart responsive data={chartData} margin={{ top: 20, right: 1 }}>
+          <ChartLegendToggleAll
+            showAllSelected={showAllSelected}
+            onToggleAll={toggleAllDataKeys}
+          />
+          {projects.map((project) => (
+            <Line
+              key={project.id}
+              dataKey={project.id}
+              hide={!dataKeys.includes(project.id)}
+              stroke={chartMeta[project.id]?.color}
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
+          ))}
+          <ChartCommonComponents
+            data={chartData}
+            isLoading={isLoading}
+            yAxis={{
+              scale: !indexed && scale === 'symlog' ? 'symlog' : 'auto',
+              tickCount: 4,
+              tickFormatter: (value) =>
+                indexed
+                  ? formatIndexValue(Number(value))
+                  : formatYAxisLabel(Number(value)),
+            }}
+            syncedUntil={syncedUntil}
+          />
+          <ChartTooltip
+            content={
+              <CustomTooltip
+                formatValue={indexed ? formatIndexValue : formatTooltipValue}
+                renderTimestamp={renderTooltipTimestamp}
+                rebasedMidRange={rebasedMidRange}
+              />
+            }
+          />
+        </LineChart>
+      </ChartContainer>
+    </div>
+  )
+}
+
+function formatIndexValue(value: number) {
+  return formatNumber(value, value < 10 ? 1 : 0)
+}
+
+function CustomTooltip({
+  payload,
+  label,
+  formatValue,
+  renderTimestamp,
+  rebasedMidRange,
+}: CustomChartTooltipProps & {
+  formatValue: (value: number) => string
+  renderTimestamp: (label: number) => ReactNode
+  rebasedMidRange: Record<string, number>
+}) {
+  const { meta } = useChart()
+  if (!payload || typeof label !== 'number') return null
+
+  const visible = payload.filter(
+    (entry) =>
+      entry.type !== 'none' &&
+      !entry.hide &&
+      entry.value !== null &&
+      entry.value !== undefined,
+  )
+  if (visible.length === 0) return null
+
+  const hasRebasedNote = visible.some(
+    (entry) => entry.name && rebasedMidRange[entry.name] !== undefined,
+  )
+
+  return (
+    <ChartTooltipWrapper>
+      <div className="flex w-[200px] flex-col [@media(min-width:600px)]:w-60">
+        <div className="font-medium text-label-value-14 text-secondary">
+          {renderTimestamp(label)}
+        </div>
+        <div className="mt-2 flex flex-col gap-2">
+          {[...visible]
+            .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+            .map((entry) => {
+              const config = entry.name ? meta[entry.name] : undefined
+              if (!config) return null
+              const isRebased =
+                entry.name !== undefined &&
+                rebasedMidRange[entry.name] !== undefined
+              return (
+                <div
+                  key={entry.name}
+                  className="flex items-center justify-between gap-x-3"
+                >
+                  <div className="flex items-center gap-1">
+                    <ChartDataIndicator
+                      backgroundColor={config.color}
+                      type={config.indicatorType}
+                    />
+                    <span className="font-medium text-label-value-14">
+                      {config.label}
+                    </span>
+                  </div>
+                  <span className="whitespace-nowrap font-medium text-label-value-15 text-primary tabular-nums">
+                    {entry.value !== null && entry.value !== undefined
+                      ? `${formatValue(entry.value)}${isRebased ? '*' : ''}`
+                      : 'No data'}
+                  </span>
+                </div>
+              )
+            })}
+        </div>
+        {hasRebasedNote && (
+          <div className="mt-2 font-medium text-2xs text-secondary">
+            * Data starts mid-range; indexed to 100 at the first available data
+            point.
+          </div>
+        )}
+      </div>
+    </ChartTooltipWrapper>
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -16,6 +16,7 @@ import {
   type CompareChartState,
   type CompareClientState,
   type CompareMetricId,
+  type CompareViewMode,
   isSameCompareState,
   toCompareClientState,
   toCompareUrlState,
@@ -81,6 +82,8 @@ export function ScalingCompareChart({
       </div>
       <metric.Chart projects={selectedProjects} state={state} />
       <Controls
+        mode={state.mode}
+        setMode={(mode) => setState((prev) => ({ ...prev, mode }))}
         scale={state.scale}
         setScale={(scale) => setState((prev) => ({ ...prev, scale }))}
         range={state.chartRange}
@@ -175,11 +178,15 @@ function MetricSwitcher({
 }
 
 function Controls({
+  mode,
+  setMode,
   scale,
   setScale,
   range,
   setRange,
 }: {
+  mode: CompareViewMode
+  setMode: (mode: CompareViewMode) => void
   scale: ChartScale
   setScale: (scale: ChartScale) => void
   range: ChartRange
@@ -190,14 +197,28 @@ function Controls({
     <ChartControlsWrapper>
       <div className="flex gap-1">
         {isClient ? (
-          <RadioGroup
-            name="compareChartScale"
-            value={scale}
-            onValueChange={(value) => setScale(value as ChartScale)}
-          >
-            <RadioGroupItem value="symlog">LOG</RadioGroupItem>
-            <RadioGroupItem value="linear">LIN</RadioGroupItem>
-          </RadioGroup>
+          <>
+            <RadioGroup
+              name="compareViewMode"
+              value={mode}
+              onValueChange={(value) => setMode(value as CompareViewMode)}
+            >
+              <RadioGroupItem value="absolute">ABSOLUTE</RadioGroupItem>
+              <RadioGroupItem value="indexed">INDEXED</RadioGroupItem>
+            </RadioGroup>
+            {/* Log scale of an index is meaningless, so the toggle is hidden
+                in indexed mode. */}
+            {mode === 'absolute' && (
+              <RadioGroup
+                name="compareChartScale"
+                value={scale}
+                onValueChange={(value) => setScale(value as ChartScale)}
+              >
+                <RadioGroupItem value="symlog">LOG</RadioGroupItem>
+                <RadioGroupItem value="linear">LIN</RadioGroupItem>
+              </RadioGroup>
+            )}
+          </>
         ) : (
           <Skeleton className="h-8 w-[91px] md:w-[95px]" />
         )}

--- a/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/activity/ActivityCompareChart.tsx
@@ -1,29 +1,12 @@
 import { UnixTime } from '@l2beat/shared-pure'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import { Line, LineChart } from 'recharts'
-import type {
-  ChartMeta,
-  CustomChartTooltipProps,
-} from '~/components/core/chart/Chart'
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipWrapper,
-  useChart,
-} from '~/components/core/chart/Chart'
-import { ChartCommonComponents } from '~/components/core/chart/ChartCommonComponents'
-import { ChartDataIndicator } from '~/components/core/chart/ChartDataIndicator'
-import { ChartLegendToggleAll } from '~/components/core/chart/ChartLegendToggleAll'
-import { ChartTimeRange } from '~/components/core/chart/ChartTimeRange'
-import { useChartDataKeys } from '~/components/core/chart/hooks/useChartDataKeys'
-import { getChartTimeRangeFromData } from '~/components/core/chart/utils/getChartTimeRangeFromData'
 import { countPerSecond } from '~/server/features/scaling/activity/utils/countPerSecond'
 import { useTRPC } from '~/trpc/React'
 import { formatRange } from '~/utils/dates'
-import { generateAccessibleColors } from '~/utils/generateColors'
 import { formatActivityCount } from '~/utils/number-format/formatActivityCount'
-import type { CompareActivityUnit } from '../../utils/compareChartState'
+import { CompareMetricLineChart } from '../../components/CompareMetricLineChart'
+import type { CompareChartPoint } from '../../utils/toIndexedChartData'
 import type { CompareMetricChartProps } from '../types'
 import { getActivityCompareChartParams } from './getActivityCompareChartParams'
 
@@ -39,39 +22,10 @@ export function ActivityCompareChart({
   )
   const unit = state.activityUnit
 
-  const chartMeta = useMemo<ChartMeta>(() => {
-    const colors = generateAccessibleColors(projects.length)
-    return projects.reduce<ChartMeta>((acc, project, index) => {
-      acc[project.id] = {
-        label: (
-          <span className="inline-flex items-center gap-1">
-            <img
-              src={project.iconUrl}
-              alt=""
-              width={14}
-              height={14}
-              className="size-3.5 rounded-full"
-            />
-            {project.name}
-          </span>
-        ),
-        legendLabel: project.shortName ?? project.name,
-        color: colors[index] ?? 'var(--secondary)',
-        indicatorType: { shape: 'line' },
-      }
-      return acc
-    }, {})
-  }, [projects])
-
-  const { dataKeys, toggleDataKey, toggleAllDataKeys, showAllSelected } =
-    useChartDataKeys(chartMeta)
-
   const chartData = useMemo(
     () =>
       data?.chart.map(([timestamp, valuesByProject]) => {
-        const point: { timestamp: number; [key: string]: number | null } = {
-          timestamp,
-        }
+        const point: CompareChartPoint = { timestamp }
         for (const project of projects) {
           const values = valuesByProject[project.id]
           point[project.id] = values
@@ -83,112 +37,21 @@ export function ActivityCompareChart({
     [data, projects, unit],
   )
 
-  const timeRange = useMemo(
-    () => getChartTimeRangeFromData(chartData),
-    [chartData],
-  )
-
   return (
-    <div className="flex flex-col">
-      <div className="mt-1 mb-2">
-        <ChartTimeRange timeRange={timeRange} />
-      </div>
-      <ChartContainer
-        data={chartData}
-        meta={chartMeta}
-        isLoading={isLoading}
-        interactiveLegend={{
-          dataKeys,
-          onItemClick: toggleDataKey,
-        }}
-      >
-        {/* Without right:1 the chart last point is not hoverable for some reason */}
-        <LineChart responsive data={chartData} margin={{ top: 20, right: 1 }}>
-          <ChartLegendToggleAll
-            showAllSelected={showAllSelected}
-            onToggleAll={toggleAllDataKeys}
-          />
-          {projects.map((project) => (
-            <Line
-              key={project.id}
-              dataKey={project.id}
-              hide={!dataKeys.includes(project.id)}
-              stroke={chartMeta[project.id]?.color}
-              strokeWidth={2}
-              dot={false}
-              isAnimationActive={false}
-            />
-          ))}
-          <ChartCommonComponents
-            data={chartData}
-            isLoading={isLoading}
-            yAxis={{
-              scale: state.scale === 'symlog' ? 'symlog' : 'auto',
-              tickCount: 4,
-              tickFormatter: (value) => formatActivityCount(Number(value)),
-            }}
-            syncedUntil={data?.syncedUntil}
-          />
-          <ChartTooltip content={<CustomTooltip unit={unit} />} />
-        </LineChart>
-      </ChartContainer>
-    </div>
-  )
-}
-
-function CustomTooltip({
-  payload,
-  label,
-  unit,
-}: CustomChartTooltipProps & { unit: CompareActivityUnit }) {
-  const { meta } = useChart()
-  if (!payload || typeof label !== 'number') return null
-
-  const visible = payload.filter(
-    (entry) =>
-      entry.type !== 'none' &&
-      !entry.hide &&
-      entry.value !== null &&
-      entry.value !== undefined,
-  )
-  if (visible.length === 0) return null
-
-  return (
-    <ChartTooltipWrapper>
-      <div className="flex w-[200px] flex-col [@media(min-width:600px)]:w-60">
-        <div className="font-medium text-label-value-14 text-secondary">
-          {formatRange(label, label + UnixTime.DAY)}
-        </div>
-        <div className="mt-2 flex flex-col gap-2">
-          {[...visible]
-            .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
-            .map((entry) => {
-              const config = entry.name ? meta[entry.name] : undefined
-              if (!config) return null
-              return (
-                <div
-                  key={entry.name}
-                  className="flex items-center justify-between gap-x-3"
-                >
-                  <div className="flex items-center gap-1">
-                    <ChartDataIndicator
-                      backgroundColor={config.color}
-                      type={config.indicatorType}
-                    />
-                    <span className="font-medium text-label-value-14">
-                      {config.label}
-                    </span>
-                  </div>
-                  <span className="whitespace-nowrap font-medium text-label-value-15 text-primary tabular-nums">
-                    {entry.value !== null && entry.value !== undefined
-                      ? `${formatActivityCount(entry.value)} ${unit.toUpperCase()}`
-                      : 'No data'}
-                  </span>
-                </div>
-              )
-            })}
-        </div>
-      </div>
-    </ChartTooltipWrapper>
+    <CompareMetricLineChart
+      projects={projects}
+      data={chartData}
+      isLoading={isLoading}
+      syncedUntil={data?.syncedUntil}
+      scale={state.scale}
+      mode={state.mode}
+      formatYAxisLabel={(value) => formatActivityCount(value)}
+      formatTooltipValue={(value) =>
+        `${formatActivityCount(value)} ${unit.toUpperCase()}`
+      }
+      renderTooltipTimestamp={(label) =>
+        formatRange(label, label + UnixTime.DAY)
+      }
+    />
   )
 }

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
@@ -1,26 +1,10 @@
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
-import { Line, LineChart } from 'recharts'
-import type {
-  ChartMeta,
-  CustomChartTooltipProps,
-} from '~/components/core/chart/Chart'
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipWrapper,
-  useChart,
-} from '~/components/core/chart/Chart'
-import { ChartCommonComponents } from '~/components/core/chart/ChartCommonComponents'
-import { ChartDataIndicator } from '~/components/core/chart/ChartDataIndicator'
-import { ChartLegendToggleAll } from '~/components/core/chart/ChartLegendToggleAll'
-import { ChartTimeRange } from '~/components/core/chart/ChartTimeRange'
-import { useChartDataKeys } from '~/components/core/chart/hooks/useChartDataKeys'
-import { getChartTimeRangeFromData } from '~/components/core/chart/utils/getChartTimeRangeFromData'
 import { useTRPC } from '~/trpc/React'
 import { formatTimestamp } from '~/utils/dates'
-import { generateAccessibleColors } from '~/utils/generateColors'
 import { formatCurrency } from '~/utils/number-format/formatCurrency'
+import { CompareMetricLineChart } from '../../components/CompareMetricLineChart'
+import type { CompareChartPoint } from '../../utils/toIndexedChartData'
 import type { CompareMetricChartProps } from '../types'
 import { getTvsCompareChartParams } from './getTvsCompareChartParams'
 
@@ -32,39 +16,10 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
     ),
   )
 
-  const chartMeta = useMemo<ChartMeta>(() => {
-    const colors = generateAccessibleColors(projects.length)
-    return projects.reduce<ChartMeta>((acc, project, index) => {
-      acc[project.id] = {
-        label: (
-          <span className="inline-flex items-center gap-1">
-            <img
-              src={project.iconUrl}
-              alt=""
-              width={14}
-              height={14}
-              className="size-3.5 rounded-full"
-            />
-            {project.name}
-          </span>
-        ),
-        legendLabel: project.shortName ?? project.name,
-        color: colors[index] ?? 'var(--secondary)',
-        indicatorType: { shape: 'line' },
-      }
-      return acc
-    }, {})
-  }, [projects])
-
-  const { dataKeys, toggleDataKey, toggleAllDataKeys, showAllSelected } =
-    useChartDataKeys(chartMeta)
-
   const chartData = useMemo(
     () =>
       data?.chart.map(([timestamp, _ethPrice, valuesByProject]) => {
-        const point: { timestamp: number; [key: string]: number | null } = {
-          timestamp,
-        }
+        const point: CompareChartPoint = { timestamp }
         for (const project of projects) {
           point[project.id] = valuesByProject[project.id]?.[0] ?? null
         }
@@ -73,111 +28,22 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
     [data, projects],
   )
 
-  const timeRange = useMemo(
-    () => getChartTimeRangeFromData(chartData),
-    [chartData],
-  )
-
   return (
-    <div className="flex flex-col">
-      <div className="mt-1 mb-2">
-        <ChartTimeRange timeRange={timeRange} />
-      </div>
-      <ChartContainer
-        data={chartData}
-        meta={chartMeta}
-        isLoading={isLoading}
-        interactiveLegend={{
-          dataKeys,
-          onItemClick: toggleDataKey,
-        }}
-      >
-        {/* Without right:1 the chart last point is not hoverable for some reason */}
-        <LineChart responsive data={chartData} margin={{ top: 20, right: 1 }}>
-          <ChartLegendToggleAll
-            showAllSelected={showAllSelected}
-            onToggleAll={toggleAllDataKeys}
-          />
-          {projects.map((project) => (
-            <Line
-              key={project.id}
-              dataKey={project.id}
-              hide={!dataKeys.includes(project.id)}
-              stroke={chartMeta[project.id]?.color}
-              strokeWidth={2}
-              dot={false}
-              isAnimationActive={false}
-            />
-          ))}
-          <ChartCommonComponents
-            data={chartData}
-            isLoading={isLoading}
-            yAxis={{
-              scale: state.scale === 'symlog' ? 'symlog' : 'auto',
-              tickCount: 4,
-              tickFormatter: (value) => formatCurrency(Number(value), 'usd'),
-            }}
-            syncedUntil={data?.syncedUntil}
-          />
-          <ChartTooltip content={<CustomTooltip />} />
-        </LineChart>
-      </ChartContainer>
-    </div>
-  )
-}
-
-function CustomTooltip({ payload, label }: CustomChartTooltipProps) {
-  const { meta } = useChart()
-  if (!payload || typeof label !== 'number') return null
-
-  const visible = payload.filter(
-    (entry) =>
-      entry.type !== 'none' &&
-      !entry.hide &&
-      entry.value !== null &&
-      entry.value !== undefined,
-  )
-  if (visible.length === 0) return null
-
-  return (
-    <ChartTooltipWrapper>
-      <div className="flex w-[200px] flex-col [@media(min-width:600px)]:w-60">
-        <div className="font-medium text-label-value-14 text-secondary">
-          {formatTimestamp(label, {
-            longMonthName: true,
-            mode: 'datetime',
-          })}
-        </div>
-        <div className="mt-2 flex flex-col gap-2">
-          {[...visible]
-            .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
-            .map((entry) => {
-              const config = entry.name ? meta[entry.name] : undefined
-              if (!config) return null
-              return (
-                <div
-                  key={entry.name}
-                  className="flex items-center justify-between gap-x-3"
-                >
-                  <div className="flex items-center gap-1">
-                    <ChartDataIndicator
-                      backgroundColor={config.color}
-                      type={config.indicatorType}
-                    />
-                    <span className="font-medium text-label-value-14">
-                      {config.label}
-                    </span>
-                  </div>
-                  <span className="whitespace-nowrap font-medium text-label-value-15 text-primary tabular-nums">
-                    {entry.value !== null && entry.value !== undefined
-                      ? formatCurrency(entry.value, 'usd')
-                      : 'No data'}
-                  </span>
-                </div>
-              )
-            })}
-        </div>
-      </div>
-    </ChartTooltipWrapper>
+    <CompareMetricLineChart
+      projects={projects}
+      data={chartData}
+      isLoading={isLoading}
+      syncedUntil={data?.syncedUntil}
+      scale={state.scale}
+      mode={state.mode}
+      formatYAxisLabel={(value) => formatCurrency(value, 'usd')}
+      formatTooltipValue={(value) => formatCurrency(value, 'usd')}
+      renderTooltipTimestamp={(label) =>
+        formatTimestamp(label, {
+          longMonthName: true,
+          mode: 'datetime',
+        })
+      }
+    />
   )
 }

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
@@ -10,6 +10,7 @@ describe(buildCompareUrl.name, () => {
       projects: [],
       range: '1y',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'uops',
     })
 
@@ -22,6 +23,7 @@ describe(buildCompareUrl.name, () => {
       projects: ['arbitrum', 'base'],
       range: '1y',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'uops',
     })
 
@@ -34,6 +36,7 @@ describe(buildCompareUrl.name, () => {
       projects: ['arbitrum'],
       range: '30d',
       scale: 'symlog',
+      mode: 'absolute',
       activityUnit: 'uops',
     })
 
@@ -48,10 +51,37 @@ describe(buildCompareUrl.name, () => {
       projects: [],
       range: { from: 1700000000, to: 1710000000 },
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?range=1700000000-1710000000')
+  })
+
+  it('serializes the indexed mode', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'tvs',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+      mode: 'indexed',
+      activityUnit: 'uops',
+    })
+
+    expect(url).toEqual('/scaling/compare?mode=indexed')
+  })
+
+  it('omits the scale in indexed mode where its toggle is hidden', () => {
+    const url = buildCompareUrl(PATH, {
+      metric: 'tvs',
+      projects: [],
+      range: '1y',
+      scale: 'symlog',
+      mode: 'indexed',
+      activityUnit: 'uops',
+    })
+
+    expect(url).toEqual('/scaling/compare?mode=indexed')
   })
 
   it('serializes a non-default metric with its non-default unit', () => {
@@ -60,6 +90,7 @@ describe(buildCompareUrl.name, () => {
       projects: [],
       range: '1y',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'tps',
     })
 
@@ -72,6 +103,7 @@ describe(buildCompareUrl.name, () => {
       projects: [],
       range: '1y',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'uops',
     })
 
@@ -84,6 +116,7 @@ describe(buildCompareUrl.name, () => {
       projects: [],
       range: '1y',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'tps',
     })
 

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
+  DEFAULT_COMPARE_VIEW_MODE,
 } from './compareChartState'
 
 /**
@@ -26,7 +27,11 @@ export function buildCompareUrl(
   } else if (state.range !== DEFAULT_COMPARE_RANGE) {
     params.set('range', state.range)
   }
-  if (state.scale !== DEFAULT_COMPARE_SCALE) {
+  if (state.mode !== DEFAULT_COMPARE_VIEW_MODE) {
+    params.set('mode', state.mode)
+  }
+  // The scale toggle is hidden in indexed mode, so its value is not encoded.
+  if (state.mode === 'absolute' && state.scale !== DEFAULT_COMPARE_SCALE) {
     params.set('scale', 'log')
   }
   // Per-metric controls are only encoded for the metric they belong to.

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -14,6 +14,9 @@ export type CompareMetricId = (typeof COMPARE_METRIC_IDS)[number]
 export const COMPARE_ACTIVITY_UNITS = ['uops', 'tps'] as const
 export type CompareActivityUnit = (typeof COMPARE_ACTIVITY_UNITS)[number]
 
+export const COMPARE_VIEW_MODES = ['absolute', 'indexed'] as const
+export type CompareViewMode = (typeof COMPARE_VIEW_MODES)[number]
+
 export const COMPARE_RANGE_OPTIONS = [
   '7d',
   '30d',
@@ -33,6 +36,8 @@ export interface CompareChartState {
   projects: string[]
   range: CompareRange
   scale: ChartScale
+  /** Absolute values or every series rebased to 100 at range start. */
+  mode: CompareViewMode
   /** Per-metric control of the activity metric; ignored elsewhere. */
   activityUnit: CompareActivityUnit
 }
@@ -46,6 +51,7 @@ export interface CompareClientState {
   metric: CompareMetricId
   projects: string[]
   scale: ChartScale
+  mode: CompareViewMode
   activityUnit: CompareActivityUnit
   chartRange: ChartRange
 }
@@ -57,6 +63,7 @@ export function toCompareUrlState(
     metric: state.metric,
     projects: state.projects,
     scale: state.scale,
+    mode: state.mode,
     activityUnit: state.activityUnit,
     range: chartRangeToCompareRange(state.chartRange),
   }
@@ -70,6 +77,7 @@ export function toCompareClientState(
     metric: state.metric,
     projects: state.projects,
     scale: state.scale,
+    mode: state.mode,
     activityUnit: state.activityUnit,
     chartRange,
   }
@@ -78,6 +86,7 @@ export function toCompareClientState(
 export const DEFAULT_COMPARE_METRIC: CompareMetricId = 'tvs'
 export const DEFAULT_COMPARE_RANGE: CompareRangeOption = '1y'
 export const DEFAULT_COMPARE_SCALE: ChartScale = 'linear'
+export const DEFAULT_COMPARE_VIEW_MODE: CompareViewMode = 'absolute'
 export const DEFAULT_COMPARE_ACTIVITY_UNIT: CompareActivityUnit = 'uops'
 export const MAX_COMPARE_PROJECTS = 10
 export const DEFAULT_COMPARE_PROJECTS_COUNT = 5
@@ -114,7 +123,10 @@ export function isSameCompareState(
 ): boolean {
   return (
     left.metric === right.metric &&
-    left.scale === right.scale &&
+    left.mode === right.mode &&
+    // The scale toggle is hidden in indexed mode, so two states that differ
+    // solely by a hidden scale map to the same URL.
+    (left.mode === 'indexed' || left.scale === right.scale) &&
     // The unit is only encoded for the activity metric, so two states that
     // differ solely by a hidden unit map to the same URL.
     (left.metric !== 'activity' || left.activityUnit === right.activityUnit) &&

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
@@ -23,6 +23,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: ['arbitrum', 'base'],
       range: '30d',
       scale: 'symlog',
+      mode: 'absolute',
       activityUnit: 'tps',
     })
   })
@@ -35,8 +36,15 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: [],
       range: '1y',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'uops',
     })
+  })
+
+  it('parses the indexed view mode', () => {
+    const result = parse('mode=indexed')
+
+    expect(result.mode).toEqual('indexed')
   })
 
   it('drops unknown slugs and deduplicates', () => {
@@ -62,13 +70,16 @@ describe(parseCompareStateFromSearchParams.name, () => {
   })
 
   it('falls back to defaults on garbage values', () => {
-    const result = parse('metric=bogus&range=yesterday&scale=cubic&unit=gas')
+    const result = parse(
+      'metric=bogus&range=yesterday&scale=cubic&unit=gas&mode=sideways',
+    )
 
     expect(result).toEqual({
       metric: 'tvs',
       projects: [],
       range: '1y',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'uops',
     })
   })
@@ -85,6 +96,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: ['base', 'arbitrum'],
       range: '90d',
       scale: 'symlog',
+      mode: 'absolute',
       activityUnit: 'uops',
     }
 
@@ -100,6 +112,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: [],
       range: { from: 1700000000, to: 1710000000 },
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'uops',
     }
 
@@ -115,7 +128,24 @@ describe(parseCompareStateFromSearchParams.name, () => {
       projects: ['optimism'],
       range: '7d',
       scale: 'linear',
+      mode: 'absolute',
       activityUnit: 'tps',
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(parse(search)).toEqual(state)
+  })
+
+  it('round-trips the indexed mode through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'tvs',
+      projects: ['arbitrum'],
+      range: '30d',
+      scale: 'linear',
+      mode: 'indexed',
+      activityUnit: 'uops',
     }
 
     const url = buildCompareUrl('/scaling/compare', state)

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
+  DEFAULT_COMPARE_VIEW_MODE,
   MAX_COMPARE_PROJECTS,
 } from './compareChartState'
 
@@ -31,6 +32,10 @@ export function parseCompareStateFromSearchParams({
     range: parseRange(searchParams.get('range')),
     scale:
       searchParams.get('scale') === 'log' ? 'symlog' : DEFAULT_COMPARE_SCALE,
+    mode:
+      searchParams.get('mode') === 'indexed'
+        ? 'indexed'
+        : DEFAULT_COMPARE_VIEW_MODE,
     activityUnit: parseActivityUnit(searchParams.get('unit')),
   }
 }

--- a/packages/frontend/src/pages/scaling/compare/utils/toIndexedChartData.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/toIndexedChartData.test.ts
@@ -1,0 +1,99 @@
+import { expect } from 'earl'
+import { toIndexedChartData } from './toIndexedChartData'
+
+describe(toIndexedChartData.name, () => {
+  it('rebases every series to 100 at the first point', () => {
+    const { data, rebasedMidRange } = toIndexedChartData(
+      [
+        { timestamp: 1, big: 2000, small: 10 },
+        { timestamp: 2, big: 3000, small: 25 },
+        { timestamp: 3, big: 1000, small: 5 },
+      ],
+      ['big', 'small'],
+    )
+
+    expect(data).toEqual([
+      { timestamp: 1, big: 100, small: 100 },
+      { timestamp: 2, big: 150, small: 250 },
+      { timestamp: 3, big: 50, small: 50 },
+    ])
+    expect(rebasedMidRange).toEqual({})
+  })
+
+  it('rebases a mid-range launch at its first data point and reports it', () => {
+    const { data, rebasedMidRange } = toIndexedChartData(
+      [
+        { timestamp: 1, old: 200, fresh: null },
+        { timestamp: 2, old: 300, fresh: 40 },
+        { timestamp: 3, old: 400, fresh: 60 },
+      ],
+      ['old', 'fresh'],
+    )
+
+    expect(data).toEqual([
+      { timestamp: 1, old: 100, fresh: null },
+      { timestamp: 2, old: 150, fresh: 100 },
+      { timestamp: 3, old: 200, fresh: 150 },
+    ])
+    expect(rebasedMidRange).toEqual({ fresh: 2 })
+  })
+
+  it('preserves gaps as nulls', () => {
+    const { data } = toIndexedChartData(
+      [
+        { timestamp: 1, a: 50 },
+        { timestamp: 2, a: null },
+        { timestamp: 3, a: 75 },
+      ],
+      ['a'],
+    )
+
+    expect(data).toEqual([
+      { timestamp: 1, a: 100 },
+      { timestamp: 2, a: null },
+      { timestamp: 3, a: 150 },
+    ])
+  })
+
+  it('indexes leading zeros to 0 against the first positive value', () => {
+    const { data, rebasedMidRange } = toIndexedChartData(
+      [
+        { timestamp: 1, a: 0 },
+        { timestamp: 2, a: 20 },
+        { timestamp: 3, a: 30 },
+      ],
+      ['a'],
+    )
+
+    expect(data).toEqual([
+      { timestamp: 1, a: 0 },
+      { timestamp: 2, a: 100 },
+      { timestamp: 3, a: 150 },
+    ])
+    // Data was present from range start, so the base shift is not reported.
+    expect(rebasedMidRange).toEqual({})
+  })
+
+  it('keeps a series without positive values null', () => {
+    const { data, rebasedMidRange } = toIndexedChartData(
+      [
+        { timestamp: 1, a: 0 },
+        { timestamp: 2, a: 0 },
+      ],
+      ['a'],
+    )
+
+    expect(data).toEqual([
+      { timestamp: 1, a: null },
+      { timestamp: 2, a: null },
+    ])
+    expect(rebasedMidRange).toEqual({})
+  })
+
+  it('handles empty data', () => {
+    const { data, rebasedMidRange } = toIndexedChartData([], ['a'])
+
+    expect(data).toEqual([])
+    expect(rebasedMidRange).toEqual({})
+  })
+})

--- a/packages/frontend/src/pages/scaling/compare/utils/toIndexedChartData.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/toIndexedChartData.ts
@@ -1,0 +1,71 @@
+/**
+ * A single compare chart point: a timestamp plus one value per project id.
+ * The shape every compare metric chart feeds into recharts.
+ */
+export interface CompareChartPoint {
+  timestamp: number
+  [projectId: string]: number | null
+}
+
+export interface IndexedChartData {
+  data: CompareChartPoint[]
+  /**
+   * For projects whose data starts after the first chart point (e.g. a
+   * mid-range launch): the timestamp of the point they were rebased at,
+   * so the tooltip can note the shifted base.
+   */
+  rebasedMidRange: Record<string, number>
+}
+
+/**
+ * Rebases every series to 100 at its first data point, making growth rates
+ * directly comparable regardless of project size. Metric-agnostic: operates
+ * on the already-fetched chart points of any compare metric.
+ *
+ * The base is the first positive value of a series - a zero base cannot be
+ * indexed, so leading zeros index to 0 against the first positive value. A
+ * series with no positive values stays null throughout.
+ */
+export function toIndexedChartData(
+  data: CompareChartPoint[],
+  projectIds: string[],
+): IndexedChartData {
+  const firstTimestamp = data[0]?.timestamp
+  const bases: Record<string, number> = {}
+  const rebasedMidRange: Record<string, number> = {}
+
+  for (const id of projectIds) {
+    let firstDataTimestamp: number | undefined
+    for (const point of data) {
+      const value = point[id]
+      if (value === null || value === undefined) continue
+      firstDataTimestamp ??= point.timestamp
+      if (value > 0) {
+        bases[id] = value
+        break
+      }
+    }
+    if (
+      bases[id] !== undefined &&
+      firstDataTimestamp !== undefined &&
+      firstDataTimestamp !== firstTimestamp
+    ) {
+      rebasedMidRange[id] = firstDataTimestamp
+    }
+  }
+
+  const indexedData = data.map((point) => {
+    const indexed: CompareChartPoint = { timestamp: point.timestamp }
+    for (const id of projectIds) {
+      const value = point[id]
+      const base = bases[id]
+      indexed[id] =
+        value !== null && value !== undefined && base !== undefined
+          ? (value / base) * 100
+          : null
+    }
+    return indexed
+  })
+
+  return { data: indexedData, rebasedMidRange }
+}


### PR DESCRIPTION
## Summary

- Add an ABSOLUTE/INDEXED toggle to the scaling compare page; in indexed mode every series is rebased to 100 at the range start so projects of very different sizes can be compared by relative growth.
- Extract the shared compare chart renderer into `CompareMetricLineChart` (legend, lines, axes, tooltip); TVS and Activity charts now only supply data and absolute-value formatting.
- Add `toIndexedChartData` util: rebases each series to its first available value, preserves gaps as nulls, indexes leading zeros against the first positive value, drops series with no positive values, and reports series that start mid-range.
- Tooltip marks mid-range-launched series with `*` and explains that they are indexed to 100 at their first data point.
- Hide the LOG/LIN toggle in indexed mode (log of an index is meaningless) and skip encoding `scale` in the URL there.
- Persist the mode in the URL (`?mode=indexed`) via `buildCompareUrl` / `parseCompareStateFromSearchParams`, with defaults and garbage-value fallback.

## Testing

- Unit tests added for `toIndexedChartData` (rebasing, mid-range launches, gaps, leading zeros, all-zero series, empty data).
- Unit tests extended for `buildCompareUrl` and `parseCompareStateFromSearchParams`, including a mode round-trip and scale omission in indexed mode.
- Manual UI verification of the toggle and tooltip: not run.