### PR TITLE
Rename home top chains card title to "Layer 2s"

### DIFF
--- a/packages/frontend/src/pages/home/components/HomeTopChainsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeTopChainsCard.tsx
@@ -56,7 +56,7 @@ export function HomeTopChainsCard({ entries, tvsData }: Props) {
   return (
     <HomeCard className="flex h-full min-w-0 flex-col">
       <HomeCardHeader
-        title="Chains"
+        title="Layer 2s"
         badge={<TopNBadge n={5} />}
         href="/scaling/summary"
         linkLabel="View all"


### PR DESCRIPTION
## Summary

- Change the `HomeTopChainsCard` header title from "Chains" to "Layer 2s" on the home page.
- Copy-only change; the badge, link target (`/scaling/summary`) and data are untouched.

## Testing

- Not run — single string change with no logic impact.