### PR TITLE
Fix WETH <> wstETH anomaly

### DIFF
--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -2736,6 +2736,158 @@
       "wormhole-ntt.Transfer"
     ]
   },
+  "wormhole-ntt-multitransceiver": {
+    "description": "NTT transfer completed by the second of two transceivers",
+    "loadConfigs": ["wormhole"],
+    "txs": [
+      // Source: burn wstETH on BSC and send the NTT message.
+      {
+        "chain": "bsc",
+        "tx": "0x30660a3957f5a8856f6fd58e779994d3dab3e2ee450e42782b0bbe46e0192f62"
+      },
+      // Destination attestation 1/2: Wormhole, without token redemption.
+      {
+        "chain": "ethereum",
+        "tx": "0x88a464caf07a9fb9ac15108eefeb53940b14894a8501de18dda3ec15c376b69b"
+      },
+      // Destination attestation 2/2: Axelar, followed by the wstETH redemption.
+      {
+        "chain": "ethereum",
+        "tx": "0xb8bc02b3a333daa7deaf7e2124dcbe36050fa6109b91fc8e445029dec10b8ca3"
+      }
+    ],
+    "expects": {
+      "transfers": [
+        {
+          "type": "wormhole-ntt.Transfer",
+          "plugin": "wormhole-ntt",
+          "bridgeType": "lockAndMint",
+          "src": {
+            "event": {
+              "ctx": {
+                "chain": "bsc",
+                "txHash": "0x30660a3957f5a8856f6fd58e779994d3dab3e2ee450e42782b0bbe46e0192f62"
+              }
+            },
+            "tokenAddress": "0x00000000000000000000000026c5e01524d2e6280a48f2c50ff6de7e52e9611c",
+            "tokenAmount": "562738060000000000",
+            "wasBurned": true,
+            "financials": { "symbol": "wstETH" }
+          },
+          "dst": {
+            "event": {
+              "ctx": {
+                "chain": "ethereum",
+                "txHash": "0xb8bc02b3a333daa7deaf7e2124dcbe36050fa6109b91fc8e445029dec10b8ca3"
+              }
+            },
+            "tokenAddress": "0x0000000000000000000000007f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+            "tokenAmount": "562738060000000000",
+            "wasMinted": false,
+            "financials": { "symbol": "wstETH" }
+          }
+        }
+      ]
+    }
+  },
+  "wormhole-ntt-lock-and-mint-batch": {
+    "description": "NTT lock-and-mint transfer redeemed inside a batched transaction",
+    "loadConfigs": ["wormhole"],
+    "txs": [
+      // Source: lock L3 on Ethereum.
+      {
+        "chain": "ethereum",
+        "tx": "0x1c29a8aca3207cadc00833d714f1843bbaf96bf90b7c3d65bb94e8935b4ee0c0"
+      },
+      // Destination: mint L3 on Polygon around log index 1500.
+      {
+        "chain": "polygonpos",
+        "tx": "0x56bc1193ca8c8e2e5def6d68a8f8ec832aef9b941bbd8c1cd38eafd8b9efca28"
+      }
+    ],
+    "expects": {
+      "transfers": [
+        {
+          "type": "wormhole-ntt.Transfer",
+          "plugin": "wormhole-ntt",
+          "bridgeType": "lockAndMint",
+          "src": {
+            "event": {
+              "ctx": {
+                "chain": "ethereum",
+                "txHash": "0x1c29a8aca3207cadc00833d714f1843bbaf96bf90b7c3d65bb94e8935b4ee0c0"
+              }
+            },
+            "tokenAddress": "0x00000000000000000000000088909d489678dd17aa6d9609f89b0419bf78fd9a",
+            "tokenAmount": "1533883220100000000000",
+            "wasBurned": false,
+            "financials": { "symbol": "L3" }
+          },
+          "dst": {
+            "event": {
+              "ctx": {
+                "chain": "polygonpos",
+                "txHash": "0x56bc1193ca8c8e2e5def6d68a8f8ec832aef9b941bbd8c1cd38eafd8b9efca28"
+              }
+            },
+            "tokenAddress": "0x00000000000000000000000046777c76dbbe40fabb2aab99e33ce20058e76c59",
+            "tokenAmount": "1533883220100000000000",
+            "wasMinted": true,
+            "financials": { "symbol": "L3" }
+          }
+        }
+      ]
+    }
+  },
+  "wormhole-ntt-burn-and-unlock-batch": {
+    "description": "NTT burn-and-unlock transfer redeemed inside a batched transaction",
+    "loadConfigs": ["wormhole"],
+    "txs": [
+      // Source: burn L3 on Base.
+      {
+        "chain": "base",
+        "tx": "0x84a6408f4cc51ff041534826b6b22fe1670f79c0d9e8c2960a899e8efc263e4e"
+      },
+      // Destination: unlock L3 on Ethereum around log index 1085.
+      {
+        "chain": "ethereum",
+        "tx": "0x4345b8f05901cf596e47044a084045512643fae181dd4da8dd69892fa14ba1c3"
+      }
+    ],
+    "expects": {
+      "transfers": [
+        {
+          "type": "wormhole-ntt.Transfer",
+          "plugin": "wormhole-ntt",
+          "bridgeType": "lockAndMint",
+          "src": {
+            "event": {
+              "ctx": {
+                "chain": "base",
+                "txHash": "0x84a6408f4cc51ff041534826b6b22fe1670f79c0d9e8c2960a899e8efc263e4e"
+              }
+            },
+            "tokenAddress": "0x00000000000000000000000046777c76dbbe40fabb2aab99e33ce20058e76c59",
+            "tokenAmount": "14494200000000000000000",
+            "wasBurned": true,
+            "financials": { "symbol": "L3" }
+          },
+          "dst": {
+            "event": {
+              "ctx": {
+                "chain": "ethereum",
+                "txHash": "0x4345b8f05901cf596e47044a084045512643fae181dd4da8dd69892fa14ba1c3"
+              }
+            },
+            "tokenAddress": "0x00000000000000000000000088909d489678dd17aa6d9609f89b0419bf78fd9a",
+            "tokenAmount": "14494200000000000000000",
+            "wasMinted": false,
+            "financials": { "symbol": "L3" }
+          }
+        }
+      ]
+    }
+  },
   "wormhole-nttonesided": {
     "loadConfigs": ["wormhole"],
     "txs": [

--- a/packages/backend/src/modules/interop/plugins/wormhole-ntt.ts
+++ b/packages/backend/src/modules/interop/plugins/wormhole-ntt.ts
@@ -25,8 +25,10 @@ Note that (TODO: )
 */
 
 import { Address32, EthereumAddress } from '@l2beat/shared-pure'
+import { encodePacked, type Hex, keccak256 } from 'viem'
 import { BinaryReader } from '../../../tools/BinaryReader'
 import type { InteropConfigStore } from '../engine/config/InteropConfigStore'
+import { findParsedAfter, findTransferLogAfter } from './logScan'
 import { getBestEffortBridgeTypeFromPartialSupplyAction } from './partialSupplyActionBridgeType'
 import {
   createEventParser,
@@ -84,10 +86,18 @@ const receivedMessageLog =
   'event ReceivedMessage(bytes32 digest, uint16 sourceChainId, bytes32 sourceNttManagerAddress, uint64 sequence)'
 const parseReceivedMessage = createEventParser(receivedMessageLog)
 
+const messageAttestedToLog =
+  'event MessageAttestedTo(bytes32 digest, address transceiver, uint8 index)'
+const parseMessageAttestedTo = createEventParser(messageAttestedToLog)
+
+const transferRedeemedLog = 'event TransferRedeemed(bytes32 indexed digest)'
+const parseTransferRedeemed = createEventParser(transferRedeemedLog)
+
 export const TransceiverMessage = createInteropEventType<{
-  sourceNttManagerAddress: string
-  recipientNttManagerAddress: string
-  nttManagerPayload: string
+  sourceNttManagerAddress: Address32
+  recipientNttManagerAddress: Address32
+  nttManagerPayload: Hex
+  messageDigest?: Hex | undefined
   $dstChain: string
   transferAmount?: bigint | undefined
   transferTokenAddress?: Address32 | undefined
@@ -98,9 +108,8 @@ export const ReceivedRelayedMessage = createInteropEventType<{
   digest: `0x${string}`
   emitterAddress: string
   $srcChain: string
-  transferAmount?: bigint | undefined
-  transferTokenAddress?: Address32 | undefined
-  dstWasMinted?: boolean | undefined
+  messageDigest?: Hex | undefined
+  nttManagerAddress?: Address32 | undefined
 }>('wormhole-ntt.ReceivedRelayedMessage')
 
 export const ReceivedMessage = createInteropEventType<{
@@ -109,16 +118,22 @@ export const ReceivedMessage = createInteropEventType<{
   sourceNttManagerAddress: `0x${string}`
   sequence: bigint
   $srcChain: string
+  messageDigest?: Hex | undefined
+  nttManagerAddress?: Address32 | undefined
+}>('wormhole-ntt.ReceivedMessage')
+
+export const NttTransferRedeemed = createInteropEventType<{
+  digest: Hex
+  nttManagerAddress: Address32
   transferAmount?: bigint | undefined
   transferTokenAddress?: Address32 | undefined
   dstWasMinted?: boolean | undefined
-}>('wormhole-ntt.ReceivedMessage')
+}>('wormhole-ntt.TransferRedeemed')
 
 type ReceivedNttEvent = InteropEvent<{
   $srcChain: string
-  transferAmount?: bigint | undefined
-  transferTokenAddress?: Address32 | undefined
-  dstWasMinted?: boolean | undefined
+  messageDigest?: Hex | undefined
+  nttManagerAddress?: Address32 | undefined
 }>
 
 export class WormholeNTTPlugin implements InteropPluginResyncable {
@@ -141,12 +156,18 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
       {
         type: 'event',
         signature: receivedRelayedMessageLog,
-        includeTxEvents: [transferLog],
+        includeTxEvents: [messageAttestedToLog],
         addresses: '*',
       },
       {
         type: 'event',
         signature: receivedMessageLog,
+        includeTxEvents: [messageAttestedToLog],
+        addresses: '*',
+      },
+      {
+        type: 'event',
+        signature: transferRedeemedLog,
         includeTxEvents: [transferLog],
         addresses: '*',
       },
@@ -159,6 +180,9 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
 
     const send = parseSendTransceiverMessage(input.log, null)
     if (send) {
+      const sourceNetwork = wormholeNetworks.find(
+        (network) => network.chain === input.chain,
+      )
       const decoded = decodeNTTManagerPayload(send.message.nttManagerPayload)
       const sourceToken = decoded?.sourceToken
         ? Address32.cropToEthereumAddress(
@@ -182,9 +206,19 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
 
       return [
         TransceiverMessage.create(input, {
-          sourceNttManagerAddress: send.message.sourceNttManagerAddress,
-          recipientNttManagerAddress: send.message.recipientNttManagerAddress,
+          sourceNttManagerAddress: Address32.from(
+            send.message.sourceNttManagerAddress,
+          ),
+          recipientNttManagerAddress: Address32.from(
+            send.message.recipientNttManagerAddress,
+          ),
           nttManagerPayload: send.message.nttManagerPayload,
+          messageDigest: sourceNetwork
+            ? getNttManagerMessageDigest(
+                sourceNetwork.wormholeChainId,
+                send.message.nttManagerPayload,
+              )
+            : undefined,
           $dstChain: findWormholeChain(
             wormholeNetworks,
             Number(send.recipientChain),
@@ -202,15 +236,7 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
 
     const received = parseReceivedRelayedMessage(input.log, null)
     if (received) {
-      // Find the ERC-20 Transfer closest after this event (token mint/unlock)
-      const dstTransfers = input.txLogs
-        // biome-ignore lint/style/noNonNullAssertion: It's there
-        .filter((x) => x.logIndex! > input.log.logIndex!)
-        .map((x) => ({ log: x, parsed: parseTransfer(x, null) }))
-        .filter((x) => x.parsed)
-        // biome-ignore lint/style/noNonNullAssertion: It's there
-        .sort((a, b) => a.log.logIndex! - b.log.logIndex!)
-      const dstClosest = dstTransfers[0]
+      const attestation = findNttMessageAttestation(input)
 
       return [
         ReceivedRelayedMessage.create(input, {
@@ -220,28 +246,15 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
             wormholeNetworks,
             Number(received.emitterChainId),
           ),
-          transferAmount: dstClosest?.parsed?.value,
-          transferTokenAddress: dstClosest
-            ? Address32.from(dstClosest.log.address)
-            : undefined,
-          dstWasMinted: dstClosest?.parsed
-            ? EthereumAddress(dstClosest.parsed.from) === ZERO_ADDRESS
-            : undefined,
+          messageDigest: attestation?.digest,
+          nttManagerAddress: attestation?.nttManagerAddress,
         }),
       ]
     }
 
     const receivedCore = parseReceivedMessage(input.log, null)
     if (receivedCore) {
-      // Find the ERC-20 Transfer closest after this event (token mint/unlock)
-      const dstTransfers = input.txLogs
-        // biome-ignore lint/style/noNonNullAssertion: It's there
-        .filter((x) => x.logIndex! > input.log.logIndex!)
-        .map((x) => ({ log: x, parsed: parseTransfer(x, null) }))
-        .filter((x) => x.parsed)
-        // biome-ignore lint/style/noNonNullAssertion: It's there
-        .sort((a, b) => a.log.logIndex! - b.log.logIndex!)
-      const dstClosest = dstTransfers[0]
+      const attestation = findNttMessageAttestation(input)
 
       return [
         ReceivedMessage.create(input, {
@@ -253,19 +266,42 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
             wormholeNetworks,
             Number(receivedCore.sourceChainId),
           ),
-          transferAmount: dstClosest?.parsed?.value,
-          transferTokenAddress: dstClosest
-            ? Address32.from(dstClosest.log.address)
-            : undefined,
-          dstWasMinted: dstClosest?.parsed
-            ? EthereumAddress(dstClosest.parsed.from) === ZERO_ADDRESS
-            : undefined,
+          messageDigest: attestation?.digest,
+          nttManagerAddress: attestation?.nttManagerAddress,
+        }),
+      ]
+    }
+
+    const redeemed = parseTransferRedeemed(input.log, null)
+    if (redeemed) {
+      const nttManagerAddress = Address32.from(input.log.address)
+      const { transfer } = findTransferLogAfter(
+        input.txLogs,
+        input.log.logIndex ?? -1,
+        (log) => parseTransfer(log, null),
+        (transfer) =>
+          transfer.from === Address32.ZERO ||
+          transfer.from === nttManagerAddress,
+      )
+
+      return [
+        NttTransferRedeemed.create(input, {
+          digest: redeemed.digest,
+          nttManagerAddress,
+          transferAmount: transfer?.value,
+          transferTokenAddress: transfer?.logAddress,
+          dstWasMinted: transfer ? transfer.from === Address32.ZERO : undefined,
         }),
       ]
     }
   }
 
-  matchTypes = [TransceiverMessage, ReceivedRelayedMessage, ReceivedMessage]
+  matchTypes = [
+    ReceivedRelayedMessage,
+    ReceivedMessage,
+    NttTransferRedeemed,
+    TransceiverMessage,
+  ]
   match(received: InteropEvent, db: InteropEventDb): MatchResult | undefined {
     if (TransceiverMessage.checkType(received)) {
       return this.matchSent(received, db)
@@ -310,45 +346,18 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
               ]
             }
 
-            // Standard NTT token transfer
-            const decoded = decodeNTTManagerPayload(
-              sentTransceiverMessage.args.nttManagerPayload,
-            )
-            // Prefer real ERC-20 Transfer amount (native decimals) over NTT trimmed amount
-            const srcAmount =
-              sentTransceiverMessage.args.transferAmount ?? decoded?.amount
-            const srcTokenAddress =
-              sentTransceiverMessage.args.transferTokenAddress ??
-              (decoded?.sourceToken
-                ? Address32.from(decoded.sourceToken)
-                : undefined)
-
             return [
               Result.Message('wormhole.Message', {
                 app: 'wormhole-ntt-relayer',
                 srcEvent: logMessagePublished,
                 dstEvent: delivery,
               }),
-              Result.Transfer('wormhole-ntt.Transfer', {
-                extraEvents: [logMessagePublished, delivery],
-                srcEvent: sentTransceiverMessage,
-                dstEvent: received,
-                srcTokenAddress,
-                srcAmount,
-                srcWasBurned: sentTransceiverMessage.args.srcWasBurned,
-                dstTokenAddress: received.args.transferTokenAddress,
-                dstAmount: received.args.transferAmount ?? srcAmount,
-                dstWasMinted: received.args.dstWasMinted,
-              }),
             ]
           }
         }
       }
 
-      return this.matchOneSidedReceived(
-        received,
-        delivery ? [delivery] : undefined,
-      )
+      return
     }
 
     // Core path (without Wormhole Relayer)
@@ -384,46 +393,87 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
           ]
         }
 
-        const decoded = decodeNTTManagerPayload(
-          sentTransceiverMessage.args.nttManagerPayload,
-        )
-        const srcAmount =
-          sentTransceiverMessage.args.transferAmount ?? decoded?.amount
-        const srcTokenAddress =
-          sentTransceiverMessage.args.transferTokenAddress ??
-          (decoded?.sourceToken
-            ? Address32.from(decoded.sourceToken)
-            : undefined)
-
         return [
           Result.Message('wormhole.Message', {
             app: 'wormhole-ntt-core',
             srcEvent: logMessagePublished,
             dstEvent: received,
           }),
-          Result.Transfer('wormhole-ntt.Transfer', {
-            extraEvents: [logMessagePublished],
-            srcEvent: sentTransceiverMessage,
-            dstEvent: received,
-            srcTokenAddress,
-            srcAmount,
-            srcWasBurned: sentTransceiverMessage.args.srcWasBurned,
-            dstTokenAddress: received.args.transferTokenAddress,
-            dstAmount: received.args.transferAmount ?? srcAmount,
-            dstWasMinted: received.args.dstWasMinted,
-          }),
         ]
       }
 
-      return this.matchOneSidedReceived(received)
+      return
     }
+
+    if (NttTransferRedeemed.checkType(received)) {
+      return this.matchTransferRedeemed(received, db)
+    }
+  }
+
+  private matchTransferRedeemed(
+    redeemed: InteropEvent<{
+      digest: Hex
+      nttManagerAddress: Address32
+      transferAmount?: bigint | undefined
+      transferTokenAddress?: Address32 | undefined
+      dstWasMinted?: boolean | undefined
+    }>,
+    db: InteropEventDb,
+  ): MatchResult | undefined {
+    const sentTransceiverMessage = db.find(TransceiverMessage, {
+      messageDigest: redeemed.args.digest,
+      recipientNttManagerAddress: redeemed.args.nttManagerAddress,
+    })
+
+    if (sentTransceiverMessage) {
+      const payloadPrefix = getPayloadPrefix(
+        sentTransceiverMessage.args.nttManagerPayload,
+      )
+      if (payloadPrefix === M0IT_PREFIX) return
+
+      const decoded = decodeNTTManagerPayload(
+        sentTransceiverMessage.args.nttManagerPayload,
+      )
+      const srcAmount =
+        sentTransceiverMessage.args.transferAmount ?? decoded?.amount
+      const srcTokenAddress =
+        sentTransceiverMessage.args.transferTokenAddress ??
+        (decoded?.sourceToken ? Address32.from(decoded.sourceToken) : undefined)
+
+      return [
+        Result.Transfer('wormhole-ntt.Transfer', {
+          srcEvent: sentTransceiverMessage,
+          dstEvent: redeemed,
+          srcTokenAddress,
+          srcAmount,
+          srcWasBurned: sentTransceiverMessage.args.srcWasBurned,
+          dstTokenAddress: redeemed.args.transferTokenAddress,
+          dstAmount: redeemed.args.transferAmount ?? srcAmount,
+          dstWasMinted: redeemed.args.dstWasMinted,
+        }),
+      ]
+    }
+
+    const received =
+      db.find(ReceivedRelayedMessage, {
+        messageDigest: redeemed.args.digest,
+        nttManagerAddress: redeemed.args.nttManagerAddress,
+      }) ??
+      db.find(ReceivedMessage, {
+        messageDigest: redeemed.args.digest,
+        nttManagerAddress: redeemed.args.nttManagerAddress,
+      })
+    if (!received) return
+
+    return this.matchOneSidedRedemption(received, redeemed)
   }
 
   private matchSent(
     sentTransceiverMessage: InteropEvent<{
-      sourceNttManagerAddress: string
-      recipientNttManagerAddress: string
-      nttManagerPayload: string
+      sourceNttManagerAddress: Address32
+      recipientNttManagerAddress: Address32
+      nttManagerPayload: Hex
+      messageDigest?: Hex | undefined
       $dstChain: string
       transferAmount?: bigint | undefined
       transferTokenAddress?: Address32 | undefined
@@ -492,16 +542,22 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
     ]
   }
 
-  private matchOneSidedReceived(
+  private matchOneSidedRedemption(
     received: ReceivedNttEvent,
-    extraEvents?: InteropEvent[],
+    redeemed: InteropEvent<{
+      digest: Hex
+      nttManagerAddress: Address32
+      transferAmount?: bigint | undefined
+      transferTokenAddress?: Address32 | undefined
+      dstWasMinted?: boolean | undefined
+    }>,
   ): MatchResult | undefined {
     const srcChain = received.args.$srcChain
     if (!this.oneSidedChains.includes(srcChain)) return
 
     if (
-      received.args.transferAmount === undefined &&
-      received.args.transferTokenAddress === undefined
+      redeemed.args.transferAmount === undefined &&
+      redeemed.args.transferTokenAddress === undefined
     ) {
       return
     }
@@ -509,18 +565,37 @@ export class WormholeNTTPlugin implements InteropPluginResyncable {
     return [
       Result.Transfer('wormhole-ntt.Transfer', {
         srcChain,
-        dstEvent: received,
-        dstTokenAddress: received.args.transferTokenAddress,
-        dstAmount: received.args.transferAmount,
-        dstWasMinted: received.args.dstWasMinted,
+        dstEvent: redeemed,
+        dstTokenAddress: redeemed.args.transferTokenAddress,
+        dstAmount: redeemed.args.transferAmount,
+        dstWasMinted: redeemed.args.dstWasMinted,
         bridgeType: getBestEffortBridgeTypeFromPartialSupplyAction({
           srcWasBurned: undefined,
-          dstWasMinted: received.args.dstWasMinted,
+          dstWasMinted: redeemed.args.dstWasMinted,
         }),
-        extraEvents,
+        extraEvents: [received],
       }),
     ]
   }
+}
+
+function findNttMessageAttestation(input: LogToCapture) {
+  const transceiverAddress = Address32.from(input.log.address)
+
+  return findParsedAfter(input.txLogs, input.log.logIndex ?? -1, (log) => {
+    const attestation = parseMessageAttestedTo(log, null)
+    if (!attestation) return
+    if (Address32.from(attestation.transceiver) !== transceiverAddress) return
+
+    return {
+      digest: attestation.digest,
+      nttManagerAddress: Address32.from(log.address),
+    }
+  })
+}
+
+function getNttManagerMessageDigest(sourceChainId: number, payload: Hex): Hex {
+  return keccak256(encodePacked(['uint16', 'bytes'], [sourceChainId, payload]))
 }
 
 // M^0 Protocol uses the same Wormhole Transceiver to broadcast M Earning Index updates.


### PR DESCRIPTION
## Summary

Fixes the incorrect WETH <> wstETH relation produced for Wormhole NTT transfers that require multiple transceiver attestations.

Previously, the plugin treated `ReceivedMessage` or `ReceivedRelayedMessage` as token-transfer completion and selected the closest following ERC-20 `Transfer`. In the affected BSC -> Ethereum transfer, the Wormhole transaction supplied only the first of two required attestations, so no wstETH was redeemed yet. An unrelated WETH transfer in that transaction was selected instead.

The plugin now:

- keeps Wormhole message delivery separate from NTT token redemption
- derives the NTT manager message digest from the source chain ID and NTT payload
- captures `MessageAttestedTo` to associate received messages with the NTT digest and manager
- creates the token transfer only when the NTT manager emits `TransferRedeemed`
- selects only the following mint from the zero address or unlock from the NTT manager
- matches source and destination using both the NTT digest and recipient manager address
- preserves one-sided transfer handling

This correctly associates the source wstETH burn with the later Ethereum wstETH unlock, after the second Axelar attestation, while still recording the earlier Wormhole delivery as a message.

## Testing

Added interop examples covering:

- the original two-transceiver BSC -> Ethereum wstETH regression
- lock -> mint redemption inside a large batched transaction
- burn -> unlock redemption inside a large batched transaction
- existing relayer, core, and one-sided NTT paths

All focused Wormhole NTT examples and Wormhole-adjacent examples pass. The backend test suite passes with 1329 passing and 1 pending.