### PR TITLE
Add onchain costs metric to the scaling compare page

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
@@ -13,11 +13,18 @@ import { CloseIcon } from '~/icons/Close'
 import { PlusIcon } from '~/icons/Plus'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
 import { cn } from '~/utils/cn'
+import type { CompareMetric } from '../metrics/types'
 import { MAX_COMPARE_PROJECTS } from '../utils/compareChartState'
 import { useCompareSeries } from './CompareSeriesContext'
 
 interface Props {
   allProjects: CompareProjectEntry[]
+  /**
+   * The active metric, for marking projects it has no data for. The chips
+   * double as the chart legend, so the "no data" note lives here instead of
+   * an empty series in the chart.
+   */
+  metric: CompareMetric
   /**
    * The effective selection shown on the chart: the explicit URL selection,
    * or the top-N defaults when nothing is selected. Editing it always emits
@@ -33,6 +40,7 @@ interface Props {
 
 export function CompareProjectPicker({
   allProjects,
+  metric,
   selectedProjects,
   isDefaultSelection,
   onChange,
@@ -48,6 +56,8 @@ export function CompareProjectPicker({
 
   const selectedSlugs = selectedProjects.map((project) => project.slug)
   const atCap = selectedSlugs.length >= MAX_COMPARE_PROJECTS
+  const hasMetricData = metric.hasData ?? (() => true)
+  const noDataLabel = metric.noDataLabel ?? 'No data'
 
   const filteredProjects = useMemo(() => {
     const pinned = new Set(pinnedSlugs)
@@ -100,20 +110,38 @@ export function CompareProjectPicker({
           onFocus={() => setHoveredProjectId(project.id)}
           onBlur={() => setHoveredProjectId(undefined)}
           className="flex h-7 items-center gap-1.5 rounded-full border border-divider bg-surface-primary primary-card:bg-surface-secondary py-1 pr-1.5 pl-1"
-          style={{ borderColor: colors[project.id] }}
+          // The ring makes the chip strip double as the chart's color key,
+          // so it must show exactly the series color the chart uses - and no
+          // color at all when the metric has no series for the project.
+          style={
+            hasMetricData(project)
+              ? { borderColor: colors[project.id] }
+              : undefined
+          }
         >
-          {/* The ring makes the chip strip double as the chart's color key,
-              so it must show exactly the series color the chart uses. */}
           <img
             src={project.iconUrl}
             alt=""
             width={18}
             height={18}
-            className="size-[18px] rounded-full"
+            className={cn(
+              'size-[18px] rounded-full',
+              !hasMetricData(project) && 'opacity-50',
+            )}
           />
-          <span className="font-medium text-sm leading-none">
+          <span
+            className={cn(
+              'font-medium text-sm leading-none',
+              !hasMetricData(project) && 'text-secondary',
+            )}
+          >
             {project.shortName ?? project.name}
           </span>
+          {!hasMetricData(project) && (
+            <span className="font-medium text-2xs text-secondary leading-none">
+              {noDataLabel}
+            </span>
+          )}
           <button
             type="button"
             aria-label={`Remove ${project.name}`}
@@ -196,6 +224,11 @@ export function CompareProjectPicker({
                   <span className="font-medium text-sm leading-none tracking-[-1%]">
                     {project.name}
                   </span>
+                  {!hasMetricData(project) && (
+                    <span className="ml-auto font-medium text-2xs text-secondary">
+                      {noDataLabel}
+                    </span>
+                  )}
                 </CommandItem>
               )
             })}

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -84,6 +84,7 @@ export function ScalingCompareChart({
       <CompareSeriesProvider projects={selectedProjects}>
         <CompareProjectPicker
           allProjects={allProjects}
+          metric={metric}
           selectedProjects={selectedProjects}
           isDefaultSelection={state.projects.length === 0}
           onChange={(projects) => setState((prev) => ({ ...prev, projects }))}
@@ -170,7 +171,7 @@ function MetricSwitcher({
 }) {
   const isClient = useIsClient()
   if (!isClient) {
-    return <Skeleton className="h-9 w-[190px]" />
+    return <Skeleton className="h-9 w-[248px]" />
   }
   return (
     <RadioGroup

--- a/packages/frontend/src/pages/scaling/compare/metrics/costs/CostsCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/costs/CostsCompareChart.tsx
@@ -1,0 +1,57 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { formatCostValue } from '~/pages/scaling/costs/utils/formatCostValue'
+import { useTRPC } from '~/trpc/React'
+import { formatRange } from '~/utils/dates'
+import { rangeToResolution } from '~/utils/range/range'
+import { CompareMetricLineChart } from '../../components/CompareMetricLineChart'
+import type { CompareChartPoint } from '../../utils/toIndexedChartData'
+import type { CompareMetricChartProps } from '../types'
+import { getCostsCompareChartParams } from './getCostsCompareChartParams'
+
+const UNIT_INDEX = { gas: 0, eth: 1, usd: 2 } as const
+
+export function CostsCompareChart({
+  projects,
+  state,
+}: CompareMetricChartProps) {
+  const trpc = useTRPC()
+  const { data, isLoading } = useQuery(
+    trpc.costs.detailedChartWithProjectsRanges.queryOptions(
+      getCostsCompareChartParams(projects, state.chartRange),
+    ),
+  )
+  const unit = state.costsUnit
+
+  const chartData = useMemo(
+    () =>
+      data?.chart.map(([timestamp, valuesByProject]) => {
+        const point: CompareChartPoint = { timestamp }
+        for (const project of projects) {
+          const values = valuesByProject[project.id]
+          point[project.id] = values ? values[UNIT_INDEX[unit]] : null
+        }
+        return point
+      }),
+    [data, projects, unit],
+  )
+
+  const resolution = rangeToResolution(state.chartRange)
+
+  return (
+    <CompareMetricLineChart
+      projects={projects}
+      data={chartData}
+      isLoading={isLoading}
+      syncedUntil={data?.syncedUntil}
+      scale={state.scale}
+      mode={state.mode}
+      formatYAxisLabel={(value) => formatCostValue(value, unit)}
+      formatTooltipValue={(value) => formatCostValue(value, unit)}
+      renderTooltipTimestamp={(label) =>
+        formatRange(label, label + UnixTime.periodToSeconds(resolution))
+      }
+    />
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/costs/CostsCompareControls.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/costs/CostsCompareControls.tsx
@@ -1,0 +1,36 @@
+import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
+import { Skeleton } from '~/components/core/Skeleton'
+import { useIsClient } from '~/hooks/useIsClient'
+import type { CompareCostsUnit } from '../../utils/compareChartState'
+import type { CompareMetricControlsProps } from '../types'
+
+export function CostsCompareControls({
+  state,
+  setState,
+}: CompareMetricControlsProps) {
+  const isClient = useIsClient()
+  if (!isClient) {
+    return <Skeleton className="h-9 w-[132px]" />
+  }
+  return (
+    <RadioGroup
+      name="compareCostsUnit"
+      value={state.costsUnit}
+      onValueChange={(value) =>
+        setState((prev) => ({ ...prev, costsUnit: value as CompareCostsUnit }))
+      }
+      variant="highlighted"
+      className="h-9"
+    >
+      <RadioGroupItem value="usd" className="h-full px-2 text-sm">
+        USD
+      </RadioGroupItem>
+      <RadioGroupItem value="eth" className="h-full px-2 text-sm">
+        ETH
+      </RadioGroupItem>
+      <RadioGroupItem value="gas" className="h-full px-2 text-sm">
+        GAS
+      </RadioGroupItem>
+    </RadioGroup>
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/costs/getCostsCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/costs/getCostsCompareChartParams.ts
@@ -1,0 +1,28 @@
+import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import type { ChartRange } from '~/utils/range/range'
+
+/**
+ * Builds the `costs.detailedChartWithProjectsRanges` input for the compare
+ * chart. Shared between the SSR prefetch and the client query so the
+ * hydrated cache always matches and the first paint needs no refetch.
+ * Projects without costs tracking are left out entirely, so they can never
+ * come back as an empty series.
+ */
+export function getCostsCompareChartParams(
+  projects: CompareProjectEntry[],
+  chartRange: ChartRange,
+) {
+  return {
+    range: chartRange,
+    projects: projects.flatMap((project) =>
+      project.costsSinceTimestamp !== undefined
+        ? [
+            {
+              projectId: project.id,
+              sinceTimestamp: project.costsSinceTimestamp,
+            },
+          ]
+        : [],
+    ),
+  }
+}

--- a/packages/frontend/src/pages/scaling/compare/metrics/index.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/index.ts
@@ -1,6 +1,8 @@
 import type { CompareMetricId } from '../utils/compareChartState'
 import { ActivityCompareChart } from './activity/ActivityCompareChart'
 import { ActivityCompareControls } from './activity/ActivityCompareControls'
+import { CostsCompareChart } from './costs/CostsCompareChart'
+import { CostsCompareControls } from './costs/CostsCompareControls'
 import { TvsCompareChart } from './tvs/TvsCompareChart'
 import { TvsCompareControls } from './tvs/TvsCompareControls'
 import type { CompareMetric } from './types'
@@ -11,11 +13,21 @@ export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
     label: 'Value Secured',
     Chart: TvsCompareChart,
     Controls: TvsCompareControls,
+    hasData: (project) => project.tvsSinceTimestamp !== undefined,
+    noDataLabel: 'No TVS data',
   },
   activity: {
     id: 'activity',
     label: 'Activity',
     Chart: ActivityCompareChart,
     Controls: ActivityCompareControls,
+  },
+  costs: {
+    id: 'costs',
+    label: 'Costs',
+    Chart: CostsCompareChart,
+    Controls: CostsCompareControls,
+    hasData: (project) => project.costsSinceTimestamp !== undefined,
+    noDataLabel: 'No costs data',
   },
 }

--- a/packages/frontend/src/pages/scaling/compare/metrics/types.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/types.ts
@@ -33,4 +33,13 @@ export interface CompareMetric {
    * per-metric slot next to the metric switcher.
    */
   Controls?: ComponentType<CompareMetricControlsProps>
+  /**
+   * Whether the project has data for this metric. Projects failing this
+   * check stay selectable but are marked with `noDataLabel` in the picker
+   * and chip strip instead of rendering an empty series. Omit when every
+   * project has the metric.
+   */
+  hasData?: (project: CompareProjectEntry) => boolean
+  /** Shown on chips and picker rows of projects failing `hasData`. */
+  noDataLabel?: string
 }

--- a/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
+++ b/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
@@ -1,8 +1,10 @@
 import { getActivityLatestUops } from '~/server/features/scaling/activity/getActivityLatestTps'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
+import { getCostsTotalUsdForProjects } from '~/server/features/scaling/costs/getCostsTotalUsdForProjects'
 import type { getSsrHelpers } from '~/trpc/server'
 import { optionToRange } from '~/utils/range/range'
 import { getActivityCompareChartParams } from '../metrics/activity/getActivityCompareChartParams'
+import { getCostsCompareChartParams } from '../metrics/costs/getCostsCompareChartParams'
 import { getTvsCompareChartParams } from '../metrics/tvs/getTvsCompareChartParams'
 import type {
   CompareClientState,
@@ -60,6 +62,34 @@ export const COMPARE_SERVER_METRICS: Record<
       await helpers.queryClient.prefetchQuery(
         helpers.trpc.activity.detailedChartWithProjectsRanges.queryOptions(
           getActivityCompareChartParams(projects, state.chartRange),
+        ),
+      )
+    },
+  },
+  costs: {
+    getDefaultProjects: async (universe, count) => {
+      // Only projects with costs tracking can rank; the recent window keeps
+      // the query cheap while still reflecting current spending.
+      const tracked = universe.filter(
+        (project) => project.costsSinceTimestamp !== undefined,
+      )
+      const totals = await getCostsTotalUsdForProjects(
+        tracked,
+        optionToRange('30d'),
+      )
+      return tracked
+        .map((project) => ({
+          project,
+          usd: totals[project.id.toString()] ?? -1,
+        }))
+        .sort((a, b) => b.usd - a.usd)
+        .slice(0, count)
+        .map(({ project }) => project)
+    },
+    prefetch: async (helpers, projects, state) => {
+      await helpers.queryClient.prefetchQuery(
+        helpers.trpc.costs.detailedChartWithProjectsRanges.queryOptions(
+          getCostsCompareChartParams(projects, state.chartRange),
         ),
       )
     },

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.test.ts
@@ -12,6 +12,7 @@ const DEFAULT_STATE: CompareChartState = {
   mode: 'absolute',
   activityUnit: 'uops',
   tvsUnit: 'usd',
+  costsUnit: 'usd',
   excludeAssociatedTokens: false,
   excludeRwaRestrictedTokens: true,
 }
@@ -96,6 +97,34 @@ describe(buildCompareUrl.name, () => {
     const url = buildCompareUrl(PATH, {
       ...DEFAULT_STATE,
       activityUnit: 'tps',
+    })
+
+    expect(url).toEqual(PATH)
+  })
+
+  it('serializes the costs metric with its non-default unit', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      metric: 'costs',
+      costsUnit: 'gas',
+    })
+
+    expect(url).toEqual('/scaling/compare?metric=costs&unit=gas')
+  })
+
+  it('omits the default costs unit', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      metric: 'costs',
+    })
+
+    expect(url).toEqual('/scaling/compare?metric=costs')
+  })
+
+  it('omits the costs unit for other metrics', () => {
+    const url = buildCompareUrl(PATH, {
+      ...DEFAULT_STATE,
+      costsUnit: 'gas',
     })
 
     expect(url).toEqual(PATH)

--- a/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/buildCompareUrl.ts
@@ -1,6 +1,7 @@
 import {
   type CompareChartState,
   DEFAULT_COMPARE_ACTIVITY_UNIT,
+  DEFAULT_COMPARE_COSTS_UNIT,
   DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
   DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS,
   DEFAULT_COMPARE_METRIC,
@@ -43,6 +44,12 @@ export function buildCompareUrl(
     state.activityUnit !== DEFAULT_COMPARE_ACTIVITY_UNIT
   ) {
     params.set('unit', state.activityUnit)
+  }
+  if (
+    state.metric === 'costs' &&
+    state.costsUnit !== DEFAULT_COMPARE_COSTS_UNIT
+  ) {
+    params.set('unit', state.costsUnit)
   }
   if (state.metric === 'tvs') {
     if (state.tvsUnit !== DEFAULT_COMPARE_TVS_UNIT) {

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -8,7 +8,7 @@ import {
 } from '~/utils/range/range'
 import { rangeToDays } from '~/utils/range/rangeToDays'
 
-export const COMPARE_METRIC_IDS = ['tvs', 'activity'] as const
+export const COMPARE_METRIC_IDS = ['tvs', 'activity', 'costs'] as const
 export type CompareMetricId = (typeof COMPARE_METRIC_IDS)[number]
 
 export const COMPARE_ACTIVITY_UNITS = ['uops', 'tps'] as const
@@ -16,6 +16,9 @@ export type CompareActivityUnit = (typeof COMPARE_ACTIVITY_UNITS)[number]
 
 export const COMPARE_TVS_UNITS = ['usd', 'eth'] as const
 export type CompareTvsUnit = (typeof COMPARE_TVS_UNITS)[number]
+
+export const COMPARE_COSTS_UNITS = ['usd', 'eth', 'gas'] as const
+export type CompareCostsUnit = (typeof COMPARE_COSTS_UNITS)[number]
 
 export const COMPARE_VIEW_MODES = ['absolute', 'indexed'] as const
 export type CompareViewMode = (typeof COMPARE_VIEW_MODES)[number]
@@ -45,6 +48,8 @@ export interface CompareChartState {
   activityUnit: CompareActivityUnit
   /** Per-metric controls of the TVS metric; ignored elsewhere. */
   tvsUnit: CompareTvsUnit
+  /** Per-metric control of the costs metric; ignored elsewhere. */
+  costsUnit: CompareCostsUnit
   excludeAssociatedTokens: boolean
   excludeRwaRestrictedTokens: boolean
 }
@@ -61,6 +66,7 @@ export interface CompareClientState {
   mode: CompareViewMode
   activityUnit: CompareActivityUnit
   tvsUnit: CompareTvsUnit
+  costsUnit: CompareCostsUnit
   excludeAssociatedTokens: boolean
   excludeRwaRestrictedTokens: boolean
   chartRange: ChartRange
@@ -76,6 +82,7 @@ export function toCompareUrlState(
     mode: state.mode,
     activityUnit: state.activityUnit,
     tvsUnit: state.tvsUnit,
+    costsUnit: state.costsUnit,
     excludeAssociatedTokens: state.excludeAssociatedTokens,
     excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
     range: chartRangeToCompareRange(state.chartRange),
@@ -93,6 +100,7 @@ export function toCompareClientState(
     mode: state.mode,
     activityUnit: state.activityUnit,
     tvsUnit: state.tvsUnit,
+    costsUnit: state.costsUnit,
     excludeAssociatedTokens: state.excludeAssociatedTokens,
     excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
     chartRange,
@@ -105,6 +113,7 @@ export const DEFAULT_COMPARE_SCALE: ChartScale = 'linear'
 export const DEFAULT_COMPARE_VIEW_MODE: CompareViewMode = 'absolute'
 export const DEFAULT_COMPARE_ACTIVITY_UNIT: CompareActivityUnit = 'uops'
 export const DEFAULT_COMPARE_TVS_UNIT: CompareTvsUnit = 'usd'
+export const DEFAULT_COMPARE_COSTS_UNIT: CompareCostsUnit = 'usd'
 // The TVS control defaults match the /scaling/tvs page so the default
 // comparison reproduces the numbers shown there.
 export const DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS = false
@@ -152,6 +161,7 @@ export function isSameCompareState(
     // so two states that differ solely by a hidden control map to the same
     // URL.
     (left.metric !== 'activity' || left.activityUnit === right.activityUnit) &&
+    (left.metric !== 'costs' || left.costsUnit === right.costsUnit) &&
     (left.metric !== 'tvs' ||
       (left.tvsUnit === right.tvsUnit &&
         left.excludeAssociatedTokens === right.excludeAssociatedTokens &&

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.test.ts
@@ -26,6 +26,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'tps',
       tvsUnit: 'usd',
+      costsUnit: 'usd',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     })
@@ -42,6 +43,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      costsUnit: 'usd',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     })
@@ -57,6 +59,22 @@ describe(parseCompareStateFromSearchParams.name, () => {
     const result = parse('unit=eth')
 
     expect(result.tvsUnit).toEqual('eth')
+    expect(result.activityUnit).toEqual('uops')
+  })
+
+  it('applies the shared unit param only to the active metric', () => {
+    const result = parse('metric=costs&unit=eth')
+
+    expect(result.costsUnit).toEqual('eth')
+    expect(result.tvsUnit).toEqual('usd')
+    expect(result.activityUnit).toEqual('uops')
+  })
+
+  it('parses the costs unit from the shared unit param', () => {
+    const result = parse('metric=costs&unit=gas')
+
+    expect(result.costsUnit).toEqual('gas')
+    expect(result.tvsUnit).toEqual('usd')
     expect(result.activityUnit).toEqual('uops')
   })
 
@@ -91,7 +109,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
 
   it('falls back to defaults on garbage values', () => {
     const result = parse(
-      'metric=bogus&range=yesterday&scale=cubic&unit=gas&mode=sideways&excludeAssociated=maybe&excludeRwa=nonsense',
+      'metric=bogus&range=yesterday&scale=cubic&unit=beans&mode=sideways&excludeAssociated=maybe&excludeRwa=nonsense',
     )
 
     expect(result).toEqual({
@@ -102,6 +120,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      costsUnit: 'usd',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     })
@@ -122,6 +141,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      costsUnit: 'usd',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }
@@ -141,6 +161,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      costsUnit: 'usd',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }
@@ -160,6 +181,27 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'tps',
       tvsUnit: 'usd',
+      costsUnit: 'usd',
+      excludeAssociatedTokens: false,
+      excludeRwaRestrictedTokens: true,
+    }
+
+    const url = buildCompareUrl('/scaling/compare', state)
+    const search = url.split('?')[1] ?? ''
+
+    expect(parse(search)).toEqual(state)
+  })
+
+  it('round-trips the costs metric with its unit through buildCompareUrl', () => {
+    const state: CompareChartState = {
+      metric: 'costs',
+      projects: ['arbitrum', 'base'],
+      range: '30d',
+      scale: 'linear',
+      mode: 'absolute',
+      activityUnit: 'uops',
+      tvsUnit: 'usd',
+      costsUnit: 'gas',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }
@@ -179,6 +221,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'absolute',
       activityUnit: 'uops',
       tvsUnit: 'eth',
+      costsUnit: 'usd',
       excludeAssociatedTokens: true,
       excludeRwaRestrictedTokens: false,
     }
@@ -198,6 +241,7 @@ describe(parseCompareStateFromSearchParams.name, () => {
       mode: 'indexed',
       activityUnit: 'uops',
       tvsUnit: 'usd',
+      costsUnit: 'usd',
       excludeAssociatedTokens: false,
       excludeRwaRestrictedTokens: true,
     }

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
@@ -1,15 +1,18 @@
 import {
   COMPARE_ACTIVITY_UNITS,
+  COMPARE_COSTS_UNITS,
   COMPARE_METRIC_IDS,
   COMPARE_RANGE_OPTIONS,
   COMPARE_TVS_UNITS,
   type CompareActivityUnit,
   type CompareChartState,
+  type CompareCostsUnit,
   type CompareMetricId,
   type CompareRange,
   type CompareRangeOption,
   type CompareTvsUnit,
   DEFAULT_COMPARE_ACTIVITY_UNIT,
+  DEFAULT_COMPARE_COSTS_UNIT,
   DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
   DEFAULT_COMPARE_EXCLUDE_RWA_RESTRICTED_TOKENS,
   DEFAULT_COMPARE_METRIC,
@@ -31,8 +34,10 @@ export function parseCompareStateFromSearchParams({
   searchParams: URLSearchParams
   validSlugs: string[]
 }): CompareChartState {
+  const metric = parseMetric(searchParams.get('metric'))
+  const unit = searchParams.get('unit')
   return {
-    metric: parseMetric(searchParams.get('metric')),
+    metric,
     projects: parseProjects(searchParams.get('projects'), validSlugs),
     range: parseRange(searchParams.get('range')),
     scale:
@@ -41,10 +46,17 @@ export function parseCompareStateFromSearchParams({
       searchParams.get('mode') === 'indexed'
         ? 'indexed'
         : DEFAULT_COMPARE_VIEW_MODE,
-    // The `unit` param is shared between metrics; the value sets are
-    // disjoint, so each metric picks up only its own units.
-    activityUnit: parseActivityUnit(searchParams.get('unit')),
-    tvsUnit: parseTvsUnit(searchParams.get('unit')),
+    // The `unit` param is shared between metrics and only encoded for the
+    // active one, so it is only applied to the active metric here - the
+    // value sets overlap (usd/eth), and without the gate a costs URL would
+    // leak its unit into the TVS control.
+    activityUnit:
+      metric === 'activity'
+        ? parseActivityUnit(unit)
+        : DEFAULT_COMPARE_ACTIVITY_UNIT,
+    tvsUnit: metric === 'tvs' ? parseTvsUnit(unit) : DEFAULT_COMPARE_TVS_UNIT,
+    costsUnit:
+      metric === 'costs' ? parseCostsUnit(unit) : DEFAULT_COMPARE_COSTS_UNIT,
     excludeAssociatedTokens: parseBoolean(
       searchParams.get('excludeAssociated'),
       DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
@@ -69,6 +81,11 @@ function parseActivityUnit(value: string | null): CompareActivityUnit {
 function parseTvsUnit(value: string | null): CompareTvsUnit {
   const unit = COMPARE_TVS_UNITS.find((unit) => unit === value)
   return unit ?? DEFAULT_COMPARE_TVS_UNIT
+}
+
+function parseCostsUnit(value: string | null): CompareCostsUnit {
+  const unit = COMPARE_COSTS_UNITS.find((unit) => unit === value)
+  return unit ?? DEFAULT_COMPARE_COSTS_UNIT
 }
 
 function parseBoolean(value: string | null, defaultValue: boolean): boolean {

--- a/packages/frontend/src/server/features/scaling/compare/getCompareProjectEntries.ts
+++ b/packages/frontend/src/server/features/scaling/compare/getCompareProjectEntries.ts
@@ -1,6 +1,7 @@
 import type {
   AmountFormula,
   CalculationFormula,
+  Project,
   TvsToken,
   ValueFormula,
 } from '@l2beat/config'
@@ -20,6 +21,11 @@ export interface CompareProjectEntry {
    * Undefined when the project has no TVS tracking.
    */
   tvsSinceTimestamp: number | undefined
+  /**
+   * Earliest onchain costs timestamp derived from the project's tracked
+   * transactions config. Undefined when the project has no costs tracking.
+   */
+  costsSinceTimestamp: number | undefined
   /** Latest total TVS, used to order the picker. 0 when not tracked. */
   tvs: number
 }
@@ -36,7 +42,7 @@ export async function getCompareProjectEntries(): Promise<
   const [projects, tvs] = await Promise.all([
     ps.getProjects({
       select: ['scalingInfo'],
-      optional: ['tvsConfig'],
+      optional: ['tvsConfig', 'trackedTxsConfig'],
       where: ['scalingInfo'],
       whereNot: ['archivedAt'],
     }),
@@ -51,9 +57,21 @@ export async function getCompareProjectEntries(): Promise<
       shortName: project.shortName,
       iconUrl: manifest.getUrl(`/icons/${project.slug}.png`),
       tvsSinceTimestamp: getTvsSinceTimestamp(project.tvsConfig),
+      costsSinceTimestamp: getCostsSinceTimestamp(project.trackedTxsConfig),
       tvs: tvs.projects[project.id.toString()]?.breakdown.total ?? 0,
     }))
     .sort((a, b) => b.tvs - a.tvs || a.name.localeCompare(b.name))
+}
+
+function getCostsSinceTimestamp(
+  trackedTxsConfig: Project<never, 'trackedTxsConfig'>['trackedTxsConfig'],
+): number | undefined {
+  const timestamps =
+    trackedTxsConfig
+      ?.filter((entry) => entry.type === 'l2costs')
+      .map((entry) => entry.sinceTimestamp) ?? []
+  if (timestamps.length === 0) return undefined
+  return Math.min(...timestamps)
 }
 
 function getTvsSinceTimestamp(

--- a/packages/frontend/src/server/features/scaling/costs/getCostsTotalUsdForProjects.ts
+++ b/packages/frontend/src/server/features/scaling/costs/getCostsTotalUsdForProjects.ts
@@ -1,0 +1,32 @@
+import type { Project } from '@l2beat/config'
+import { env } from '~/env'
+import { getDb } from '~/server/database'
+import type { ChartRange } from '~/utils/range/range'
+
+/**
+ * @returns total onchain costs in USD per project id over the given range.
+ * Projects without any costs records are absent from the result.
+ */
+export async function getCostsTotalUsdForProjects(
+  projects: Pick<Project, 'id'>[],
+  range: ChartRange,
+): Promise<Record<string, number>> {
+  if (env.MOCK) {
+    return Object.fromEntries(
+      projects.map((project, index) => [project.id, 1000 * (index + 1)]),
+    )
+  }
+
+  const db = getDb()
+  const records = await db.aggregatedL2Cost.getByProjectsAndTimeRange(
+    projects.map((p) => p.id),
+    range,
+  )
+
+  const totals: Record<string, number> = {}
+  for (const record of records) {
+    totals[record.projectId] =
+      (totals[record.projectId] ?? 0) + record.totalGasUsd
+  }
+  return totals
+}

--- a/packages/frontend/src/server/features/scaling/costs/getDetailedCostsChartWithProjectsRanges.test.ts
+++ b/packages/frontend/src/server/features/scaling/costs/getDetailedCostsChartWithProjectsRanges.test.ts
@@ -1,0 +1,168 @@
+import type { AggregatedL2CostRecord, Database } from '@l2beat/database'
+import { ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { expect, mockObject } from 'earl'
+import { getCostsChartData } from './getDetailedCostsChartWithProjectsRanges'
+
+const DAY = UnixTime.DAY
+const HOUR = UnixTime.HOUR
+// 2023-11-15T00:00:00Z, aligned to a full day
+const T = UnixTime(1700006400)
+
+const ARBITRUM = ProjectId('arbitrum')
+const BASE = ProjectId('base')
+
+describe(getCostsChartData.name, () => {
+  it('returns one gas/eth/usd series per project', async () => {
+    const repository = repositoryMock([
+      record(ARBITRUM, T, 100, 1, 1000),
+      record(ARBITRUM, T + DAY, 200, 2, 2000),
+      record(BASE, T, 10, 0.1, 100),
+      record(BASE, T + DAY, 20, 0.2, 200),
+    ])
+
+    const result = await getCostsChartData(
+      repository,
+      [
+        { projectId: ARBITRUM, sinceTimestamp: T },
+        { projectId: BASE, sinceTimestamp: T },
+      ],
+      [T, T + DAY],
+    )
+
+    expect(result).toEqual({
+      chart: [
+        [T, { [ARBITRUM]: [100, 1, 1000], [BASE]: [10, 0.1, 100] }],
+        [T + DAY, { [ARBITRUM]: [200, 2, 2000], [BASE]: [20, 0.2, 200] }],
+      ],
+      projects: [
+        { projectId: ARBITRUM, sinceTimestamp: T },
+        { projectId: BASE, sinceTimestamp: T },
+      ],
+      syncedUntil: T + DAY,
+    })
+  })
+
+  it('sums sub-resolution records into one bucket', async () => {
+    const repository = repositoryMock([
+      record(ARBITRUM, T + HOUR, 100, 1, 1000),
+      record(ARBITRUM, T + 2 * HOUR, 50, 0.5, 500),
+    ])
+
+    const result = await getCostsChartData(
+      repository,
+      [{ projectId: ARBITRUM, sinceTimestamp: T }],
+      [T, T + DAY],
+    )
+
+    expect(result.chart).toEqual([[T, { [ARBITRUM]: [150, 1.5, 1500] }]])
+  })
+
+  it('fills zeros after tracking start and nulls before', async () => {
+    const repository = repositoryMock([
+      record(ARBITRUM, T, 100, 1, 1000),
+      record(ARBITRUM, T + 2 * DAY, 300, 3, 3000),
+      record(BASE, T + 2 * DAY, 20, 0.2, 200),
+    ])
+
+    const result = await getCostsChartData(
+      repository,
+      [
+        { projectId: ARBITRUM, sinceTimestamp: T },
+        { projectId: BASE, sinceTimestamp: T + DAY },
+      ],
+      [T, T + 2 * DAY],
+    )
+
+    expect(result.chart).toEqual([
+      [T, { [ARBITRUM]: [100, 1, 1000], [BASE]: null }],
+      [T + DAY, { [ARBITRUM]: [0, 0, 0], [BASE]: [0, 0, 0] }],
+      [T + 2 * DAY, { [ARBITRUM]: [300, 3, 3000], [BASE]: [20, 0.2, 200] }],
+    ])
+  })
+
+  it('rounds sinceTimestamp to the resolution for the gate and the returned ranges', async () => {
+    const repository = repositoryMock([record(ARBITRUM, T + DAY, 100, 1, 1000)])
+
+    const result = await getCostsChartData(
+      repository,
+      [{ projectId: ARBITRUM, sinceTimestamp: T + 3 * HOUR }],
+      [T, T + DAY],
+    )
+
+    expect(result.projects).toEqual([
+      { projectId: ARBITRUM, sinceTimestamp: T },
+    ])
+    expect(result.chart).toEqual([
+      [T, { [ARBITRUM]: [0, 0, 0] }],
+      [T + DAY, { [ARBITRUM]: [100, 1, 1000] }],
+    ])
+  })
+
+  it('nulls the unsynced tail past the last record', async () => {
+    const repository = repositoryMock([record(ARBITRUM, T, 100, 1, 1000)])
+
+    const result = await getCostsChartData(
+      repository,
+      [{ projectId: ARBITRUM, sinceTimestamp: T }],
+      [T, T + 2 * DAY],
+    )
+
+    expect(result.chart).toEqual([
+      [T, { [ARBITRUM]: [100, 1, 1000] }],
+      [T + DAY, { [ARBITRUM]: null }],
+    ])
+    expect(result.syncedUntil).toEqual(T)
+  })
+
+  it('returns an empty chart when there are no records', async () => {
+    const repository = repositoryMock([])
+
+    const result = await getCostsChartData(
+      repository,
+      [{ projectId: ARBITRUM, sinceTimestamp: T }],
+      [T, T + DAY],
+    )
+
+    expect(result).toEqual({
+      chart: [],
+      projects: [{ projectId: ARBITRUM, sinceTimestamp: T }],
+      syncedUntil: 0,
+    })
+  })
+})
+
+function repositoryMock(
+  records: AggregatedL2CostRecord[],
+): Database['aggregatedL2Cost'] {
+  return mockObject<Database['aggregatedL2Cost']>({
+    getByProjectsAndTimeRange: async () => records,
+  })
+}
+
+function record(
+  projectId: ProjectId,
+  timestamp: UnixTime,
+  gas: number,
+  eth: number,
+  usd: number,
+): AggregatedL2CostRecord {
+  return {
+    projectId,
+    timestamp,
+    totalGas: gas,
+    totalGasEth: eth,
+    totalGasUsd: usd,
+    overheadGas: gas,
+    overheadGasEth: eth,
+    overheadGasUsd: usd,
+    calldataGas: 0,
+    calldataGasEth: 0,
+    calldataGasUsd: 0,
+    computeGas: 0,
+    computeGasEth: 0,
+    computeGasUsd: 0,
+    blobsGas: null,
+    blobsGasEth: null,
+    blobsGasUsd: null,
+  }
+}

--- a/packages/frontend/src/server/features/scaling/costs/getDetailedCostsChartWithProjectsRanges.ts
+++ b/packages/frontend/src/server/features/scaling/costs/getDetailedCostsChartWithProjectsRanges.ts
@@ -1,0 +1,211 @@
+import type { Database } from '@l2beat/database'
+import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { v } from '@l2beat/validate'
+import { env } from '~/env'
+import { getDb } from '~/server/database'
+import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
+import { getChartStartTimestamp } from '~/server/features/utils/getChartStartTimestamp'
+import { ChartRange, rangeToResolution } from '~/utils/range/range'
+import { getCostsExpectedTimestamp } from './utils/getCostsExpectedTimestamp'
+import { isCostsSynced } from './utils/isCostsSynced'
+
+export const CostsChartWithProjectsRangesDataParams = v.object({
+  range: ChartRange,
+  projects: v.array(
+    v.object({
+      projectId: v.string().transform((value) => value as ProjectId),
+      sinceTimestamp: v.number(),
+    }),
+  ),
+})
+
+export type CostsChartWithProjectsRangesDataParams = v.infer<
+  typeof CostsChartWithProjectsRangesDataParams
+>
+
+export type ProjectCostsChartDataPoint = [gas: number, eth: number, usd: number]
+
+export type DetailedCostsChartWithProjectsRangesDataPoint = [
+  timestamp: number,
+  projects: Record<string, ProjectCostsChartDataPoint | null>,
+]
+
+export type CostsChartProjectRange = {
+  projectId: ProjectId
+  /** First timestamp with tracked costs, floored to the active resolution. */
+  sinceTimestamp: number
+}
+
+export type DetailedCostsChartWithProjectsRangesData = {
+  chart: DetailedCostsChartWithProjectsRangesDataPoint[]
+  projects: CostsChartProjectRange[]
+  syncedUntil: number
+}
+
+/**
+ * @returns onchain costs chart data split by project id and timestamp,
+ * mirroring the shape of `getDetailedTvsChartWithProjectsRanges`. Like the
+ * TVS variant, each project's `sinceTimestamp` comes from its config so the
+ * data gate here can't drift from the client's.
+ */
+export async function getDetailedCostsChartWithProjectsRanges({
+  range,
+  projects,
+}: CostsChartWithProjectsRangesDataParams): Promise<DetailedCostsChartWithProjectsRangesData> {
+  if (env.MOCK) {
+    return getMockDetailedCostsChartWithProjectsRangesData({ range, projects })
+  }
+
+  if (projects.length === 0) {
+    return { chart: [], projects: [], syncedUntil: UnixTime.now() }
+  }
+
+  const db = getDb()
+  return await getCostsChartData(db.aggregatedL2Cost, projects, range)
+}
+
+/**
+ * The unit behind the tRPC procedure, taking the repository so tests can
+ * exercise it with mocked records.
+ */
+export async function getCostsChartData(
+  repository: Database['aggregatedL2Cost'],
+  projects: CostsChartWithProjectsRangesDataParams['projects'],
+  range: ChartRange,
+): Promise<DetailedCostsChartWithProjectsRangesData> {
+  const resolution = rangeToResolution(range)
+
+  // Round each project's `sinceTimestamp` down to the active resolution so
+  // the `>= sinceTimestamp` gate aligns with the generated buckets. The
+  // rounded values are returned to the client so its tooltip gate can't
+  // drift from the data gate computed here.
+  const projectRanges: CostsChartProjectRange[] = projects.map((project) => ({
+    projectId: project.projectId,
+    sinceTimestamp: UnixTime.toStartOf(project.sinceTimestamp, resolution),
+  }))
+  const projectIds = projectRanges.map((p) => p.projectId)
+
+  const records = await repository.getByProjectsAndTimeRange(projectIds, range)
+
+  // Dismiss the still-filling current bucket - charting its partial sum
+  // would read as a costs drop (mirrors `getCostsChart`).
+  const bucketCutoff = UnixTime.toStartOf(UnixTime.now(), resolution)
+  const syncedRecords = records.filter((r) => r.timestamp < bucketCutoff)
+  if (syncedRecords.length === 0) {
+    return { chart: [], projects: projectRanges, syncedUntil: 0 }
+  }
+
+  const summedByProjectId = new Map<
+    string,
+    Map<number, ProjectCostsChartDataPoint>
+  >()
+  let dataStart = Number.POSITIVE_INFINITY
+  let maxBucket = Number.NEGATIVE_INFINITY
+  let syncedUntil = Number.NEGATIVE_INFINITY
+  for (const record of syncedRecords) {
+    syncedUntil = Math.max(syncedUntil, record.timestamp)
+    const bucket = UnixTime.toStartOf(record.timestamp, resolution)
+    dataStart = Math.min(dataStart, bucket)
+    maxBucket = Math.max(maxBucket, bucket)
+
+    let projectSums = summedByProjectId.get(record.projectId)
+    if (!projectSums) {
+      projectSums = new Map()
+      summedByProjectId.set(record.projectId, projectSums)
+    }
+    const existing = projectSums.get(bucket)
+    if (existing) {
+      existing[0] += record.totalGas
+      existing[1] += record.totalGasEth
+      existing[2] += record.totalGasUsd
+      continue
+    }
+    projectSums.set(bucket, [
+      record.totalGas,
+      record.totalGasEth,
+      record.totalGasUsd,
+    ])
+  }
+
+  const sinceByProjectId = new Map(
+    projectRanges.map((p) => [p.projectId, p.sinceTimestamp]),
+  )
+  const firstProjectTimestamp = Math.min(
+    ...projectRanges.map((p) => p.sinceTimestamp),
+  )
+
+  const adjustedTo = isCostsSynced({ to: range[1], syncedUntil })
+    ? maxBucket
+    : getCostsExpectedTimestamp(range[1], resolution)
+  const startTimestamp = getChartStartTimestamp({
+    rangeStart: range[0],
+    firstProjectTimestamp,
+    dataStart,
+    resolution,
+  })
+  const timestamps = generateTimestamps(
+    [startTimestamp, adjustedTo],
+    resolution,
+  )
+
+  const chart: DetailedCostsChartWithProjectsRangesDataPoint[] = timestamps.map(
+    (timestamp) => {
+      const projectsForTimestamp: Record<
+        string,
+        ProjectCostsChartDataPoint | null
+      > = {}
+
+      for (const projectId of projectIds) {
+        const values = summedByProjectId.get(projectId)?.get(timestamp)
+        if (values) {
+          projectsForTimestamp[projectId] = values
+          continue
+        }
+
+        // Zero only inside the synced window and after the project's costs
+        // tracking start; null marks buckets before tracking (or past the
+        // synced window) so the client can distinguish "no costs" from
+        // "no data".
+        const sinceTimestamp = sinceByProjectId.get(projectId)
+        projectsForTimestamp[projectId] =
+          timestamp <= maxBucket &&
+          sinceTimestamp !== undefined &&
+          timestamp >= sinceTimestamp
+            ? [0, 0, 0]
+            : null
+      }
+
+      return [timestamp, projectsForTimestamp]
+    },
+  )
+
+  return { chart, projects: projectRanges, syncedUntil }
+}
+
+function getMockDetailedCostsChartWithProjectsRangesData({
+  range,
+  projects,
+}: CostsChartWithProjectsRangesDataParams): DetailedCostsChartWithProjectsRangesData {
+  const resolution = rangeToResolution(range)
+  const timestamps = generateTimestamps(
+    [range[0] ?? 1573776000, range[1]],
+    resolution,
+  )
+
+  return {
+    chart: timestamps.map((timestamp) => [
+      timestamp,
+      Object.fromEntries(
+        projects.map(({ projectId }, index) => [
+          projectId,
+          [1_000_000 * (index + 1), 10 * (index + 1), 30_000 * (index + 1)],
+        ]),
+      ),
+    ]),
+    projects: projects.map(({ projectId }) => ({
+      projectId,
+      sinceTimestamp: timestamps[0] ?? 0,
+    })),
+    syncedUntil: timestamps[timestamps.length - 1] ?? 0,
+  }
+}

--- a/packages/frontend/src/server/trpc/routers/costs.ts
+++ b/packages/frontend/src/server/trpc/routers/costs.ts
@@ -5,6 +5,10 @@ import {
 } from '~/server/features/scaling/costs/getCostsChart'
 import { getCostsTable } from '~/server/features/scaling/costs/getCostsTableData'
 import {
+  CostsChartWithProjectsRangesDataParams,
+  getDetailedCostsChartWithProjectsRanges,
+} from '~/server/features/scaling/costs/getDetailedCostsChartWithProjectsRanges'
+import {
   getProjectCostsChart,
   ProjectCostsChartParams,
 } from '~/server/features/scaling/costs/getProjectCostsChart'
@@ -15,6 +19,9 @@ export const costsRouter = router({
   chart: procedure
     .input(CostsChartParams)
     .query(async ({ input }) => getCostsChart(input)),
+  detailedChartWithProjectsRanges: procedure
+    .input(CostsChartWithProjectsRangesDataParams)
+    .query(({ input }) => getDetailedCostsChartWithProjectsRanges(input)),
   projectChart: procedure
     .input(ProjectCostsChartParams)
     .query(async ({ input }) => getProjectCostsChart(input)),


### PR DESCRIPTION
## Summary

- Adds a third `costs` metric to the scaling compare page, alongside TVS and activity, with a USD/ETH/GAS unit switcher rendered in the per-metric controls slot.
- New server feature `getDetailedCostsChartWithProjectsRanges` returns per-project gas/eth/usd series bucketed to the range resolution, mirroring the TVS with-projects-ranges shape: records are summed into buckets, `null` before a project's tracking start and past the synced tail, zeros in between. Exposed via a new `costs.detailedChartWithProjectsRanges` tRPC procedure.
- Default project selection for the costs metric ranks tracked projects by total USD spend over the last 30 days (`getCostsTotalUsdForProjects`), with SSR prefetch sharing the exact query input with the client so the hydrated cache needs no refetch.
- `getCompareProjectEntries` now derives `costsSinceTimestamp` from each project's `trackedTxsConfig` (earliest `l2costs` entry).
- The picker and chip strip mark projects the active metric has no data for (`hasData` / `noDataLabel` on the metric definition) — dimmed icon, no series color, "No costs data" note — instead of rendering an empty series.
- URL state: `costsUnit` added to compare state, serialized through the shared `unit` param. Parsing is now gated on the active metric, since the costs and TVS unit sets overlap (`usd`/`eth`) and an unhandled costs URL would otherwise leak its unit into the TVS control.

## Testing

- `getDetailedCostsChartWithProjectsRanges` unit tests: per-project series, sub-resolution bucket summing, zero-fill after tracking start vs. nulls before, `sinceTimestamp` rounding to resolution, unsynced tail nulling, empty-records case.
- `buildCompareUrl` tests: costs unit serialized only for the costs metric, default unit omitted.
- `parseCompareStateFromSearchParams` tests: costs unit parsed from the shared `unit` param, unit applied only to the active metric, garbage values fall back to defaults, costs state round-trips through `buildCompareUrl`.
- Manual check of the costs chart, unit switcher, and no-data chips in the browser: Not run.