### PR TITLE
Pin selected projects to the top of the compare picker

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
@@ -39,12 +39,21 @@ export function CompareProjectPicker({
 }: Props) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
+  // Selection snapshotted when the dialog opens. Sorting by the snapshot
+  // instead of the live selection keeps rows from jumping under the pointer
+  // while toggling; the fresh order applies on the next open.
+  const [pinnedSlugs, setPinnedSlugs] = useState<string[]>([])
 
   const selectedSlugs = selectedProjects.map((project) => project.slug)
   const atCap = selectedSlugs.length >= MAX_COMPARE_PROJECTS
 
   const filteredProjects = useMemo(() => {
-    const sorted = [...allProjects].sort((a, b) => a.name.localeCompare(b.name))
+    const pinned = new Set(pinnedSlugs)
+    const sorted = [...allProjects].sort(
+      (a, b) =>
+        Number(pinned.has(b.slug)) - Number(pinned.has(a.slug)) ||
+        a.name.localeCompare(b.name),
+    )
     const query = search.trim().toLowerCase()
     if (!query) return sorted
     return sorted.filter(
@@ -52,7 +61,7 @@ export function CompareProjectPicker({
         project.name.toLowerCase().includes(query) ||
         project.shortName?.toLowerCase().includes(query),
     )
-  }, [allProjects, search])
+  }, [allProjects, search, pinnedSlugs])
 
   const toggleProject = (slug: string) => {
     if (selectedSlugs.includes(slug)) {
@@ -108,7 +117,10 @@ export function CompareProjectPicker({
       ))}
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={() => {
+          setPinnedSlugs(selectedSlugs)
+          setOpen(true)
+        }}
         className="flex h-7 cursor-pointer items-center gap-1.5 rounded-full border border-divider border-dashed py-1 pr-2.5 pl-1.5 font-medium text-secondary text-sm leading-none hover:bg-surface-secondary primary-card:hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         <PlusIcon className="size-4" />


### PR DESCRIPTION
## Description

Closes [L2B-14641](https://linear.app/l2beat/issue/L2B-14641/selected-projects-pinned-to-the-top-of-the-picker)

Opening the "Add project" dialog now lists the current selection first (still checkmarked), followed by the remaining projects; both groups stay alphabetical. At 10/10 this puts the visitor's own picks right at the top, so following the "remove one to add another" message no longer requires scrolling.

The ordering is computed from a snapshot of the selection taken when the dialog opens, not live on every toggle — checking or unchecking an item does not move rows under the pointer; the fresh ordering applies the next time the dialog opens.

Verified in the mock app: selected-first on open, no reorder while toggling, search ("arb") keeps the selected project first, and the same dialog serves the mobile full-screen sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)