### PR TITLE
Refresh the scaling compare page UI

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/ScalingComparePage.tsx
+++ b/packages/frontend/src/pages/scaling/compare/ScalingComparePage.tsx
@@ -1,6 +1,7 @@
 import type { DehydratedState } from '@tanstack/react-query'
 import { HydrationBoundary } from '@tanstack/react-query'
 import { MainPageHeader } from '~/components/MainPageHeader'
+import { PrimaryCard } from '~/components/primary-card/PrimaryCard'
 import type { AppLayoutProps } from '~/layouts/AppLayout'
 import { AppLayout } from '~/layouts/AppLayout'
 import { SideNavLayout } from '~/layouts/SideNavLayout'
@@ -29,13 +30,17 @@ export function ScalingComparePage({
     <AppLayout {...props}>
       <HydrationBoundary state={queryState}>
         <SideNavLayout>
-          <MainPageHeader>Compare Projects</MainPageHeader>
-          <ScalingCompareChart
-            allProjects={allProjects}
-            initialState={initialState}
-            defaultProjectSlugs={defaultProjectSlugs}
-            initialChartRange={initialChartRange}
-          />
+          <MainPageHeader description="Compare Ethereum scaling projects on a single chart. Pick up to 10 projects, switch between metrics, and share the exact view with a link.">
+            Compare Projects
+          </MainPageHeader>
+          <PrimaryCard className="max-md:mt-4 md:mt-2">
+            <ScalingCompareChart
+              allProjects={allProjects}
+              initialState={initialState}
+              defaultProjectSlugs={defaultProjectSlugs}
+              initialChartRange={initialChartRange}
+            />
+          </PrimaryCard>
         </SideNavLayout>
       </HydrationBoundary>
     </AppLayout>

--- a/packages/frontend/src/pages/scaling/compare/components/CompareMetricLineChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareMetricLineChart.tsx
@@ -103,7 +103,7 @@ export function CompareMetricLineChart({
 
   return (
     <div className="flex flex-col">
-      <div className="mt-1 mb-2">
+      <div className="mt-3 mb-2">
         <ChartTimeRange timeRange={timeRange} />
       </div>
       <ChartContainer

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
@@ -24,13 +24,18 @@ interface Props {
    * into the URL.
    */
   selectedProjects: CompareProjectEntry[]
+  /** True when the chips show the top-N defaults instead of a user selection. */
+  isDefaultSelection: boolean
   onChange: (slugs: string[]) => void
+  className?: string
 }
 
 export function CompareProjectPicker({
   allProjects,
   selectedProjects,
+  isDefaultSelection,
   onChange,
+  className,
 }: Props) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -75,7 +80,7 @@ export function CompareProjectPicker({
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-1.5">
+    <div className={cn('flex flex-wrap items-center gap-1.5', className)}>
       {selectedProjects.map((project) => (
         <div
           key={project.slug}
@@ -95,7 +100,7 @@ export function CompareProjectPicker({
             type="button"
             aria-label={`Remove ${project.name}`}
             onClick={() => toggleProject(project.slug)}
-            className="flex size-4 cursor-pointer items-center justify-center rounded-full hover:bg-surface-tertiary"
+            className="flex size-4 cursor-pointer items-center justify-center rounded-full hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
           >
             <CloseIcon className="size-2 fill-secondary" aria-hidden />
           </button>
@@ -104,11 +109,20 @@ export function CompareProjectPicker({
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="flex h-7 cursor-pointer items-center gap-1.5 rounded-full border border-divider border-dashed py-1 pr-2.5 pl-1.5 font-medium text-secondary text-sm leading-none hover:bg-surface-secondary"
+        className="flex h-7 cursor-pointer items-center gap-1.5 rounded-full border border-divider border-dashed py-1 pr-2.5 pl-1.5 font-medium text-secondary text-sm leading-none hover:bg-surface-secondary primary-card:hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         <PlusIcon className="size-4" />
         Add project
       </button>
+      <span className="ml-auto whitespace-nowrap font-medium text-2xs text-secondary tabular-nums">
+        {selectedSlugs.length}/{MAX_COMPARE_PROJECTS}
+      </span>
+      {isDefaultSelection && (
+        <p className="w-full font-medium text-2xs text-secondary">
+          Showing top projects by default. Add or remove projects to build your
+          own comparison.
+        </p>
+      )}
       <CommandDialog
         title="Add projects to compare"
         description="Search for scaling projects to add to the comparison"

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -65,13 +65,8 @@ export function ScalingCompareChart({
   const metric = COMPARE_METRICS[state.metric]
 
   return (
-    <section className="mt-4 flex flex-col gap-2 md:mt-6">
-      <CompareProjectPicker
-        allProjects={allProjects}
-        selectedProjects={selectedProjects}
-        onChange={(projects) => setState((prev) => ({ ...prev, projects }))}
-      />
-      <div className="flex items-center justify-between gap-2">
+    <section className="flex flex-col">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
         <MetricSwitcher
           value={state.metric}
           onValueChange={(metric) => setState((prev) => ({ ...prev, metric }))}
@@ -80,6 +75,13 @@ export function ScalingCompareChart({
           <metric.Controls state={state} setState={setState} />
         )}
       </div>
+      <CompareProjectPicker
+        allProjects={allProjects}
+        selectedProjects={selectedProjects}
+        isDefaultSelection={state.projects.length === 0}
+        onChange={(projects) => setState((prev) => ({ ...prev, projects }))}
+        className="mt-3 border-divider border-b pb-3"
+      />
       <metric.Chart projects={selectedProjects} state={state} />
       <Controls
         mode={state.mode}
@@ -154,11 +156,12 @@ function MetricSwitcher({
 }) {
   const isClient = useIsClient()
   if (!isClient) {
-    return <Skeleton className="h-9 w-[180px]" />
+    return <Skeleton className="h-9 w-[190px]" />
   }
   return (
     <RadioGroup
       name="compareMetric"
+      aria-label="Chart metric"
       value={value}
       onValueChange={(value) => onValueChange(value as CompareMetricId)}
       variant="highlighted"
@@ -194,12 +197,13 @@ function Controls({
 }) {
   const isClient = useIsClient()
   return (
-    <ChartControlsWrapper>
-      <div className="flex gap-1">
+    <ChartControlsWrapper className="mt-2">
+      <div className="flex flex-wrap gap-1">
         {isClient ? (
           <>
             <RadioGroup
               name="compareViewMode"
+              aria-label="View mode"
               value={mode}
               onValueChange={(value) => setMode(value as CompareViewMode)}
             >
@@ -211,6 +215,7 @@ function Controls({
             {mode === 'absolute' && (
               <RadioGroup
                 name="compareChartScale"
+                aria-label="Chart scale"
                 value={scale}
                 onValueChange={(value) => setScale(value as ChartScale)}
               >


### PR DESCRIPTION
## Summary

- Wrap the compare chart in a `PrimaryCard` and add a descriptive subtitle to the page header.
- Reorder the chart layout: metric switcher and its controls on top, project picker below with a bottom divider.
- Show a `selected/max` counter in the project picker, plus a hint line when the default top-N selection is still active.
- Add `aria-label`s to the metric, view mode, and chart scale radio groups and focus-visible rings to picker buttons.
- Minor spacing/wrapping tweaks (chart time range margin, wrapping controls, skeleton width).

## Testing

- Not run — visual-only change; verified by reading the diff.
- Suggested manual checks: page renders inside the card on mobile and desktop, counter updates as projects are added/removed, hint disappears once a custom selection is made, keyboard focus is visible on the chips and "Add project" button.