### PR TITLE
Restore dropped DA tracking eras and fix pepeunchained's celestia sinceBlock

### DIFF
--- a/packages/config/src/projects/arbitrum/daTracking.json
+++ b/packages/config/src/projects/arbitrum/daTracking.json
@@ -4,12 +4,39 @@
       "type": "ethereum",
       "daLayer": "ethereum",
       "inbox": "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
+      "sequencers": ["0xa4b1E63Cb4901E327597bc35d36FE8a23e4C253f"],
+      "sinceBlock": 15447728,
+      "untilBlock": 16335422,
+      "closed": {
+        "reason": "batch poster handover to 0xC1b6/0x0C59 (granted @ 16327016); last old-poster batch @ 16335422, revoked @ 16342010",
+        "precision": "exact"
+      }
+    },
+    {
+      "type": "ethereum",
+      "daLayer": "ethereum",
+      "inbox": "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
+      "sequencers": [
+        "0x0C5911d57B24FCF1DC8B2608eFbAe57C7098E32D",
+        "0xC1b634853Cb333D3aD8663715b08f41A3Aec47cc"
+      ],
+      "sinceBlock": 16335392,
+      "untilBlock": 22618103,
+      "closed": {
+        "reason": "standby batch poster 0x0237e0EA added via setIsBatchPoster @ 22618104; ranges kept disjoint because the new sequencer set is a superset",
+        "precision": "exact"
+      }
+    },
+    {
+      "type": "ethereum",
+      "daLayer": "ethereum",
+      "inbox": "0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6",
       "sequencers": [
         "0x0237e0EA0d86D53aF18dCf4CbE8182037b44ef1A",
         "0x0C5911d57B24FCF1DC8B2608eFbAe57C7098E32D",
         "0xC1b634853Cb333D3aD8663715b08f41A3Aec47cc"
       ],
-      "sinceBlock": 15411056
+      "sinceBlock": 22618104
     }
   ]
 }

--- a/packages/config/src/projects/hypr/daTracking.json
+++ b/packages/config/src/projects/hypr/daTracking.json
@@ -1,6 +1,18 @@
 {
   "eras": [
     {
+      "type": "ethereum",
+      "daLayer": "ethereum",
+      "inbox": "0x0C57B7f3bAc278bE091431B52470fBAdBc4240E6",
+      "sequencers": ["0x994c288de8418c8D3c5a4D21A69f35bF9641781C"],
+      "sinceBlock": 19028146,
+      "untilBlock": 19028146,
+      "closed": {
+        "reason": "single full-calldata batch at chain start; celestia pointer frames from 19028191 (2024-01-17)",
+        "precision": "exact"
+      }
+    },
+    {
       "type": "celestia",
       "daLayer": "celestia",
       "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAABqVjuNvNnoE=",

--- a/packages/config/src/projects/lyra/daTracking.json
+++ b/packages/config/src/projects/lyra/daTracking.json
@@ -1,6 +1,18 @@
 {
   "eras": [
     {
+      "type": "ethereum",
+      "daLayer": "ethereum",
+      "inbox": "0x5f7f7f6DB967F0ef10BdA0678964DBA185d16c50",
+      "sequencers": ["0x14e4E97bDc195d399Ad8E7FC14451C279FE04c8e"],
+      "sinceBlock": 18574910,
+      "untilBlock": 19020830,
+      "closed": {
+        "reason": "migration to Celestia DA; last full-calldata batch @ 19020830, celestia pointer frames from 19020920 (2024-01-16)",
+        "precision": "exact"
+      }
+    },
+    {
       "type": "celestia",
       "daLayer": "celestia",
       "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAACLkdk+ILapw=",

--- a/packages/config/src/projects/mantapacific/daTracking.json
+++ b/packages/config/src/projects/mantapacific/daTracking.json
@@ -1,6 +1,18 @@
 {
   "eras": [
     {
+      "type": "ethereum",
+      "daLayer": "ethereum",
+      "inbox": "0xAEbA8e2307A22B6824a9a7a39f8b016C357Cd1Fe",
+      "sequencers": ["0xA76E31D8471D569EfDd3D95d1b11Ce6710f4533F"],
+      "sinceBlock": 18095772,
+      "untilBlock": 18808468,
+      "closed": {
+        "reason": "migration to Celestia DA; last full-calldata batch @ 18808468, celestia blobs start 2023-12-15 (overlap with pointer frames is safe - different type/daLayer)",
+        "precision": "exact"
+      }
+    },
+    {
       "type": "celestia",
       "daLayer": "celestia",
       "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAIZiad33fbxA7Z0=",

--- a/packages/config/src/projects/orderly/daTracking.json
+++ b/packages/config/src/projects/orderly/daTracking.json
@@ -1,6 +1,18 @@
 {
   "eras": [
     {
+      "type": "ethereum",
+      "daLayer": "ethereum",
+      "inbox": "0x08aA34cC843CeEBcC88A627F18430294aA9780be",
+      "sequencers": ["0xf8dB8Aba597fF36cCD16fECfbb1B816B3236E9b8"],
+      "sinceBlock": 18292645,
+      "untilBlock": 19021210,
+      "closed": {
+        "reason": "migration to Celestia DA; last full-calldata batch @ 19021210, celestia pointer frames from 19021262 (2024-01-16)",
+        "precision": "exact"
+      }
+    },
+    {
       "type": "celestia",
       "daLayer": "celestia",
       "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAABYTLU4hLOUU=",

--- a/packages/config/src/projects/pepeunchained/daTracking.json
+++ b/packages/config/src/projects/pepeunchained/daTracking.json
@@ -4,7 +4,7 @@
       "type": "celestia",
       "daLayer": "celestia",
       "namespace": "AAAAAAAAAAAAAAAAAAAAAAAAAAAADzZzvipmzP4=",
-      "sinceBlock": 21314461
+      "sinceBlock": 2920309
     }
   ]
 }

--- a/packages/config/src/projects/pepeunchained/pepeunchained.ts
+++ b/packages/config/src/projects/pepeunchained/pepeunchained.ts
@@ -12,7 +12,7 @@ export const pepeunchained: ScalingProject = opStackL2({
   archivedAt: UnixTime(1752134764), //2025-07-10
   daProvider: CELESTIA_DA_PROVIDER(DA_LAYERS.ETH_CALLDATA),
   celestiaDa: {
-    sinceBlock: 21314461,
+    sinceBlock: 2920309, // first blob in this celestia block https://celenium.io/block/2920309 (the previous value 21314461 was an ethereum block number - beyond celestia's chain height, so nothing was ever fetched)
     namespace: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAADzZzvipmzP4=',
   },
   additionalBadges: [BADGES.RaaS.Conduit],

--- a/packages/config/src/projects/r0ar/daTracking.json
+++ b/packages/config/src/projects/r0ar/daTracking.json
@@ -4,8 +4,20 @@
       "type": "ethereum",
       "daLayer": "ethereum",
       "inbox": "0xFF00000000000000000000000000000000193939",
+      "sequencers": ["0x2986bF308d0684Ad77cD32Ee1C60429e6573B5AF"],
+      "sinceBlock": 20912449,
+      "untilBlock": 21308934,
+      "closed": {
+        "reason": "batcher rotation via SystemConfig ConfigUpdate @ 21371879; last old-batcher batch @ 21308934",
+        "precision": "exact"
+      }
+    },
+    {
+      "type": "ethereum",
+      "daLayer": "ethereum",
+      "inbox": "0xFF00000000000000000000000000000000193939",
       "sequencers": ["0xF263a0AA8aFEaA7d516B596d49d7BA6C0FeB102c"],
-      "sinceBlock": 20912148
+      "sinceBlock": 21372120
     }
   ]
 }

--- a/packages/config/src/snapshots/daTracking/snapshot.json
+++ b/packages/config/src/snapshots/daTracking/snapshot.json
@@ -427,6 +427,10 @@
   ],
   "hypr": [
     {
+      "id": "15c149d86d11",
+      "label": "ethereum inbox 0x0C57B7f3bAc278bE091431B52470fBAdBc4240E6 sequencers[1] since 19028146"
+    },
+    {
       "id": "44b9bc7dd0a3",
       "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABqVjuNvNnoE= since 0"
     }
@@ -575,9 +579,17 @@
     {
       "id": "43f8068a2801",
       "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAACLkdk+ILapw= since 0"
+    },
+    {
+      "id": "98d4c99c5825",
+      "label": "ethereum inbox 0x5f7f7f6DB967F0ef10BdA0678964DBA185d16c50 sequencers[1] since 18574910"
     }
   ],
   "mantapacific": [
+    {
+      "id": "8fdcc48f4af9",
+      "label": "ethereum inbox 0xAEbA8e2307A22B6824a9a7a39f8b016C357Cd1Fe sequencers[1] since 18095772"
+    },
     {
       "id": "b90581385a42",
       "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAIZiad33fbxA7Z0= since 0"
@@ -713,6 +725,10 @@
     {
       "id": "89362db2d62d",
       "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABYTLU4hLOUU= since 0"
+    },
+    {
+      "id": "bb154c3a5f6e",
+      "label": "ethereum inbox 0x08aA34cC843CeEBcC88A627F18430294aA9780be sequencers[1] since 18292645"
     }
   ],
   "paradex": [

--- a/packages/config/src/snapshots/daTracking/snapshot.json
+++ b/packages/config/src/snapshots/daTracking/snapshot.json
@@ -89,8 +89,16 @@
   ],
   "arbitrum": [
     {
+      "id": "44b2139c580b",
+      "label": "ethereum inbox 0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6 sequencers[1] since 15447728"
+    },
+    {
+      "id": "ca30fc63f237",
+      "label": "ethereum inbox 0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6 sequencers[2] since 16335392"
+    },
+    {
       "id": "f2eb27779e5d",
-      "label": "ethereum inbox 0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6 sequencers[3] since 15411056"
+      "label": "ethereum inbox 0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6 sequencers[3] since 22618104"
     }
   ],
   "arenaz": [

--- a/packages/config/src/snapshots/daTracking/snapshot.json
+++ b/packages/config/src/snapshots/daTracking/snapshot.json
@@ -724,7 +724,7 @@
   "pepeunchained": [
     {
       "id": "465561f40619",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADzZzvipmzP4= since 21314461"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADzZzvipmzP4= since 2920309"
     }
   ],
   "perennial": [
@@ -771,8 +771,12 @@
   ],
   "r0ar": [
     {
+      "id": "a0c84e18d366",
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000193939 sequencers[1] since 20912449"
+    },
+    {
       "id": "b005d8668b33",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000193939 sequencers[1] since 20912148"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000193939 sequencers[1] since 21372120"
     }
   ],
   "race": [


### PR DESCRIPTION
## Summary

- Restore arbitrum's two pre-handover ethereum eras (batch poster handover at 16335422, standby poster added at 22618104) and move the open era's `sinceBlock` to 22618104
- Restore r0ar's pre-rotation batcher era (`0x2986bF…B5AF`, 20912449–21308934) and set the current era to start at 21372120
- Restore the pre-Celestia full-calldata eras for mantapacific, lyra, orderly and hypr, each closed at its last calldata batch with an `exact` reason
- Fix pepeunchained's celestia `sinceBlock`: 21314461 was an ethereum block number beyond celestia's chain height, so nothing was ever fetched; now 2920309 (first blob) in both `daTracking.json` and `pepeunchained.ts`
- Update the daTracking snapshot to match the new/changed eras

## Testing

- `daTracking` config snapshot regenerated and committed; diff matches the era changes above
- Block boundaries verified on-chain (handover/rotation events, last old-batcher batch, first Celestia frame) and recorded in each era's `closed.reason`
- pepeunchained's new sinceBlock cross-checked against the first blob at https://celenium.io/block/2920309
- No backend backfill run