### PR TITLE
Highlight a compare series when hovering its selection chip

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/components/CompareMetricLineChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareMetricLineChart.tsx
@@ -57,7 +57,7 @@ export function CompareMetricLineChart({
   formatTooltipValue,
   renderTooltipTimestamp,
 }: Props) {
-  const { colors } = useCompareSeries()
+  const { colors, hoveredProjectId } = useCompareSeries()
   const chartMeta = useMemo<ChartMeta>(() => {
     return projects.reduce<ChartMeta>((acc, project) => {
       acc[project.id] = {
@@ -127,6 +127,13 @@ export function CompareMetricLineChart({
               dataKey={project.id}
               hide={!dataKeys.includes(project.id)}
               stroke={chartMeta[project.id]?.color}
+              strokeOpacity={
+                hoveredProjectId !== undefined &&
+                hoveredProjectId !== project.id
+                  ? 0.2
+                  : 1
+              }
+              className="[&_.recharts-line-curve]:transition-[stroke-opacity] [&_.recharts-line-curve]:duration-200 motion-reduce:[&_.recharts-line-curve]:transition-none"
               strokeWidth={2}
               dot={false}
               isAnimationActive={false}

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
@@ -40,7 +40,7 @@ export function CompareProjectPicker({
 }: Props) {
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
-  const { colors } = useCompareSeries()
+  const { colors, setHoveredProjectId } = useCompareSeries()
 
   const selectedSlugs = selectedProjects.map((project) => project.slug)
   const atCap = selectedSlugs.length >= MAX_COMPARE_PROJECTS
@@ -84,8 +84,14 @@ export function CompareProjectPicker({
   return (
     <div className={cn('flex flex-wrap items-center gap-1.5', className)}>
       {selectedProjects.map((project) => (
+        // Focus and blur bubble in React, so keyboard-focusing the remove
+        // button highlights the series the same way hovering the chip does.
         <div
           key={project.slug}
+          onMouseEnter={() => setHoveredProjectId(project.id)}
+          onMouseLeave={() => setHoveredProjectId(undefined)}
+          onFocus={() => setHoveredProjectId(project.id)}
+          onBlur={() => setHoveredProjectId(undefined)}
           className="flex h-7 items-center gap-1.5 rounded-full border border-divider bg-surface-primary primary-card:bg-surface-secondary py-1 pr-1.5 pl-1"
         >
           {/* The ring makes the chip strip double as the chart's color key,

--- a/packages/frontend/src/pages/scaling/compare/components/CompareSeriesContext.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareSeriesContext.tsx
@@ -1,10 +1,19 @@
-import { createContext, type ReactNode, useContext, useMemo } from 'react'
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
 import { getCompareSeriesColors } from '../utils/getCompareSeriesColors'
 
 interface CompareSeriesContextType {
   /** Series color per project id, assigned by selection order. */
   colors: Record<string, string>
+  /** Project id of the chip being hovered or focused, if any. */
+  hoveredProjectId: string | undefined
+  setHoveredProjectId: (projectId: string | undefined) => void
 }
 
 const CompareSeriesContext = createContext<
@@ -24,11 +33,23 @@ export function CompareSeriesProvider({
   projects: CompareProjectEntry[]
   children: ReactNode
 }) {
+  const [hoveredProjectId, setHoveredProjectId] = useState<string>()
+
   const colors = useMemo(
     () => getCompareSeriesColors(projects.map((project) => project.id)),
     [projects],
   )
-  const value = useMemo(() => ({ colors }), [colors])
+  // A hover can outlive its project (chip removed mid-hover, so no
+  // mouseleave fires) - ignore it instead of dimming every series with
+  // nothing highlighted.
+  const hovered =
+    hoveredProjectId !== undefined && colors[hoveredProjectId] !== undefined
+      ? hoveredProjectId
+      : undefined
+  const value = useMemo(
+    () => ({ colors, hoveredProjectId: hovered, setHoveredProjectId }),
+    [colors, hovered],
+  )
 
   return (
     <CompareSeriesContext.Provider value={value}>


### PR DESCRIPTION
## Summary

Implements [L2B-14642](https://linear.app/l2beat/issue/L2B-14642/hovering-a-chip-highlights-its-series-on-the-chart). Stacked on #12502 (L2B-14640) — review only the last commit until that merges.

- Adds a hovered-series value to the shared `CompareSeriesContext` introduced in #12502. Chip `mouseenter`/`mouseleave` and `focus`/`blur` (focus bubbles from the remove button) set it; the chart renderer dims non-hovered lines to `strokeOpacity` 0.2 while the hovered line stays at full strength.
- Composes with the interactive legend: series hidden via the legend stay hidden (only opacity is touched, never `hide`), and visible series still dim. Tooltip plumbing is untouched.
- A hover that outlives its project (chip removed mid-hover, so no `mouseleave` fires) is ignored, so the chart doesn't stay dimmed with nothing highlighted.
- The dimming uses a 200ms `stroke-opacity` CSS transition, disabled under `prefers-reduced-motion`.

## Test plan

- Verified in the mock-mode dev server: hover dims the other four of five series and restores on un-hover; `focusin`/`focusout` on a chip's remove button produces the same highlight; a legend-hidden series is not revealed by hovering its chip; removing the hovered chip restores full opacity; the generated CSS includes the `prefers-reduced-motion: reduce → transition-property: none` rule.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (505 passing) in `packages/frontend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)