### PR TITLE
Extract shared URL sync, chart params, and series chart helpers

### DIFF
--- a/packages/frontend/src/components/core/chart/ChartRangeControls.tsx
+++ b/packages/frontend/src/components/core/chart/ChartRangeControls.tsx
@@ -63,7 +63,10 @@ export function ChartRangeControls({ name, value, setValue, options }: Props) {
   if (!isClient) {
     return <Skeleton className={cn('h-8 w-14 md:w-[320px]')} />
   }
-  const selectedOption = rangeToOption(value, options)
+  const selectedOption = rangeToOption(
+    value,
+    options.map((option) => option.value),
+  )
 
   function onDateRangeChange(dateRange: DateRange | undefined) {
     setInternalValue(dateRange)
@@ -261,10 +264,15 @@ function CalendarComponent({
   )
 }
 
-function rangeToOption(
+/**
+ * Detects whether a resolved chart range matches one of the predefined
+ * options. Shared with URL serializers so a serialized range always agrees
+ * with the highlighted control.
+ */
+export function rangeToOption<T extends ChartRangeOptionValue>(
   [from, to]: ChartRange,
-  options: { value: ChartRangeOptionValue }[],
-): ChartRangeOptionValue | 'custom' {
+  values: readonly T[],
+): T | 'max' | 'custom' {
   if (
     UnixTime.toStartOf(to, 'day') !== UnixTime.toStartOf(UnixTime.now(), 'day')
   ) {
@@ -272,8 +280,5 @@ function rangeToOption(
   }
   if (from === null) return 'max'
   const days = rangeToDays([from, to])
-  const option = options.find((option) => optionToDays(option.value) === days)
-  if (option) return option.value
-
-  return 'custom'
+  return values.find((value) => optionToDays(value) === days) ?? 'custom'
 }

--- a/packages/frontend/src/hooks/useUrlStateSync.ts
+++ b/packages/frontend/src/hooks/useUrlStateSync.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react'
+import { useDebouncedValue } from './useDebouncedValue'
+import { useEventCallback } from './useEventCallback'
+import { useEventListener } from './useEventListener'
+
+interface UseUrlStateSyncOptions<T> {
+  /** The live client state; its canonical URL is pushed (debounced). */
+  state: T
+  debounceMs: number
+  /** Parses state from URL search params, tolerating garbage. */
+  parse: (searchParams: URLSearchParams) => T
+  /** Builds the canonical URL (path + query) of a state. */
+  build: (pathname: string, state: T) => string
+  /** Applies the parsed URL state on browser back/forward. */
+  onPopState: (parsed: T) => void
+  /** Notified after a URL is pushed, e.g. for tracking. */
+  onPushState?: (url: string, state: T) => void
+}
+
+/**
+ * Keeps the URL in sync with client state (debounced) and applies URL state
+ * on browser back/forward.
+ *
+ * Two states are considered equal iff they build the same canonical URL, so
+ * `build` is the single place encoding which state is visible in the URL -
+ * there is no separate equality predicate to keep in sync with it.
+ */
+export function useUrlStateSync<T>({
+  state,
+  debounceMs,
+  parse,
+  build,
+  onPopState,
+  onPushState,
+}: UseUrlStateSyncOptions<T>) {
+  const debouncedState = useDebouncedValue(state, debounceMs)
+  // Skips the sync right after a popstate, so restoring a non-canonical URL
+  // (e.g. hand-edited params) doesn't immediately push its canonical form
+  // and trap the back button.
+  const skipNextUrlUpdate = useRef(false)
+
+  const sync = useEventCallback((nextState: T) => {
+    if (skipNextUrlUpdate.current) {
+      skipNextUrlUpdate.current = false
+      return
+    }
+
+    const pathname = window.location.pathname
+    const nextUrl = build(pathname, nextState)
+    const canonicalCurrentUrl = build(
+      pathname,
+      parse(new URLSearchParams(window.location.search)),
+    )
+    if (nextUrl === canonicalCurrentUrl) {
+      return
+    }
+
+    window.history.pushState({}, '', nextUrl)
+    onPushState?.(nextUrl, nextState)
+  })
+
+  useEffect(() => sync(debouncedState), [sync, debouncedState])
+
+  useEventListener('popstate', () => {
+    skipNextUrlUpdate.current = true
+    onPopState(parse(new URLSearchParams(window.location.search)))
+  })
+}

--- a/packages/frontend/src/pages/interop/utils/InteropSelectedChainsContext.tsx
+++ b/packages/frontend/src/pages/interop/utils/InteropSelectedChainsContext.tsx
@@ -5,12 +5,10 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react'
-import { useDebouncedValue } from '~/hooks/useDebouncedValue'
-import { useEventListener } from '~/hooks/useEventListener'
 import { useTracking } from '~/hooks/useTracking'
+import { useUrlStateSync } from '~/hooks/useUrlStateSync'
 import type { InteropChainWithIcon } from '../components/chain-selector/types'
 import { buildInteropUrl } from './buildInteropUrl'
 import { getValidInteropSelection } from './getValidInteropSelection'
@@ -71,55 +69,26 @@ export function InteropSelectedChainsProvider({
   )
 
   const { track } = useTracking()
-  const debouncedSelection = useDebouncedValue(selection, 500)
-  const skipNextUrlUpdate = useRef(false)
-
-  useEffect(() => {
-    if (skipNextUrlUpdate.current) {
-      skipNextUrlUpdate.current = false
-      return
-    }
-
-    const currentSelection = parseInteropSelectionFromSearchParams({
-      searchParams: new URLSearchParams(window.location.search),
-      interopChainsIds: allChainIds,
-    })
-    if (isSameSelection(currentSelection, debouncedSelection)) {
-      return
-    }
-
-    const nextUrl = buildInteropUrl(
-      window.location.pathname,
-      debouncedSelection,
-    )
-
-    const currentUrl = window.location.pathname + window.location.search
-    if (nextUrl === currentUrl) {
-      return
-    }
-
-    window.history.pushState({}, '', nextUrl)
-
-    const chains = [
-      ...new Set([...debouncedSelection.from, ...debouncedSelection.to]),
-    ]
-      .sort()
-      .join(',')
-    track('interopChainsSelected', {
-      chains,
-      page: window.location.pathname,
-    })
-  }, [debouncedSelection, allChainIds, track])
-
-  useEventListener('popstate', () => {
-    skipNextUrlUpdate.current = true
-
-    const parsedSelection = parseInteropSelectionFromSearchParams({
-      searchParams: new URLSearchParams(window.location.search),
-      interopChainsIds: allChainIds,
-    })
-
-    setSelection(getValidInteropSelection(parsedSelection, allChainIds))
+  useUrlStateSync({
+    state: selection,
+    debounceMs: 500,
+    parse: (searchParams) =>
+      parseInteropSelectionFromSearchParams({
+        searchParams,
+        interopChainsIds: allChainIds,
+      }),
+    build: buildInteropUrl,
+    onPopState: (parsed) =>
+      setSelection(getValidInteropSelection(parsed, allChainIds)),
+    onPushState: (_url, pushed) => {
+      const chains = [...new Set([...pushed.from, ...pushed.to])]
+        .sort()
+        .join(',')
+      track('interopChainsSelected', {
+        chains,
+        page: window.location.pathname,
+      })
+    },
   })
 
   const selectChain = useCallback(
@@ -202,15 +171,6 @@ export function InteropSelectedChainsProvider({
     >
       {children}
     </InteropSelectedChainsContext.Provider>
-  )
-}
-
-function isSameSelection(left: InteropSelection, right: InteropSelection) {
-  return (
-    left.from.length === right.from.length &&
-    left.to.length === right.to.length &&
-    left.from.every((value, index) => value === right.from[index]) &&
-    left.to.every((value, index) => value === right.to[index])
   )
 }
 

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareChart.tsx
@@ -1,14 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { ChartScale } from '~/components/chart/types'
 import { ChartControlsWrapper } from '~/components/core/chart/ChartControlsWrapper'
 import { ChartRangeControls } from '~/components/core/chart/ChartRangeControls'
 import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
 import { Skeleton } from '~/components/core/Skeleton'
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard'
-import { useDebouncedValue } from '~/hooks/useDebouncedValue'
-import { useEventListener } from '~/hooks/useEventListener'
 import { useIsClient } from '~/hooks/useIsClient'
 import { useTimeout } from '~/hooks/useTimeout'
+import { useUrlStateSync } from '~/hooks/useUrlStateSync'
 import { CheckIcon } from '~/icons/Check'
 import { CopyIcon } from '~/icons/Copy'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
@@ -22,7 +21,6 @@ import {
   type CompareClientState,
   type CompareMetricId,
   type CompareViewMode,
-  isSameCompareState,
   toCompareClientState,
   toCompareUrlState,
 } from '../utils/compareChartState'
@@ -112,49 +110,21 @@ export function ScalingCompareChart({
 
 /**
  * Keeps the URL in sync with the chart state (defaults omitted) and applies
- * URL state on browser back/forward, mirroring the interop pages.
+ * URL state on browser back/forward.
  */
 function useCompareUrlSync(
   state: CompareClientState,
   validSlugs: string[],
   onPopState: (parsed: CompareChartState) => void,
 ) {
-  const debouncedState = useDebouncedValue(state, 300)
-  const skipNextUrlUpdate = useRef(false)
-
-  useEffect(() => {
-    if (skipNextUrlUpdate.current) {
-      skipNextUrlUpdate.current = false
-      return
-    }
-
-    const currentState = parseCompareStateFromSearchParams({
-      searchParams: new URLSearchParams(window.location.search),
-      validSlugs,
-    })
-    const urlState = toCompareUrlState(debouncedState)
-    if (isSameCompareState(currentState, urlState)) {
-      return
-    }
-
-    const nextUrl = buildCompareUrl(window.location.pathname, urlState)
-    const currentUrl = window.location.pathname + window.location.search
-    if (nextUrl === currentUrl) {
-      return
-    }
-
-    window.history.pushState({}, '', nextUrl)
-  }, [debouncedState, validSlugs])
-
-  useEventListener('popstate', () => {
-    skipNextUrlUpdate.current = true
-
-    onPopState(
-      parseCompareStateFromSearchParams({
-        searchParams: new URLSearchParams(window.location.search),
-        validSlugs,
-      }),
-    )
+  const urlState = useMemo(() => toCompareUrlState(state), [state])
+  useUrlStateSync({
+    state: urlState,
+    debounceMs: 300,
+    parse: (searchParams) =>
+      parseCompareStateFromSearchParams({ searchParams, validSlugs }),
+    build: buildCompareUrl,
+    onPopState,
   })
 }
 

--- a/packages/frontend/src/pages/scaling/compare/metrics/costs/getCostsCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/costs/getCostsCompareChartParams.ts
@@ -2,6 +2,17 @@ import type { CompareProjectEntry } from '~/server/features/scaling/compare/getC
 import type { ChartRange } from '~/utils/range/range'
 
 /**
+ * Whether the project has onchain costs tracking. The single source for the
+ * picker's no-data marking and the query params, so a project marked
+ * "no data" can never be queried anyway (or vice versa).
+ */
+export function hasCostsData(
+  project: CompareProjectEntry,
+): project is CompareProjectEntry & { costsSinceTimestamp: number } {
+  return project.costsSinceTimestamp !== undefined
+}
+
+/**
  * Builds the `costs.detailedChartWithProjectsRanges` input for the compare
  * chart. Shared between the SSR prefetch and the client query so the
  * hydrated cache always matches and the first paint needs no refetch.
@@ -14,15 +25,9 @@ export function getCostsCompareChartParams(
 ) {
   return {
     range: chartRange,
-    projects: projects.flatMap((project) =>
-      project.costsSinceTimestamp !== undefined
-        ? [
-            {
-              projectId: project.id,
-              sinceTimestamp: project.costsSinceTimestamp,
-            },
-          ]
-        : [],
-    ),
+    projects: projects.filter(hasCostsData).map((project) => ({
+      projectId: project.id,
+      sinceTimestamp: project.costsSinceTimestamp,
+    })),
   }
 }

--- a/packages/frontend/src/pages/scaling/compare/metrics/data-posted/getDataPostedCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/data-posted/getDataPostedCompareChartParams.ts
@@ -2,6 +2,15 @@ import type { CompareProjectEntry } from '~/server/features/scaling/compare/getC
 import type { ChartRange } from '~/utils/range/range'
 
 /**
+ * Whether the project has DA tracking. The single source for the picker's
+ * no-data marking and the query params, so a project marked "no data" can
+ * never be queried anyway (or vice versa).
+ */
+export function hasDataPostedData(project: CompareProjectEntry): boolean {
+  return project.hasDaTracking
+}
+
+/**
  * Builds the `da.detailedChartWithProjectsRanges` input for the compare
  * chart. Shared between the SSR prefetch and the client query so the
  * hydrated cache always matches and the first paint needs no refetch.
@@ -13,8 +22,6 @@ export function getDataPostedCompareChartParams(
 ) {
   return {
     range,
-    projects: projects
-      .filter((project) => project.hasDaTracking)
-      .map((project) => project.id),
+    projects: projects.filter(hasDataPostedData).map((project) => project.id),
   }
 }

--- a/packages/frontend/src/pages/scaling/compare/metrics/index.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/index.ts
@@ -3,7 +3,10 @@ import { ActivityCompareChart } from './activity/ActivityCompareChart'
 import { ActivityCompareControls } from './activity/ActivityCompareControls'
 import { CostsCompareChart } from './costs/CostsCompareChart'
 import { CostsCompareControls } from './costs/CostsCompareControls'
+import { hasCostsData } from './costs/getCostsCompareChartParams'
 import { DataPostedCompareChart } from './data-posted/DataPostedCompareChart'
+import { hasDataPostedData } from './data-posted/getDataPostedCompareChartParams'
+import { hasTvsData } from './tvs/getTvsCompareChartParams'
 import { TvsCompareChart } from './tvs/TvsCompareChart'
 import { TvsCompareControls } from './tvs/TvsCompareControls'
 import type { CompareMetric } from './types'
@@ -14,7 +17,7 @@ export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
     label: 'Value Secured',
     Chart: TvsCompareChart,
     Controls: TvsCompareControls,
-    hasData: (project) => project.tvsSinceTimestamp !== undefined,
+    hasData: hasTvsData,
     noDataLabel: 'No TVS data',
   },
   activity: {
@@ -28,14 +31,14 @@ export const COMPARE_METRICS: Record<CompareMetricId, CompareMetric> = {
     label: 'Costs',
     Chart: CostsCompareChart,
     Controls: CostsCompareControls,
-    hasData: (project) => project.costsSinceTimestamp !== undefined,
+    hasData: hasCostsData,
     noDataLabel: 'No costs data',
   },
   'data-posted': {
     id: 'data-posted',
     label: 'Data posted',
     Chart: DataPostedCompareChart,
-    hasData: (project) => project.hasDaTracking,
+    hasData: hasDataPostedData,
     noDataLabel: 'No data posted tracking',
   },
 }

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/getTvsCompareChartParams.ts
@@ -5,6 +5,17 @@ import {
 } from '../../utils/compareChartState'
 
 /**
+ * Whether the project has TVS tracking. The single source for the picker's
+ * no-data marking and the query params, so a project marked "no data" can
+ * never be queried anyway (or vice versa).
+ */
+export function hasTvsData(
+  project: CompareProjectEntry,
+): project is CompareProjectEntry & { tvsSinceTimestamp: number } {
+  return project.tvsSinceTimestamp !== undefined
+}
+
+/**
  * Builds the `tvs.detailedChartWithProjectsRanges` input for the compare
  * chart. Shared between the SSR prefetch and the client query so the
  * hydrated cache always matches and the first paint needs no refetch.
@@ -23,15 +34,9 @@ export function getTvsCompareChartParams(
     range: state.chartRange,
     excludeAssociatedTokens: state.excludeAssociatedTokens,
     excludeRwaRestrictedTokens: effectiveExcludeRwaRestrictedTokens(state),
-    projects: projects.flatMap((project) =>
-      project.tvsSinceTimestamp !== undefined
-        ? [
-            {
-              projectId: project.id,
-              sinceTimestamp: project.tvsSinceTimestamp,
-            },
-          ]
-        : [],
-    ),
+    projects: projects.filter(hasTvsData).map((project) => ({
+      projectId: project.id,
+      sinceTimestamp: project.tvsSinceTimestamp,
+    })),
   }
 }

--- a/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
+++ b/packages/frontend/src/pages/scaling/compare/server/compareServerMetrics.ts
@@ -5,8 +5,14 @@ import { getCostsTotalUsdForProjects } from '~/server/features/scaling/costs/get
 import type { getSsrHelpers } from '~/trpc/server'
 import { optionToRange } from '~/utils/range/range'
 import { getActivityCompareChartParams } from '../metrics/activity/getActivityCompareChartParams'
-import { getCostsCompareChartParams } from '../metrics/costs/getCostsCompareChartParams'
-import { getDataPostedCompareChartParams } from '../metrics/data-posted/getDataPostedCompareChartParams'
+import {
+  getCostsCompareChartParams,
+  hasCostsData,
+} from '../metrics/costs/getCostsCompareChartParams'
+import {
+  getDataPostedCompareChartParams,
+  hasDataPostedData,
+} from '../metrics/data-posted/getDataPostedCompareChartParams'
 import { getTvsCompareChartParams } from '../metrics/tvs/getTvsCompareChartParams'
 import type {
   CompareClientState,
@@ -14,6 +20,15 @@ import type {
 } from '../utils/compareChartState'
 
 type SsrHelpers = ReturnType<typeof getSsrHelpers>
+
+/** Ranks the metric's default top-N selection, ties kept in universe order. */
+function topByScore(
+  projects: CompareProjectEntry[],
+  count: number,
+  score: (project: CompareProjectEntry) => number,
+): CompareProjectEntry[] {
+  return [...projects].sort((a, b) => score(b) - score(a)).slice(0, count)
+}
 
 /**
  * Server-side half of the metric registry: default top-N ranking and the
@@ -51,14 +66,11 @@ export const COMPARE_SERVER_METRICS: Record<
       // The ranking only needs the latest daily counts, so a short range
       // keeps the query far cheaper than the summary page's 1y default.
       const uops = await getActivityLatestUops(universe, optionToRange('30d'))
-      return universe
-        .map((project) => ({
-          project,
-          uops: uops[project.id.toString()]?.pastDayUops ?? -1,
-        }))
-        .sort((a, b) => b.uops - a.uops)
-        .slice(0, count)
-        .map(({ project }) => project)
+      return topByScore(
+        universe,
+        count,
+        (project) => uops[project.id.toString()]?.pastDayUops ?? -1,
+      )
     },
     prefetch: async (helpers, projects, state) => {
       await helpers.queryClient.prefetchQuery(
@@ -72,21 +84,16 @@ export const COMPARE_SERVER_METRICS: Record<
     getDefaultProjects: async (universe, count) => {
       // Only projects with costs tracking can rank; the recent window keeps
       // the query cheap while still reflecting current spending.
-      const tracked = universe.filter(
-        (project) => project.costsSinceTimestamp !== undefined,
-      )
+      const tracked = universe.filter(hasCostsData)
       const totals = await getCostsTotalUsdForProjects(
         tracked,
         optionToRange('30d'),
       )
-      return tracked
-        .map((project) => ({
-          project,
-          usd: totals[project.id.toString()] ?? -1,
-        }))
-        .sort((a, b) => b.usd - a.usd)
-        .slice(0, count)
-        .map(({ project }) => project)
+      return topByScore(
+        tracked,
+        count,
+        (project) => totals[project.id.toString()] ?? -1,
+      )
     },
     prefetch: async (helpers, projects, state) => {
       await helpers.queryClient.prefetchQuery(
@@ -98,18 +105,15 @@ export const COMPARE_SERVER_METRICS: Record<
   },
   'data-posted': {
     getDefaultProjects: async (universe, count) => {
-      const tracked = universe.filter((project) => project.hasDaTracking)
+      const tracked = universe.filter(hasDataPostedData)
       const dataPosted = await getProjectsDataPosted(
         tracked.map((project) => project.id),
       )
-      return tracked
-        .map((project) => ({
-          project,
-          pastDay: dataPosted[project.id.toString()]?.pastDay ?? -1,
-        }))
-        .sort((a, b) => b.pastDay - a.pastDay)
-        .slice(0, count)
-        .map(({ project }) => project)
+      return topByScore(
+        tracked,
+        count,
+        (project) => dataPosted[project.id.toString()]?.pastDay ?? -1,
+      )
     },
     prefetch: async (helpers, projects, state) => {
       await helpers.queryClient.prefetchQuery(

--- a/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/compareChartState.ts
@@ -1,12 +1,9 @@
-import { UnixTime } from '@l2beat/shared-pure'
 import type { ChartScale } from '~/components/chart/types'
-import type { ChartRangeOptionValue } from '~/components/core/chart/ChartRangeControls'
 import {
-  type ChartRange,
-  optionToDays,
-  optionToRange,
-} from '~/utils/range/range'
-import { rangeToDays } from '~/utils/range/rangeToDays'
+  type ChartRangeOptionValue,
+  rangeToOption,
+} from '~/components/core/chart/ChartRangeControls'
+import { type ChartRange, optionToRange } from '~/utils/range/range'
 
 export const COMPARE_METRIC_IDS = [
   'tvs',
@@ -97,55 +94,22 @@ export interface CompareChartState {
  * range is always resolved to concrete timestamps, so there is a single
  * source of truth for what the chart queries.
  */
-export interface CompareClientState {
-  metric: CompareMetricId
-  projects: string[]
-  scale: ChartScale
-  mode: CompareViewMode
-  activityUnit: CompareActivityUnit
-  tvsUnit: CompareTvsUnit
-  tvsFilter: CompareTvsFilter
-  costsUnit: CompareCostsUnit
-  excludeAssociatedTokens: boolean
-  excludeRwaRestrictedTokens: boolean
+export type CompareClientState = Omit<CompareChartState, 'range'> & {
   chartRange: ChartRange
 }
 
-export function toCompareUrlState(
-  state: CompareClientState,
-): CompareChartState {
-  return {
-    metric: state.metric,
-    projects: state.projects,
-    scale: state.scale,
-    mode: state.mode,
-    activityUnit: state.activityUnit,
-    tvsUnit: state.tvsUnit,
-    tvsFilter: state.tvsFilter,
-    costsUnit: state.costsUnit,
-    excludeAssociatedTokens: state.excludeAssociatedTokens,
-    excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
-    range: chartRangeToCompareRange(state.chartRange),
-  }
+export function toCompareUrlState({
+  chartRange,
+  ...state
+}: CompareClientState): CompareChartState {
+  return { ...state, range: chartRangeToCompareRange(chartRange) }
 }
 
 export function toCompareClientState(
-  state: CompareChartState,
-  chartRange: ChartRange = compareRangeToChartRange(state.range),
+  { range, ...state }: CompareChartState,
+  chartRange: ChartRange = compareRangeToChartRange(range),
 ): CompareClientState {
-  return {
-    metric: state.metric,
-    projects: state.projects,
-    scale: state.scale,
-    mode: state.mode,
-    activityUnit: state.activityUnit,
-    tvsUnit: state.tvsUnit,
-    tvsFilter: state.tvsFilter,
-    costsUnit: state.costsUnit,
-    excludeAssociatedTokens: state.excludeAssociatedTokens,
-    excludeRwaRestrictedTokens: state.excludeRwaRestrictedTokens,
-    chartRange,
-  }
+  return { ...state, chartRange }
 }
 
 export const DEFAULT_COMPARE_METRIC: CompareMetricId = 'tvs'
@@ -186,58 +150,12 @@ export function compareRangeToChartRange(range: CompareRange): ChartRange {
 }
 
 /**
- * Maps a resolved chart range back to its URL representation. Mirrors the
- * predefined-option detection of `ChartRangeControls` so the URL matches the
- * highlighted control.
+ * Maps a resolved chart range back to its URL representation, reusing the
+ * predefined-option detection of `ChartRangeControls` so the URL always
+ * matches the highlighted control.
  */
 export function chartRangeToCompareRange([from, to]: ChartRange): CompareRange {
   if (from === null) return 'max'
-  if (
-    UnixTime.toStartOf(to, 'day') === UnixTime.toStartOf(UnixTime.now(), 'day')
-  ) {
-    const days = rangeToDays([from, to])
-    const option = COMPARE_RANGE_OPTIONS.find(
-      (option) => optionToDays(option) === days,
-    )
-    if (option) return option
-  }
-  return { from, to }
-}
-
-export function isSameCompareState(
-  left: CompareChartState,
-  right: CompareChartState,
-): boolean {
-  return (
-    left.metric === right.metric &&
-    left.mode === right.mode &&
-    // The scale toggle is hidden in indexed mode, so two states that differ
-    // solely by a hidden scale map to the same URL.
-    (left.mode === 'indexed' || left.scale === right.scale) &&
-    // Per-metric controls are only encoded for the metric they belong to,
-    // so two states that differ solely by a hidden control map to the same
-    // URL.
-    (left.metric !== 'activity' || left.activityUnit === right.activityUnit) &&
-    (left.metric !== 'costs' || left.costsUnit === right.costsUnit) &&
-    (left.metric !== 'tvs' ||
-      (left.tvsUnit === right.tvsUnit &&
-        left.tvsFilter === right.tvsFilter &&
-        left.excludeAssociatedTokens === right.excludeAssociatedTokens &&
-        // The exclude-restricted-RWA toggle is disabled and overridden while
-        // the Restricted RWAs filter is active, so its stored value is
-        // hidden and not encoded.
-        (left.tvsFilter === 'rwaRestricted' ||
-          left.excludeRwaRestrictedTokens ===
-            right.excludeRwaRestrictedTokens))) &&
-    isSameRange(left.range, right.range) &&
-    left.projects.length === right.projects.length &&
-    left.projects.every((slug, index) => slug === right.projects[index])
-  )
-}
-
-function isSameRange(left: CompareRange, right: CompareRange): boolean {
-  if (typeof left === 'string' || typeof right === 'string') {
-    return left === right
-  }
-  return left.from === right.from && left.to === right.to
+  const option = rangeToOption([from, to], COMPARE_RANGE_OPTIONS)
+  return option === 'custom' ? { from, to } : option
 }

--- a/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/parseCompareStateFromSearchParams.ts
@@ -5,14 +5,9 @@ import {
   COMPARE_RANGE_OPTIONS,
   COMPARE_TVS_FILTERS,
   COMPARE_TVS_UNITS,
-  type CompareActivityUnit,
   type CompareChartState,
-  type CompareCostsUnit,
-  type CompareMetricId,
   type CompareRange,
   type CompareRangeOption,
-  type CompareTvsFilter,
-  type CompareTvsUnit,
   DEFAULT_COMPARE_ACTIVITY_UNIT,
   DEFAULT_COMPARE_COSTS_UNIT,
   DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
@@ -37,7 +32,11 @@ export function parseCompareStateFromSearchParams({
   searchParams: URLSearchParams
   validSlugs: string[]
 }): CompareChartState {
-  const metric = parseMetric(searchParams.get('metric'))
+  const metric = parseOneOf(
+    searchParams.get('metric'),
+    COMPARE_METRIC_IDS,
+    DEFAULT_COMPARE_METRIC,
+  )
   const unit = searchParams.get('unit')
   return {
     metric,
@@ -55,15 +54,28 @@ export function parseCompareStateFromSearchParams({
     // leak its unit into the TVS control.
     activityUnit:
       metric === 'activity'
-        ? parseActivityUnit(unit)
+        ? parseOneOf(
+            unit,
+            COMPARE_ACTIVITY_UNITS,
+            DEFAULT_COMPARE_ACTIVITY_UNIT,
+          )
         : DEFAULT_COMPARE_ACTIVITY_UNIT,
-    tvsUnit: metric === 'tvs' ? parseTvsUnit(unit) : DEFAULT_COMPARE_TVS_UNIT,
+    tvsUnit:
+      metric === 'tvs'
+        ? parseOneOf(unit, COMPARE_TVS_UNITS, DEFAULT_COMPARE_TVS_UNIT)
+        : DEFAULT_COMPARE_TVS_UNIT,
     tvsFilter:
       metric === 'tvs'
-        ? parseTvsFilter(searchParams.get('filter'))
+        ? parseOneOf(
+            searchParams.get('filter'),
+            COMPARE_TVS_FILTERS,
+            DEFAULT_COMPARE_TVS_FILTER,
+          )
         : DEFAULT_COMPARE_TVS_FILTER,
     costsUnit:
-      metric === 'costs' ? parseCostsUnit(unit) : DEFAULT_COMPARE_COSTS_UNIT,
+      metric === 'costs'
+        ? parseOneOf(unit, COMPARE_COSTS_UNITS, DEFAULT_COMPARE_COSTS_UNIT)
+        : DEFAULT_COMPARE_COSTS_UNIT,
     excludeAssociatedTokens: parseBoolean(
       searchParams.get('excludeAssociated'),
       DEFAULT_COMPARE_EXCLUDE_ASSOCIATED_TOKENS,
@@ -75,29 +87,12 @@ export function parseCompareStateFromSearchParams({
   }
 }
 
-function parseMetric(value: string | null): CompareMetricId {
-  const metric = COMPARE_METRIC_IDS.find((id) => id === value)
-  return metric ?? DEFAULT_COMPARE_METRIC
-}
-
-function parseActivityUnit(value: string | null): CompareActivityUnit {
-  const unit = COMPARE_ACTIVITY_UNITS.find((unit) => unit === value)
-  return unit ?? DEFAULT_COMPARE_ACTIVITY_UNIT
-}
-
-function parseTvsUnit(value: string | null): CompareTvsUnit {
-  const unit = COMPARE_TVS_UNITS.find((unit) => unit === value)
-  return unit ?? DEFAULT_COMPARE_TVS_UNIT
-}
-
-function parseTvsFilter(value: string | null): CompareTvsFilter {
-  const filter = COMPARE_TVS_FILTERS.find((filter) => filter === value)
-  return filter ?? DEFAULT_COMPARE_TVS_FILTER
-}
-
-function parseCostsUnit(value: string | null): CompareCostsUnit {
-  const unit = COMPARE_COSTS_UNITS.find((unit) => unit === value)
-  return unit ?? DEFAULT_COMPARE_COSTS_UNIT
+function parseOneOf<T extends string>(
+  value: string | null,
+  options: readonly T[],
+  fallback: T,
+): T {
+  return options.find((option) => option === value) ?? fallback
 }
 
 function parseBoolean(value: string | null, defaultValue: boolean): boolean {

--- a/packages/frontend/src/server/features/data-availability/throughput/getDetailedDataPostedChartWithProjectsRanges.ts
+++ b/packages/frontend/src/server/features/data-availability/throughput/getDetailedDataPostedChartWithProjectsRanges.ts
@@ -1,16 +1,22 @@
 import type { Database } from '@l2beat/database'
 import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
-import { v } from '@l2beat/validate'
+import type { v } from '@l2beat/validate'
 import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
 import { getChartStartTimestamp } from '~/server/features/utils/getChartStartTimestamp'
-import { ChartRange } from '~/utils/range/range'
+import {
+  buildProjectSeriesChart,
+  type ChartProjectRange,
+  getMockProjectSeriesChartData,
+  minSinceTimestamp,
+  ProjectsChartParams,
+  sinceTimestampGate,
+  toProjectRanges,
+} from '~/server/features/utils/projectSeriesChart'
+import type { ChartRange } from '~/utils/range/range'
 
-export const DataPostedChartWithProjectsRangesDataParams = v.object({
-  range: ChartRange,
-  projects: v.array(v.string().transform((value) => value as ProjectId)),
-})
+export const DataPostedChartWithProjectsRangesDataParams = ProjectsChartParams
 
 export type DataPostedChartWithProjectsRangesDataParams = v.infer<
   typeof DataPostedChartWithProjectsRangesDataParams
@@ -22,15 +28,9 @@ export type DetailedDataPostedChartWithProjectsRangesDataPoint = [
   projects: Record<string, number | null>,
 ]
 
-export type DataPostedChartProjectRange = {
-  projectId: ProjectId
-  /** First day with data-posted data, floored to the day resolution. */
-  sinceTimestamp: number
-}
-
 export type DetailedDataPostedChartWithProjectsRangesData = {
   chart: DetailedDataPostedChartWithProjectsRangesDataPoint[]
-  projects: DataPostedChartProjectRange[]
+  projects: ChartProjectRange[]
   syncedUntil: number
 }
 
@@ -84,18 +84,10 @@ export async function getDataPostedChartData(
     repository.getFirstTimestampsByProjectIds(projectIds),
   ])
 
-  const projectRanges: DataPostedChartProjectRange[] = projectIds.flatMap(
-    (projectId) => {
-      const sinceTimestamp = firstTimestamps[projectId]
-      return sinceTimestamp !== undefined
-        ? [
-            {
-              projectId,
-              sinceTimestamp: UnixTime.toStartOf(sinceTimestamp, 'day'),
-            },
-          ]
-        : []
-    },
+  const projectRanges = toProjectRanges(
+    projectIds,
+    (projectId) => firstTimestamps[projectId],
+    'day',
   )
 
   if (records.length === 0) {
@@ -135,44 +127,38 @@ export async function getDataPostedChartData(
     }
   }
 
-  const sinceByProjectId = new Map(
-    projectRanges.map((p) => [p.projectId, p.sinceTimestamp]),
-  )
-  const firstProjectTimestamp =
-    projectRanges.length > 0
-      ? Math.min(...projectRanges.map((p) => p.sinceTimestamp))
-      : undefined
-
   const startTimestamp = getChartStartTimestamp({
     rangeStart: range[0],
-    firstProjectTimestamp,
+    firstProjectTimestamp: minSinceTimestamp(projectRanges),
     dataStart,
     resolution: 'day',
   })
   const timestamps = generateTimestamps([startTimestamp, dataEnd], 'day')
 
-  const chart: DetailedDataPostedChartWithProjectsRangesDataPoint[] =
-    timestamps.map((timestamp) => {
-      const projectsForTimestamp: Record<string, number | null> = {}
-
-      for (const projectId of projectIds) {
-        // Zero only between the project's first record and its last non-zero
-        // day; null everywhere else so the client can distinguish "posted
-        // nothing" from "no data" (pre-launch, stopped, or untracked).
-        const sinceTimestamp = sinceByProjectId.get(projectId)
-        const lastNonzero = lastNonzeroByProjectId.get(projectId)
-        const isActive =
-          sinceTimestamp !== undefined &&
-          timestamp >= sinceTimestamp &&
-          lastNonzero !== undefined &&
-          timestamp <= lastNonzero
-        projectsForTimestamp[projectId] = isActive
-          ? (bytesByProjectId.get(projectId)?.get(timestamp) ?? 0)
-          : null
-      }
-
-      return [timestamp, projectsForTimestamp]
-    })
+  // Zero only between the project's first record and its last non-zero day;
+  // null everywhere else so the client can distinguish "posted nothing"
+  // from "no data" (pre-launch, stopped, or untracked).
+  const sinceGate = sinceTimestampGate(projectRanges)
+  const isActive = (projectId: ProjectId, timestamp: number) => {
+    const lastNonzero = lastNonzeroByProjectId.get(projectId)
+    return (
+      sinceGate(projectId, timestamp) &&
+      lastNonzero !== undefined &&
+      timestamp <= lastNonzero
+    )
+  }
+  const chart = buildProjectSeriesChart<number>({
+    timestamps,
+    projectIds,
+    // Values outside the active window are dropped too, so a trailing zero
+    // bucket can't extend a series past its last non-zero day.
+    getValue: (projectId, timestamp) =>
+      isActive(projectId, timestamp)
+        ? bytesByProjectId.get(projectId)?.get(timestamp)
+        : undefined,
+    fillZero: isActive,
+    zero: 0,
+  })
 
   return { chart, projects: projectRanges, syncedUntil: dataEnd }
 }
@@ -181,25 +167,11 @@ function getMockDetailedDataPostedChartWithProjectsRangesData({
   range,
   projects,
 }: DataPostedChartWithProjectsRangesDataParams): DetailedDataPostedChartWithProjectsRangesData {
-  const timestamps = generateTimestamps(
-    [range[0] ?? 1590883200, range[1]],
-    'day',
-  )
-
-  return {
-    chart: timestamps.map((timestamp) => [
-      timestamp,
-      Object.fromEntries(
-        projects.map((projectId, index) => [
-          projectId,
-          100_000_000 * (index + 1),
-        ]),
-      ),
-    ]),
-    projects: projects.map((projectId) => ({
-      projectId,
-      sinceTimestamp: timestamps[0] ?? 0,
-    })),
-    syncedUntil: timestamps[timestamps.length - 1] ?? 0,
-  }
+  return getMockProjectSeriesChartData<number>({
+    projectIds: projects,
+    range,
+    resolution: 'day',
+    defaultStart: 1590883200,
+    value: (index) => 100_000_000 * (index + 1),
+  })
 }

--- a/packages/frontend/src/server/features/scaling/activity/getDetailedActivityChartWithProjectsRanges.ts
+++ b/packages/frontend/src/server/features/scaling/activity/getDetailedActivityChartWithProjectsRanges.ts
@@ -1,17 +1,23 @@
 import type { ActivityRecord, Database } from '@l2beat/database'
 import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
-import { v } from '@l2beat/validate'
+import type { v } from '@l2beat/validate'
 import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
 import { getChartStartTimestamp } from '~/server/features/utils/getChartStartTimestamp'
-import { ChartRange } from '~/utils/range/range'
+import {
+  buildProjectSeriesChart,
+  type ChartProjectRange,
+  getMockProjectSeriesChartData,
+  minSinceTimestamp,
+  ProjectsChartParams,
+  sinceTimestampGate,
+  toProjectRanges,
+} from '~/server/features/utils/projectSeriesChart'
+import type { ChartRange } from '~/utils/range/range'
 import { getFullySyncedActivityRange } from './utils/getFullySyncedActivityRange'
 
-export const ActivityChartWithProjectsRangesDataParams = v.object({
-  range: ChartRange,
-  projects: v.array(v.string().transform((value) => value as ProjectId)),
-})
+export const ActivityChartWithProjectsRangesDataParams = ProjectsChartParams
 
 export type ActivityChartWithProjectsRangesDataParams = v.infer<
   typeof ActivityChartWithProjectsRangesDataParams
@@ -24,15 +30,9 @@ export type DetailedActivityChartWithProjectsRangesDataPoint = [
   projects: Record<string, ProjectActivityChartDataPoint | null>,
 ]
 
-export type ActivityChartProjectRange = {
-  projectId: ProjectId
-  /** First day with activity data, floored to the day resolution. */
-  sinceTimestamp: number
-}
-
 export type DetailedActivityChartWithProjectsRangesData = {
   chart: DetailedActivityChartWithProjectsRangesDataPoint[]
-  projects: ActivityChartProjectRange[]
+  projects: ChartProjectRange[]
   syncedUntil: number
 }
 
@@ -75,18 +75,10 @@ export async function getActivityChartData(
     repository.getActivityTotalsForProjects(projectIds),
   ])
 
-  const projectRanges: ActivityChartProjectRange[] = projectIds.flatMap(
-    (projectId) => {
-      const sinceTimestamp = totals[projectId]?.sinceTimestamp
-      return sinceTimestamp !== undefined
-        ? [
-            {
-              projectId,
-              sinceTimestamp: UnixTime.toStartOf(sinceTimestamp, 'day'),
-            },
-          ]
-        : []
-    },
+  const projectRanges = toProjectRanges(
+    projectIds,
+    (projectId) => totals[projectId]?.sinceTimestamp,
+    'day',
   )
 
   const syncedUntil = range[1]
@@ -98,62 +90,34 @@ export async function getActivityChartData(
   let dataStart = Number.POSITIVE_INFINITY
   for (const record of records) {
     dataStart = Math.min(dataStart, record.timestamp)
-    const projectRecords = recordsByProjectId.get(record.projectId)
-    if (projectRecords) {
-      projectRecords.set(record.timestamp, record)
-      continue
-    }
-    recordsByProjectId.set(
-      record.projectId,
-      new Map([[record.timestamp, record]]),
-    )
+    const projectRecords = recordsByProjectId.get(record.projectId) ?? new Map()
+    projectRecords.set(record.timestamp, record)
+    recordsByProjectId.set(record.projectId, projectRecords)
   }
-
-  const sinceByProjectId = new Map(
-    projectRanges.map((p) => [p.projectId, p.sinceTimestamp]),
-  )
-  const firstProjectTimestamp =
-    projectRanges.length > 0
-      ? Math.min(...projectRanges.map((p) => p.sinceTimestamp))
-      : undefined
 
   const startTimestamp = getChartStartTimestamp({
     rangeStart: range[0],
-    firstProjectTimestamp,
+    firstProjectTimestamp: minSinceTimestamp(projectRanges),
     dataStart,
     resolution: 'day',
   })
   const timestamps = generateTimestamps([startTimestamp, range[1]], 'day')
 
-  const chart: DetailedActivityChartWithProjectsRangesDataPoint[] =
-    timestamps.map((timestamp) => {
-      const projectsForTimestamp: Record<
-        string,
-        ProjectActivityChartDataPoint | null
-      > = {}
-
-      for (const projectId of projectIds) {
-        const record = recordsByProjectId.get(projectId)?.get(timestamp)
-        if (record) {
-          projectsForTimestamp[projectId] = [
-            record.count,
-            record.uopsCount ?? record.count,
-          ]
-          continue
-        }
-
-        // Zero only after the project's first record; null marks days before
-        // launch (or projects without activity tracking) so the client can
-        // distinguish "no activity" from "no data".
-        const sinceTimestamp = sinceByProjectId.get(projectId)
-        projectsForTimestamp[projectId] =
-          sinceTimestamp !== undefined && timestamp >= sinceTimestamp
-            ? [0, 0]
-            : null
-      }
-
-      return [timestamp, projectsForTimestamp]
-    })
+  const chart = buildProjectSeriesChart<ProjectActivityChartDataPoint>({
+    timestamps,
+    projectIds,
+    getValue: (projectId, timestamp) => {
+      const record = recordsByProjectId.get(projectId)?.get(timestamp)
+      return record
+        ? [record.count, record.uopsCount ?? record.count]
+        : undefined
+    },
+    // Zero only after the project's first record; null marks days before
+    // launch (or projects without activity tracking) so the client can
+    // distinguish "no activity" from "no data".
+    fillZero: sinceTimestampGate(projectRanges),
+    zero: [0, 0],
+  })
 
   return { chart, projects: projectRanges, syncedUntil }
 }
@@ -162,25 +126,11 @@ function getMockDetailedActivityChartWithProjectsRangesData({
   range,
   projects,
 }: ActivityChartWithProjectsRangesDataParams): DetailedActivityChartWithProjectsRangesData {
-  const timestamps = generateTimestamps(
-    [range[0] ?? 1590883200, range[1]],
-    'day',
-  )
-
-  return {
-    chart: timestamps.map((timestamp) => [
-      timestamp,
-      Object.fromEntries(
-        projects.map((projectId, index) => [
-          projectId,
-          [1_000_000 * (index + 1), 1_500_000 * (index + 1)],
-        ]),
-      ),
-    ]),
-    projects: projects.map((projectId) => ({
-      projectId,
-      sinceTimestamp: timestamps[0] ?? 0,
-    })),
-    syncedUntil: timestamps[timestamps.length - 1] ?? 0,
-  }
+  return getMockProjectSeriesChartData<ProjectActivityChartDataPoint>({
+    projectIds: projects,
+    range,
+    resolution: 'day',
+    defaultStart: 1590883200,
+    value: (index) => [1_000_000 * (index + 1), 1_500_000 * (index + 1)],
+  })
 }

--- a/packages/frontend/src/server/features/scaling/costs/getDetailedCostsChartWithProjectsRanges.ts
+++ b/packages/frontend/src/server/features/scaling/costs/getDetailedCostsChartWithProjectsRanges.ts
@@ -5,6 +5,13 @@ import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { generateTimestamps } from '~/server/features/utils/generateTimestamps'
 import { getChartStartTimestamp } from '~/server/features/utils/getChartStartTimestamp'
+import {
+  buildProjectSeriesChart,
+  type ChartProjectRange,
+  getMockProjectSeriesChartData,
+  minSinceTimestamp,
+  sinceTimestampGate,
+} from '~/server/features/utils/projectSeriesChart'
 import { ChartRange, rangeToResolution } from '~/utils/range/range'
 import { getCostsExpectedTimestamp } from './utils/getCostsExpectedTimestamp'
 import { isCostsSynced } from './utils/isCostsSynced'
@@ -30,15 +37,9 @@ export type DetailedCostsChartWithProjectsRangesDataPoint = [
   projects: Record<string, ProjectCostsChartDataPoint | null>,
 ]
 
-export type CostsChartProjectRange = {
-  projectId: ProjectId
-  /** First timestamp with tracked costs, floored to the active resolution. */
-  sinceTimestamp: number
-}
-
 export type DetailedCostsChartWithProjectsRangesData = {
   chart: DetailedCostsChartWithProjectsRangesDataPoint[]
-  projects: CostsChartProjectRange[]
+  projects: ChartProjectRange[]
   syncedUntil: number
 }
 
@@ -79,7 +80,7 @@ export async function getCostsChartData(
   // the `>= sinceTimestamp` gate aligns with the generated buckets. The
   // rounded values are returned to the client so its tooltip gate can't
   // drift from the data gate computed here.
-  const projectRanges: CostsChartProjectRange[] = projects.map((project) => ({
+  const projectRanges: ChartProjectRange[] = projects.map((project) => ({
     projectId: project.projectId,
     sinceTimestamp: UnixTime.toStartOf(project.sinceTimestamp, resolution),
   }))
@@ -127,19 +128,12 @@ export async function getCostsChartData(
     ])
   }
 
-  const sinceByProjectId = new Map(
-    projectRanges.map((p) => [p.projectId, p.sinceTimestamp]),
-  )
-  const firstProjectTimestamp = Math.min(
-    ...projectRanges.map((p) => p.sinceTimestamp),
-  )
-
   const adjustedTo = isCostsSynced({ to: range[1], syncedUntil })
     ? maxBucket
     : getCostsExpectedTimestamp(range[1], resolution)
   const startTimestamp = getChartStartTimestamp({
     rangeStart: range[0],
-    firstProjectTimestamp,
+    firstProjectTimestamp: minSinceTimestamp(projectRanges),
     dataStart,
     resolution,
   })
@@ -148,36 +142,19 @@ export async function getCostsChartData(
     resolution,
   )
 
-  const chart: DetailedCostsChartWithProjectsRangesDataPoint[] = timestamps.map(
-    (timestamp) => {
-      const projectsForTimestamp: Record<
-        string,
-        ProjectCostsChartDataPoint | null
-      > = {}
-
-      for (const projectId of projectIds) {
-        const values = summedByProjectId.get(projectId)?.get(timestamp)
-        if (values) {
-          projectsForTimestamp[projectId] = values
-          continue
-        }
-
-        // Zero only inside the synced window and after the project's costs
-        // tracking start; null marks buckets before tracking (or past the
-        // synced window) so the client can distinguish "no costs" from
-        // "no data".
-        const sinceTimestamp = sinceByProjectId.get(projectId)
-        projectsForTimestamp[projectId] =
-          timestamp <= maxBucket &&
-          sinceTimestamp !== undefined &&
-          timestamp >= sinceTimestamp
-            ? [0, 0, 0]
-            : null
-      }
-
-      return [timestamp, projectsForTimestamp]
-    },
-  )
+  // Zero only inside the synced window and after the project's costs
+  // tracking start; null marks buckets before tracking (or past the synced
+  // window) so the client can distinguish "no costs" from "no data".
+  const sinceGate = sinceTimestampGate(projectRanges)
+  const chart = buildProjectSeriesChart<ProjectCostsChartDataPoint>({
+    timestamps,
+    projectIds,
+    getValue: (projectId, timestamp) =>
+      summedByProjectId.get(projectId)?.get(timestamp),
+    fillZero: (projectId, timestamp) =>
+      timestamp <= maxBucket && sinceGate(projectId, timestamp),
+    zero: [0, 0, 0],
+  })
 
   return { chart, projects: projectRanges, syncedUntil }
 }
@@ -186,26 +163,15 @@ function getMockDetailedCostsChartWithProjectsRangesData({
   range,
   projects,
 }: CostsChartWithProjectsRangesDataParams): DetailedCostsChartWithProjectsRangesData {
-  const resolution = rangeToResolution(range)
-  const timestamps = generateTimestamps(
-    [range[0] ?? 1573776000, range[1]],
-    resolution,
-  )
-
-  return {
-    chart: timestamps.map((timestamp) => [
-      timestamp,
-      Object.fromEntries(
-        projects.map(({ projectId }, index) => [
-          projectId,
-          [1_000_000 * (index + 1), 10 * (index + 1), 30_000 * (index + 1)],
-        ]),
-      ),
-    ]),
-    projects: projects.map(({ projectId }) => ({
-      projectId,
-      sinceTimestamp: timestamps[0] ?? 0,
-    })),
-    syncedUntil: timestamps[timestamps.length - 1] ?? 0,
-  }
+  return getMockProjectSeriesChartData<ProjectCostsChartDataPoint>({
+    projectIds: projects.map(({ projectId }) => projectId),
+    range,
+    resolution: rangeToResolution(range),
+    defaultStart: 1573776000,
+    value: (index) => [
+      1_000_000 * (index + 1),
+      10 * (index + 1),
+      30_000 * (index + 1),
+    ],
+  })
 }

--- a/packages/frontend/src/server/features/utils/projectSeriesChart.ts
+++ b/packages/frontend/src/server/features/utils/projectSeriesChart.ts
@@ -1,0 +1,138 @@
+import { type ProjectId, UnixTime } from '@l2beat/shared-pure'
+import { v } from '@l2beat/validate'
+import { ChartRange, type ChartResolution } from '~/utils/range/range'
+import { generateTimestamps } from './generateTimestamps'
+
+/**
+ * Shared input schema of the `detailedChartWithProjectsRanges` endpoints
+ * keyed by plain project ids (activity, data posted).
+ */
+export const ProjectsChartParams = v.object({
+  range: ChartRange,
+  projects: v.array(v.string().transform((value) => value as ProjectId)),
+})
+
+export type ChartProjectRange = {
+  projectId: ProjectId
+  /** First timestamp with data, floored to the chart resolution. */
+  sinceTimestamp: number
+}
+
+/**
+ * Maps project ids to their {@link ChartProjectRange}, flooring each since
+ * timestamp to the chart resolution and dropping projects without data.
+ */
+export function toProjectRanges(
+  projectIds: ProjectId[],
+  getSinceTimestamp: (projectId: ProjectId) => number | undefined,
+  resolution: ChartResolution,
+): ChartProjectRange[] {
+  return projectIds.flatMap((projectId) => {
+    const sinceTimestamp = getSinceTimestamp(projectId)
+    return sinceTimestamp !== undefined
+      ? [
+          {
+            projectId,
+            sinceTimestamp: UnixTime.toStartOf(sinceTimestamp, resolution),
+          },
+        ]
+      : []
+  })
+}
+
+export function minSinceTimestamp(
+  projectRanges: ChartProjectRange[],
+): number | undefined {
+  return projectRanges.length > 0
+    ? Math.min(...projectRanges.map((p) => p.sinceTimestamp))
+    : undefined
+}
+
+/**
+ * The shared "has this project launched yet" gate: true from the project's
+ * first data point on, false before it and for projects without data.
+ */
+export function sinceTimestampGate(
+  projectRanges: ChartProjectRange[],
+): (projectId: ProjectId, timestamp: number) => boolean {
+  const sinceByProjectId = new Map(
+    projectRanges.map((p) => [p.projectId, p.sinceTimestamp]),
+  )
+  return (projectId, timestamp) => {
+    const sinceTimestamp = sinceByProjectId.get(projectId)
+    return sinceTimestamp !== undefined && timestamp >= sinceTimestamp
+  }
+}
+
+/**
+ * Assembles the per-timestamp rows of a multi-project chart, applying the
+ * shared zero/null convention: an absent bucket is `zero` where `fillZero`
+ * holds (inside the project's active window) and `null` everywhere else
+ * (pre-launch, past sync, or untracked), so clients can distinguish
+ * "measured zero" from "no data".
+ */
+export function buildProjectSeriesChart<T>({
+  timestamps,
+  projectIds,
+  getValue,
+  fillZero,
+  zero,
+}: {
+  timestamps: number[]
+  projectIds: ProjectId[]
+  /** The project's bucket at the timestamp, undefined when there is none. */
+  getValue: (projectId: ProjectId, timestamp: number) => T | undefined
+  /** Whether an absent bucket means `zero` rather than "no data". */
+  fillZero: (projectId: ProjectId, timestamp: number) => boolean
+  /** Shared read-only value emitted for every zero-filled bucket. */
+  zero: T
+}): [timestamp: number, projects: Record<string, T | null>][] {
+  return timestamps.map((timestamp) => {
+    const projectsForTimestamp: Record<string, T | null> = {}
+    for (const projectId of projectIds) {
+      projectsForTimestamp[projectId] =
+        getValue(projectId, timestamp) ??
+        (fillZero(projectId, timestamp) ? zero : null)
+    }
+    return [timestamp, projectsForTimestamp]
+  })
+}
+
+/** The shared shape of the env.MOCK variants of these endpoints. */
+export function getMockProjectSeriesChartData<T>({
+  projectIds,
+  range,
+  resolution,
+  defaultStart,
+  value,
+}: {
+  projectIds: ProjectId[]
+  range: ChartRange
+  resolution: ChartResolution
+  /** Chart start when the range is 'max' (null start). */
+  defaultStart: number
+  value: (index: number) => T
+}): {
+  chart: [timestamp: number, projects: Record<string, T | null>][]
+  projects: ChartProjectRange[]
+  syncedUntil: number
+} {
+  const timestamps = generateTimestamps(
+    [range[0] ?? defaultStart, range[1]],
+    resolution,
+  )
+
+  return {
+    chart: timestamps.map((timestamp) => [
+      timestamp,
+      Object.fromEntries(
+        projectIds.map((projectId, index) => [projectId, value(index)]),
+      ),
+    ]),
+    projects: projectIds.map((projectId) => ({
+      projectId,
+      sinceTimestamp: timestamps[0] ?? 0,
+    })),
+    syncedUntil: timestamps[timestamps.length - 1] ?? 0,
+  }
+}


### PR DESCRIPTION
## Summary

- Add a `useUrlStateSync` hook that debounces state → URL pushes and applies URL state on back/forward; two states are equal iff they build the same canonical URL, so no separate equality predicate is needed
- Use it in the interop chain selector and the scaling compare chart, dropping `isSameSelection` and `isSameCompareState` along with their hand-maintained "which field is visible in the URL" rules
- Export `rangeToOption` from `ChartRangeControls` and reuse it in `chartRangeToCompareRange`, so the serialized range always agrees with the highlighted control
- Extract per-metric `hasData` predicates (`hasTvsData`, `hasCostsData`, `hasDataPostedData`) as the single source for both the picker's no-data marking and the query params, and reuse them in the server-side default ranking
- Collapse the four near-identical enum parsers in `parseCompareStateFromSearchParams` into one `parseOneOf`, and derive `CompareClientState` from `CompareChartState` instead of restating every field
- Add `topByScore` for the server metric registry's top-N ranking
- Add `server/features/utils/projectSeriesChart.ts` (shared params schema, `toProjectRanges`, `minSinceTimestamp`, `sinceTimestampGate`, `buildProjectSeriesChart`, mock data) and use it in the detailed data-posted, activity, and costs project-range charts

## Testing

- Not run — behavior-preserving refactor; no new tests added
- Recommended manual checks: compare page URL updates on metric/range/project changes, back/forward restores state, hand-edited params don't trap the back button, and interop chain selection still tracks `interopChainsSelected`