### PR TITLE
Copy link button for the current compare chart view

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -4,10 +4,15 @@ import { ChartControlsWrapper } from '~/components/core/chart/ChartControlsWrapp
 import { ChartRangeControls } from '~/components/core/chart/ChartRangeControls'
 import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
 import { Skeleton } from '~/components/core/Skeleton'
+import { useCopyToClipboard } from '~/hooks/useCopyToClipboard'
 import { useDebouncedValue } from '~/hooks/useDebouncedValue'
 import { useEventListener } from '~/hooks/useEventListener'
 import { useIsClient } from '~/hooks/useIsClient'
+import { useTimeout } from '~/hooks/useTimeout'
+import { CheckIcon } from '~/icons/Check'
+import { CopyIcon } from '~/icons/Copy'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import { cn } from '~/utils/cn'
 import type { ChartRange } from '~/utils/range/range'
 import { COMPARE_METRICS } from '../metrics'
 import { buildCompareUrl } from '../utils/buildCompareUrl'
@@ -90,6 +95,12 @@ export function ScalingCompareChart({
         setScale={(scale) => setState((prev) => ({ ...prev, scale }))}
         range={state.chartRange}
         setRange={(chartRange) => setState((prev) => ({ ...prev, chartRange }))}
+        // Serialized on click from the live state, because the address bar
+        // only catches up after the URL-sync debounce.
+        getShareUrl={() =>
+          window.location.origin +
+          buildCompareUrl(window.location.pathname, toCompareUrlState(state))
+        }
       />
     </section>
   )
@@ -187,6 +198,7 @@ function Controls({
   setScale,
   range,
   setRange,
+  getShareUrl,
 }: {
   mode: CompareViewMode
   setMode: (mode: CompareViewMode) => void
@@ -194,6 +206,7 @@ function Controls({
   setScale: (scale: ChartScale) => void
   range: ChartRange
   setRange: (range: ChartRange) => void
+  getShareUrl: () => string
 }) {
   const isClient = useIsClient()
   return (
@@ -227,6 +240,7 @@ function Controls({
         ) : (
           <Skeleton className="h-8 w-[91px] md:w-[95px]" />
         )}
+        <CopyLinkButton getShareUrl={getShareUrl} />
       </div>
       <ChartRangeControls
         name="compareChart"
@@ -238,5 +252,31 @@ function Controls({
         }))}
       />
     </ChartControlsWrapper>
+  )
+}
+
+function CopyLinkButton({ getShareUrl }: { getShareUrl: () => string }) {
+  const copy = useCopyToClipboard()
+  const [copied, setCopied] = useState(false)
+  useTimeout(() => setCopied(false), copied ? 1400 : null)
+
+  return (
+    <button
+      type="button"
+      aria-live="polite"
+      onClick={() => void copy(getShareUrl()).then(setCopied)}
+      className={cn(
+        'inline-flex h-8 items-center gap-1.5 rounded-lg px-2 font-medium text-xs md:text-sm',
+        'bg-surface-primary primary-card:bg-surface-secondary',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
+      )}
+    >
+      {copied ? (
+        <CheckIcon className="size-4 stroke-green-700 dark:stroke-green-450" />
+      ) : (
+        <CopyIcon className="size-4 fill-current" />
+      )}
+      {copied ? 'Copied' : 'Copy link'}
+    </button>
   )
 }


### PR DESCRIPTION
Resolves L2B-14639

Adds a "Copy link" control to the compare chart card, next to the view-mode and scale toggles. Clicking it serializes the **live** chart state through `toCompareUrlState` + `buildCompareUrl` (defaults omitted, same canonical form the entry points emit) and writes the full URL to the clipboard — so a click inside the 300ms URL-sync debounce still copies the up-to-date link, even while the address bar lags. On success the button swaps to "Copied" with a check icon and reverts after 1.4s (`aria-live="polite"` announces the change).

Verified in the browser: copying immediately after toggling a control produces the correct URL while the address bar is still stale; opening a copied link reproduces the exact view and re-copies identically; the button fits the mobile layout and is a native button with the shared focus-visible ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)