### PR TITLE
Add TVS asset category filter to the compare page

### DIFF
--- a/packages/frontend/src/components/table/display/DisplayControls.tsx
+++ b/packages/frontend/src/components/table/display/DisplayControls.tsx
@@ -29,10 +29,13 @@ import {
 interface Props<K extends DisplayOptionsKey> {
   display: Record<K, boolean>
   setDisplay: (key: K, value: boolean) => void
+  /** Options to disable, mapped to the hint explaining why. */
+  disabled?: Partial<Record<K, string>>
 }
 export function DisplayControls<K extends DisplayOptionsKey>({
   display,
   setDisplay,
+  disabled,
 }: Props<K>) {
   const providedEntries = Object.entries(display) as [K, boolean][]
 
@@ -74,6 +77,7 @@ export function DisplayControls<K extends DisplayOptionsKey>({
               optionKey={key}
               value={value}
               setDisplay={setDisplay}
+              disabledReason={disabled?.[key]}
             />
           ))}
         </PopoverContent>
@@ -98,6 +102,7 @@ export function DisplayControls<K extends DisplayOptionsKey>({
                 optionKey={key}
                 value={value}
                 setDisplay={setDisplay}
+                disabledReason={disabled?.[key]}
               />
             ))}
           </div>
@@ -111,27 +116,30 @@ function DisplayCheckbox<K extends DisplayOptionsKey>({
   optionKey,
   value,
   setDisplay,
+  disabledReason,
 }: {
   optionKey: K
   value: boolean
   setDisplay: (key: K, value: boolean) => void
+  disabledReason?: string
 }) {
   const option: DisplayOption = DISPLAY_OPTIONS[optionKey]
   return (
     <Checkbox
       name={optionKey}
       checked={value}
+      disabled={disabledReason !== undefined}
       onCheckedChange={(checked) => setDisplay(optionKey, !!checked)}
       className="w-full rounded-sm hover:bg-surface-primary-hover max-md:pl-0"
     >
       <div className="flex items-center gap-1 text-sm">
         {option.label}
-        {option.tooltip && (
+        {(disabledReason ?? option.tooltip) && (
           <Tooltip>
             <TooltipTrigger>
               <InfoIcon className="size-3.5" />
             </TooltipTrigger>
-            <TooltipContent>{option.tooltip}</TooltipContent>
+            <TooltipContent>{disabledReason ?? option.tooltip}</TooltipContent>
           </Tooltip>
         )}
       </div>

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareChart.tsx
@@ -15,6 +15,12 @@ const TVS_FILTER_VALUE_INDEX: Record<CompareTvsFilter, number> = {
   canonical: 1,
   external: 2,
   native: 3,
+  ether: 4,
+  stablecoin: 5,
+  btc: 6,
+  rwaRestricted: 7,
+  rwaPublic: 8,
+  other: 9,
 }
 
 export function TvsCompareChart({ projects, state }: CompareMetricChartProps) {

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
@@ -12,10 +12,13 @@ import { Skeleton } from '~/components/core/Skeleton'
 import { DisplayControls } from '~/components/table/display/DisplayControls'
 import { useIsClient } from '~/hooks/useIsClient'
 import {
+  COMPARE_TVS_ASSET_CATEGORIES,
   COMPARE_TVS_BRIDGE_TYPES,
+  type CompareTvsAssetCategory,
   type CompareTvsBridgeType,
   type CompareTvsFilter,
   type CompareTvsUnit,
+  effectiveExcludeRwaRestrictedTokens,
 } from '../../utils/compareChartState'
 import type { CompareMetricControlsProps } from '../types'
 
@@ -23,6 +26,16 @@ const TVS_BRIDGE_TYPE_LABELS: Record<CompareTvsBridgeType, string> = {
   canonical: 'Canonical',
   native: 'Native',
   external: 'External',
+}
+
+// Same labels as the TVS page's "By asset category" chart.
+const TVS_ASSET_CATEGORY_LABELS: Record<CompareTvsAssetCategory, string> = {
+  ether: 'ETH & derivatives',
+  stablecoin: 'Stablecoins',
+  btc: 'BTC & derivatives',
+  rwaPublic: 'Public RWAs',
+  rwaRestricted: 'Restricted RWAs',
+  other: 'Other',
 }
 
 export function TvsCompareControls({
@@ -33,6 +46,7 @@ export function TvsCompareControls({
   if (!isClient) {
     return <Skeleton className="h-9 w-[264px]" />
   }
+  const restrictedRwaFilterActive = state.tvsFilter === 'rwaRestricted'
   return (
     <div className="flex items-center gap-1">
       <Select
@@ -59,6 +73,16 @@ export function TvsCompareControls({
               </SelectItem>
             ))}
           </SelectGroup>
+          <SelectGroup>
+            <SelectLabel className="pl-2.5 text-secondary">
+              Asset category
+            </SelectLabel>
+            {COMPARE_TVS_ASSET_CATEGORIES.map((assetCategory) => (
+              <SelectItem key={assetCategory} value={assetCategory}>
+                {TVS_ASSET_CATEGORY_LABELS[assetCategory]}
+              </SelectItem>
+            ))}
+          </SelectGroup>
         </SelectContent>
       </Select>
       <RadioGroup
@@ -79,9 +103,21 @@ export function TvsCompareControls({
       </RadioGroup>
       <DisplayControls
         display={{
-          excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
+          // Show the effective value: the toggle is overridden to false
+          // while the Restricted RWAs filter is active, because excluding
+          // restricted RWAs while comparing them would zero the chart.
+          excludeRwaRestrictedTokens:
+            effectiveExcludeRwaRestrictedTokens(state),
           excludeAssociatedTokens: state.excludeAssociatedTokens,
         }}
+        disabled={
+          restrictedRwaFilterActive
+            ? {
+                excludeRwaRestrictedTokens:
+                  'Unavailable while comparing restricted RWAs - it would exclude the very tokens being compared.',
+              }
+            : undefined
+        }
         setDisplay={(key, value) =>
           setState((prev) => ({ ...prev, [key]: value }))
         }

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.test.ts
@@ -1,0 +1,31 @@
+import { expect } from 'earl'
+import type { ChartRange } from '~/utils/range/range'
+import { getTvsCompareChartParams } from './getTvsCompareChartParams'
+
+const BASE_STATE = {
+  chartRange: [1700000000, 1710000000] as ChartRange,
+  excludeAssociatedTokens: false,
+  excludeRwaRestrictedTokens: true,
+}
+
+describe(getTvsCompareChartParams.name, () => {
+  it('passes the exclusion toggles through', () => {
+    const params = getTvsCompareChartParams([], {
+      ...BASE_STATE,
+      tvsFilter: 'canonical',
+    })
+
+    expect(params.excludeRwaRestrictedTokens).toEqual(true)
+  })
+
+  it('overrides the rwa exclusion while the restricted rwa filter is active', () => {
+    // Excluding restricted RWAs while comparing them would query an
+    // all-zero restricted RWA component for every project.
+    const params = getTvsCompareChartParams([], {
+      ...BASE_STATE,
+      tvsFilter: 'rwaRestricted',
+    })
+
+    expect(params.excludeRwaRestrictedTokens).toEqual(false)
+  })
+})

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
@@ -1,5 +1,8 @@
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
-import type { CompareClientState } from '../../utils/compareChartState'
+import {
+  type CompareClientState,
+  effectiveExcludeRwaRestrictedTokens,
+} from '../../utils/compareChartState'
 
 /**
  * Builds the `tvs.detailedChartWithProjectsRanges` input for the compare
@@ -10,13 +13,16 @@ export function getTvsCompareChartParams(
   projects: CompareProjectEntry[],
   state: Pick<
     CompareClientState,
-    'chartRange' | 'excludeAssociatedTokens' | 'excludeRwaRestrictedTokens'
+    | 'chartRange'
+    | 'tvsFilter'
+    | 'excludeAssociatedTokens'
+    | 'excludeRwaRestrictedTokens'
   >,
 ) {
   return {
     range: state.chartRange,
     excludeAssociatedTokens: state.excludeAssociatedTokens,
-    excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
+    excludeRwaRestrictedTokens: effectiveExcludeRwaRestrictedTokens(state),
     projects: projects.flatMap((project) =>
       project.tvsSinceTimestamp !== undefined
         ? [

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
@@ -165,6 +165,25 @@ describe(buildCompareUrl.name, () => {
     expect(url).toEqual('/scaling/compare?filter=canonical')
   })
 
+  it('serializes an asset category tvs filter', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      tvsFilter: 'stablecoin',
+    })
+
+    expect(url).toEqual('/scaling/compare?filter=stablecoin')
+  })
+
+  it('omits the overridden rwa toggle while the restricted rwa filter is active', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      tvsFilter: 'rwaRestricted',
+      excludeRwaRestrictedTokens: false,
+    })
+
+    expect(url).toEqual('/scaling/compare?filter=rwaRestricted')
+  })
+
   it('omits the tvs controls for other metrics', () => {
     const url = buildCompareUrl(PATH, {
       ...DEFAULT_STATE,

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
@@ -65,9 +65,12 @@ export function buildCompareUrl(
     ) {
       params.set('excludeAssociated', String(state.excludeAssociatedTokens))
     }
+    // The exclude-restricted-RWA toggle is disabled and overridden while
+    // the Restricted RWAs filter is active, so its value is not encoded.
     if (
+      state.tvsFilter !== 'rwaRestricted' &&
       state.excludeRwaRestrictedTokens !==
-      DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS
+        DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS
     ) {
       params.set('excludeRwa', String(state.excludeRwaRestrictedTokens))
     }

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -29,14 +29,29 @@ export const COMPARE_TVS_BRIDGE_TYPES = [
 ] as const
 export type CompareTvsBridgeType = (typeof COMPARE_TVS_BRIDGE_TYPES)[number]
 
+export const COMPARE_TVS_ASSET_CATEGORIES = [
+  'ether',
+  'stablecoin',
+  'btc',
+  'rwaPublic',
+  'rwaRestricted',
+  'other',
+] as const
+export type CompareTvsAssetCategory =
+  (typeof COMPARE_TVS_ASSET_CATEGORIES)[number]
+
 /**
  * The TVS component filter, restricting the compared value to a single
  * component of the split. A single field rather than one field per grouping:
- * the data carries the groupings as independent axes with no cross-product
- * (bridge type now, asset category later), so only one grouping can be
+ * the data carries the two groupings (bridge type and asset category) as
+ * independent axes with no cross-product, so only one grouping can be
  * non-"all" at a time.
  */
-export const COMPARE_TVS_FILTERS = ['all', ...COMPARE_TVS_BRIDGE_TYPES] as const
+export const COMPARE_TVS_FILTERS = [
+  'all',
+  ...COMPARE_TVS_BRIDGE_TYPES,
+  ...COMPARE_TVS_ASSET_CATEGORIES,
+] as const
 export type CompareTvsFilter = (typeof COMPARE_TVS_FILTERS)[number]
 
 export const COMPARE_COSTS_UNITS = ['usd', 'eth', 'gas'] as const
@@ -148,6 +163,21 @@ export const DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS = true
 export const MAX_COMPARE_PROJECTS = 10
 export const DEFAULT_COMPARE_PROJECTS_COUNT = 5
 
+/**
+ * The exclude-restricted-RWA toggle conflicts with the Restricted RWAs
+ * filter: combined they would render an all-zero chart. While that filter is
+ * active the toggle is disabled and overridden to false; the stored value is
+ * kept so switching the filter away restores the user's choice.
+ */
+export function effectiveExcludeRwaRestrictedTokens(state: {
+  tvsFilter: CompareTvsFilter
+  excludeRwaRestrictedTokens: boolean
+}): boolean {
+  return state.tvsFilter === 'rwaRestricted'
+    ? false
+    : state.excludeRwaRestrictedTokens
+}
+
 export function compareRangeToChartRange(range: CompareRange): ChartRange {
   if (typeof range === 'string') {
     return optionToRange(range)
@@ -193,8 +223,12 @@ export function isSameCompareState(
       (left.tvsUnit === right.tvsUnit &&
         left.tvsFilter === right.tvsFilter &&
         left.excludeAssociatedTokens === right.excludeAssociatedTokens &&
-        left.excludeRwaRestrictedTokens ===
-          right.excludeRwaRestrictedTokens)) &&
+        // The exclude-restricted-RWA toggle is disabled and overridden while
+        // the Restricted RWAs filter is active, so its stored value is
+        // hidden and not encoded.
+        (left.tvsFilter === 'rwaRestricted' ||
+          left.excludeRwaRestrictedTokens ===
+            right.excludeRwaRestrictedTokens))) &&
     isSameRange(left.range, right.range) &&
     left.projects.length === right.projects.length &&
     left.projects.every((slug, index) => slug === right.projects[index])

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
@@ -72,6 +72,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      tvsFilter: 'all',
       costsUnit: 'usd',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
@@ -92,6 +93,18 @@ describe(parseCompareStateFromSearchParams.name, () => {
 
   it('parses the tvs filter', () => {
     const result = parse('filter=canonical')
+
+    expect(result.tvsFilter).toEqual('canonical')
+  })
+
+  it('parses an asset category tvs filter', () => {
+    const result = parse('filter=stablecoin')
+
+    expect(result.tvsFilter).toEqual('stablecoin')
+  })
+
+  it('keeps bridge type and asset category mutually exclusive by holding a single filter value', () => {
+    const result = parse('filter=canonical&filter=stablecoin')
 
     expect(result.tvsFilter).toEqual('canonical')
   })
@@ -269,6 +282,51 @@ describe(parseCompareStateFromSearchParams.name, () => {
     const url = buildCompareUrl('/scaling/compare', state)
     const search = url.split('?')[1] ?? ''
 
+    expect(parse(search)).toEqual(state)
+  })
+
+  it('round-trips an asset category filter through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'tvs',
+      projects: ['base'],
+      range: '90d',
+      scale: 'linear',
+      mode: 'absolute',
+      activityUnit: 'uops',
+      tvsUnit: 'usd',
+      tvsFilter: 'stablecoin',
+      costsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(parse(search)).toEqual(state)
+  })
+
+  it('round-trips the restricted rwa filter through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'tvs',
+      projects: [],
+      range: '1y',
+      scale: 'linear',
+      mode: 'absolute',
+      activityUnit: 'uops',
+      tvsUnit: 'usd',
+      tvsFilter: 'rwaRestricted',
+      costsUnit: 'usd',
+      // The stored toggle value stays at the default; while this filter is
+      // active it is overridden to false everywhere it is applied.
+      excludeRwaRestrictedTokens: true,
+      excludeAssociatedTokens: false,
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(url).toEqual('/scaling/compare?filter=rwaRestricted')
     expect(parse(search)).toEqual(state)
   })
 


### PR DESCRIPTION
## Summary

Stacked on #12506. Extends the TVS filter on `/scaling/compare` with an asset category grouping — **ETH & derivatives, Stablecoins, BTC & derivatives, Public RWAs, Restricted RWAs, Other** — using the same labels as the TVS page's "By asset category" chart.

- The single-select filter keeps bridge type and asset category mutually exclusive by construction: one field holds one grouping value, matching the data, which carries the two splits as independent axes with no cross-product.
- Selecting a category re-renders all series from the already-fetched per-project split — no new network request (except the Restricted RWAs case below, which necessarily changes the query).
- Restricted RWAs × exclude-restricted-RWA toggle: combined they would render an all-zero chart. While that filter is active the toggle is disabled with a hint and overridden to false. The stored toggle value is kept so switching the filter away restores the user's choice, and the hidden value is not URL-encoded (mirroring the existing hidden-control pattern for scale in indexed mode).
- URL encoding follows the per-metric-control pattern; `?filter=` round-trips only while the TVS metric is active.

## Test plan

- [x] URL round-trip tests extended: asset category values, the mutual-exclusion rule (single filter value), and the Restricted RWAs / excludeRwa interplay
- [x] New unit test for the query-input override that prevents the all-zero chart
- [x] Verified in the mock app: grouped select renders both groupings, `?filter=stablecoin` re-renders series with no refetch, selecting Restricted RWAs disables the toggle (shown unchecked) and encodes only `?filter=rwaRestricted`, switching back to All restores the toggle to its stored value

Closes L2B-14649

🤖 Generated with [Claude Code](https://claude.com/claude-code)