### PR TITLE
Sort home flows chart chains by 24h volume

### DIFF
--- a/packages/frontend/src/pages/home/getHomeData.ts
+++ b/packages/frontend/src/pages/home/getHomeData.ts
@@ -28,6 +28,7 @@ import {
   MIN_SELECTED_CHAINS,
   MIN_SELECTED_PROTOCOLS,
 } from '../interop/components/flows/consts'
+import { getFlowChainOrderByVolume } from '../interop/utils/getFlowChainOrderByVolume'
 import { getInteropChainHref } from '../interop/utils/getInteropChainHref'
 import type { HomeScalingCategoryCounts } from './components/HomeScalingCard'
 import type { HomeWhatsNewItem } from './components/HomeWhatsNewCard'
@@ -99,9 +100,23 @@ async function getCachedData(manifest: Manifest) {
   )
   const activeInteropChains = interopChains.filter((chain) => !chain.isUpcoming)
 
-  const sortedChains: InteropChainWithIcon[] = activeInteropChains.toSorted(
-    (a, b) => a.name.localeCompare(b.name),
+  const interopProtocols = await ps.getProjects({ select: ['interopConfig'] })
+  const protocolIds = interopProtocols.map((protocol) => protocol.id)
+
+  // Order chains and pick defaults the same way as the interop summary page
+  // (top chains by 24h volume) so both flows charts show the same data.
+  const activeChainIds = activeInteropChains.map((chain) => chain.id)
+  const defaultFlowChainOrder =
+    activeChainIds.length > 0 && protocolIds.length > 0
+      ? await getFlowChainOrderByVolume(activeChainIds, protocolIds)
+      : activeChainIds
+
+  const activeInteropChainsById = new Map(
+    activeInteropChains.map((chain) => [chain.id, chain]),
   )
+  const sortedChains: InteropChainWithIcon[] = defaultFlowChainOrder
+    .map((chainId) => activeInteropChainsById.get(chainId))
+    .filter((chain) => chain !== undefined)
 
   const defaultSelectedFlowChains = sortedChains
     .slice(0, MAX_SELECTED_CHAINS)
@@ -112,13 +127,10 @@ async function getCachedData(manifest: Manifest) {
   // refetch.
   const chartRange = optionToRange(HOME_CHART_RANGE)
 
-  const interopProtocolsPromise = ps.getProjects({ select: ['interopConfig'] })
-
   const [
     summaryData,
     recentProjects,
     projectCounts,
-    interopProtocols,
     recentChanges,
     ongoingAnomalies,
     scalingCharts,
@@ -130,7 +142,6 @@ async function getCachedData(manifest: Manifest) {
     getScalingSummaryData(),
     getRecentProjectsForHome(manifest),
     getHomeProjectCounts(),
-    interopProtocolsPromise,
     getRecentChangesOverview(),
     getOngoingAnomaliesOverview(),
     getHomeScalingCharts(chartRange),
@@ -147,21 +158,15 @@ async function getCachedData(manifest: Manifest) {
           }),
         )
       : undefined,
-    interopProtocolsPromise.then((projects) => {
-      const protocolIds = projects.map((protocol) => protocol.id)
-      if (
-        defaultSelectedFlowChains.length < MIN_SELECTED_CHAINS ||
-        protocolIds.length < MIN_SELECTED_PROTOCOLS
-      ) {
-        return
-      }
-      return helpers.queryClient.prefetchQuery(
-        helpers.trpc.interop.flows.queryOptions({
-          chains: defaultSelectedFlowChains,
-          protocolIds,
-        }),
-      )
-    }),
+    defaultSelectedFlowChains.length >= MIN_SELECTED_CHAINS &&
+    protocolIds.length >= MIN_SELECTED_PROTOCOLS
+      ? helpers.queryClient.prefetchQuery(
+          helpers.trpc.interop.flows.queryOptions({
+            chains: defaultSelectedFlowChains,
+            protocolIds,
+          }),
+        )
+      : undefined,
   ])
 
   const summaryTabs = summaryData.tabs

--- a/packages/frontend/src/pages/home/getHomeData.ts
+++ b/packages/frontend/src/pages/home/getHomeData.ts
@@ -24,12 +24,12 @@ import type { Manifest } from '~/utils/Manifest'
 import { optionToRange } from '~/utils/range/range'
 import type { InteropChainWithIcon } from '../interop/components/chain-selector/types'
 import {
-  MAX_SELECTED_CHAINS,
   MIN_SELECTED_CHAINS,
   MIN_SELECTED_PROTOCOLS,
 } from '../interop/components/flows/consts'
 import { getFlowChainOrderByVolume } from '../interop/utils/getFlowChainOrderByVolume'
 import { getInteropChainHref } from '../interop/utils/getInteropChainHref'
+import { selectDefaultFlowChains } from '../interop/utils/selectDefaultFlowChains'
 import type { HomeScalingCategoryCounts } from './components/HomeScalingCard'
 import type { HomeWhatsNewItem } from './components/HomeWhatsNewCard'
 import { getHomeProjectCounts } from './getHomeProjectCounts'
@@ -111,16 +111,10 @@ async function getCachedData(manifest: Manifest) {
       ? await getFlowChainOrderByVolume(activeChainIds, protocolIds)
       : activeChainIds
 
-  const activeInteropChainsById = new Map(
-    activeInteropChains.map((chain) => [chain.id, chain]),
+  const { sortedChains, defaultSelectedFlowChains } = selectDefaultFlowChains(
+    activeInteropChains,
+    defaultFlowChainOrder,
   )
-  const sortedChains: InteropChainWithIcon[] = defaultFlowChainOrder
-    .map((chainId) => activeInteropChainsById.get(chainId))
-    .filter((chain) => chain !== undefined)
-
-  const defaultSelectedFlowChains = sortedChains
-    .slice(0, MAX_SELECTED_CHAINS)
-    .map((chain) => chain.id)
 
   // The interop prefetch inputs must match the client queries exactly
   // (HomeTopInteropProtocolsCard, HomeInteropCard) so hydration avoids a

--- a/packages/frontend/src/pages/interop/summary/getInteropSummaryData.ts
+++ b/packages/frontend/src/pages/interop/summary/getInteropSummaryData.ts
@@ -5,11 +5,11 @@ import { getInteropChains } from '~/server/features/scaling/interop/utils/getInt
 import { ps } from '~/server/projects'
 import { getMetadata } from '~/ssr/head/getMetadata'
 import type { RenderData } from '~/ssr/types'
-import type { RouterOutputs } from '~/trpc/React'
 import { getSsrHelpers } from '~/trpc/server'
 import { type Manifest, manifest } from '~/utils/Manifest'
 import { MAX_SELECTED_CHAINS } from '../components/flows/consts'
 import type { InteropQuery } from '../InteropRouter'
+import { getFlowChainOrderByVolume } from '../utils/getFlowChainOrderByVolume'
 import { getInitialInteropSelection } from '../utils/getInitialInteropSelection'
 import { getInteropChainHref } from '../utils/getInteropChainHref'
 import { mapInteropChainsToWithIcons } from '../utils/mapInteropChainsToWithIcons'
@@ -126,23 +126,10 @@ async function getCachedData(
 
   if (shouldPrefetchFlows) {
     const protocolIds = protocols.map((protocol) => protocol.id)
-    // Determine the volume order across all chains on a throwaway client so the
-    // all-chains query is not dehydrated (the client never requests it).
-    const ordering = getSsrHelpers()
-    const flowsData: RouterOutputs['interop']['flows'] =
-      await ordering.queryClient.fetchQuery(
-        ordering.trpc.interop.flows.queryOptions({
-          chains: initialFlowsChains,
-          protocolIds,
-        }),
-      )
-    const chainsByVolume = flowsData.chainData
-      .toSorted((a, b) => b.totalVolume - a.totalVolume)
-      .map((chain) => chain.chainId)
-
-    if (chainsByVolume.length > 0) {
-      defaultFlowChainOrder = chainsByVolume
-    }
+    defaultFlowChainOrder = await getFlowChainOrderByVolume(
+      initialFlowsChains,
+      protocolIds,
+    )
 
     // The client's flows chart defaults to the top chains by volume, so
     // prefetch that exact query to hydrate it from cache.

--- a/packages/frontend/src/pages/interop/summary/getInteropSummaryData.ts
+++ b/packages/frontend/src/pages/interop/summary/getInteropSummaryData.ts
@@ -13,6 +13,7 @@ import { getFlowChainOrderByVolume } from '../utils/getFlowChainOrderByVolume'
 import { getInitialInteropSelection } from '../utils/getInitialInteropSelection'
 import { getInteropChainHref } from '../utils/getInteropChainHref'
 import { mapInteropChainsToWithIcons } from '../utils/mapInteropChainsToWithIcons'
+import { selectDefaultFlowChains } from '../utils/selectDefaultFlowChains'
 import type { InteropSelection } from '../utils/types'
 
 export async function getInteropSummaryData(
@@ -67,15 +68,13 @@ export async function getInteropSummaryData(
       ),
   )
 
-  const activeInteropChainsById = new Map(
-    activeInteropChains.map((chain) => [chain.id, chain]),
+  const {
+    sortedChains: activeInteropChainsSortedByVolume,
+    defaultSelectedFlowChains,
+  } = selectDefaultFlowChains(
+    activeInteropChains,
+    queryState.defaultFlowChainOrder,
   )
-  const activeInteropChainsSortedByVolume = queryState.defaultFlowChainOrder
-    .map((chainId) => activeInteropChainsById.get(chainId))
-    .filter((chain) => chain !== undefined)
-  const defaultSelectedFlowChains = activeInteropChainsSortedByVolume
-    .slice(0, MAX_SELECTED_CHAINS)
-    .map((chain) => chain.id)
 
   return {
     head: {

--- a/packages/frontend/src/pages/interop/utils/getFlowChainOrderByVolume.ts
+++ b/packages/frontend/src/pages/interop/utils/getFlowChainOrderByVolume.ts
@@ -1,0 +1,22 @@
+import type { RouterOutputs } from '~/trpc/React'
+import { getSsrHelpers } from '~/trpc/server'
+
+// Determine the volume order across all chains on a throwaway client so the
+// all-chains query is not dehydrated (the client never requests it).
+export async function getFlowChainOrderByVolume(
+  chainIds: string[],
+  protocolIds: string[],
+): Promise<string[]> {
+  const ordering = getSsrHelpers()
+  const flowsData: RouterOutputs['interop']['flows'] =
+    await ordering.queryClient.fetchQuery(
+      ordering.trpc.interop.flows.queryOptions({
+        chains: chainIds,
+        protocolIds,
+      }),
+    )
+  const chainsByVolume = flowsData.chainData
+    .toSorted((a, b) => b.totalVolume - a.totalVolume)
+    .map((chain) => chain.chainId)
+  return chainsByVolume.length > 0 ? chainsByVolume : chainIds
+}

--- a/packages/frontend/src/pages/interop/utils/selectDefaultFlowChains.ts
+++ b/packages/frontend/src/pages/interop/utils/selectDefaultFlowChains.ts
@@ -1,0 +1,19 @@
+import { MAX_SELECTED_CHAINS } from '../components/flows/consts'
+
+// Shared by Home and the interop summary page so their flows charts default
+// to the same selection: chains ordered by flow volume, top ones selected.
+export function selectDefaultFlowChains<T extends { id: string }>(
+  chains: T[],
+  flowChainOrder: string[],
+): { sortedChains: T[]; defaultSelectedFlowChains: string[] } {
+  const chainsById = new Map(chains.map((chain) => [chain.id, chain]))
+  const sortedChains = flowChainOrder
+    .map((chainId) => chainsById.get(chainId))
+    .filter((chain) => chain !== undefined)
+  return {
+    sortedChains,
+    defaultSelectedFlowChains: sortedChains
+      .slice(0, MAX_SELECTED_CHAINS)
+      .map((chain) => chain.id),
+  }
+}


### PR DESCRIPTION
## Summary

- Extract `getFlowChainOrderByVolume` into `pages/interop/utils`, shared by the home page and the interop summary page
- Home flows chart now defaults to the top chains by 24h volume instead of alphabetical order
- Ordering query runs on a throwaway SSR helper client so the all-chains `interop.flows` query is not dehydrated into the page payload
- Falls back to the original chain list when the volume query returns nothing

## Testing

- `cd packages/frontend && pnpm test` — not run
- Manual check of the home page flows chart chain order vs. interop summary — not run