### PR TITLE
Add TVS control parity to the scaling compare page

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
+++ b/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
@@ -13,6 +13,7 @@ import {
   type CompareChartState,
   compareRangeToChartRange,
   DEFAULT_COMPARE_PROJECTS_COUNT,
+  toCompareClientState,
 } from './utils/compareChartState'
 import { parseCompareStateFromSearchParams } from './utils/parseCompareStateFromSearchParams'
 
@@ -100,7 +101,11 @@ async function getPrefetchedChartData(
 
   const initialChartRange = compareRangeToChartRange(initialState.range)
   const helpers = getSsrHelpers()
-  await serverMetric.prefetch(helpers, selectedProjects, initialChartRange)
+  await serverMetric.prefetch(
+    helpers,
+    selectedProjects,
+    toCompareClientState(initialState, initialChartRange),
+  )
 
   return {
     defaultProjectSlugs: defaultProjects.map((project) => project.slug),

--- a/packages/frontend/src/pages/scaling/compare/metrics/index.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/index.ts
@@ -2,6 +2,7 @@ import type { CompareMetricId } from '../utils/compareChartState'
 import { ActivityCompareChart } from './activity/ActivityCompareChart'
 import { ActivityCompareControls } from './activity/ActivityCompareControls'
 import { TvsCompareChart } from './tvs/TvsCompareChart'
+import { TvsCompareControls } from './tvs/TvsCompareControls'
 import type { CompareMetric } from './types'
 
 export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
@@ -9,6 +10,7 @@ export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
     id: 'tvs',
     label: 'Value Secured',
     Chart: TvsCompareChart,
+    Controls: TvsCompareControls,
   },
   activity: {
     id: 'activity',

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
@@ -12,20 +12,26 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
   const trpc = useTRPC()
   const { data, isLoading } = useQuery(
     trpc.tvs.detailedChartWithProjectsRanges.queryOptions(
-      getTvsCompareChartParams(projects, state.chartRange),
+      getTvsCompareChartParams(projects, state),
     ),
   )
+  const unit = state.tvsUnit
 
   const chartData = useMemo(
     () =>
-      data?.chart.map(([timestamp, _ethPrice, valuesByProject]) => {
+      data?.chart.map(([timestamp, ethPrice, valuesByProject]) => {
         const point: CompareChartPoint = { timestamp }
+        const divider = unit === 'usd' ? 1 : ethPrice
         for (const project of projects) {
-          point[project.id] = valuesByProject[project.id]?.[0] ?? null
+          const value = valuesByProject[project.id]?.[0]
+          point[project.id] =
+            value !== undefined && divider !== null && divider !== 0
+              ? value / divider
+              : null
         }
         return point
       }),
-    [data, projects],
+    [data, projects, unit],
   )
 
   return (
@@ -36,8 +42,8 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
       syncedUntil={data?.syncedUntil}
       scale={state.scale}
       mode={state.mode}
-      formatYAxisLabel={(value) => formatCurrency(value, 'usd')}
-      formatTooltipValue={(value) => formatCurrency(value, 'usd')}
+      formatYAxisLabel={(value) => formatCurrency(value, unit)}
+      formatTooltipValue={(value) => formatCurrency(value, unit)}
       renderTooltipTimestamp={(label) =>
         formatTimestamp(label, {
           longMonthName: true,

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
@@ -1,0 +1,45 @@
+import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
+import { Skeleton } from '~/components/core/Skeleton'
+import { DisplayControls } from '~/components/table/display/DisplayControls'
+import { useIsClient } from '~/hooks/useIsClient'
+import type { CompareTvsUnit } from '../../utils/compareChartState'
+import type { CompareMetricControlsProps } from '../types'
+
+export function TvsCompareControls({
+  state,
+  setState,
+}: CompareMetricControlsProps) {
+  const isClient = useIsClient()
+  if (!isClient) {
+    return <Skeleton className="h-9 w-[196px]" />
+  }
+  return (
+    <div className="flex items-center gap-1">
+      <RadioGroup
+        name="compareTvsUnit"
+        value={state.tvsUnit}
+        onValueChange={(value) =>
+          setState((prev) => ({ ...prev, tvsUnit: value as CompareTvsUnit }))
+        }
+        variant="highlighted"
+        className="h-9"
+      >
+        <RadioGroupItem value="usd" className="h-full px-2 text-sm">
+          USD
+        </RadioGroupItem>
+        <RadioGroupItem value="eth" className="h-full px-2 text-sm">
+          ETH
+        </RadioGroupItem>
+      </RadioGroup>
+      <DisplayControls
+        display={{
+          excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
+          excludeAssociatedTokens: state.excludeAssociatedTokens,
+        }}
+        setDisplay={(key, value) =>
+          setState((prev) => ({ ...prev, [key]: value }))
+        }
+      />
+    </div>
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
@@ -1,5 +1,5 @@
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
-import type { ChartRange } from '~/utils/range/range'
+import type { CompareClientState } from '../../utils/compareChartState'
 
 /**
  * Builds the `tvs.detailedChartWithProjectsRanges` input for the compare
@@ -8,13 +8,15 @@ import type { ChartRange } from '~/utils/range/range'
  */
 export function getTvsCompareChartParams(
   projects: CompareProjectEntry[],
-  range: ChartRange,
+  state: Pick<
+    CompareClientState,
+    'chartRange' | 'excludeAssociatedTokens' | 'excludeRwaRestrictedTokens'
+  >,
 ) {
   return {
-    range,
-    // Matches the TVS page defaults; control parity is a follow-up ticket.
-    excludeAssociatedTokens: false,
-    excludeRwaRestrictedTokens: true,
+    range: state.chartRange,
+    excludeAssociatedTokens: state.excludeAssociatedTokens,
+    excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
     projects: projects.flatMap((project) =>
       project.tvsSinceTimestamp !== undefined
         ? [

--- a/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
+++ b/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
@@ -2,10 +2,13 @@ import { getActivityLatestUops } from '~/server/features/scaling/activity/getAct
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
 import { get7dTvsBreakdown } from '~/server/features/scaling/tvs/get7dTvsBreakdown'
 import type { getSsrHelpers } from '~/trpc/server'
-import { type ChartRange, optionToRange } from '~/utils/range/range'
+import { optionToRange } from '~/utils/range/range'
 import { getActivityCompareChartParams } from '../metrics/activity/getActivityCompareChartParams'
 import { getTvsCompareChartParams } from '../metrics/tvs/getTvsCompareChartParams'
-import type { CompareMetricId } from '../utils/compareChartState'
+import type {
+  CompareClientState,
+  CompareMetricId,
+} from '../utils/compareChartState'
 
 type SsrHelpers = ReturnType<typeof getSsrHelpers>
 
@@ -21,7 +24,7 @@ interface CompareServerMetric {
   prefetch: (
     helpers: SsrHelpers,
     projects: CompareProjectEntry[],
-    range: ChartRange,
+    state: CompareClientState,
   ) => Promise<void>
 }
 
@@ -41,10 +44,10 @@ export const COMPARE_SERVER_METRICS: Record<
         .slice(0, count)
         .map(({ project }) => project)
     },
-    prefetch: async (helpers, projects, range) => {
+    prefetch: async (helpers, projects, state) => {
       await helpers.queryClient.prefetchQuery(
         helpers.trpc.tvs.detailedChartWithProjectsRanges.queryOptions(
-          getTvsCompareChartParams(projects, range),
+          getTvsCompareChartParams(projects, state),
         ),
       )
     },
@@ -63,10 +66,10 @@ export const COMPARE_SERVER_METRICS: Record<
         .slice(0, count)
         .map(({ project }) => project)
     },
-    prefetch: async (helpers, projects, range) => {
+    prefetch: async (helpers, projects, state) => {
       await helpers.queryClient.prefetchQuery(
         helpers.trpc.activity.detailedChartWithProjectsRanges.queryOptions(
-          getActivityCompareChartParams(projects, range),
+          getActivityCompareChartParams(projects, state.chartRange),
         ),
       )
     },

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
@@ -1,30 +1,32 @@
 import { expect } from 'earl'
 import { buildCompareUrl } from './buildCompareUrl'
+import type { CompareChartState } from './compareChartState'
 
 const PATH = '/scaling/compare'
 
+const DEFAULT_STATE: CompareChartState = {
+  metric: 'tvs',
+  projects: [],
+  range: '1y',
+  scale: 'linear',
+  mode: 'absolute',
+  activityUnit: 'uops',
+  tvsUnit: 'usd',
+  excludeAssociatedTokens: false,
+  excludeRwaRestrictedTokens: true,
+}
+
 describe(buildCompareUrl.name, () => {
   it('returns a bare path for the default state', () => {
-    const url = buildCompareUrl(PATH, {
-      metric: 'tvs',
-      projects: [],
-      range: '1y',
-      scale: 'linear',
-      mode: 'absolute',
-      activityUnit: 'uops',
-    })
+    const url = buildCompareUrl(PATH, DEFAULT_STATE)
 
     expect(url).toEqual(PATH)
   })
 
   it('serializes projects as a comma-separated list', () => {
     const url = buildCompareUrl(PATH, {
-      metric: 'tvs',
+      ...DEFAULT_STATE,
       projects: ['arbitrum', 'base'],
-      range: '1y',
-      scale: 'linear',
-      mode: 'absolute',
-      activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?projects=arbitrum,base')
@@ -32,12 +34,10 @@ describe(buildCompareUrl.name, () => {
 
   it('omits defaults and serializes non-default range and scale', () => {
     const url = buildCompareUrl(PATH, {
-      metric: 'tvs',
+      ...DEFAULT_STATE,
       projects: ['arbitrum'],
       range: '30d',
       scale: 'symlog',
-      mode: 'absolute',
-      activityUnit: 'uops',
     })
 
     expect(url).toEqual(
@@ -47,12 +47,8 @@ describe(buildCompareUrl.name, () => {
 
   it('serializes a custom range as from-to', () => {
     const url = buildCompareUrl(PATH, {
-      metric: 'tvs',
-      projects: [],
+      ...DEFAULT_STATE,
       range: { from: 1700000000, to: 1710000000 },
-      scale: 'linear',
-      mode: 'absolute',
-      activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?range=1700000000-1710000000')
@@ -60,12 +56,8 @@ describe(buildCompareUrl.name, () => {
 
   it('serializes the indexed mode', () => {
     const url = buildCompareUrl(PATH, {
-      metric: 'tvs',
-      projects: [],
-      range: '1y',
-      scale: 'linear',
+      ...DEFAULT_STATE,
       mode: 'indexed',
-      activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?mode=indexed')
@@ -73,12 +65,9 @@ describe(buildCompareUrl.name, () => {
 
   it('omits the scale in indexed mode where its toggle is hidden', () => {
     const url = buildCompareUrl(PATH, {
-      metric: 'tvs',
-      projects: [],
-      range: '1y',
+      ...DEFAULT_STATE,
       scale: 'symlog',
       mode: 'indexed',
-      activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?mode=indexed')
@@ -86,11 +75,8 @@ describe(buildCompareUrl.name, () => {
 
   it('serializes a non-default metric with its non-default unit', () => {
     const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
       metric: 'activity',
-      projects: [],
-      range: '1y',
-      scale: 'linear',
-      mode: 'absolute',
       activityUnit: 'tps',
     })
 
@@ -99,12 +85,8 @@ describe(buildCompareUrl.name, () => {
 
   it('omits the default activity unit', () => {
     const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
       metric: 'activity',
-      projects: [],
-      range: '1y',
-      scale: 'linear',
-      mode: 'absolute',
-      activityUnit: 'uops',
     })
 
     expect(url).toEqual('/scaling/compare?metric=activity')
@@ -112,14 +94,35 @@ describe(buildCompareUrl.name, () => {
 
   it('omits the activity unit for other metrics', () => {
     const url = buildCompareUrl(PATH, {
-      metric: 'tvs',
-      projects: [],
-      range: '1y',
-      scale: 'linear',
-      mode: 'absolute',
+      ...DEFAULT_STATE,
       activityUnit: 'tps',
     })
 
     expect(url).toEqual(PATH)
+  })
+
+  it('serializes the non-default tvs controls', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      tvsUnit: 'eth',
+      excludeAssociatedTokens: true,
+      excludeRwaRestrictedTokens: false,
+    })
+
+    expect(url).toEqual(
+      '/scaling/compare?unit=eth&excludeAssociated=true&excludeRwa=false',
+    )
+  })
+
+  it('omits the tvs controls for other metrics', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      metric: 'activity',
+      tvsUnit: 'eth',
+      excludeAssociatedTokens: true,
+      excludeRwaRestrictedTokens: false,
+    })
+
+    expect(url).toEqual('/scaling/compare?metric=activity')
   })
 })

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
@@ -1,9 +1,12 @@
 import {
   type CompareChartState,
   DEFAULT_COMPARE_ACTIVITY_UNIT,
+  DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
+  DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS,
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
+  DEFAULT_COMPARE_TVS_UNIT,
   DEFAULT_COMPARE_VIEW_MODE,
 } from './compareChartState'
 
@@ -40,6 +43,23 @@ export function buildCompareUrl(
     state.activityUnit !== DEFAULT_COMPARE_ACTIVITY_UNIT
   ) {
     params.set('unit', state.activityUnit)
+  }
+  if (state.metric === 'tvs') {
+    if (state.tvsUnit !== DEFAULT_COMPARE_TVS_UNIT) {
+      params.set('unit', state.tvsUnit)
+    }
+    if (
+      state.excludeAssociatedTokens !==
+      DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS
+    ) {
+      params.set('excludeAssociated', String(state.excludeAssociatedTokens))
+    }
+    if (
+      state.excludeRwaRestrictedTokens !==
+      DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS
+    ) {
+      params.set('excludeRwa', String(state.excludeRwaRestrictedTokens))
+    }
   }
   // Keep commas literal so shared links stay readable.
   const query = params.toString().replaceAll('%2C', ',')

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -14,6 +14,9 @@ export type CompareMetricId = (typeof COMPARE_METRIC_IDS)[number]
 export const COMPARE_ACTIVITY_UNITS = ['uops', 'tps'] as const
 export type CompareActivityUnit = (typeof COMPARE_ACTIVITY_UNITS)[number]
 
+export const COMPARE_TVS_UNITS = ['usd', 'eth'] as const
+export type CompareTvsUnit = (typeof COMPARE_TVS_UNITS)[number]
+
 export const COMPARE_VIEW_MODES = ['absolute', 'indexed'] as const
 export type CompareViewMode = (typeof COMPARE_VIEW_MODES)[number]
 
@@ -40,6 +43,10 @@ export interface CompareChartState {
   mode: CompareViewMode
   /** Per-metric control of the activity metric; ignored elsewhere. */
   activityUnit: CompareActivityUnit
+  /** Per-metric controls of the TVS metric; ignored elsewhere. */
+  tvsUnit: CompareTvsUnit
+  excludeAssociatedTokens: boolean
+  excludeRwaRestrictedTokens: boolean
 }
 
 /**
@@ -53,6 +60,9 @@ export interface CompareClientState {
   scale: ChartScale
   mode: CompareViewMode
   activityUnit: CompareActivityUnit
+  tvsUnit: CompareTvsUnit
+  excludeAssociatedTokens: boolean
+  excludeRwaRestrictedTokens: boolean
   chartRange: ChartRange
 }
 
@@ -65,6 +75,9 @@ export function toCompareUrlState(
     scale: state.scale,
     mode: state.mode,
     activityUnit: state.activityUnit,
+    tvsUnit: state.tvsUnit,
+    excludeAssociatedTokens: state.excludeAssociatedTokens,
+    excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
     range: chartRangeToCompareRange(state.chartRange),
   }
 }
@@ -79,6 +92,9 @@ export function toCompareClientState(
     scale: state.scale,
     mode: state.mode,
     activityUnit: state.activityUnit,
+    tvsUnit: state.tvsUnit,
+    excludeAssociatedTokens: state.excludeAssociatedTokens,
+    excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
     chartRange,
   }
 }
@@ -88,6 +104,11 @@ export const DEFAULT_COMPARE_RANGE: CompareRangeOption = '1y'
 export const DEFAULT_COMPARE_SCALE: ChartScale = 'linear'
 export const DEFAULT_COMPARE_VIEW_MODE: CompareViewMode = 'absolute'
 export const DEFAULT_COMPARE_ACTIVITY_UNIT: CompareActivityUnit = 'uops'
+export const DEFAULT_COMPARE_TVS_UNIT: CompareTvsUnit = 'usd'
+// The TVS control defaults match the /scaling/tvs page so the default
+// comparison reproduces the numbers shown there.
+export const DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS = false
+export const DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS = true
 export const MAX_COMPARE_PROJECTS = 10
 export const DEFAULT_COMPARE_PROJECTS_COUNT = 5
 
@@ -127,9 +148,15 @@ export function isSameCompareState(
     // The scale toggle is hidden in indexed mode, so two states that differ
     // solely by a hidden scale map to the same URL.
     (left.mode === 'indexed' || left.scale === right.scale) &&
-    // The unit is only encoded for the activity metric, so two states that
-    // differ solely by a hidden unit map to the same URL.
+    // Per-metric controls are only encoded for the metric they belong to,
+    // so two states that differ solely by a hidden control map to the same
+    // URL.
     (left.metric !== 'activity' || left.activityUnit === right.activityUnit) &&
+    (left.metric !== 'tvs' ||
+      (left.tvsUnit === right.tvsUnit &&
+        left.excludeAssociatedTokens === right.excludeAssociatedTokens &&
+        left.excludeRwaRestrictedTokens ===
+          right.excludeRwaRestrictedTokens)) &&
     isSameRange(left.range, right.range) &&
     left.projects.length === right.projects.length &&
     left.projects.every((slug, index) => slug === right.projects[index])

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
@@ -25,6 +25,9 @@ describe(parseCompareStateFromSearchParams.name, () => {
       scale: 'symlog',
       mode: 'absolute',
       activityUnit: 'tps',
+      tvsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
     })
   })
 
@@ -38,6 +41,9 @@ describe(parseCompareStateFromSearchParams.name, () => {
       scale: 'linear',
       mode: 'absolute',
       activityUnit: 'uops',
+      tvsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
     })
   })
 
@@ -45,6 +51,20 @@ describe(parseCompareStateFromSearchParams.name, () => {
     const result = parse('mode=indexed')
 
     expect(result.mode).toEqual('indexed')
+  })
+
+  it('parses the tvs unit from the shared unit param', () => {
+    const result = parse('unit=eth')
+
+    expect(result.tvsUnit).toEqual('eth')
+    expect(result.activityUnit).toEqual('uops')
+  })
+
+  it('parses the tvs token exclusion toggles', () => {
+    const result = parse('excludeAssociated=true&excludeRwa=false')
+
+    expect(result.excludeAssociatedTokens).toEqual(true)
+    expect(result.excludeRwaRestrictedTokens).toEqual(false)
   })
 
   it('drops unknown slugs and deduplicates', () => {
@@ -71,7 +91,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
 
   it('falls back to defaults on garbage values', () => {
     const result = parse(
-      'metric=bogus&range=yesterday&scale=cubic&unit=gas&mode=sideways',
+      'metric=bogus&range=yesterday&scale=cubic&unit=gas&mode=sideways&excludeAssociated=maybe&excludeRwa=nonsense',
     )
 
     expect(result).toEqual({
@@ -81,6 +101,9 @@ describe(parseCompareStateFromSearchParams.name, () => {
       scale: 'linear',
       mode: 'absolute',
       activityUnit: 'uops',
+      tvsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
     })
   })
 
@@ -98,6 +121,9 @@ describe(parseCompareStateFromSearchParams.name, () => {
       scale: 'symlog',
       mode: 'absolute',
       activityUnit: 'uops',
+      tvsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
     }
 
     const url = buildCompareUrl('/scaling/compare', state)
@@ -114,6 +140,9 @@ describe(parseCompareStateFromSearchParams.name, () => {
       scale: 'linear',
       mode: 'absolute',
       activityUnit: 'uops',
+      tvsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
     }
 
     const url = buildCompareUrl('/scaling/compare', state)
@@ -130,6 +159,28 @@ describe(parseCompareStateFromSearchParams.name, () => {
       scale: 'linear',
       mode: 'absolute',
       activityUnit: 'tps',
+      tvsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(parse(search)).toEqual(state)
+  })
+
+  it('round-trips the tvs metric with all its controls through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'tvs',
+      projects: ['arbitrum'],
+      range: '30d',
+      scale: 'linear',
+      mode: 'absolute',
+      activityUnit: 'uops',
+      tvsUnit: 'eth',
+      excludeAssociatedTokens: true,
+      excludeRwaRestrictedTokens: false,
     }
 
     const url = buildCompareUrl('/scaling/compare', state)
@@ -146,6 +197,9 @@ describe(parseCompareStateFromSearchParams.name, () => {
       scale: 'linear',
       mode: 'indexed',
       activityUnit: 'uops',
+      tvsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
     }
 
     const url = buildCompareUrl('/scaling/compare', state)

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
@@ -2,15 +2,20 @@ import {
   COMPARE_ACTIVITY_UNITS,
   COMPARE_METRIC_IDS,
   COMPARE_RANGE_OPTIONS,
+  COMPARE_TVS_UNITS,
   type CompareActivityUnit,
   type CompareChartState,
   type CompareMetricId,
   type CompareRange,
   type CompareRangeOption,
+  type CompareTvsUnit,
   DEFAULT_COMPARE_ACTIVITY_UNIT,
+  DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
+  DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS,
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
+  DEFAULT_COMPARE_TVS_UNIT,
   DEFAULT_COMPARE_VIEW_MODE,
   MAX_COMPARE_PROJECTS,
 } from './compareChartState'
@@ -36,7 +41,18 @@ export function parseCompareStateFromSearchParams({
       searchParams.get('mode') === 'indexed'
         ? 'indexed'
         : DEFAULT_COMPARE_VIEW_MODE,
+    // The `unit` param is shared between metrics; the value sets are
+    // disjoint, so each metric picks up only its own units.
     activityUnit: parseActivityUnit(searchParams.get('unit')),
+    tvsUnit: parseTvsUnit(searchParams.get('unit')),
+    excludeAssociatedTokens: parseBoolean(
+      searchParams.get('excludeAssociated'),
+      DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
+    ),
+    excludeRwaRestrictedTokens: parseBoolean(
+      searchParams.get('excludeRwa'),
+      DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS,
+    ),
   }
 }
 
@@ -48,6 +64,17 @@ function parseMetric(value: string | null): CompareMetricId {
 function parseActivityUnit(value: string | null): CompareActivityUnit {
   const unit = COMPARE_ACTIVITY_UNITS.find((unit) => unit === value)
   return unit ?? DEFAULT_COMPARE_ACTIVITY_UNIT
+}
+
+function parseTvsUnit(value: string | null): CompareTvsUnit {
+  const unit = COMPARE_TVS_UNITS.find((unit) => unit === value)
+  return unit ?? DEFAULT_COMPARE_TVS_UNIT
+}
+
+function parseBoolean(value: string | null, defaultValue: boolean): boolean {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return defaultValue
 }
 
 function parseProjects(value: string | null, validSlugs: string[]): string[] {


### PR DESCRIPTION
Implements [L2B-14548](https://linear.app/l2beat/issue/L2B-14548/tvs-control-parity-usdeth-associated-tokens-rwa).

Adds full control parity between the compare page's TVS metric and `/scaling/tvs`, so a comparison always reproduces what the source page shows:

- **USD / ETH** unit toggle (client-side conversion via the per-timestamp ETH price already returned by the endpoint)
- **Exclude associated tokens** toggle
- **Exclude restricted RWA tokens** toggle, reusing the site-wide `DisplayControls` popover with the same labels, tooltip and defaults as the TVS page

All three are declared through the metric registry's per-metric `Controls` slot — no metric-specific conditionals in the page shell — and are URL-encoded with defaults omitted (`unit=eth`, `excludeAssociated=true`, `excludeRwa=false`), only while TVS is the active metric. The SSR prefetch now derives the query input from the parsed URL state, so shared links first-paint with the exact configuration and no client refetch. Indexed mode composes unchanged: rebasing runs on whatever series the controls configure.

Verified in mock mode: toggles render only for TVS, round-trip through the URL (including back/forward), and switching metrics swaps the control strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)