### PR TITLE
Add TVS bridge type filter to the compare page

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
@@ -4,9 +4,18 @@ import { useMemo } from 'react'
 import { useTRPC } from '~/trpc/React'
 import { formatTimestamp } from '~/utils/dates'
 import { CompareMetricLineChart } from '../../components/CompareMetricLineChart'
+import type { CompareTvsFilter } from '../../utils/compareChartState'
 import type { CompareChartPoint } from '../../utils/toIndexedChartData'
 import type { CompareMetricChartProps } from '../types'
 import { getTvsCompareChartParams } from './getTvsCompareChartParams'
+
+/** Indices into `ProjectTvsChartDataPoint` for each TVS filter. */
+const TVS_FILTER_VALUE_INDEX: Record<CompareTvsFilter, number> = {
+  all: 0,
+  canonical: 1,
+  external: 2,
+  native: 3,
+}
 
 export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
   const trpc = useTRPC()
@@ -16,6 +25,7 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
     ),
   )
   const unit = state.tvsUnit
+  const valueIndex = TVS_FILTER_VALUE_INDEX[state.tvsFilter]
 
   const chartData = useMemo(
     () =>
@@ -23,7 +33,7 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
         const point: CompareChartPoint = { timestamp }
         const divider = unit === 'usd' ? 1 : ethPrice
         for (const project of projects) {
-          const value = valuesByProject[project.id]?.[0]
+          const value = valuesByProject[project.id]?.[valueIndex]
           point[project.id] =
             value !== undefined && divider !== null && divider !== 0
               ? value / divider
@@ -31,7 +41,7 @@ export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {
         }
         return point
       }),
-    [data, projects, unit],
+    [data, projects, unit, valueIndex],
   )
 
   return (

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
@@ -1,9 +1,29 @@
 import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/core/Select'
 import { Skeleton } from '~/components/core/Skeleton'
 import { DisplayControls } from '~/components/table/display/DisplayControls'
 import { useIsClient } from '~/hooks/useIsClient'
-import type { CompareTvsUnit } from '../../utils/compareChartState'
+import {
+  COMPARE_TVS_BRIDGE_TYPES,
+  type CompareTvsBridgeType,
+  type CompareTvsFilter,
+  type CompareTvsUnit,
+} from '../../utils/compareChartState'
 import type { CompareMetricControlsProps } from '../types'
+
+const TVS_BRIDGE_TYPE_LABELS: Record<CompareTvsBridgeType, string> = {
+  canonical: 'Canonical',
+  native: 'Native',
+  external: 'External',
+}
 
 export function TvsCompareControls({
   state,
@@ -11,10 +31,36 @@ export function TvsCompareControls({
 }: CompareMetricControlsProps) {
   const isClient = useIsClient()
   if (!isClient) {
-    return <Skeleton className="h-9 w-[196px]" />
+    return <Skeleton className="h-9 w-[264px]" />
   }
   return (
     <div className="flex items-center gap-1">
+      <Select
+        value={state.tvsFilter}
+        onValueChange={(value) =>
+          setState((prev) => ({
+            ...prev,
+            tvsFilter: value as CompareTvsFilter,
+          }))
+        }
+      >
+        <SelectTrigger className="h-9" aria-label="Filter the compared value">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent align="end">
+          <SelectItem value="all">All</SelectItem>
+          <SelectGroup>
+            <SelectLabel className="pl-2.5 text-secondary">
+              Bridge type
+            </SelectLabel>
+            {COMPARE_TVS_BRIDGE_TYPES.map((bridgeType) => (
+              <SelectItem key={bridgeType} value={bridgeType}>
+                {TVS_BRIDGE_TYPE_LABELS[bridgeType]}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
       <RadioGroup
         name="compareTvsUnit"
         value={state.tvsUnit}

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
@@ -12,6 +12,7 @@ const DEFAULT_STATE: CompareChartState = {
   mode: 'absolute',
   activityUnit: 'uops',
   tvsUnit: 'usd',
+  tvsFilter: 'all',
   excludeAssociatedTokens: false,
   excludeRwaRestrictedTokens: true,
 }
@@ -114,11 +115,21 @@ describe(buildCompareUrl.name, () => {
     )
   })
 
+  it('serializes the non-default tvs filter', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      tvsFilter: 'canonical',
+    })
+
+    expect(url).toEqual('/scaling/compare?filter=canonical')
+  })
+
   it('omits the tvs controls for other metrics', () => {
     const url = buildCompareUrl(PATH, {
       ...DEFAULT_STATE,
       metric: 'activity',
       tvsUnit: 'eth',
+      tvsFilter: 'native',
       excludeAssociatedTokens: true,
       excludeRwaRestrictedTokens: false,
     })

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
+  DEFAULT_COMPARE_TVS_FILTER,
   DEFAULT_COMPARE_TVS_UNIT,
   DEFAULT_COMPARE_VIEW_MODE,
 } from './compareChartState'
@@ -47,6 +48,9 @@ export function buildCompareUrl(
   if (state.metric === 'tvs') {
     if (state.tvsUnit !== DEFAULT_COMPARE_TVS_UNIT) {
       params.set('unit', state.tvsUnit)
+    }
+    if (state.tvsFilter !== DEFAULT_COMPARE_TVS_FILTER) {
+      params.set('filter', state.tvsFilter)
     }
     if (
       state.excludeAssociatedTokens !==

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -17,6 +17,23 @@ export type CompareActivityUnit = (typeof COMPARE_ACTIVITY_UNITS)[number]
 export const COMPARE_TVS_UNITS = ['usd', 'eth'] as const
 export type CompareTvsUnit = (typeof COMPARE_TVS_UNITS)[number]
 
+export const COMPARE_TVS_BRIDGE_TYPES = [
+  'canonical',
+  'native',
+  'external',
+] as const
+export type CompareTvsBridgeType = (typeof COMPARE_TVS_BRIDGE_TYPES)[number]
+
+/**
+ * The TVS component filter, restricting the compared value to a single
+ * component of the split. A single field rather than one field per grouping:
+ * the data carries the groupings as independent axes with no cross-product
+ * (bridge type now, asset category later), so only one grouping can be
+ * non-"all" at a time.
+ */
+export const COMPARE_TVS_FILTERS = ['all', ...COMPARE_TVS_BRIDGE_TYPES] as const
+export type CompareTvsFilter = (typeof COMPARE_TVS_FILTERS)[number]
+
 export const COMPARE_VIEW_MODES = ['absolute', 'indexed'] as const
 export type CompareViewMode = (typeof COMPARE_VIEW_MODES)[number]
 
@@ -45,6 +62,7 @@ export interface CompareChartState {
   activityUnit: CompareActivityUnit
   /** Per-metric controls of the TVS metric; ignored elsewhere. */
   tvsUnit: CompareTvsUnit
+  tvsFilter: CompareTvsFilter
   excludeAssociatedTokens: boolean
   excludeRwaRestrictedTokens: boolean
 }
@@ -61,6 +79,7 @@ export interface CompareClientState {
   mode: CompareViewMode
   activityUnit: CompareActivityUnit
   tvsUnit: CompareTvsUnit
+  tvsFilter: CompareTvsFilter
   excludeAssociatedTokens: boolean
   excludeRwaRestrictedTokens: boolean
   chartRange: ChartRange
@@ -76,6 +95,7 @@ export function toCompareUrlState(
     mode: state.mode,
     activityUnit: state.activityUnit,
     tvsUnit: state.tvsUnit,
+    tvsFilter: state.tvsFilter,
     excludeAssociatedTokens: state.excludeAssociatedTokens,
     excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
     range: chartRangeToCompareRange(state.chartRange),
@@ -93,6 +113,7 @@ export function toCompareClientState(
     mode: state.mode,
     activityUnit: state.activityUnit,
     tvsUnit: state.tvsUnit,
+    tvsFilter: state.tvsFilter,
     excludeAssociatedTokens: state.excludeAssociatedTokens,
     excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
     chartRange,
@@ -105,6 +126,7 @@ export const DEFAULT_COMPARE_SCALE: ChartScale = 'linear'
 export const DEFAULT_COMPARE_VIEW_MODE: CompareViewMode = 'absolute'
 export const DEFAULT_COMPARE_ACTIVITY_UNIT: CompareActivityUnit = 'uops'
 export const DEFAULT_COMPARE_TVS_UNIT: CompareTvsUnit = 'usd'
+export const DEFAULT_COMPARE_TVS_FILTER: CompareTvsFilter = 'all'
 // The TVS control defaults match the /scaling/tvs page so the default
 // comparison reproduces the numbers shown there.
 export const DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS = false
@@ -154,6 +176,7 @@ export function isSameCompareState(
     (left.metric !== 'activity' || left.activityUnit === right.activityUnit) &&
     (left.metric !== 'tvs' ||
       (left.tvsUnit === right.tvsUnit &&
+        left.tvsFilter === right.tvsFilter &&
         left.excludeAssociatedTokens === right.excludeAssociatedTokens &&
         left.excludeRwaRestrictedTokens ===
           right.excludeRwaRestrictedTokens)) &&

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
@@ -26,6 +26,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'tps',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     })
@@ -42,6 +43,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     })
@@ -58,6 +60,12 @@ describe(parseCompareStateFromSearchParams.name, () => {
 
     expect(result.tvsUnit).toEqual('eth')
     expect(result.activityUnit).toEqual('uops')
+  })
+
+  it('parses the tvs filter', () => {
+    const result = parse('filter=canonical')
+
+    expect(result.tvsFilter).toEqual('canonical')
   })
 
   it('parses the tvs token exclusion toggles', () => {
@@ -91,7 +99,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
 
   it('falls back to defaults on garbage values', () => {
     const result = parse(
-      'metric=bogus&range=yesterday&scale=cubic&unit=gas&mode=sideways&excludeAssociated=maybe&excludeRwa=nonsense',
+      'metric=bogus&range=yesterday&scale=cubic&unit=gas&mode=sideways&filter=everything&excludeAssociated=maybe&excludeRwa=nonsense',
     )
 
     expect(result).toEqual({
@@ -102,6 +110,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     })
@@ -122,6 +131,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }
@@ -141,6 +151,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }
@@ -160,6 +171,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'tps',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }
@@ -179,6 +191,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'eth',
+      tvsFilter: 'external',
       excludeAssociatedTokens: true,
       excludeRwaRestrictedTokens: false,
     }
@@ -198,6 +211,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'indexed',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
@@ -2,12 +2,14 @@ import {
   COMPARE_ACTIVITY_UNITS,
   COMPARE_METRIC_IDS,
   COMPARE_RANGE_OPTIONS,
+  COMPARE_TVS_FILTERS,
   COMPARE_TVS_UNITS,
   type CompareActivityUnit,
   type CompareChartState,
   type CompareMetricId,
   type CompareRange,
   type CompareRangeOption,
+  type CompareTvsFilter,
   type CompareTvsUnit,
   DEFAULT_COMPARE_ACTIVITY_UNIT,
   DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
@@ -15,6 +17,7 @@ import {
   DEFAULT_COMPARE_METRIC,
   DEFAULT_COMPARE_RANGE,
   DEFAULT_COMPARE_SCALE,
+  DEFAULT_COMPARE_TVS_FILTER,
   DEFAULT_COMPARE_TVS_UNIT,
   DEFAULT_COMPARE_VIEW_MODE,
   MAX_COMPARE_PROJECTS,
@@ -45,6 +48,7 @@ export function parseCompareStateFromSearchParams({
     // disjoint, so each metric picks up only its own units.
     activityUnit: parseActivityUnit(searchParams.get('unit')),
     tvsUnit: parseTvsUnit(searchParams.get('unit')),
+    tvsFilter: parseTvsFilter(searchParams.get('filter')),
     excludeAssociatedTokens: parseBoolean(
       searchParams.get('excludeAssociated'),
       DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
@@ -69,6 +73,11 @@ function parseActivityUnit(value: string | null): CompareActivityUnit {
 function parseTvsUnit(value: string | null): CompareTvsUnit {
   const unit = COMPARE_TVS_UNITS.find((unit) => unit === value)
   return unit ?? DEFAULT_COMPARE_TVS_UNIT
+}
+
+function parseTvsFilter(value: string | null): CompareTvsFilter {
+  const filter = COMPARE_TVS_FILTERS.find((filter) => filter === value)
+  return filter ?? DEFAULT_COMPARE_TVS_FILTER
 }
 
 function parseBoolean(value: string | null, defaultValue: boolean): boolean {


### PR DESCRIPTION
## Summary

Adds a bridge type filter (**All / Canonical / Native / External**) to the TVS metric on `/scaling/compare`, mirroring the "By bridge type" grouping on the TVS page.

- The detailed TVS chart data already carries the per-project bridge type split at every timestamp, so selecting a bridge type re-renders all series client-side — no new network request.
- The filter is a single select with the bridge types as a labelled group, designed so the asset category grouping (L2B-14649) can join as a sibling group later with only one grouping active at a time (the data has no bridge-type × asset-category cross-product).
- URL encoding follows the per-metric-control pattern: `?filter=` is only encoded while the TVS metric is active and omitted at the default "All"; unknown values fall back to the default.
- Works combined with the ETH unit, indexed mode, and both exclusion toggles (exclusions are query inputs and keep applying server-side).

## Test plan

- [x] URL round-trip tests extended for the new control (build + parse + garbage fallback)
- [x] Verified in the mock app: selecting Canonical re-renders series from already-fetched data with zero network requests, URL updates to `?filter=canonical`, and `?filter=canonical&unit=eth&mode=indexed` restores all controls on load

Closes L2B-14647

🤖 Generated with [Claude Code](https://claude.com/claude-code)