### PR TITLE
Fix address overflowing in token node tooltip

### DIFF
--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
@@ -414,7 +414,7 @@ export function TokenRelationsGraph({
       <div
         ref={tooltipRef}
         className={cn(
-          'pointer-events-none absolute top-0 left-0 z-10 w-max max-w-72',
+          'pointer-events-none absolute top-0 left-0 z-10 w-max',
           'whitespace-pre-line rounded-md border bg-background px-2.5 py-1.5 text-xs shadow-md',
           tooltip === undefined && 'hidden',
         )}
@@ -442,7 +442,7 @@ function nodeTooltip(node: SceneNode) {
   const { data } = node
   return [
     `${node.label} on ${data.chain}`,
-    `${data.chain}:${data.address}`,
+    data.address,
     data.isDeployed ? 'Deployed token exists' : 'Missing deployed token',
   ].join('\n')
 }


### PR DESCRIPTION
<img width="479" height="158" alt="image" src="https://github.com/user-attachments/assets/1dae3d57-63c5-4d0d-bdf6-73589ff0944f" />

to
<img width="457" height="155" alt="image" src="https://github.com/user-attachments/assets/b36a1d1f-ba93-4b8f-a43b-2facdddaf3c4" />
