### PR TITLE
Add Denylist for tokens in TokenDB

### DIFF
--- a/docs/mdbook/specs/l2b_specs/token_db/automatic_token_ingestion.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/automatic_token_ingestion.md
@@ -80,6 +80,12 @@ The address might be brand new, already in TokenDB, or already have an
 abstract token. The queue does not pre-judge — it lets the processing
 logic figure out what, if anything, needs to change.
 
+One check runs before any of that: an address on the
+[token denylist](./token_denylist.md) short-circuits to a terminal `skip`
+with a `token-denylisted` trace step — no resolution, no write, no
+propagation. This is what keeps a human ban durable against the
+enqueue → resolve → write loop.
+
 This framing is load-bearing: every external trigger collapses into the
 same act (enqueue). Conflicts in already-resolved tokens, propagation
 between linked tokens, manual retries — all of them work because the

--- a/docs/mdbook/specs/l2b_specs/token_db/intent_plan_execute.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/intent_plan_execute.md
@@ -84,8 +84,8 @@ plans are used when the user action has a larger blast radius. For example,
 merging one abstract token into another updates the target token's additional
 CoinGecko entries, reassigns deployed tokens, and then deletes the source
 abstract token; denylisting an address adds the denylist entry and deletes
-the deployed token and all relations touching it. The dialog already knows
-how to render the full command list.
+the catalogued deployed token. The dialog already knows how to render the
+full command list.
 
 ### 2. Make concurrent edits safe without manual locking
 

--- a/docs/mdbook/specs/l2b_specs/token_db/intent_plan_execute.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/intent_plan_execute.md
@@ -83,7 +83,9 @@ Most planners today are 1:1 — one intent produces one command. Multi-command
 plans are used when the user action has a larger blast radius. For example,
 merging one abstract token into another updates the target token's additional
 CoinGecko entries, reassigns deployed tokens, and then deletes the source
-abstract token. The dialog already knows how to render the full command list.
+abstract token; denylisting an address adds the denylist entry and deletes
+the deployed token and all relations touching it. The dialog already knows
+how to render the full command list.
 
 ### 2. Make concurrent edits safe without manual locking
 

--- a/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
@@ -7,7 +7,7 @@
   - [The table](#the-table)
   - [One intent, one plan](#one-intent-one-plan)
   - [Where the denylist is consulted](#where-the-denylist-is-consulted)
-  - [Why relation ingestion honors the denylist](#why-relation-ingestion-honors-the-denylist)
+  - [Relations are not deleted — the graph filters](#relations-are-not-deleted--the-graph-filters)
   - [Lifting a ban](#lifting-a-ban)
   - [What this deliberately does not do](#what-this-deliberately-does-not-do)
 
@@ -26,11 +26,10 @@ graph and visible to every downstream consumer.
 
 ## Why prevention, not filtration
 
-Deleting such a token is not durable on its own: relations survive token
-deletion (by design), and the next test transfer re-runs the whole loop —
-relation ingestion re-inserts the edge, the queue pre-step re-enqueues the
-address, and the processor re-resolves the abstract token from the
-non-swapping transfer evidence and recreates the deployed token.
+Deleting such a token is not durable on its own: the queue pre-step
+re-enqueues the address with the next test transfer, and the processor
+re-resolves the abstract token from the non-swapping transfer evidence and
+recreates the deployed token.
 
 The alternative considered was a `DeployedToken.ignored` flag with
 filtering on every read path. It was rejected: a flag turns the catalogue
@@ -38,10 +37,14 @@ into a two-state store, and every read — present and future — must then
 decide whether it wants ignored rows. That decision genuinely differs per
 call site (existence checks yes, graph no, suggestion suppression yes...),
 which makes every future endpoint a chance to leak. The denylist instead
-stops the data at the **write and observation boundaries**: what was never
-stored cannot leak, and read paths need zero awareness. Only a handful of
-entry points consult the list, and they all ask the same one-directional
-question — "is this address banned? then skip/refuse".
+stops the data at the **catalogue write boundary**: a banned address is
+never a `DeployedToken`, so the catalogue's read paths need zero awareness.
+Only a handful of entry points consult the list, and they all ask the same
+one-directional question — "is this address banned? then skip/refuse".
+
+Relation *observations* are the deliberate exception to prevention: they
+keep being recorded (see below), and the one interpretation surface that
+draws them — the relations graph — filters denylisted endpoints out.
 
 ## The table
 
@@ -51,30 +54,41 @@ lowercase, same as everywhere else) and carries a mandatory human-written
 command payload — `executePlan` regenerates plans and compares them
 byte-for-byte, so plan-time data must not contain "now".
 
+Planning canonicalizes the pasted address with the same helper ingestion
+uses for its lookups (Address32 forms cropped to 20 bytes, lowercase) — an
+entry stored under any other form would never match a lookup and the ban
+would silently do nothing. The free-form `chain` gets the same protection
+against silent no-ops: a chain that is missing from the chain table *and*
+referenced by nothing in TokenDB (no token, no relations, no queue entry)
+is rejected as a probable typo. A chain missing from the table is still
+accepted when something references the address under it — production has
+queued tokens on chains that were never added to the table.
+
 ## One intent, one plan
 
-`DenylistDeployedTokenIntent { pk, reason }` produces a single plan that:
+`AddTokenToDenylistIntent { pk, reason }` produces a single plan that:
 
-1. adds the denylist entry,
-2. deletes the `DeployedToken` row, when the address is catalogued, and
-3. deletes every `TokenRelation` touching the address.
+1. adds the denylist entry, and
+2. deletes the `DeployedToken` row, when the address is catalogued.
+
+Relations touching the address are **not** deleted — see below.
 
 One intent rather than separate "delete" and "denylist" actions, so no
 half-state is reachable: deleted-but-not-denylisted is recreated by
 ingestion within a minute, and denylisted-but-not-deleted leaves a stale
 catalogue entry. The confirmation dialog shows the full command list (the
 same visible-blast-radius rationale as
-[abstract token merging](./abstract_token_merging.md)), and every deleted
+[abstract token merging](./abstract_token_merging.md)), and the deleted
 record is preserved verbatim inside its command in `TokenDbHistory`, from
 which it can be reconstructed if the ban was a mistake.
 
 The address does **not** have to be catalogued — an uncatalogued endpoint
 seen only in relations (an orange node on the graph) can be denylisted too;
-the plan then consists of the entry plus whatever relations exist.
+the plan then consists of the entry alone.
 
 ## Where the denylist is consulted
 
-Five entry points, all additive "if banned → skip/refuse" checks:
+Five entry points, all additive "if banned → skip/refuse/filter" checks:
 
 1. **Token ingestion** — `plan()` checks the denylist first and
    short-circuits to a terminal `skip` with a `token-denylisted` trace
@@ -84,52 +98,59 @@ Five entry points, all additive "if banned → skip/refuse" checks:
    denylist inside the same serializable transaction as the write — an
    address denylisted between planning and applying is skipped, not
    written next to its own ban.
-2. **Relation ingestion** — transfers with a denylisted endpoint are not
-   turned into relations (see below). The denylist is read inside each
-   batch's serializable write transaction, never cached for a whole run,
-   so an address denylisted mid-run cannot slip back in with a later
-   batch.
-3. **The add path** — `planAddDeployedToken` refuses denylisted addresses,
+2. **The add path** — `planAddDeployedToken` refuses denylisted addresses,
    and the `deployedTokens.checks` route returns a `denylisted` error so
    the add form blocks before a plan is even attempted.
-4. **Suggestion surfaces** — CoinGecko and partial-transfer suggestions
+3. **Suggestion surfaces** — CoinGecko and partial-transfer suggestions
    treat denylisted addresses as known, so a banned address never
    resurfaces as "add this token".
-5. **The interop missing-tokens dashboard** — a denylisted address gets a
+4. **The interop missing-tokens dashboard** — a denylisted address gets a
    dedicated `denylisted` status instead of `missing`, so nobody is
    invited to re-add it.
+5. **The relations graph** — `getRelationsGraph` drops relations with a
+   denylisted endpoint when assembling the graph (see below). This is the
+   only read-side consult point.
 
-Everything else — the relations graph, `TokenMap`, financials, the public
-frontend, search — needs no awareness at all: the data does not exist.
+Everything else — `TokenMap`, financials, the public frontend, search —
+needs no awareness at all: for the catalogue, the data does not exist.
 
-## Why relation ingestion honors the denylist
+## Relations are not deleted — the graph filters
 
 [Token relations](./token_relations.md) says observation recording must
-never be gated on the interpretation being consistent. The denylist is not
-that kind of gate. That rule exists so *systematic* interpretation failures
-(token-level conflicts) cannot suppress exactly the evidence needed to
-diagnose them. A denylist entry is the opposite: a rare, explicit,
-human-confirmed statement that observations involving this address are
-noise, not signal — the same category as the address normalization that
-already drops `0x0` and `Address32.ZERO` before they enter the system. The
-price, paid knowingly: if an address is denylisted by mistake, transfers
-observed during the ban age out of the ~7-day retention and those
-observations are unrecoverable.
+never be gated on interpretation. A human ban is an interpretation ("this
+address is not a real asset"), so it gets no carve-out: relation ingestion
+keeps recording transfers touching a denylisted address, and the ban plan
+deletes no relations. Granting the denylist an exception here would invite
+the next exception, and the observation record would stop being the one
+thing it must be — complete.
+
+Instead the ban acts where interpretations belong: the relations graph, the
+one surface that turns relations into a picture of asset clusters, filters
+out relations with a denylisted endpoint when assembling the graph. The
+banned test token's edge therefore disappears from the graph while the
+underlying observation stays queryable, and if the ban was a mistake,
+nothing was lost — lifting it makes the edges reappear on the next load.
+The per-token Relations tab still lists such relations: it displays raw
+observations for a catalogued token, and a denylisted address has no token
+page of its own.
 
 ## Lifting a ban
 
-`RemoveTokenDenylistEntryIntent` deletes the entry (through the same
+`DeleteTokenFromDenylistIntent` deletes the entry (through the same
 plan/confirm flow, recorded in history). Removal only lifts the ban: the
-deleted token and relations are not restored automatically. If the route is
-still active, ingestion re-creates them from live transfers within a
-minute; otherwise a human re-adds them manually, using the records
-preserved in history.
+deleted token is not restored automatically. If the route is still active,
+ingestion re-creates it from live transfers within a minute; otherwise a
+human re-adds it manually, using the record preserved in history. Relations
+were never deleted, so the graph shows the address again immediately.
 
 ## What this deliberately does not do
 
 - No banner on a token page — a denylisted address has no token page. The
   denylist page in token-UI lists all entries with their reasons and is
   where bans are added (for uncatalogued addresses) and lifted.
-- No filtering anywhere in the query layer. If you find yourself adding a
-  denylist check to a read path, stop — the address should not have data
-  there in the first place; find the write path that let it in.
+- No filtering in the catalogue's query layer. The relations graph filter
+  is the single sanctioned read-side check, because relations are
+  observations that must outlive any ban. If you find yourself adding a
+  denylist check to any *catalogue* read path, stop — the address should
+  not have data there in the first place; find the write path that let it
+  in.

--- a/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
@@ -43,8 +43,9 @@ Only a handful of entry points consult the list, and they all ask the same
 one-directional question — "is this address banned? then skip/refuse".
 
 Relation *observations* are the deliberate exception to prevention: they
-keep being recorded (see below), and the one interpretation surface that
-draws them — the relations graph — filters denylisted endpoints out.
+keep being recorded (see below), and the displays that draw them act
+instead — the relations graph filters denylisted endpoints out, the
+Relations tab marks them.
 
 ## The table
 

--- a/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
@@ -1,0 +1,128 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
+
+- [Token Denylist](#token-denylist)
+  - [Why prevention, not filtration](#why-prevention-not-filtration)
+  - [The table](#the-table)
+  - [One intent, one plan](#one-intent-one-plan)
+  - [Where the denylist is consulted](#where-the-denylist-is-consulted)
+  - [Why relation ingestion honors the denylist](#why-relation-ingestion-honors-the-denylist)
+  - [Lifting a ban](#lifting-a-ban)
+  - [What this deliberately does not do](#what-this-deliberately-does-not-do)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Token Denylist
+
+`TokenDenylist` holds addresses that must never (re-)enter TokenDB. An entry
+means a human decided the address is not a real asset deployment and banned
+it. The motivating case: a test token wired through a LayerZero OFT to a
+real token. The resulting transfers are genuine on-chain observations, but
+interpreting them catalogued the test token as a deployment of the real
+asset — in production, a token named TPAXG ended up recorded as a
+deployment of OP this way, connected to the OP cluster on the relations
+graph and visible to every downstream consumer.
+
+## Why prevention, not filtration
+
+Deleting such a token is not durable on its own: relations survive token
+deletion (by design), and the next test transfer re-runs the whole loop —
+relation ingestion re-inserts the edge, the queue pre-step re-enqueues the
+address, and the processor re-resolves the abstract token from the
+non-swapping transfer evidence and recreates the deployed token.
+
+The alternative considered was a `DeployedToken.ignored` flag with
+filtering on every read path. It was rejected: a flag turns the catalogue
+into a two-state store, and every read — present and future — must then
+decide whether it wants ignored rows. That decision genuinely differs per
+call site (existence checks yes, graph no, suggestion suppression yes...),
+which makes every future endpoint a chance to leak. The denylist instead
+stops the data at the **write and observation boundaries**: what was never
+stored cannot leak, and read paths need zero awareness. Only a handful of
+entry points consult the list, and they all ask the same one-directional
+question — "is this address banned? then skip/refuse".
+
+## The table
+
+`TokenDenylist` is keyed by `(chain, address)` (addresses normalized
+lowercase, same as everywhere else) and carries a mandatory human-written
+`reason` plus a database-filled `createdAt`. `createdAt` is not part of any
+command payload — `executePlan` regenerates plans and compares them
+byte-for-byte, so plan-time data must not contain "now".
+
+## One intent, one plan
+
+`DenylistDeployedTokenIntent { pk, reason }` produces a single plan that:
+
+1. adds the denylist entry,
+2. deletes the `DeployedToken` row, when the address is catalogued, and
+3. deletes every `TokenRelation` touching the address.
+
+One intent rather than separate "delete" and "denylist" actions, so no
+half-state is reachable: deleted-but-not-denylisted is recreated by
+ingestion within a minute, and denylisted-but-not-deleted leaves a stale
+catalogue entry. The confirmation dialog shows the full command list (the
+same visible-blast-radius rationale as
+[abstract token merging](./abstract_token_merging.md)), and every deleted
+record is preserved verbatim inside its command in `TokenDbHistory`, from
+which it can be reconstructed if the ban was a mistake.
+
+The address does **not** have to be catalogued — an uncatalogued endpoint
+seen only in relations (an orange node on the graph) can be denylisted too;
+the plan then consists of the entry plus whatever relations exist.
+
+## Where the denylist is consulted
+
+Five entry points, all additive "if banned → skip/refuse" checks:
+
+1. **Token ingestion** — `plan()` checks the denylist first and
+   short-circuits to a terminal `skip` with a `token-denylisted` trace
+   step. The queue entry is removed; nothing is resolved, written, or
+   propagated. Enqueueing a denylisted address is always harmless.
+2. **Relation ingestion** — transfers with a denylisted endpoint are not
+   turned into relations (see below).
+3. **The add path** — `planAddDeployedToken` refuses denylisted addresses,
+   and the `deployedTokens.checks` route returns a `denylisted` error so
+   the add form blocks before a plan is even attempted.
+4. **Suggestion surfaces** — CoinGecko and partial-transfer suggestions
+   treat denylisted addresses as known, so a banned address never
+   resurfaces as "add this token".
+5. **The interop missing-tokens dashboard** — a denylisted address gets a
+   dedicated `denylisted` status instead of `missing`, so nobody is
+   invited to re-add it.
+
+Everything else — the relations graph, `TokenMap`, financials, the public
+frontend, search — needs no awareness at all: the data does not exist.
+
+## Why relation ingestion honors the denylist
+
+[Token relations](./token_relations.md) says observation recording must
+never be gated on the interpretation being consistent. The denylist is not
+that kind of gate. That rule exists so *systematic* interpretation failures
+(token-level conflicts) cannot suppress exactly the evidence needed to
+diagnose them. A denylist entry is the opposite: a rare, explicit,
+human-confirmed statement that observations involving this address are
+noise, not signal — the same category as the address normalization that
+already drops `0x0` and `Address32.ZERO` before they enter the system. The
+price, paid knowingly: if an address is denylisted by mistake, transfers
+observed during the ban age out of the ~7-day retention and those
+observations are unrecoverable.
+
+## Lifting a ban
+
+`RemoveTokenDenylistEntryIntent` deletes the entry (through the same
+plan/confirm flow, recorded in history). Removal only lifts the ban: the
+deleted token and relations are not restored automatically. If the route is
+still active, ingestion re-creates them from live transfers within a
+minute; otherwise a human re-adds them manually, using the records
+preserved in history.
+
+## What this deliberately does not do
+
+- No banner on a token page — a denylisted address has no token page. The
+  denylist page in token-UI lists all entries with their reasons and is
+  where bans are added (for uncatalogued addresses) and lifted.
+- No filtering anywhere in the query layer. If you find yourself adding a
+  denylist check to a read path, stop — the address should not have data
+  there in the first place; find the write path that let it in.

--- a/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
@@ -107,9 +107,12 @@ Five entry points, all additive "if banned → skip/refuse/filter" checks:
 4. **The interop missing-tokens dashboard** — a denylisted address gets a
    dedicated `denylisted` status instead of `missing`, so nobody is
    invited to re-add it.
-5. **The relations graph** — `getRelationsGraph` drops relations with a
-   denylisted endpoint when assembling the graph (see below). This is the
-   only read-side consult point.
+5. **Relation displays** — the relations graph drops relations with a
+   denylisted endpoint; the per-token Relations tab shows them but marks
+   the banned counterparty (see below). These are the only read-side
+   consult points. The minting-plugins summary is deliberately *not*
+   denylist-aware: a plugin observed minting this token minted it,
+   whatever the counterparty was.
 
 Everything else — `TokenMap`, financials, the public frontend, search —
 needs no awareness at all: for the catalogue, the data does not exist.
@@ -124,15 +127,15 @@ deletes no relations. Granting the denylist an exception here would invite
 the next exception, and the observation record would stop being the one
 thing it must be — complete.
 
-Instead the ban acts where interpretations belong: the relations graph, the
-one surface that turns relations into a picture of asset clusters, filters
-out relations with a denylisted endpoint when assembling the graph. The
-banned test token's edge therefore disappears from the graph while the
-underlying observation stays queryable, and if the ban was a mistake,
-nothing was lost — lifting it makes the edges reappear on the next load.
-The per-token Relations tab still lists such relations: it displays raw
-observations for a catalogued token, and a denylisted address has no token
-page of its own.
+Instead the ban acts where interpretations belong, proportionally to what
+each display claims. The relations graph filters out relations with a
+denylisted endpoint entirely: drawing the banned node would wire it back
+into a real asset cluster, which is exactly what the ban exists to prevent.
+The per-token Relations tab keeps showing such relations — it lists raw
+observations for one token — but marks the banned counterparty (🚫), so the
+observation stays visible without inviting anyone to treat the address as a
+real asset. If the ban was a mistake, nothing was lost: lifting it makes
+the graph edges reappear on the next load.
 
 ## Lifting a ban
 
@@ -148,9 +151,9 @@ were never deleted, so the graph shows the address again immediately.
 - No banner on a token page — a denylisted address has no token page. The
   denylist page in token-UI lists all entries with their reasons and is
   where bans are added (for uncatalogued addresses) and lifted.
-- No filtering in the catalogue's query layer. The relations graph filter
-  is the single sanctioned read-side check, because relations are
-  observations that must outlive any ban. If you find yourself adding a
-  denylist check to any *catalogue* read path, stop — the address should
-  not have data there in the first place; find the write path that let it
-  in.
+- No filtering in the catalogue's query layer. Read-side denylist checks
+  are sanctioned only where relations are displayed (the graph filters,
+  the Relations tab marks), because relations are observations that must
+  outlive any ban. If you find yourself adding a denylist check to any
+  *catalogue* read path, stop — the address should not have data there in
+  the first place; find the write path that let it in.

--- a/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_denylist.md
@@ -80,8 +80,15 @@ Five entry points, all additive "if banned → skip/refuse" checks:
    short-circuits to a terminal `skip` with a `token-denylisted` trace
    step. The queue entry is removed; nothing is resolved, written, or
    propagated. Enqueueing a denylisted address is always harmless.
+   Because `fetch()` makes slow external calls, `apply()` rechecks the
+   denylist inside the same serializable transaction as the write — an
+   address denylisted between planning and applying is skipped, not
+   written next to its own ban.
 2. **Relation ingestion** — transfers with a denylisted endpoint are not
-   turned into relations (see below).
+   turned into relations (see below). The denylist is read inside each
+   batch's serializable write transaction, never cached for a whole run,
+   so an address denylisted mid-run cannot slip back in with a later
+   batch.
 3. **The add path** — `planAddDeployedToken` refuses denylisted addresses,
    and the `deployedTokens.checks` route returns a `denylisted` error so
    the add form blocks before a plan is even attempted.

--- a/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
@@ -49,12 +49,12 @@ It follows that observation recording must never be gated on the
 interpretation being consistent. Any design where a token-level conflict
 can suppress a relation destroys the primary use of relations.
 
-The one exception is the [token denylist](./token_denylist.md): transfers
-touching a denylisted address are not turned into relations. That is not an
-interpretation-consistency gate — it is an explicit human ban declaring the
-address's observations noise, in the same category as the address
-normalization that already drops `0x0`. See the denylist doc for why the
-trade-off is accepted.
+The [token denylist](./token_denylist.md) is no exception: transfers
+touching a denylisted address are still turned into relations, and a ban
+does not delete existing ones. The ban is an interpretation ("this address
+is not a real asset"), and interpretations act at interpretation surfaces —
+the relations graph filters out relations with a denylisted endpoint at
+display time, while the observation record stays complete.
 
 ## A transfer has a direction; a relation has roles
 

--- a/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
@@ -49,6 +49,13 @@ It follows that observation recording must never be gated on the
 interpretation being consistent. Any design where a token-level conflict
 can suppress a relation destroys the primary use of relations.
 
+The one exception is the [token denylist](./token_denylist.md): transfers
+touching a denylisted address are not turned into relations. That is not an
+interpretation-consistency gate — it is an explicit human ban declaring the
+address's observations noise, in the same category as the address
+normalization that already drops `0x0`. See the denylist doc for why the
+trade-off is accepted.
+
 ## A transfer has a direction; a relation has roles
 
 This is the second load-bearing distinction, and getting it wrong has

--- a/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
+++ b/docs/mdbook/specs/l2b_specs/token_db/token_relations.md
@@ -54,7 +54,8 @@ touching a denylisted address are still turned into relations, and a ban
 does not delete existing ones. The ban is an interpretation ("this address
 is not a real asset"), and interpretations act at interpretation surfaces —
 the relations graph filters out relations with a denylisted endpoint at
-display time, while the observation record stays complete.
+display time and the Relations tab marks the banned counterparty, while the
+observation record stays complete.
 
 ## A transfer has a direction; a relation has roles
 

--- a/packages/backend/src/modules/interop/engine/dashboard/impls/missingTokens.ts
+++ b/packages/backend/src/modules/interop/engine/dashboard/impls/missingTokens.ts
@@ -14,6 +14,7 @@ export type MissingTokenDbStatus =
   | 'incomplete'
   | 'ready'
   | 'unsupported'
+  | 'denylisted'
 
 export interface MissingTokenRecord extends InteropMissingTokenInfo {
   tokenDbStatus: MissingTokenDbStatus
@@ -138,11 +139,21 @@ export async function getMissingTokenStatuses(
     ]),
   )
 
+  // A denylisted token is deliberately absent from TokenDB — reporting it as
+  // "missing" would invite someone to re-add it.
+  const denylist = await deps.tokenDbClient.tokenDenylist.getAll.query()
+  const denylisted = new Set(
+    denylist.map((entry) => DeployedTokenId.from(entry.chain, entry.address)),
+  )
+
   for (const [key, deployedTokenId] of deployedTokenIdsByKey) {
     const tokenInfo = tokenInfoById.get(deployedTokenId)
 
     if (!tokenInfo) {
-      statuses.set(key, 'missing')
+      statuses.set(
+        key,
+        denylisted.has(deployedTokenId) ? 'denylisted' : 'missing',
+      )
       continue
     }
 

--- a/packages/backend/src/modules/interop/engine/dashboard/trpc/routers/missingTokens.test.ts
+++ b/packages/backend/src/modules/interop/engine/dashboard/trpc/routers/missingTokens.test.ts
@@ -10,14 +10,17 @@ describe(createMissingTokensRouter.name, () => {
     const missingAddress = EthereumAddress.random()
     const incompleteAddress = EthereumAddress.random()
     const readyAddress = EthereumAddress.random()
+    const denylistedAddress = EthereumAddress.random()
     const normalizedMissingAddress = missingAddress.toLowerCase()
     const normalizedIncompleteAddress = incompleteAddress.toLowerCase()
     const normalizedReadyAddress = readyAddress.toLowerCase()
+    const normalizedDenylistedAddress = denylistedAddress.toLowerCase()
 
     const getMissingTokensInfo = mockFn().resolvesTo([
       missingTokenInfo('ethereum', Address32.from(missingAddress), 5),
       missingTokenInfo('base', Address32.from(incompleteAddress), 3),
       missingTokenInfo('arbitrum', Address32.from(readyAddress), 2),
+      missingTokenInfo('arbitrum', Address32.from(denylistedAddress), 7),
       missingTokenInfo('ethereum', Address32.ZERO, 1),
     ])
     const query = mockFn().resolvesTo([
@@ -50,6 +53,7 @@ describe(createMissingTokensRouter.name, () => {
         }),
       },
       query,
+      [{ chain: 'arbitrum', address: normalizedDenylistedAddress }],
     )
 
     const result = await caller.list({ range: 'all' })
@@ -59,6 +63,7 @@ describe(createMissingTokensRouter.name, () => {
       { chain: 'ethereum', address: normalizedMissingAddress },
       { chain: 'base', address: normalizedIncompleteAddress },
       { chain: 'arbitrum', address: normalizedReadyAddress },
+      { chain: 'arbitrum', address: normalizedDenylistedAddress },
     ])
     expect(result).toEqual([
       {
@@ -81,6 +86,15 @@ describe(createMissingTokensRouter.name, () => {
         count: 2,
         plugins: ['plugin'],
         tokenDbStatus: 'ready',
+      },
+      {
+        chain: 'arbitrum',
+        tokenAddress: Address32.from(denylistedAddress),
+        count: 7,
+        plugins: ['plugin'],
+        // Deliberately absent from TokenDB and banned — not "missing", so
+        // nobody is invited to re-add it.
+        tokenDbStatus: 'denylisted',
       },
       {
         chain: 'ethereum',
@@ -177,7 +191,11 @@ describe(createMissingTokensRouter.name, () => {
   })
 })
 
-function createCaller(db: Partial<Database>, query: ReturnType<typeof mockFn>) {
+function createCaller(
+  db: Partial<Database>,
+  query: ReturnType<typeof mockFn>,
+  denylist: { chain: string; address: string }[] = [],
+) {
   const callerFactory = createCallerFactory(
     createMissingTokensRouter({
       chains: [
@@ -187,6 +205,7 @@ function createCaller(db: Partial<Database>, query: ReturnType<typeof mockFn>) {
       ],
       tokenDbClient: mockObject<TokenDbClient>({
         deployedTokens: { getByChainAndAddress: { query } },
+        tokenDenylist: { getAll: { query: mockFn().resolvesTo(denylist) } },
       } as any),
     }),
   )

--- a/packages/backoffice/src/pages/interop/missing-tokens/MissingTokensPage.tsx
+++ b/packages/backoffice/src/pages/interop/missing-tokens/MissingTokensPage.tsx
@@ -53,6 +53,7 @@ export function MissingTokensPage() {
       incomplete: 0,
       ready: 0,
       unsupported: 0,
+      denylisted: 0,
     },
   )
 
@@ -127,6 +128,9 @@ export function MissingTokensPage() {
           </MissingTokenStatusBadge>
           <MissingTokenStatusBadge status="unsupported">
             {statusCounts.unsupported} unsupported
+          </MissingTokenStatusBadge>
+          <MissingTokenStatusBadge status="denylisted">
+            {statusCounts.denylisted} denylisted
           </MissingTokenStatusBadge>
           <div className="ml-auto">
             <MissingTokenStatusGuide />

--- a/packages/backoffice/src/pages/interop/missing-tokens/utils.ts
+++ b/packages/backoffice/src/pages/interop/missing-tokens/utils.ts
@@ -6,6 +6,7 @@ export const MISSING_TOKEN_STATUSES: MissingTokenStatus[] = [
   'incomplete',
   'ready',
   'unsupported',
+  'denylisted',
 ]
 
 export function getMissingTokenAddressDisplay(address: string) {
@@ -90,6 +91,7 @@ export function getMissingTokenAction(options: {
       return href ? { href, label: 'Open token' } : undefined
     }
     case 'unsupported':
+    case 'denylisted':
       return undefined
   }
 }
@@ -127,6 +129,14 @@ export function getMissingTokenStatusMeta(status: MissingTokenStatus) {
         label: 'Unsupported',
         description:
           'This chain and address cannot be resolved to a supported TokenDB deployed token, so there is no action or requeue path here.',
+        badgeVariant: 'secondary' as const,
+        badgeClassName: 'bg-muted text-muted-foreground hover:bg-muted',
+      }
+    case 'denylisted':
+      return {
+        label: 'Denylisted',
+        description:
+          'A human banned this address from TokenDB (e.g. a test token). Ingestion refuses to observe it — do not re-add it. Manage entries on the token-UI denylist page.',
         badgeVariant: 'secondary' as const,
         badgeClassName: 'bg-muted text-muted-foreground hover:bg-muted',
       }

--- a/packages/backoffice/src/pages/interop/missing-tokens/utils.ts
+++ b/packages/backoffice/src/pages/interop/missing-tokens/utils.ts
@@ -136,7 +136,7 @@ export function getMissingTokenStatusMeta(status: MissingTokenStatus) {
       return {
         label: 'Denylisted',
         description:
-          'A human banned this address from TokenDB (e.g. a test token). Ingestion refuses to observe it — do not re-add it. Manage entries on the token-UI denylist page.',
+          'A human banned this address from TokenDB (e.g. a test token). Ingestion refuses to catalogue it — do not re-add it. Manage entries on the token-UI denylist page.',
         badgeVariant: 'secondary' as const,
         badgeClassName: 'bg-muted text-muted-foreground hover:bg-muted',
       }

--- a/packages/database/prisma/migrations/20260810000000_add_token_denylist/migration.sql
+++ b/packages/database/prisma/migrations/20260810000000_add_token_denylist/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "TokenDenylist" (
+    "chain" VARCHAR(32) NOT NULL,
+    "address" VARCHAR(255) NOT NULL,
+    "reason" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TokenDenylist_pkey" PRIMARY KEY ("chain","address")
+);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -520,6 +520,15 @@ model DeployedToken {
   @@index([abstractTokenId])
 }
 
+model TokenDenylist {
+  chain     String   @db.VarChar(32)
+  address   String   @db.VarChar(255)
+  reason    String   @db.Text
+  createdAt DateTime @default(now()) @db.Timestamp(6)
+
+  @@id([chain, address])
+}
+
 model TokenIngestionQueue {
   chain     String   @db.VarChar(32)
   address   String   @db.VarChar(255)

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -120,6 +120,10 @@ export type {
   TokenDbHistorySource,
 } from './repositories/TokenDbHistoryRepository'
 export type { TokenDbSettingRecord } from './repositories/TokenDbSettingRepository'
+export type {
+  TokenDenylistEntryInsert,
+  TokenDenylistEntryRecord,
+} from './repositories/TokenDenylistRepository'
 export type { TokenFactInputRecord } from './repositories/TokenFactInputRepository'
 export type {
   TokenIngestionQueueAddress,

--- a/packages/database/src/repositories/TokenDenylistRepository.test.ts
+++ b/packages/database/src/repositories/TokenDenylistRepository.test.ts
@@ -24,7 +24,7 @@ describeTokenDatabase(TokenDenylistRepository.name, (db) => {
         reason: 'test token',
       },
     ])
-    expect(stored[0]?.createdAt).toBeGreaterThan(0)
+    expect(stored[0]?.createdAt ?? 0).toBeGreaterThan(0)
   })
 
   it('finds an entry with case-insensitive address matching', async () => {

--- a/packages/database/src/repositories/TokenDenylistRepository.test.ts
+++ b/packages/database/src/repositories/TokenDenylistRepository.test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'earl'
+import { describeTokenDatabase } from '../test/tokenDatabase'
+import { TokenDenylistRepository } from './TokenDenylistRepository'
+
+describeTokenDatabase(TokenDenylistRepository.name, (db) => {
+  const repository = db.tokenDenylist
+
+  afterEach(async () => {
+    await repository.deleteAll()
+  })
+
+  it('inserts entries, normalizing the address to lower-case', async () => {
+    await repository.insert({
+      chain: 'arbitrum',
+      address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      reason: 'test token',
+    })
+
+    const stored = await repository.getAll()
+    expect(stored.map(({ createdAt: _, ...entry }) => entry)).toEqual([
+      {
+        chain: 'arbitrum',
+        address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        reason: 'test token',
+      },
+    ])
+    expect(stored[0]?.createdAt).toBeGreaterThan(0)
+  })
+
+  it('finds an entry with case-insensitive address matching', async () => {
+    await repository.insert({
+      chain: 'arbitrum',
+      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      reason: 'test token',
+    })
+
+    const found = await repository.findByChainAndAddress({
+      chain: 'arbitrum',
+      address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    })
+    expect(found?.reason).toEqual('test token')
+
+    const missing = await repository.findByChainAndAddress({
+      chain: 'ethereum',
+      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+    expect(missing).toEqual(undefined)
+  })
+
+  it('deletes an entry by primary key', async () => {
+    await repository.insert({
+      chain: 'arbitrum',
+      address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      reason: 'test token',
+    })
+
+    const deleted = await repository.deleteByPrimaryKey({
+      chain: 'arbitrum',
+      address: '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    })
+    expect(deleted).toEqual(1)
+    expect(await repository.getAll()).toEqual([])
+  })
+})

--- a/packages/database/src/repositories/TokenDenylistRepository.ts
+++ b/packages/database/src/repositories/TokenDenylistRepository.ts
@@ -7,8 +7,8 @@ import type { DeployedTokenPrimaryKey } from './DeployedTokenRepository'
 /**
  * Addresses that must never (re-)enter TokenDB. An entry means a human
  * decided the address is not a real asset deployment (e.g. a test token
- * simulating a bridge into a real token) — ingestion refuses to observe it
- * and planning refuses to catalogue it. See
+ * simulating a bridge into a real token) — ingestion refuses to catalogue it
+ * and planning refuses to add it. See
  * docs/mdbook/specs/l2b_specs/token_db/token_denylist.md.
  */
 export type TokenDenylistEntryRecord = {

--- a/packages/database/src/repositories/TokenDenylistRepository.ts
+++ b/packages/database/src/repositories/TokenDenylistRepository.ts
@@ -1,0 +1,74 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { Selectable } from 'kysely'
+import { BaseRepository } from '../BaseRepository'
+import type { TokenDenylist } from '../kysely/generated/types'
+import type { DeployedTokenPrimaryKey } from './DeployedTokenRepository'
+
+/**
+ * Addresses that must never (re-)enter TokenDB. An entry means a human
+ * decided the address is not a real asset deployment (e.g. a test token
+ * simulating a bridge into a real token) — ingestion refuses to observe it
+ * and planning refuses to catalogue it. See
+ * docs/mdbook/specs/l2b_specs/token_db/token_denylist.md.
+ */
+export type TokenDenylistEntryRecord = {
+  chain: string
+  address: string
+  reason: string
+  createdAt: UnixTime
+}
+
+/** `createdAt` is filled by the database, keeping planning deterministic —
+ * `executePlan` regenerates the plan and deep-compares it with the confirmed
+ * one, so plan-time commands must not carry "now". */
+export type TokenDenylistEntryInsert = Omit<
+  TokenDenylistEntryRecord,
+  'createdAt'
+>
+
+function toRecord(row: Selectable<TokenDenylist>): TokenDenylistEntryRecord {
+  return {
+    ...row,
+    createdAt: UnixTime.fromDate(row.createdAt),
+  }
+}
+
+export class TokenDenylistRepository extends BaseRepository {
+  async insert(record: TokenDenylistEntryInsert): Promise<void> {
+    await this.db
+      .insertInto('TokenDenylist')
+      .values({ ...record, address: record.address.toLowerCase() })
+      .execute()
+  }
+
+  async findByChainAndAddress(
+    pk: DeployedTokenPrimaryKey,
+  ): Promise<TokenDenylistEntryRecord | undefined> {
+    const row = await this.db
+      .selectFrom('TokenDenylist')
+      .selectAll()
+      .where('chain', '=', pk.chain)
+      .where('address', '=', pk.address.toLowerCase())
+      .executeTakeFirst()
+    return row ? toRecord(row) : undefined
+  }
+
+  async getAll(): Promise<TokenDenylistEntryRecord[]> {
+    const rows = await this.db.selectFrom('TokenDenylist').selectAll().execute()
+    return rows.map(toRecord)
+  }
+
+  async deleteByPrimaryKey(pk: DeployedTokenPrimaryKey): Promise<number> {
+    const result = await this.db
+      .deleteFrom('TokenDenylist')
+      .where('chain', '=', pk.chain)
+      .where('address', '=', pk.address.toLowerCase())
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
+  async deleteAll(): Promise<bigint> {
+    const result = await this.db.deleteFrom('TokenDenylist').executeTakeFirst()
+    return result.numDeletedRows
+  }
+}

--- a/packages/database/src/repositories/TokenIngestionQueueRepository.test.ts
+++ b/packages/database/src/repositories/TokenIngestionQueueRepository.test.ts
@@ -56,6 +56,31 @@ describeTokenDatabase(TokenIngestionQueueRepository.name, (db) => {
     })
   })
 
+  describe(
+    TokenIngestionQueueRepository.prototype.findByChainAndAddress.name,
+    () => {
+      it('finds an entry with case-insensitive address matching', async () => {
+        await repository.enqueue({ chain: 'ethereum', address: '0xabc' })
+
+        const found = await repository.findByChainAndAddress({
+          chain: 'ethereum',
+          address: '0xABC',
+        })
+        expect(found!).toHaveSubset({
+          chain: 'ethereum',
+          address: '0xabc',
+          state: 'pending',
+        })
+
+        const missing = await repository.findByChainAndAddress({
+          chain: 'base',
+          address: '0xabc',
+        })
+        expect(missing).toEqual(undefined)
+      })
+    },
+  )
+
   describe(TokenIngestionQueueRepository.prototype.findNextPending.name, () => {
     it('returns the oldest pending entry', async () => {
       const first = { chain: 'ethereum', address: '0x111' }

--- a/packages/database/src/repositories/TokenIngestionQueueRepository.ts
+++ b/packages/database/src/repositories/TokenIngestionQueueRepository.ts
@@ -78,6 +78,20 @@ export class TokenIngestionQueueRepository extends BaseRepository {
       .execute()
   }
 
+  async findByChainAndAddress(
+    address: TokenIngestionQueueAddress,
+  ): Promise<TokenIngestionQueueRecord | undefined> {
+    const normalized = normalizeAddress(address)
+    const row = await this.db
+      .selectFrom('TokenIngestionQueue')
+      .selectAll()
+      .where('chain', '=', normalized.chain)
+      .where('address', '=', normalized.address)
+      .executeTakeFirst()
+
+    return row ? toRecord(row) : undefined
+  }
+
   async findNextPending(): Promise<TokenIngestionQueueRecord | undefined> {
     const row = await this.db
       .selectFrom('TokenIngestionQueue')

--- a/packages/database/src/tokenDatabase.ts
+++ b/packages/database/src/tokenDatabase.ts
@@ -6,6 +6,7 @@ import { ChainRepository } from './repositories/ChainRepository'
 import { DeployedTokenRepository } from './repositories/DeployedTokenRepository'
 import { TokenDbHistoryRepository } from './repositories/TokenDbHistoryRepository'
 import { TokenDbSettingRepository } from './repositories/TokenDbSettingRepository'
+import { TokenDenylistRepository } from './repositories/TokenDenylistRepository'
 import { TokenIngestionQueueRepository } from './repositories/TokenIngestionQueueRepository'
 import { TokenRelationRepository } from './repositories/TokenRelationRepository'
 import { getDatabaseStats } from './utils/getDatabaseStats'
@@ -22,6 +23,7 @@ export function createTokenDatabase(config?: PoolConfig & { log?: LogConfig }) {
     abstractToken: new AbstractTokenRepository(db),
     deployedToken: new DeployedTokenRepository(db),
     tokenRelation: new TokenRelationRepository(db),
+    tokenDenylist: new TokenDenylistRepository(db),
     tokenDbHistory: new TokenDbHistoryRepository(db),
     tokenDbSettings: new TokenDbSettingRepository(db),
     tokenIngestionQueue: new TokenIngestionQueueRepository(db),

--- a/packages/token-backend/README.md
+++ b/packages/token-backend/README.md
@@ -52,3 +52,7 @@ These documents MUST be kept up to date when their subjects change:
   why duplicate abstract tokens arise, why an abstract token keeps
   multiple CoinGecko entries, and how merging resolves relation
   conflicts.
+- [Token denylist](../../docs/mdbook/specs/l2b_specs/token_db/token_denylist.md) —
+  banning bogus/test token addresses from TokenDB: why a denylist at the
+  ingestion boundary beats a flag filtered on every read, and which entry
+  points consult it.

--- a/packages/token-backend/src/commands.ts
+++ b/packages/token-backend/src/commands.ts
@@ -93,19 +93,19 @@ export const DeleteTokenRelationCommand = v.object({
   existing: TokenRelationRecord,
 })
 
-export type AddTokenDenylistEntryCommand = v.infer<
-  typeof AddTokenDenylistEntryCommand
+export type AddTokenToDenylistCommand = v.infer<
+  typeof AddTokenToDenylistCommand
 >
-export const AddTokenDenylistEntryCommand = v.object({
-  type: v.literal('AddTokenDenylistEntryCommand'),
+export const AddTokenToDenylistCommand = v.object({
+  type: v.literal('AddTokenToDenylistCommand'),
   record: TokenDenylistEntryInsert,
 })
 
-export type DeleteTokenDenylistEntryCommand = v.infer<
-  typeof DeleteTokenDenylistEntryCommand
+export type DeleteTokenFromDenylistCommand = v.infer<
+  typeof DeleteTokenFromDenylistCommand
 >
-export const DeleteTokenDenylistEntryCommand = v.object({
-  type: v.literal('DeleteTokenDenylistEntryCommand'),
+export const DeleteTokenFromDenylistCommand = v.object({
+  type: v.literal('DeleteTokenFromDenylistCommand'),
   pk: DeployedTokenPrimaryKey,
   existing: TokenDenylistEntryRecord,
 })
@@ -121,6 +121,6 @@ export const Command = v.union([
   AddTokenRelationCommand,
   UpdateTokenRelationCommand,
   DeleteTokenRelationCommand,
-  AddTokenDenylistEntryCommand,
-  DeleteTokenDenylistEntryCommand,
+  AddTokenToDenylistCommand,
+  DeleteTokenFromDenylistCommand,
 ])

--- a/packages/token-backend/src/commands.ts
+++ b/packages/token-backend/src/commands.ts
@@ -9,6 +9,10 @@ import {
   DeployedTokenUpdateable,
 } from './schemas/DeployedToken'
 import {
+  TokenDenylistEntryInsert,
+  TokenDenylistEntryRecord,
+} from './schemas/TokenDenylist'
+import {
   TokenRelationPrimaryKey,
   TokenRelationRecord,
   TokenRelationUpdateable,
@@ -89,6 +93,23 @@ export const DeleteTokenRelationCommand = v.object({
   existing: TokenRelationRecord,
 })
 
+export type AddTokenDenylistEntryCommand = v.infer<
+  typeof AddTokenDenylistEntryCommand
+>
+export const AddTokenDenylistEntryCommand = v.object({
+  type: v.literal('AddTokenDenylistEntryCommand'),
+  record: TokenDenylistEntryInsert,
+})
+
+export type DeleteTokenDenylistEntryCommand = v.infer<
+  typeof DeleteTokenDenylistEntryCommand
+>
+export const DeleteTokenDenylistEntryCommand = v.object({
+  type: v.literal('DeleteTokenDenylistEntryCommand'),
+  pk: DeployedTokenPrimaryKey,
+  existing: TokenDenylistEntryRecord,
+})
+
 export type Command = v.infer<typeof Command>
 export const Command = v.union([
   AddAbstractTokenCommand,
@@ -100,4 +121,6 @@ export const Command = v.union([
   AddTokenRelationCommand,
   UpdateTokenRelationCommand,
   DeleteTokenRelationCommand,
+  AddTokenDenylistEntryCommand,
+  DeleteTokenDenylistEntryCommand,
 ])

--- a/packages/token-backend/src/commitTokenChanges.test.ts
+++ b/packages/token-backend/src/commitTokenChanges.test.ts
@@ -27,10 +27,15 @@ describe(commitTokenChanges.name, () => {
       updateByPrimaryKey: mockFn().resolvesTo(undefined),
       deleteByPrimaryKey: mockFn().resolvesTo(undefined),
     })
+    const tokenDenylist = mockObject<TokenDatabase['tokenDenylist']>({
+      insert: mockFn().resolvesTo(undefined),
+      deleteByPrimaryKey: mockFn().resolvesTo(undefined),
+    })
     const tokenDb = mockObject<TokenDatabase>({
       abstractToken,
       deployedToken,
       tokenRelation,
+      tokenDenylist,
       tokenDbHistory: mockHistory(),
     })
 
@@ -78,6 +83,24 @@ describe(commitTokenChanges.name, () => {
         pk: relationPk(relation),
         existing: relation,
       },
+      {
+        type: 'AddTokenDenylistEntryCommand',
+        record: {
+          chain: deployed.chain,
+          address: deployed.address,
+          reason: 'test token',
+        },
+      },
+      {
+        type: 'DeleteTokenDenylistEntryCommand',
+        pk: { chain: deployed.chain, address: deployed.address },
+        existing: {
+          chain: deployed.chain,
+          address: deployed.address,
+          reason: 'test token',
+          createdAt: 1,
+        },
+      },
     ]
 
     await commitTokenChanges(tokenDb, commands, {
@@ -108,6 +131,15 @@ describe(commitTokenChanges.name, () => {
     expect(tokenRelation.deleteByPrimaryKey).toHaveBeenOnlyCalledWith(
       relationPk(relation),
     )
+    expect(tokenDenylist.insert).toHaveBeenOnlyCalledWith({
+      chain: deployed.chain,
+      address: deployed.address,
+      reason: 'test token',
+    })
+    expect(tokenDenylist.deleteByPrimaryKey).toHaveBeenOnlyCalledWith({
+      chain: deployed.chain,
+      address: deployed.address,
+    })
   })
 
   it('passes deployed-token commands through verbatim, including any proof field', async () => {

--- a/packages/token-backend/src/commitTokenChanges.test.ts
+++ b/packages/token-backend/src/commitTokenChanges.test.ts
@@ -84,7 +84,7 @@ describe(commitTokenChanges.name, () => {
         existing: relation,
       },
       {
-        type: 'AddTokenDenylistEntryCommand',
+        type: 'AddTokenToDenylistCommand',
         record: {
           chain: deployed.chain,
           address: deployed.address,
@@ -92,7 +92,7 @@ describe(commitTokenChanges.name, () => {
         },
       },
       {
-        type: 'DeleteTokenDenylistEntryCommand',
+        type: 'DeleteTokenFromDenylistCommand',
         pk: { chain: deployed.chain, address: deployed.address },
         existing: {
           chain: deployed.chain,

--- a/packages/token-backend/src/commitTokenChanges.ts
+++ b/packages/token-backend/src/commitTokenChanges.ts
@@ -118,10 +118,10 @@ async function executeCommand(tokenDb: TokenDatabase, command: Command) {
     case 'DeleteTokenRelationCommand':
       await tokenDb.tokenRelation.deleteByPrimaryKey(command.pk)
       break
-    case 'AddTokenDenylistEntryCommand':
+    case 'AddTokenToDenylistCommand':
       await tokenDb.tokenDenylist.insert(command.record)
       break
-    case 'DeleteTokenDenylistEntryCommand':
+    case 'DeleteTokenFromDenylistCommand':
       await tokenDb.tokenDenylist.deleteByPrimaryKey(command.pk)
       break
     default:

--- a/packages/token-backend/src/commitTokenChanges.ts
+++ b/packages/token-backend/src/commitTokenChanges.ts
@@ -118,6 +118,12 @@ async function executeCommand(tokenDb: TokenDatabase, command: Command) {
     case 'DeleteTokenRelationCommand':
       await tokenDb.tokenRelation.deleteByPrimaryKey(command.pk)
       break
+    case 'AddTokenDenylistEntryCommand':
+      await tokenDb.tokenDenylist.insert(command.record)
+      break
+    case 'DeleteTokenDenylistEntryCommand':
+      await tokenDb.tokenDenylist.deleteByPrimaryKey(command.pk)
+      break
     default:
       assertUnreachable(command)
   }

--- a/packages/token-backend/src/ingestion/IngestionTrace.ts
+++ b/packages/token-backend/src/ingestion/IngestionTrace.ts
@@ -22,6 +22,7 @@ export type AbstractTokenRef = { id: string; symbol: string }
 
 export type IngestionStep =
   | { kind: 'invalid-address'; rawAddress: string }
+  | { kind: 'token-denylisted'; reason: string }
   | { kind: 'existing-token'; record: DeployedTokenRecord }
   | { kind: 'no-existing-token' }
   | {

--- a/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
@@ -1249,9 +1249,10 @@ function transfer(
   }
 }
 
+// Only the single-address lookup is stubbed: ingestion asks "is this
+// address banned?" and never reads the whole list.
 function emptyDenylist() {
   return mockObject<TokenDatabase['tokenDenylist']>({
     findByChainAndAddress: mockFn().resolvesTo(undefined),
-    getAll: mockFn().resolvesTo([]),
   })
 }

--- a/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionLoop.test.ts
@@ -47,6 +47,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -95,6 +96,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -136,6 +138,7 @@ describe(TokenIngestionLoop.name, () => {
 
       const loop = createLoop({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get,
             set,
@@ -175,6 +178,7 @@ describe(TokenIngestionLoop.name, () => {
       const loop = createLoop({
         newQueueState: 'staged',
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
             set: mockFn().resolvesTo(undefined),
@@ -211,6 +215,7 @@ describe(TokenIngestionLoop.name, () => {
       })
       const loop = createLoop({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -238,6 +243,7 @@ describe(TokenIngestionLoop.name, () => {
       const enqueue = mockFn().resolvesTo(undefined)
       const loop = createLoop({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo({
               key: 'interop-transfers:lastSerialId',
@@ -296,6 +302,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -361,6 +368,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           transaction: async (callback) => await callback(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
@@ -439,6 +447,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -480,6 +489,7 @@ describe(TokenIngestionLoop.name, () => {
 
       const loop = createLoop({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -555,6 +565,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -625,6 +636,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -709,6 +721,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -757,6 +770,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           transaction: async (callback) => await callback(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
@@ -858,6 +872,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           transaction: async (callback) => await callback(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
@@ -967,6 +982,7 @@ describe(TokenIngestionLoop.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
             get: mockFn().resolvesTo(undefined),
           }),
@@ -1075,6 +1091,7 @@ function createLoop(deps: {
     ...deps.db,
   })
   const tokenDb = mockObject<TokenDatabase>({
+    tokenDenylist: emptyDenylist(),
     tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({
       get: mockFn().resolvesTo(undefined),
     }),
@@ -1230,4 +1247,11 @@ function transfer(
     isProcessed: true,
     ...overrides,
   }
+}
+
+function emptyDenylist() {
+  return mockObject<TokenDatabase['tokenDenylist']>({
+    findByChainAndAddress: mockFn().resolvesTo(undefined),
+    getAll: mockFn().resolvesTo([]),
+  })
 }

--- a/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
@@ -1232,6 +1232,77 @@ describe(TokenIngestionProcessor.name, () => {
       expect(remove).toHaveBeenCalledWith(queueEntry(address))
     })
 
+    it('skips the write when the address was denylisted after planning', async () => {
+      // plan() consults the denylist, but fetch() makes slow external calls —
+      // an operator can denylist the address in between. The write
+      // transaction rechecks, so no token is created next to its ban.
+      const address = token('ethereum', '0xaaa')
+      const neighbor = token('base', '0xbbb')
+      const insert = mockFn().resolvesTo(undefined)
+      const enqueue = mockFn().resolvesTo(undefined)
+      const remove = mockFn().resolvesTo(1)
+
+      const processor = createProcessor({
+        tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
+            findByChainAndAddress: mockFn().resolvesTo({
+              ...address,
+              reason: 'test token',
+              createdAt: UnixTime(1),
+            }),
+          }),
+          transaction: async (callback) => await callback(),
+          deployedToken: mockObject<TokenDatabase['deployedToken']>({
+            insert,
+          }),
+          tokenIngestionQueue: mockObject<TokenDatabase['tokenIngestionQueue']>(
+            {
+              enqueue,
+              remove,
+            },
+          ),
+        }),
+      })
+
+      const trace: IngestionTrace = {
+        id: 'ing_test',
+        address,
+        existingDeployedToken: undefined,
+        steps: [],
+        outcome: {
+          kind: 'write',
+          newAbstractToken: undefined,
+          deployedToken: {
+            type: 'insert',
+            record: {
+              ...address,
+              abstractTokenId: 'USDC01',
+              symbol: 'USDC',
+              decimals: 6,
+              deploymentTimestamp: UnixTime(1),
+              comment: null,
+              metadata: null,
+              abstractTokenAssignmentProof: { kind: 'coingecko' },
+            },
+          },
+          neighborsToEnqueue: [neighbor],
+        },
+      }
+
+      const result = await processor.apply(queueEntry(address), trace)
+
+      expect(insert).toHaveBeenCalledTimes(0)
+      expect(enqueue).toHaveBeenCalledTimes(0)
+      expect(remove).toHaveBeenCalledWith(queueEntry(address))
+      expect(result.outcome).toEqual({
+        kind: 'skip',
+        reason: 'Address is denylisted: test token',
+      })
+      expect(result.steps).toEqual([
+        { kind: 'token-denylisted', reason: 'test token' },
+      ])
+    })
+
     it('throws when called with a pending outcome', async () => {
       const processor = createProcessor({})
       const trace: IngestionTrace = {

--- a/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
@@ -22,6 +22,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo(undefined),
             getByPrimaryKeys,
@@ -75,6 +76,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo(existing),
             getByPrimaryKeys: mockFn().resolvesTo([]),
@@ -97,6 +99,53 @@ describe(TokenIngestionProcessor.name, () => {
 
       expect(trace.existingDeployedToken).toEqual(existing)
       expect(trace.outcome).toEqual({ kind: 'noop', deployedToken: existing })
+    })
+
+    it('short-circuits to skip for a denylisted address', async () => {
+      const address = token('ethereum', '0xaaa')
+      const findByChainAndAddress = mockFn().resolvesTo(undefined)
+      const getByPrimaryKeys = mockFn().resolvesTo([])
+
+      const processor = createProcessor({
+        tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
+            findByChainAndAddress: mockFn().resolvesTo({
+              ...address,
+              reason: 'test token',
+              createdAt: UnixTime(1),
+            }),
+          }),
+          deployedToken: mockObject<TokenDatabase['deployedToken']>({
+            findByChainAndAddress,
+            getByPrimaryKeys,
+          }),
+        }),
+      })
+
+      const trace = await processor.plan(
+        queueEntry(address),
+        buildInteropTransferIndex([
+          route({
+            srcChain: address.chain,
+            srcTokenAddress: `0x${address.address.slice(2).padStart(64, '0')}`,
+            dstChain: 'base',
+            dstTokenAddress: Address32.ZERO,
+            bridgeType: 'lockAndMint',
+          }),
+        ]),
+      )
+
+      expect(trace.steps).toEqual([
+        { kind: 'token-denylisted', reason: 'test token' },
+      ])
+      expect(trace.outcome).toEqual({
+        kind: 'skip',
+        reason: 'Address is denylisted: test token',
+      })
+      // The gate fires before any resolution work: no catalogue lookup, no
+      // transfer-evidence lookup.
+      expect(findByChainAndAddress).not.toHaveBeenCalled()
+      expect(getByPrimaryKeys).not.toHaveBeenCalled()
     })
 
     it('returns pending-insert without fetching deployed-token facts for a new address', async () => {
@@ -129,6 +178,7 @@ describe(TokenIngestionProcessor.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo(undefined),
             getByPrimaryKeys: mockFn().resolvesTo([
@@ -202,6 +252,7 @@ describe(TokenIngestionProcessor.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo(undefined),
             getByPrimaryKeys: mockFn().resolvesTo([
@@ -281,6 +332,7 @@ describe(TokenIngestionProcessor.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo({
               ...address,
@@ -355,6 +407,7 @@ describe(TokenIngestionProcessor.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo(existing),
             getByPrimaryKeys: mockFn().resolvesTo([
@@ -407,6 +460,7 @@ describe(TokenIngestionProcessor.name, () => {
           }),
         }),
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo({
               ...address,
@@ -466,6 +520,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             findByChainAndAddress: mockFn().resolvesTo(undefined),
             getByPrimaryKeys: mockFn().resolvesTo([]),
@@ -549,6 +604,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -616,6 +672,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -675,6 +732,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -753,6 +811,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -827,6 +886,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -881,6 +941,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -939,6 +1000,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -1006,6 +1068,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           abstractToken: mockObject<TokenDatabase['abstractToken']>({
             findById: mockFn().resolvesTo(undefined),
           }),
@@ -1066,6 +1129,7 @@ describe(TokenIngestionProcessor.name, () => {
       const address = token('ethereum', '0xaaa')
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           chain: mockObject<TokenDatabase['chain']>({
             findByName: mockFn().resolvesTo({
               name: 'ethereum',
@@ -1119,6 +1183,7 @@ describe(TokenIngestionProcessor.name, () => {
 
       const processor = createProcessor({
         tokenDb: mockObject<TokenDatabase>({
+          tokenDenylist: emptyDenylist(),
           transaction: async (callback) => await callback(),
           deployedToken: mockObject<TokenDatabase['deployedToken']>({
             insert,
@@ -1267,7 +1332,9 @@ function createProcessor(deps: {
 }) {
   return new TokenIngestionProcessor({
     db: deps.db ?? mockObject<Database>({}),
-    tokenDb: deps.tokenDb ?? mockObject<TokenDatabase>({}),
+    tokenDb:
+      deps.tokenDb ??
+      mockObject<TokenDatabase>({ tokenDenylist: emptyDenylist() }),
     coingeckoClient: deps.coingeckoClient ?? mockObject<CoingeckoClient>({}),
     etherscanApiKey: undefined,
     fetchDeployedTokenFacts: deps.fetchDeployedTokenFacts,
@@ -1376,4 +1443,11 @@ function transfer(
     isProcessed: true,
     ...overrides,
   }
+}
+
+function emptyDenylist() {
+  return mockObject<TokenDatabase['tokenDenylist']>({
+    findByChainAndAddress: mockFn().resolvesTo(undefined),
+    getAll: mockFn().resolvesTo([]),
+  })
 }

--- a/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionProcessor.test.ts
@@ -1516,9 +1516,10 @@ function transfer(
   }
 }
 
+// Only the single-address lookup is stubbed: ingestion asks "is this
+// address banned?" and never reads the whole list.
 function emptyDenylist() {
   return mockObject<TokenDatabase['tokenDenylist']>({
     findByChainAndAddress: mockFn().resolvesTo(undefined),
-    getAll: mockFn().resolvesTo([]),
   })
 }

--- a/packages/token-backend/src/ingestion/TokenIngestionProcessor.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionProcessor.ts
@@ -145,6 +145,26 @@ export class TokenIngestionProcessor {
       }
     }
 
+    // A denylisted address must never (re-)enter TokenDB: a human explicitly
+    // banned it (e.g. a test token simulating a bridge into a real asset).
+    // Skipping here — before any resolution — is what makes the ban durable
+    // against the enqueue → resolve → write loop.
+    const denylisted =
+      await this.deps.tokenDb.tokenDenylist.findByChainAndAddress(address)
+    if (denylisted) {
+      steps.push({ kind: 'token-denylisted', reason: denylisted.reason })
+      return {
+        id,
+        address,
+        existingDeployedToken: undefined,
+        steps,
+        outcome: {
+          kind: 'skip',
+          reason: `Address is denylisted: ${denylisted.reason}`,
+        },
+      }
+    }
+
     const existing =
       await this.deps.tokenDb.deployedToken.findByChainAndAddress(address)
     steps.push(

--- a/packages/token-backend/src/ingestion/TokenIngestionProcessor.ts
+++ b/packages/token-backend/src/ingestion/TokenIngestionProcessor.ts
@@ -123,8 +123,7 @@ export class TokenIngestionProcessor {
   ): Promise<IngestionTrace> {
     const planned = await this.plan(entry, transferIndex)
     const trace = await this.fetch(planned)
-    await this.apply(entry, trace)
-    return trace
+    return await this.apply(entry, trace)
   }
 
   async plan(
@@ -346,23 +345,23 @@ export class TokenIngestionProcessor {
   async apply(
     entry: TokenIngestionQueueRecord,
     trace: IngestionTrace,
-  ): Promise<void> {
+  ): Promise<IngestionTrace> {
     const { outcome } = trace
     const queue = this.deps.tokenDb.tokenIngestionQueue
 
     switch (outcome.kind) {
       case 'skip':
         await queue.remove(entry)
-        return
+        return trace
       case 'conflict':
         await queue.markConflict(entry, outcome.message)
-        return
+        return trace
       case 'error':
         await queue.markError(entry, outcome.message)
-        return
+        return trace
       case 'noop':
         await queue.remove(entry)
-        return
+        return trace
       case 'pending':
         throw new Error(
           'apply() called with a pending outcome; call fetch() first',
@@ -370,12 +369,42 @@ export class TokenIngestionProcessor {
       case 'write': {
         const commands = buildWriteCommands(outcome)
         const log = formatIngestionTrace(trace)
-        await this.deps.tokenDb.transaction(async () => {
+        // plan() already consulted the denylist, but fetch() makes slow
+        // external calls — an operator may denylist the address in between,
+        // and their plan would see nothing to delete. Rechecking inside the
+        // same serializable transaction as the write closes the race: either
+        // this transaction sees the entry and skips, or it serializes before
+        // the denylist execution, whose in-transaction plan regeneration then
+        // sees this token and makes the operator re-plan the deletion.
+        const denylisted = await this.deps.tokenDb.transaction(async () => {
+          const denylistEntry =
+            await this.deps.tokenDb.tokenDenylist.findByChainAndAddress(
+              trace.address,
+            )
+          if (denylistEntry) {
+            return denylistEntry
+          }
           await commitTokenChanges(this.deps.tokenDb, commands, {
             kind: 'ingestion',
             log,
           })
+          return undefined
         }, 'serializable')
+
+        if (denylisted) {
+          await queue.remove(entry)
+          return {
+            ...trace,
+            steps: [
+              ...trace.steps,
+              { kind: 'token-denylisted', reason: denylisted.reason },
+            ],
+            outcome: {
+              kind: 'skip',
+              reason: `Address is denylisted: ${denylisted.reason}`,
+            },
+          }
+        }
 
         for (const neighbor of outcome.neighborsToEnqueue) {
           await this.deps.tokenDb.tokenIngestionQueue.enqueue(
@@ -384,7 +413,7 @@ export class TokenIngestionProcessor {
           )
         }
         await queue.remove(entry)
-        return
+        return trace
       }
     }
   }

--- a/packages/token-backend/src/ingestion/TokenRelationIngestion.test.ts
+++ b/packages/token-backend/src/ingestion/TokenRelationIngestion.test.ts
@@ -64,16 +64,17 @@ describe(TokenRelationIngestion.name, () => {
     expect(set).toHaveBeenCalledWith({ key: CURSOR_KEY, value: '12' })
   })
 
-  it('commits all new relations of a batch in a single transaction', async () => {
+  it('commits all new relations of a batch in a single serializable transaction', async () => {
     const events: string[] = []
     const insert = mockFn().executes(async () => {
       events.push('insert')
     })
     const transaction = mockFn().executes(
-      async (callback: () => Promise<void>) => {
-        events.push('begin')
-        await callback()
+      async (callback: () => Promise<unknown>, isolation?: string) => {
+        events.push(`begin:${isolation}`)
+        const result = await callback()
         events.push('commit')
+        return result
       },
     )
     const getAfterSerialId = mockFn()
@@ -98,7 +99,7 @@ describe(TokenRelationIngestion.name, () => {
 
     await ingestion.runOnce()
 
-    expect(events).toEqual(['begin', 'insert', 'insert', 'commit'])
+    expect(events).toEqual(['begin:serializable', 'insert', 'insert', 'commit'])
   })
 
   it('creates relations without ever consulting the token catalogue', async () => {
@@ -152,6 +153,50 @@ describe(TokenRelationIngestion.name, () => {
     expect(insert).toHaveBeenCalledTimes(1)
     const inserted = insert.calls[0]?.args[0] as TokenRelationRecord
     expect(evidenceTransferId(inserted)).toEqual('regular')
+  })
+
+  it('honors a denylist entry added while a run is in progress', async () => {
+    // The denylist is read inside every batch's write transaction — a run
+    // processes up to 50 pages, so a run-level snapshot could go stale and
+    // re-insert a relation right after a denylist plan deleted it.
+    const insert = mockFn().resolvesTo(undefined)
+    const denylistGetAll = mockFn()
+      .resolvesToOnce([])
+      .resolvesToOnce([
+        {
+          chain: 'base',
+          address: token('0xbbb'),
+          reason: 'test token',
+          createdAt: UnixTime(1),
+        },
+      ])
+
+    const ingestion = createIngestion({
+      getAfterSerialId: mockFn()
+        .resolvesToOnce({
+          latestSerialId: '1',
+          transfers: [transfer({ transferId: 'before-denylisting' })],
+        })
+        .resolvesToOnce({
+          latestSerialId: '2',
+          transfers: [
+            transfer({
+              transferId: 'after-denylisting',
+              plugin: 'other-plugin',
+            }),
+          ],
+        })
+        .resolvesToOnce(emptyBatch()),
+      insert,
+      denylistGetAll,
+    })
+
+    await ingestion.runOnce()
+
+    expect(denylistGetAll).toHaveBeenCalledTimes(2)
+    expect(insert).toHaveBeenCalledTimes(1)
+    const inserted = insert.calls[0]?.args[0] as TokenRelationRecord
+    expect(evidenceTransferId(inserted)).toEqual('before-denylisting')
   })
 
   it('records one relation for both observed directions of a lock-and-mint route', async () => {
@@ -581,6 +626,7 @@ function createIngestion(opts: {
   set?: ReturnType<typeof mockFn>
   transaction?: ReturnType<typeof mockFn>
   denylisted?: { chain: string; address: string }[]
+  denylistGetAll?: ReturnType<typeof mockFn>
 }) {
   const db = mockObject<Database>({
     interopTransfer: mockObject<Database['interopTransfer']>({
@@ -590,13 +636,15 @@ function createIngestion(opts: {
   })
   const tokenDb = mockObject<TokenDatabase>({
     tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
-      getAll: mockFn().resolvesTo(
-        (opts.denylisted ?? []).map((entry) => ({
-          ...entry,
-          reason: 'test token',
-          createdAt: UnixTime(1),
-        })),
-      ),
+      getAll:
+        opts.denylistGetAll ??
+        mockFn().resolvesTo(
+          (opts.denylisted ?? []).map((entry) => ({
+            ...entry,
+            reason: 'test token',
+            createdAt: UnixTime(1),
+          })),
+        ),
     }),
     transaction: (opts.transaction ??
       (async (callback) => await callback())) as TokenDatabase['transaction'],

--- a/packages/token-backend/src/ingestion/TokenRelationIngestion.test.ts
+++ b/packages/token-backend/src/ingestion/TokenRelationIngestion.test.ts
@@ -64,17 +64,16 @@ describe(TokenRelationIngestion.name, () => {
     expect(set).toHaveBeenCalledWith({ key: CURSOR_KEY, value: '12' })
   })
 
-  it('commits all new relations of a batch in a single serializable transaction', async () => {
+  it('commits all new relations of a batch in a single transaction', async () => {
     const events: string[] = []
     const insert = mockFn().executes(async () => {
       events.push('insert')
     })
     const transaction = mockFn().executes(
-      async (callback: () => Promise<unknown>, isolation?: string) => {
-        events.push(`begin:${isolation}`)
-        const result = await callback()
+      async (callback: () => Promise<void>) => {
+        events.push('begin')
+        await callback()
         events.push('commit')
-        return result
       },
     )
     const getAfterSerialId = mockFn()
@@ -99,13 +98,15 @@ describe(TokenRelationIngestion.name, () => {
 
     await ingestion.runOnce()
 
-    expect(events).toEqual(['begin:serializable', 'insert', 'insert', 'commit'])
+    expect(events).toEqual(['begin', 'insert', 'insert', 'commit'])
   })
 
-  it('creates relations without ever consulting the token catalogue', async () => {
-    // No deployedToken or tokenIngestionQueue mocks exist on the database
-    // object below — any attempt to look up deployed tokens (e.g. to gate
-    // relations behind token-level conflicts) would make this test throw.
+  it('creates relations without consulting the token catalogue or the denylist', async () => {
+    // No deployedToken, tokenIngestionQueue, or tokenDenylist mocks exist on
+    // the database object below — any attempt to gate relation recording on
+    // an interpretation (token-level conflicts, human bans) would make this
+    // test throw. Relations are observations; interpretation surfaces like
+    // the relations graph filter denylisted endpoints instead.
     const insert = mockFn().resolvesTo(undefined)
 
     const ingestion = createIngestion({
@@ -123,80 +124,6 @@ describe(TokenRelationIngestion.name, () => {
     await ingestion.runOnce()
 
     expect(insert).toHaveBeenCalledTimes(1)
-  })
-
-  it('skips transfers touching a denylisted address', async () => {
-    // The denylist is not the catalogue: an entry is an explicit human ban,
-    // so this is the one gate relation recording honors. Without it the
-    // denylisted test token's edge would reappear with the next transfer.
-    const insert = mockFn().resolvesTo(undefined)
-
-    const ingestion = createIngestion({
-      getAfterSerialId: mockFn()
-        .resolvesToOnce({
-          latestSerialId: '2',
-          transfers: [
-            transfer({
-              transferId: 'to-denylisted',
-              dstTokenAddress: token('0xccc'),
-            }),
-            transfer({ transferId: 'regular' }),
-          ],
-        })
-        .resolvesToOnce(emptyBatch()),
-      insert,
-      denylisted: [{ chain: 'base', address: token('0xccc') }],
-    })
-
-    await ingestion.runOnce()
-
-    expect(insert).toHaveBeenCalledTimes(1)
-    const inserted = insert.calls[0]?.args[0] as TokenRelationRecord
-    expect(evidenceTransferId(inserted)).toEqual('regular')
-  })
-
-  it('honors a denylist entry added while a run is in progress', async () => {
-    // The denylist is read inside every batch's write transaction — a run
-    // processes up to 50 pages, so a run-level snapshot could go stale and
-    // re-insert a relation right after a denylist plan deleted it.
-    const insert = mockFn().resolvesTo(undefined)
-    const denylistGetAll = mockFn()
-      .resolvesToOnce([])
-      .resolvesToOnce([
-        {
-          chain: 'base',
-          address: token('0xbbb'),
-          reason: 'test token',
-          createdAt: UnixTime(1),
-        },
-      ])
-
-    const ingestion = createIngestion({
-      getAfterSerialId: mockFn()
-        .resolvesToOnce({
-          latestSerialId: '1',
-          transfers: [transfer({ transferId: 'before-denylisting' })],
-        })
-        .resolvesToOnce({
-          latestSerialId: '2',
-          transfers: [
-            transfer({
-              transferId: 'after-denylisting',
-              plugin: 'other-plugin',
-            }),
-          ],
-        })
-        .resolvesToOnce(emptyBatch()),
-      insert,
-      denylistGetAll,
-    })
-
-    await ingestion.runOnce()
-
-    expect(denylistGetAll).toHaveBeenCalledTimes(2)
-    expect(insert).toHaveBeenCalledTimes(1)
-    const inserted = insert.calls[0]?.args[0] as TokenRelationRecord
-    expect(evidenceTransferId(inserted)).toEqual('before-denylisting')
   })
 
   it('records one relation for both observed directions of a lock-and-mint route', async () => {
@@ -625,8 +552,6 @@ function createIngestion(opts: {
   historyInsert?: ReturnType<typeof mockFn>
   set?: ReturnType<typeof mockFn>
   transaction?: ReturnType<typeof mockFn>
-  denylisted?: { chain: string; address: string }[]
-  denylistGetAll?: ReturnType<typeof mockFn>
 }) {
   const db = mockObject<Database>({
     interopTransfer: mockObject<Database['interopTransfer']>({
@@ -635,17 +560,6 @@ function createIngestion(opts: {
     }),
   })
   const tokenDb = mockObject<TokenDatabase>({
-    tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
-      getAll:
-        opts.denylistGetAll ??
-        mockFn().resolvesTo(
-          (opts.denylisted ?? []).map((entry) => ({
-            ...entry,
-            reason: 'test token',
-            createdAt: UnixTime(1),
-          })),
-        ),
-    }),
     transaction: (opts.transaction ??
       (async (callback) => await callback())) as TokenDatabase['transaction'],
     tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({

--- a/packages/token-backend/src/ingestion/TokenRelationIngestion.test.ts
+++ b/packages/token-backend/src/ingestion/TokenRelationIngestion.test.ts
@@ -124,6 +124,36 @@ describe(TokenRelationIngestion.name, () => {
     expect(insert).toHaveBeenCalledTimes(1)
   })
 
+  it('skips transfers touching a denylisted address', async () => {
+    // The denylist is not the catalogue: an entry is an explicit human ban,
+    // so this is the one gate relation recording honors. Without it the
+    // denylisted test token's edge would reappear with the next transfer.
+    const insert = mockFn().resolvesTo(undefined)
+
+    const ingestion = createIngestion({
+      getAfterSerialId: mockFn()
+        .resolvesToOnce({
+          latestSerialId: '2',
+          transfers: [
+            transfer({
+              transferId: 'to-denylisted',
+              dstTokenAddress: token('0xccc'),
+            }),
+            transfer({ transferId: 'regular' }),
+          ],
+        })
+        .resolvesToOnce(emptyBatch()),
+      insert,
+      denylisted: [{ chain: 'base', address: token('0xccc') }],
+    })
+
+    await ingestion.runOnce()
+
+    expect(insert).toHaveBeenCalledTimes(1)
+    const inserted = insert.calls[0]?.args[0] as TokenRelationRecord
+    expect(evidenceTransferId(inserted)).toEqual('regular')
+  })
+
   it('records one relation for both observed directions of a lock-and-mint route', async () => {
     // The deposit locks on ethereum and mints on base; the withdrawal burns on
     // base and unlocks on ethereum. Same pair, same locked endpoint, one row.
@@ -550,6 +580,7 @@ function createIngestion(opts: {
   historyInsert?: ReturnType<typeof mockFn>
   set?: ReturnType<typeof mockFn>
   transaction?: ReturnType<typeof mockFn>
+  denylisted?: { chain: string; address: string }[]
 }) {
   const db = mockObject<Database>({
     interopTransfer: mockObject<Database['interopTransfer']>({
@@ -558,6 +589,15 @@ function createIngestion(opts: {
     }),
   })
   const tokenDb = mockObject<TokenDatabase>({
+    tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
+      getAll: mockFn().resolvesTo(
+        (opts.denylisted ?? []).map((entry) => ({
+          ...entry,
+          reason: 'test token',
+          createdAt: UnixTime(1),
+        })),
+      ),
+    }),
     transaction: (opts.transaction ??
       (async (callback) => await callback())) as TokenDatabase['transaction'],
     tokenDbSettings: mockObject<TokenDatabase['tokenDbSettings']>({

--- a/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
+++ b/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
@@ -55,6 +55,14 @@ export class TokenRelationIngestion {
     )
     let lastSerialId = setting?.value ?? '0'
 
+    // Relations are recorded without consulting the token *catalogue* — but
+    // the denylist is not the catalogue. An entry is an explicit human ban
+    // ("this address is not a real asset; refuse to observe it"), the same
+    // category as the address normalization that already drops 0x0. Without
+    // this, a denylisted test token's edge would reappear on the graph with
+    // the next test transfer.
+    const denylisted = tokenKeySet(await this.tokenDb.tokenDenylist.getAll())
+
     for (let page = 0; page < MAX_PAGES_PER_RUN; page++) {
       const batch = await this.db.interopTransfer.getAfterSerialId(
         lastSerialId,
@@ -64,7 +72,7 @@ export class TokenRelationIngestion {
         break
       }
 
-      const outcome = await this.ingestBatch(batch.transfers)
+      const outcome = await this.ingestBatch(batch.transfers, denylisted)
       inserted += outcome.inserted
       resolved += outcome.resolved
       scanned += batch.transfers.length
@@ -91,6 +99,7 @@ export class TokenRelationIngestion {
 
   private async ingestBatch(
     transfers: InteropTransferRecord[],
+    denylisted: Set<string>,
   ): Promise<{ inserted: number; resolved: number }> {
     const candidates = new Map<
       string,
@@ -98,6 +107,9 @@ export class TokenRelationIngestion {
     >()
     for (const transfer of transfers) {
       const route = tokenRouteFromTransfer(transfer)
+      if (route && hasDenylistedEndpoint(route, denylisted)) {
+        continue
+      }
       if (route && !candidates.has(relationKey(route))) {
         candidates.set(relationKey(route), { route, transfer })
       }
@@ -242,6 +254,26 @@ function relationKey(relation: TokenRelationRoute): string {
     relation.plugin,
     relation.bridgeType,
   ].join(':')
+}
+
+function tokenKeySet(
+  entries: { chain: string; address: string }[],
+): Set<string> {
+  return new Set(
+    entries.map((entry) => `${entry.chain}:${entry.address.toLowerCase()}`),
+  )
+}
+
+function hasDenylistedEndpoint(
+  route: TokenRelationRoute,
+  denylisted: Set<string>,
+): boolean {
+  // Route endpoints are already normalized (lowercase) by
+  // `normalizeTransferSide` / `normalizeTokenRelation`.
+  return (
+    denylisted.has(`${route.tokenAChain}:${route.tokenAAddress}`) ||
+    denylisted.has(`${route.tokenBChain}:${route.tokenBAddress}`)
+  )
 }
 
 function formatRelationLog(relation: TokenRelationRoute): string {

--- a/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
+++ b/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
@@ -30,9 +30,11 @@ const MAX_PAGES_PER_RUN = 50
  * Materializes `TokenRelation` rows from interop transfers. A relation is an
  * observation: "we witnessed a non-swapping transfer between these two token
  * addresses via this plugin". It is recorded unconditionally — without
- * consulting the token catalogue — so a token-level conflict can never
- * suppress relation evidence. This is deliberately NOT part of the token
- * ingestion queue. See
+ * consulting the token catalogue or the denylist — so no interpretation
+ * (token-level conflict, human ban) can ever suppress relation evidence.
+ * Interpretation surfaces filter instead: the relations graph drops
+ * relations touching denylisted addresses. This is deliberately NOT part of
+ * the token ingestion queue. See
  * docs/mdbook/specs/l2b_specs/token_db/token_relations.md.
  */
 export class TokenRelationIngestion {
@@ -141,34 +143,15 @@ export class TokenRelationIngestion {
         ),
       }),
     )
-    // Relations are recorded without consulting the token *catalogue* — but
-    // the denylist is not the catalogue. An entry is an explicit human ban
-    // ("this address is not a real asset; refuse to observe it"), the same
-    // category as the address normalization that already drops 0x0. Without
-    // this, a denylisted test token's edge would reappear on the graph with
-    // the next test transfer. The denylist is read inside the serializable
-    // write transaction — a run processes up to 50 pages, so a run-level
-    // snapshot could go stale mid-run and insert a relation right after a
-    // denylist plan deleted it. Reading here means this transaction either
-    // sees the entry, or serializes before the denylist execution, whose
-    // in-transaction plan regeneration then sees the new relation and makes
-    // the operator re-plan the deletion.
-    return await this.tokenDb.transaction(async () => {
-      const denylisted = tokenKeySet(await this.tokenDb.tokenDenylist.getAll())
-      const inserts = newRelations.filter(
-        (relation) => !hasDenylistedEndpoint(relation, denylisted),
-      )
-      const updates = resolutions.filter(
-        (relation) => !hasDenylistedEndpoint(relation, denylisted),
-      )
-      for (const relation of inserts) {
+    await this.tokenDb.transaction(async () => {
+      for (const relation of newRelations) {
         await commitTokenChanges(
           this.tokenDb,
           [{ type: 'AddTokenRelationCommand', record: relation }],
           { kind: 'ingestion', log: formatRelationLog(relation) },
         )
       }
-      for (const relation of updates) {
+      for (const relation of resolutions) {
         await commitTokenChanges(
           this.tokenDb,
           [
@@ -182,8 +165,8 @@ export class TokenRelationIngestion {
           { kind: 'ingestion', log: formatResolutionLog(relation) },
         )
       }
-      return { inserted: inserts.length, resolved: updates.length }
-    }, 'serializable')
+    })
+    return { inserted: newRelations.length, resolved: resolutions.length }
   }
 }
 
@@ -261,26 +244,6 @@ function relationKey(relation: TokenRelationRoute): string {
     relation.plugin,
     relation.bridgeType,
   ].join(':')
-}
-
-function tokenKeySet(
-  entries: { chain: string; address: string }[],
-): Set<string> {
-  return new Set(
-    entries.map((entry) => `${entry.chain}:${entry.address.toLowerCase()}`),
-  )
-}
-
-function hasDenylistedEndpoint(
-  route: TokenRelationRoute,
-  denylisted: Set<string>,
-): boolean {
-  // Route endpoints are already normalized (lowercase) by
-  // `normalizeTransferSide` / `normalizeTokenRelation`.
-  return (
-    denylisted.has(`${route.tokenAChain}:${route.tokenAAddress}`) ||
-    denylisted.has(`${route.tokenBChain}:${route.tokenBAddress}`)
-  )
 }
 
 function formatRelationLog(relation: TokenRelationRoute): string {

--- a/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
+++ b/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
@@ -55,14 +55,6 @@ export class TokenRelationIngestion {
     )
     let lastSerialId = setting?.value ?? '0'
 
-    // Relations are recorded without consulting the token *catalogue* — but
-    // the denylist is not the catalogue. An entry is an explicit human ban
-    // ("this address is not a real asset; refuse to observe it"), the same
-    // category as the address normalization that already drops 0x0. Without
-    // this, a denylisted test token's edge would reappear on the graph with
-    // the next test transfer.
-    const denylisted = tokenKeySet(await this.tokenDb.tokenDenylist.getAll())
-
     for (let page = 0; page < MAX_PAGES_PER_RUN; page++) {
       const batch = await this.db.interopTransfer.getAfterSerialId(
         lastSerialId,
@@ -72,7 +64,7 @@ export class TokenRelationIngestion {
         break
       }
 
-      const outcome = await this.ingestBatch(batch.transfers, denylisted)
+      const outcome = await this.ingestBatch(batch.transfers)
       inserted += outcome.inserted
       resolved += outcome.resolved
       scanned += batch.transfers.length
@@ -99,7 +91,6 @@ export class TokenRelationIngestion {
 
   private async ingestBatch(
     transfers: InteropTransferRecord[],
-    denylisted: Set<string>,
   ): Promise<{ inserted: number; resolved: number }> {
     const candidates = new Map<
       string,
@@ -107,9 +98,6 @@ export class TokenRelationIngestion {
     >()
     for (const transfer of transfers) {
       const route = tokenRouteFromTransfer(transfer)
-      if (route && hasDenylistedEndpoint(route, denylisted)) {
-        continue
-      }
       if (route && !candidates.has(relationKey(route))) {
         candidates.set(relationKey(route), { route, transfer })
       }
@@ -153,15 +141,34 @@ export class TokenRelationIngestion {
         ),
       }),
     )
-    await this.tokenDb.transaction(async () => {
-      for (const relation of newRelations) {
+    // Relations are recorded without consulting the token *catalogue* — but
+    // the denylist is not the catalogue. An entry is an explicit human ban
+    // ("this address is not a real asset; refuse to observe it"), the same
+    // category as the address normalization that already drops 0x0. Without
+    // this, a denylisted test token's edge would reappear on the graph with
+    // the next test transfer. The denylist is read inside the serializable
+    // write transaction — a run processes up to 50 pages, so a run-level
+    // snapshot could go stale mid-run and insert a relation right after a
+    // denylist plan deleted it. Reading here means this transaction either
+    // sees the entry, or serializes before the denylist execution, whose
+    // in-transaction plan regeneration then sees the new relation and makes
+    // the operator re-plan the deletion.
+    return await this.tokenDb.transaction(async () => {
+      const denylisted = tokenKeySet(await this.tokenDb.tokenDenylist.getAll())
+      const inserts = newRelations.filter(
+        (relation) => !hasDenylistedEndpoint(relation, denylisted),
+      )
+      const updates = resolutions.filter(
+        (relation) => !hasDenylistedEndpoint(relation, denylisted),
+      )
+      for (const relation of inserts) {
         await commitTokenChanges(
           this.tokenDb,
           [{ type: 'AddTokenRelationCommand', record: relation }],
           { kind: 'ingestion', log: formatRelationLog(relation) },
         )
       }
-      for (const relation of resolutions) {
+      for (const relation of updates) {
         await commitTokenChanges(
           this.tokenDb,
           [
@@ -175,8 +182,8 @@ export class TokenRelationIngestion {
           { kind: 'ingestion', log: formatResolutionLog(relation) },
         )
       }
-    })
-    return { inserted: newRelations.length, resolved: resolutions.length }
+      return { inserted: inserts.length, resolved: updates.length }
+    }, 'serializable')
   }
 }
 

--- a/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
+++ b/packages/token-backend/src/ingestion/TokenRelationIngestion.ts
@@ -32,10 +32,10 @@ const MAX_PAGES_PER_RUN = 50
  * addresses via this plugin". It is recorded unconditionally — without
  * consulting the token catalogue or the denylist — so no interpretation
  * (token-level conflict, human ban) can ever suppress relation evidence.
- * Interpretation surfaces filter instead: the relations graph drops
- * relations touching denylisted addresses. This is deliberately NOT part of
- * the token ingestion queue. See
- * docs/mdbook/specs/l2b_specs/token_db/token_relations.md.
+ * Interpretation surfaces act instead: the relations graph drops relations
+ * touching denylisted addresses, and the Relations tab marks the banned
+ * endpoint. This is deliberately NOT part of the token ingestion queue.
+ * See docs/mdbook/specs/l2b_specs/token_db/token_relations.md.
  */
 export class TokenRelationIngestion {
   constructor(

--- a/packages/token-backend/src/ingestion/formatIngestionTrace.ts
+++ b/packages/token-backend/src/ingestion/formatIngestionTrace.ts
@@ -37,6 +37,8 @@ export function describeIngestionStep(step: IngestionStep): string {
   switch (step.kind) {
     case 'invalid-address':
       return `Address ${step.rawAddress} could not be normalized.`
+    case 'token-denylisted':
+      return `Address is denylisted (${step.reason}) — ingestion refuses to touch it.`
     case 'existing-token':
       return `Found existing deployed token (abstract: ${step.record.abstractTokenId ?? 'none'}).`
     case 'no-existing-token':

--- a/packages/token-backend/src/intents.ts
+++ b/packages/token-backend/src/intents.ts
@@ -75,20 +75,18 @@ export const DeleteDeployedTokenIntent = v.object({
  * denylisted → recreated by ingestion; denylisted but not deleted → stale
  * catalogue entry).
  */
-export type DenylistDeployedTokenIntent = v.infer<
-  typeof DenylistDeployedTokenIntent
->
-export const DenylistDeployedTokenIntent = v.object({
-  type: v.literal('DenylistDeployedTokenIntent'),
+export type AddTokenToDenylistIntent = v.infer<typeof AddTokenToDenylistIntent>
+export const AddTokenToDenylistIntent = v.object({
+  type: v.literal('AddTokenToDenylistIntent'),
   pk: DeployedTokenPrimaryKey,
   reason: v.string(),
 })
 
-export type RemoveTokenDenylistEntryIntent = v.infer<
-  typeof RemoveTokenDenylistEntryIntent
+export type DeleteTokenFromDenylistIntent = v.infer<
+  typeof DeleteTokenFromDenylistIntent
 >
-export const RemoveTokenDenylistEntryIntent = v.object({
-  type: v.literal('RemoveTokenDenylistEntryIntent'),
+export const DeleteTokenFromDenylistIntent = v.object({
+  type: v.literal('DeleteTokenFromDenylistIntent'),
   pk: DeployedTokenPrimaryKey,
 })
 
@@ -124,8 +122,8 @@ export const Intent = v.union([
   AddDeployedTokenIntent,
   UpdateDeployedTokenIntent,
   DeleteDeployedTokenIntent,
-  DenylistDeployedTokenIntent,
-  RemoveTokenDenylistEntryIntent,
+  AddTokenToDenylistIntent,
+  DeleteTokenFromDenylistIntent,
   AddTokenRelationIntent,
   UpdateTokenRelationIntent,
   DeleteTokenRelationIntent,

--- a/packages/token-backend/src/intents.ts
+++ b/packages/token-backend/src/intents.ts
@@ -69,11 +69,11 @@ export const DeleteDeployedTokenIntent = v.object({
 
 /**
  * Ban an address from TokenDB in one confirmable step: add the denylist
- * entry and, when present, delete the catalogued deployed token and every
- * relation touching the address. One intent rather than separate delete +
- * denylist actions, so no half-state is reachable (deleted but not
- * denylisted → recreated by ingestion; denylisted but not deleted → stale
- * catalogue entry).
+ * entry and, when present, delete the catalogued deployed token. One intent
+ * rather than separate delete + denylist actions, so no half-state is
+ * reachable (deleted but not denylisted → recreated by ingestion; denylisted
+ * but not deleted → stale catalogue entry). Relations touching the address
+ * are observations and stay recorded.
  */
 export type AddTokenToDenylistIntent = v.infer<typeof AddTokenToDenylistIntent>
 export const AddTokenToDenylistIntent = v.object({

--- a/packages/token-backend/src/intents.ts
+++ b/packages/token-backend/src/intents.ts
@@ -67,6 +67,31 @@ export const DeleteDeployedTokenIntent = v.object({
   pk: DeployedTokenPrimaryKey,
 })
 
+/**
+ * Ban an address from TokenDB in one confirmable step: add the denylist
+ * entry and, when present, delete the catalogued deployed token and every
+ * relation touching the address. One intent rather than separate delete +
+ * denylist actions, so no half-state is reachable (deleted but not
+ * denylisted → recreated by ingestion; denylisted but not deleted → stale
+ * catalogue entry).
+ */
+export type DenylistDeployedTokenIntent = v.infer<
+  typeof DenylistDeployedTokenIntent
+>
+export const DenylistDeployedTokenIntent = v.object({
+  type: v.literal('DenylistDeployedTokenIntent'),
+  pk: DeployedTokenPrimaryKey,
+  reason: v.string(),
+})
+
+export type RemoveTokenDenylistEntryIntent = v.infer<
+  typeof RemoveTokenDenylistEntryIntent
+>
+export const RemoveTokenDenylistEntryIntent = v.object({
+  type: v.literal('RemoveTokenDenylistEntryIntent'),
+  pk: DeployedTokenPrimaryKey,
+})
+
 export type AddTokenRelationIntent = v.infer<typeof AddTokenRelationIntent>
 export const AddTokenRelationIntent = v.object({
   type: v.literal('AddTokenRelationIntent'),
@@ -99,6 +124,8 @@ export const Intent = v.union([
   AddDeployedTokenIntent,
   UpdateDeployedTokenIntent,
   DeleteDeployedTokenIntent,
+  DenylistDeployedTokenIntent,
+  RemoveTokenDenylistEntryIntent,
   AddTokenRelationIntent,
   UpdateTokenRelationIntent,
   DeleteTokenRelationIntent,

--- a/packages/token-backend/src/planning.test.ts
+++ b/packages/token-backend/src/planning.test.ts
@@ -357,26 +357,22 @@ describe('planning proof stamping', () => {
   })
 })
 
-describe('DenylistDeployedTokenIntent', () => {
-  it('adds the entry and deletes the token and its relations in one plan', async () => {
+describe('AddTokenToDenylistIntent', () => {
+  it('adds the entry and deletes the token, leaving relations untouched', async () => {
     const existing = deployedRecord('ethereum', '0xaaa', 'USDC01')
-    const relationOne = tokenRelation(existing, {
+    const relation = tokenRelation(existing, {
       chain: 'arbitrum',
       address: '0xbbb',
     })
-    const relationTwo = {
-      ...tokenRelation(existing, { chain: 'base', address: '0xccc' }),
-      plugin: 'otherbridge',
-    }
     const db = mockDb({
       existingDeployed: existing,
-      relations: [relationTwo, relationOne],
+      relations: [relation],
     })
 
     const result = await generatePlan(
       db,
       {
-        type: 'DenylistDeployedTokenIntent',
+        type: 'AddTokenToDenylistIntent',
         pk: { chain: existing.chain, address: existing.address },
         reason: 'test token',
       },
@@ -384,9 +380,12 @@ describe('DenylistDeployedTokenIntent', () => {
     )
 
     assertSuccess(result)
+    // No DeleteTokenRelationCommand even though a relation exists: relations
+    // are observations and no interpretation (including a ban) deletes them.
+    // The relations graph filters denylisted endpoints at display time.
     expect(result.plan.commands).toEqual([
       {
-        type: 'AddTokenDenylistEntryCommand',
+        type: 'AddTokenToDenylistCommand',
         record: {
           chain: existing.chain,
           address: existing.address,
@@ -398,18 +397,6 @@ describe('DenylistDeployedTokenIntent', () => {
         pk: { chain: existing.chain, address: existing.address },
         existing,
       },
-      // Relations sorted deterministically (plugin first): otherbridge before
-      // superbridge.
-      {
-        type: 'DeleteTokenRelationCommand',
-        pk: relationPk(relationTwo),
-        existing: relationTwo,
-      },
-      {
-        type: 'DeleteTokenRelationCommand',
-        pk: relationPk(relationOne),
-        existing: relationOne,
-      },
     ])
   })
 
@@ -419,8 +406,8 @@ describe('DenylistDeployedTokenIntent', () => {
     const result = await generatePlan(
       db,
       {
-        type: 'DenylistDeployedTokenIntent',
-        pk: { chain: 'arbitrum', address: '0xAAA' },
+        type: 'AddTokenToDenylistIntent',
+        pk: { chain: 'arbitrum', address: paddedAddress('0xAAA') },
         reason: 'test token',
       },
       { user: USER, skipLogs: true },
@@ -429,8 +416,121 @@ describe('DenylistDeployedTokenIntent', () => {
     assertSuccess(result)
     expect(result.plan.commands).toEqual([
       {
-        type: 'AddTokenDenylistEntryCommand',
-        record: { chain: 'arbitrum', address: '0xaaa', reason: 'test token' },
+        type: 'AddTokenToDenylistCommand',
+        record: {
+          chain: 'arbitrum',
+          address: paddedAddress('0xaaa'),
+          reason: 'test token',
+        },
+      },
+    ])
+  })
+
+  it('crops an Address32-form address to the form the catalogue uses', async () => {
+    // The missing-tokens dashboard displays Address32 forms; a ban recorded
+    // under that form would never match an ingestion lookup.
+    const existing = deployedRecord('ethereum', '0xaaa', 'USDC01')
+    const address32 = `0x${'0'.repeat(24)}${existing.address.slice(2)}`
+    const db = mockDb({
+      deployedByPk: { [`ethereum:${existing.address}`]: existing },
+    })
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'AddTokenToDenylistIntent',
+        pk: { chain: 'ethereum', address: address32 },
+        reason: 'test token',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    assertSuccess(result)
+    expect(result.plan.commands).toEqual([
+      {
+        type: 'AddTokenToDenylistCommand',
+        record: {
+          chain: 'ethereum',
+          address: existing.address,
+          reason: 'test token',
+        },
+      },
+      {
+        type: 'DeleteDeployedTokenCommand',
+        pk: { chain: 'ethereum', address: existing.address },
+        existing,
+      },
+    ])
+  })
+
+  it('fails for a value that is not a token address', async () => {
+    const db = mockDb({})
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'AddTokenToDenylistIntent',
+        pk: { chain: 'arbitrum', address: '0xnothex' },
+        reason: 'test token',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: '0xnothex is not a valid token address',
+    })
+  })
+
+  it('fails when the chain is unknown and nothing references the address', async () => {
+    // The chain field is free-form text — a typo'd chain would record an
+    // entry that bans nothing while the UI reports success.
+    const db = mockDb({ knownChains: ['arbitrum'] })
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'AddTokenToDenylistIntent',
+        pk: { chain: 'arbtirum', address: paddedAddress('0xaaa') },
+        reason: 'test token',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: `Chain arbtirum is not known to TokenDB and nothing references arbtirum+${paddedAddress('0xaaa')} — check the chain for a typo`,
+    })
+  })
+
+  it('denylists an address on an unknown chain when it is queued for ingestion', async () => {
+    // Production has queued tokens on chains that were never added to the
+    // chain table — the queue entry proves the chain string is what
+    // ingestion uses, so the ban is meaningful.
+    const db = mockDb({
+      knownChains: [],
+      queued: [{ chain: 'solana', address: paddedAddress('0xaaa') }],
+    })
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'AddTokenToDenylistIntent',
+        pk: { chain: 'solana', address: paddedAddress('0xAAA') },
+        reason: 'test token',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    assertSuccess(result)
+    expect(result.plan.commands).toEqual([
+      {
+        type: 'AddTokenToDenylistCommand',
+        record: {
+          chain: 'solana',
+          address: paddedAddress('0xaaa'),
+          reason: 'test token',
+        },
       },
     ])
   })
@@ -440,7 +540,7 @@ describe('DenylistDeployedTokenIntent', () => {
       denylisted: [
         {
           chain: 'arbitrum',
-          address: '0xaaa',
+          address: paddedAddress('0xaaa'),
           reason: 'test token',
           createdAt: 1,
         },
@@ -450,8 +550,8 @@ describe('DenylistDeployedTokenIntent', () => {
     const result = await generatePlan(
       db,
       {
-        type: 'DenylistDeployedTokenIntent',
-        pk: { chain: 'arbitrum', address: '0xAAA' },
+        type: 'AddTokenToDenylistIntent',
+        pk: { chain: 'arbitrum', address: paddedAddress('0xAAA') },
         reason: 'again',
       },
       { user: USER, skipLogs: true },
@@ -459,7 +559,7 @@ describe('DenylistDeployedTokenIntent', () => {
 
     expect(result).toEqual({
       outcome: 'error',
-      error: 'arbitrum+0xaaa is already denylisted (test token)',
+      error: `arbitrum+${paddedAddress('0xaaa')} is already denylisted (test token)`,
     })
   })
 
@@ -469,8 +569,8 @@ describe('DenylistDeployedTokenIntent', () => {
     const result = await generatePlan(
       db,
       {
-        type: 'DenylistDeployedTokenIntent',
-        pk: { chain: 'arbitrum', address: '0xaaa' },
+        type: 'AddTokenToDenylistIntent',
+        pk: { chain: 'arbitrum', address: paddedAddress('0xaaa') },
         reason: '  ',
       },
       { user: USER, skipLogs: true },
@@ -483,11 +583,11 @@ describe('DenylistDeployedTokenIntent', () => {
   })
 })
 
-describe('RemoveTokenDenylistEntryIntent', () => {
+describe('DeleteTokenFromDenylistIntent', () => {
   it('deletes an existing entry', async () => {
     const entry = {
       chain: 'arbitrum',
-      address: '0xaaa',
+      address: paddedAddress('0xaaa'),
       reason: 'test token',
       createdAt: 1,
     }
@@ -496,8 +596,8 @@ describe('RemoveTokenDenylistEntryIntent', () => {
     const result = await generatePlan(
       db,
       {
-        type: 'RemoveTokenDenylistEntryIntent',
-        pk: { chain: 'arbitrum', address: '0xaaa' },
+        type: 'DeleteTokenFromDenylistIntent',
+        pk: { chain: 'arbitrum', address: paddedAddress('0xaaa') },
       },
       { user: USER, skipLogs: true },
     )
@@ -505,8 +605,39 @@ describe('RemoveTokenDenylistEntryIntent', () => {
     assertSuccess(result)
     expect(result.plan.commands).toEqual([
       {
-        type: 'DeleteTokenDenylistEntryCommand',
-        pk: { chain: 'arbitrum', address: '0xaaa' },
+        type: 'DeleteTokenFromDenylistCommand',
+        pk: { chain: 'arbitrum', address: paddedAddress('0xaaa') },
+        existing: entry,
+      },
+    ])
+  })
+
+  it('finds the entry through an Address32-form address', async () => {
+    const entry = {
+      chain: 'arbitrum',
+      address: paddedAddress('0xaaa'),
+      reason: 'test token',
+      createdAt: 1,
+    }
+    const db = mockDb({ denylisted: [entry] })
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'DeleteTokenFromDenylistIntent',
+        pk: {
+          chain: 'arbitrum',
+          address: `0x${'0'.repeat(24)}${paddedAddress('0xaaa').slice(2)}`,
+        },
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    assertSuccess(result)
+    expect(result.plan.commands).toEqual([
+      {
+        type: 'DeleteTokenFromDenylistCommand',
+        pk: { chain: 'arbitrum', address: paddedAddress('0xaaa') },
         existing: entry,
       },
     ])
@@ -518,15 +649,15 @@ describe('RemoveTokenDenylistEntryIntent', () => {
     const result = await generatePlan(
       db,
       {
-        type: 'RemoveTokenDenylistEntryIntent',
-        pk: { chain: 'arbitrum', address: '0xaaa' },
+        type: 'DeleteTokenFromDenylistIntent',
+        pk: { chain: 'arbitrum', address: paddedAddress('0xaaa') },
       },
       { user: USER, skipLogs: true },
     )
 
     expect(result).toEqual({
       outcome: 'error',
-      error: 'arbitrum+0xaaa is not denylisted',
+      error: `arbitrum+${paddedAddress('0xaaa')} is not denylisted`,
     })
   })
 })
@@ -742,6 +873,9 @@ function mockDb(opts: {
   existingRelation?: ReturnType<typeof tokenRelation>
   relations?: ReturnType<typeof tokenRelation>[]
   denylisted?: TokenDenylistEntryRecord[]
+  /** Chains known to the chain table. Undefined means every chain exists. */
+  knownChains?: string[]
+  queued?: { chain: string; address: string }[]
 }): TokenDatabase {
   const findDeployed = mockFn().executes(
     async (pk: { chain: string; address: string }) => {
@@ -753,6 +887,38 @@ function mockDb(opts: {
   )
 
   return mockObject<TokenDatabase>({
+    chain: mockObject<TokenDatabase['chain']>({
+      findByName: mockFn().executes(async (name: string) =>
+        opts.knownChains === undefined || opts.knownChains.includes(name)
+          ? {
+              name,
+              chainId: 1,
+              explorerUrl: null,
+              aliases: null,
+              apis: null,
+            }
+          : undefined,
+      ),
+    }),
+    tokenIngestionQueue: mockObject<TokenDatabase['tokenIngestionQueue']>({
+      findByChainAndAddress: mockFn().executes(
+        async (pk: { chain: string; address: string }) => {
+          const entry = opts.queued?.find(
+            (queued) =>
+              queued.chain === pk.chain &&
+              queued.address === pk.address.toLowerCase(),
+          )
+          if (!entry) return undefined
+          return {
+            ...entry,
+            state: 'pending' as const,
+            message: null,
+            createdAt: UnixTime(1),
+            updatedAt: UnixTime(1),
+          }
+        },
+      ),
+    }),
     deployedToken: mockObject<TokenDatabase['deployedToken']>({
       findByChainAndAddress: findDeployed,
       getByAbstractTokenId: mockFn((id: string) =>
@@ -808,6 +974,10 @@ function abstractRecord(
   }
 }
 
+function paddedAddress(shortAddress: string): string {
+  return `0x${shortAddress.slice(2).toLowerCase().padStart(40, '0')}`
+}
+
 function deployedRecord(
   chain: string,
   shortAddress: string,
@@ -815,7 +985,7 @@ function deployedRecord(
 ): DeployedTokenRecord {
   return {
     chain,
-    address: `0x${shortAddress.slice(2).padStart(40, '0')}`,
+    address: paddedAddress(shortAddress),
     abstractTokenId,
     symbol: 'USDC',
     decimals: 6,

--- a/packages/token-backend/src/planning.test.ts
+++ b/packages/token-backend/src/planning.test.ts
@@ -2,6 +2,7 @@ import type {
   AbstractTokenRecord,
   DeployedTokenRecord,
   TokenDatabase,
+  TokenDenylistEntryRecord,
 } from '@l2beat/database'
 import { UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
@@ -356,6 +357,207 @@ describe('planning proof stamping', () => {
   })
 })
 
+describe('DenylistDeployedTokenIntent', () => {
+  it('adds the entry and deletes the token and its relations in one plan', async () => {
+    const existing = deployedRecord('ethereum', '0xaaa', 'USDC01')
+    const relationOne = tokenRelation(existing, {
+      chain: 'arbitrum',
+      address: '0xbbb',
+    })
+    const relationTwo = {
+      ...tokenRelation(existing, { chain: 'base', address: '0xccc' }),
+      plugin: 'otherbridge',
+    }
+    const db = mockDb({
+      existingDeployed: existing,
+      relations: [relationTwo, relationOne],
+    })
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'DenylistDeployedTokenIntent',
+        pk: { chain: existing.chain, address: existing.address },
+        reason: 'test token',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    assertSuccess(result)
+    expect(result.plan.commands).toEqual([
+      {
+        type: 'AddTokenDenylistEntryCommand',
+        record: {
+          chain: existing.chain,
+          address: existing.address,
+          reason: 'test token',
+        },
+      },
+      {
+        type: 'DeleteDeployedTokenCommand',
+        pk: { chain: existing.chain, address: existing.address },
+        existing,
+      },
+      // Relations sorted deterministically (plugin first): otherbridge before
+      // superbridge.
+      {
+        type: 'DeleteTokenRelationCommand',
+        pk: relationPk(relationTwo),
+        existing: relationTwo,
+      },
+      {
+        type: 'DeleteTokenRelationCommand',
+        pk: relationPk(relationOne),
+        existing: relationOne,
+      },
+    ])
+  })
+
+  it('denylists an uncatalogued address with no relations', async () => {
+    const db = mockDb({})
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'DenylistDeployedTokenIntent',
+        pk: { chain: 'arbitrum', address: '0xAAA' },
+        reason: 'test token',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    assertSuccess(result)
+    expect(result.plan.commands).toEqual([
+      {
+        type: 'AddTokenDenylistEntryCommand',
+        record: { chain: 'arbitrum', address: '0xaaa', reason: 'test token' },
+      },
+    ])
+  })
+
+  it('fails when the address is already denylisted', async () => {
+    const db = mockDb({
+      denylisted: [
+        {
+          chain: 'arbitrum',
+          address: '0xaaa',
+          reason: 'test token',
+          createdAt: 1,
+        },
+      ],
+    })
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'DenylistDeployedTokenIntent',
+        pk: { chain: 'arbitrum', address: '0xAAA' },
+        reason: 'again',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: 'arbitrum+0xaaa is already denylisted (test token)',
+    })
+  })
+
+  it('fails without a reason', async () => {
+    const db = mockDb({})
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'DenylistDeployedTokenIntent',
+        pk: { chain: 'arbitrum', address: '0xaaa' },
+        reason: '  ',
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: 'A denylist entry requires a reason',
+    })
+  })
+})
+
+describe('RemoveTokenDenylistEntryIntent', () => {
+  it('deletes an existing entry', async () => {
+    const entry = {
+      chain: 'arbitrum',
+      address: '0xaaa',
+      reason: 'test token',
+      createdAt: 1,
+    }
+    const db = mockDb({ denylisted: [entry] })
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'RemoveTokenDenylistEntryIntent',
+        pk: { chain: 'arbitrum', address: '0xaaa' },
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    assertSuccess(result)
+    expect(result.plan.commands).toEqual([
+      {
+        type: 'DeleteTokenDenylistEntryCommand',
+        pk: { chain: 'arbitrum', address: '0xaaa' },
+        existing: entry,
+      },
+    ])
+  })
+
+  it('fails when the entry does not exist', async () => {
+    const db = mockDb({})
+
+    const result = await generatePlan(
+      db,
+      {
+        type: 'RemoveTokenDenylistEntryIntent',
+        pk: { chain: 'arbitrum', address: '0xaaa' },
+      },
+      { user: USER, skipLogs: true },
+    )
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: 'arbitrum+0xaaa is not denylisted',
+    })
+  })
+})
+
+describe('AddDeployedTokenIntent denylist gate', () => {
+  it('refuses to add a denylisted address', async () => {
+    const record = deployedRecord('ethereum', '0xaaa', 'USDC01')
+    const db = mockDb({
+      denylisted: [
+        {
+          chain: record.chain,
+          address: record.address,
+          reason: 'test token',
+          createdAt: 1,
+        },
+      ],
+    })
+
+    const result = await generatePlan(
+      db,
+      { type: 'AddDeployedTokenIntent', record },
+      { user: USER, skipLogs: true },
+    )
+
+    expect(result).toEqual({
+      outcome: 'error',
+      error: `DeployedToken ${record.chain}+${record.address} is denylisted (test token) — remove the denylist entry first`,
+    })
+  })
+})
+
 describe('MergeAbstractTokenIntent', () => {
   it('copies source CoinGecko entries, reassigns deployed tokens, and deletes source', async () => {
     const source = abstractRecord('SOURCE', 'USDC', {
@@ -538,6 +740,8 @@ function mockDb(opts: {
   deployedTokens?: DeployedTokenRecord[]
   deployedByPk?: Record<string, DeployedTokenRecord>
   existingRelation?: ReturnType<typeof tokenRelation>
+  relations?: ReturnType<typeof tokenRelation>[]
+  denylisted?: TokenDenylistEntryRecord[]
 }): TokenDatabase {
   const findDeployed = mockFn().executes(
     async (pk: { chain: string; address: string }) => {
@@ -568,6 +772,17 @@ function mockDb(opts: {
     }),
     tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
       findByPrimaryKey: mockFn().resolvesTo(opts.existingRelation),
+      getRelationsFor: mockFn().resolvesTo(opts.relations ?? []),
+    }),
+    tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
+      findByChainAndAddress: mockFn().executes(
+        async (pk: { chain: string; address: string }) =>
+          opts.denylisted?.find(
+            (entry) =>
+              entry.chain === pk.chain &&
+              entry.address === pk.address.toLowerCase(),
+          ),
+      ),
     }),
   })
 }

--- a/packages/token-backend/src/planning.ts
+++ b/packages/token-backend/src/planning.ts
@@ -362,8 +362,9 @@ async function planDeleteDeployedToken(
  *
  * Relations touching the address are deliberately NOT deleted: they are
  * observations of on-chain transfers and stay recorded regardless of any
- * interpretation — including this ban. Interpretation surfaces (the
- * relations graph) filter denylisted endpoints out instead.
+ * interpretation — including this ban. Interpretation surfaces act instead:
+ * the relations graph filters denylisted endpoints out, the Relations tab
+ * marks them.
  *
  * The token does not have to exist — an uncatalogued address observed only
  * in relations can be denylisted too.

--- a/packages/token-backend/src/planning.ts
+++ b/packages/token-backend/src/planning.ts
@@ -14,8 +14,10 @@ import {
   type DeleteAbstractTokenIntent,
   type DeleteDeployedTokenIntent,
   type DeleteTokenRelationIntent,
+  type DenylistDeployedTokenIntent,
   Intent,
   type MergeAbstractTokenIntent,
+  type RemoveTokenDenylistEntryIntent,
   type UpdateAbstractTokenIntent,
   type UpdateDeployedTokenIntent,
   type UpdateTokenRelationIntent,
@@ -96,6 +98,12 @@ export async function generatePlan(
 
       case 'DeleteDeployedTokenIntent':
         commands = await planDeleteDeployedToken(db, intent)
+        break
+      case 'DenylistDeployedTokenIntent':
+        commands = await planDenylistDeployedToken(db, intent)
+        break
+      case 'RemoveTokenDenylistEntryIntent':
+        commands = await planRemoveTokenDenylistEntry(db, intent)
         break
       case 'AddTokenRelationIntent':
         commands = await planAddTokenRelation(db, intent)
@@ -279,6 +287,12 @@ async function planAddDeployedToken(
   opts: PlanOptions,
 ): Promise<Command[]> {
   const record = intent.record
+  const denylisted = await db.tokenDenylist.findByChainAndAddress(record)
+  if (denylisted !== undefined) {
+    throw new PlanningError(
+      `DeployedToken ${record.chain}+${record.address} is denylisted (${denylisted.reason}) — remove the denylist entry first`,
+    )
+  }
   const existing = await db.deployedToken.findByChainAndAddress(record)
   if (existing !== undefined) {
     throw new PlanningError(
@@ -335,6 +349,96 @@ async function planDeleteDeployedToken(
       existing,
     },
   ]
+}
+
+/**
+ * One confirmable ban: add the denylist entry and clean up everything TokenDB
+ * currently holds about the address. The deployed token (when catalogued) and
+ * all relations touching the address are deleted in the same plan, so the
+ * user sees the full blast radius before confirming and no half-state is
+ * reachable. All deleted records land in `TokenDbHistory` via the executed
+ * commands, from which they can be reconstructed if the ban was a mistake.
+ *
+ * The token does not have to exist — an uncatalogued address observed only in
+ * relations can be denylisted too.
+ */
+async function planDenylistDeployedToken(
+  db: TokenDatabase,
+  intent: DenylistDeployedTokenIntent,
+): Promise<Command[]> {
+  if (intent.reason.trim() === '') {
+    throw new PlanningError('A denylist entry requires a reason')
+  }
+  const pk = {
+    chain: intent.pk.chain,
+    address: intent.pk.address.toLowerCase(),
+  }
+
+  const [alreadyDenylisted, existingToken, relations] = await Promise.all([
+    db.tokenDenylist.findByChainAndAddress(pk),
+    db.deployedToken.findByChainAndAddress(pk),
+    db.tokenRelation.getRelationsFor(pk),
+  ])
+  if (alreadyDenylisted !== undefined) {
+    throw new PlanningError(
+      `${pk.chain}+${pk.address} is already denylisted (${alreadyDenylisted.reason})`,
+    )
+  }
+
+  const commands: Command[] = [
+    {
+      type: 'AddTokenDenylistEntryCommand',
+      record: { ...pk, reason: intent.reason },
+    },
+  ]
+  if (existingToken !== undefined) {
+    commands.push({
+      type: 'DeleteDeployedTokenCommand',
+      pk,
+      existing: existingToken,
+    })
+  }
+  for (const relation of [...relations].sort(compareTokenRelations)) {
+    commands.push({
+      type: 'DeleteTokenRelationCommand',
+      pk: toTokenRelationPrimaryKey(relation),
+      existing: relation,
+    })
+  }
+  return commands
+}
+
+async function planRemoveTokenDenylistEntry(
+  db: TokenDatabase,
+  intent: RemoveTokenDenylistEntryIntent,
+): Promise<Command[]> {
+  const existing = await db.tokenDenylist.findByChainAndAddress(intent.pk)
+  if (existing === undefined) {
+    throw new PlanningError(
+      `${intent.pk.chain}+${intent.pk.address} is not denylisted`,
+    )
+  }
+  // Removal only lifts the ban. The deleted token and relations are not
+  // restored automatically — ingestion re-creates them from live transfers,
+  // or a human re-adds them from history.
+  return [
+    {
+      type: 'DeleteTokenDenylistEntryCommand',
+      pk: { chain: existing.chain, address: existing.address },
+      existing,
+    },
+  ]
+}
+
+function compareTokenRelations(a: TokenRelationRecord, b: TokenRelationRecord) {
+  return (
+    a.plugin.localeCompare(b.plugin) ||
+    a.bridgeType.localeCompare(b.bridgeType) ||
+    a.tokenAChain.localeCompare(b.tokenAChain) ||
+    a.tokenAAddress.localeCompare(b.tokenAAddress) ||
+    a.tokenBChain.localeCompare(b.tokenBChain) ||
+    a.tokenBAddress.localeCompare(b.tokenBAddress)
+  )
 }
 
 function mergeAdditionalCoingeckoEntries(

--- a/packages/token-backend/src/planning.ts
+++ b/packages/token-backend/src/planning.ts
@@ -7,17 +7,18 @@ import { assertUnreachable } from '@l2beat/shared-pure'
 import { v } from '@l2beat/validate'
 import { Command } from './commands'
 import { manualProof } from './commitTokenChanges'
+import { normalizeInteropTokenAddress } from './ingestion/tokenIngestionUtils'
 import {
   type AddAbstractTokenIntent,
   type AddDeployedTokenIntent,
   type AddTokenRelationIntent,
+  type AddTokenToDenylistIntent,
   type DeleteAbstractTokenIntent,
   type DeleteDeployedTokenIntent,
+  type DeleteTokenFromDenylistIntent,
   type DeleteTokenRelationIntent,
-  type DenylistDeployedTokenIntent,
   Intent,
   type MergeAbstractTokenIntent,
-  type RemoveTokenDenylistEntryIntent,
   type UpdateAbstractTokenIntent,
   type UpdateDeployedTokenIntent,
   type UpdateTokenRelationIntent,
@@ -99,11 +100,11 @@ export async function generatePlan(
       case 'DeleteDeployedTokenIntent':
         commands = await planDeleteDeployedToken(db, intent)
         break
-      case 'DenylistDeployedTokenIntent':
-        commands = await planDenylistDeployedToken(db, intent)
+      case 'AddTokenToDenylistIntent':
+        commands = await planAddTokenToDenylist(db, intent)
         break
-      case 'RemoveTokenDenylistEntryIntent':
-        commands = await planRemoveTokenDenylistEntry(db, intent)
+      case 'DeleteTokenFromDenylistIntent':
+        commands = await planDeleteTokenFromDenylist(db, intent)
         break
       case 'AddTokenRelationIntent':
         commands = await planAddTokenRelation(db, intent)
@@ -352,42 +353,71 @@ async function planDeleteDeployedToken(
 }
 
 /**
- * One confirmable ban: add the denylist entry and clean up everything TokenDB
- * currently holds about the address. The deployed token (when catalogued) and
- * all relations touching the address are deleted in the same plan, so the
- * user sees the full blast radius before confirming and no half-state is
- * reachable. All deleted records land in `TokenDbHistory` via the executed
- * commands, from which they can be reconstructed if the ban was a mistake.
+ * One confirmable ban: add the denylist entry and delete the catalogued
+ * deployed token in the same plan, so no half-state is reachable (deleted
+ * but not denylisted → recreated by ingestion; denylisted but not deleted →
+ * stale catalogue entry). The deleted record lands in `TokenDbHistory` via
+ * the executed command, from which it can be reconstructed if the ban was a
+ * mistake.
  *
- * The token does not have to exist — an uncatalogued address observed only in
- * relations can be denylisted too.
+ * Relations touching the address are deliberately NOT deleted: they are
+ * observations of on-chain transfers and stay recorded regardless of any
+ * interpretation — including this ban. Interpretation surfaces (the
+ * relations graph) filter denylisted endpoints out instead.
+ *
+ * The token does not have to exist — an uncatalogued address observed only
+ * in relations can be denylisted too.
  */
-async function planDenylistDeployedToken(
+async function planAddTokenToDenylist(
   db: TokenDatabase,
-  intent: DenylistDeployedTokenIntent,
+  intent: AddTokenToDenylistIntent,
 ): Promise<Command[]> {
   if (intent.reason.trim() === '') {
     throw new PlanningError('A denylist entry requires a reason')
   }
-  const pk = {
-    chain: intent.pk.chain,
-    address: intent.pk.address.toLowerCase(),
+  // Ingestion consults the denylist with canonical addresses (Address32
+  // forms cropped to 20 bytes, lowercase). An entry stored under any other
+  // form — e.g. an Address32 pasted from the missing-tokens dashboard —
+  // would never match a lookup and the ban would silently do nothing.
+  const address = normalizeDenylistAddress(intent.pk.address)
+  if (address === undefined) {
+    throw new PlanningError(`${intent.pk.address} is not a valid token address`)
   }
+  const pk = { chain: intent.pk.chain, address }
 
-  const [alreadyDenylisted, existingToken, relations] = await Promise.all([
-    db.tokenDenylist.findByChainAndAddress(pk),
-    db.deployedToken.findByChainAndAddress(pk),
-    db.tokenRelation.getRelationsFor(pk),
-  ])
+  const [alreadyDenylisted, existingToken, relations, chainRecord, queued] =
+    await Promise.all([
+      db.tokenDenylist.findByChainAndAddress(pk),
+      db.deployedToken.findByChainAndAddress(pk),
+      db.tokenRelation.getRelationsFor(pk),
+      db.chain.findByName(pk.chain),
+      db.tokenIngestionQueue.findByChainAndAddress(pk),
+    ])
   if (alreadyDenylisted !== undefined) {
     throw new PlanningError(
       `${pk.chain}+${pk.address} is already denylisted (${alreadyDenylisted.reason})`,
     )
   }
+  // The chain is free-form text on the denylist page — a typo'd chain would
+  // record an entry that bans nothing while the UI reports success. A chain
+  // missing from the chain table is still accepted when TokenDB references
+  // the address under it (production has queued tokens on chains that were
+  // never added to the table): then the string provably matches what
+  // ingestion uses.
+  if (
+    chainRecord === undefined &&
+    existingToken === undefined &&
+    relations.length === 0 &&
+    queued === undefined
+  ) {
+    throw new PlanningError(
+      `Chain ${pk.chain} is not known to TokenDB and nothing references ${pk.chain}+${pk.address} — check the chain for a typo`,
+    )
+  }
 
   const commands: Command[] = [
     {
-      type: 'AddTokenDenylistEntryCommand',
+      type: 'AddTokenToDenylistCommand',
       record: { ...pk, reason: intent.reason },
     },
   ]
@@ -398,47 +428,46 @@ async function planDenylistDeployedToken(
       existing: existingToken,
     })
   }
-  for (const relation of [...relations].sort(compareTokenRelations)) {
-    commands.push({
-      type: 'DeleteTokenRelationCommand',
-      pk: toTokenRelationPrimaryKey(relation),
-      existing: relation,
-    })
-  }
   return commands
 }
 
-async function planRemoveTokenDenylistEntry(
+async function planDeleteTokenFromDenylist(
   db: TokenDatabase,
-  intent: RemoveTokenDenylistEntryIntent,
+  intent: DeleteTokenFromDenylistIntent,
 ): Promise<Command[]> {
-  const existing = await db.tokenDenylist.findByChainAndAddress(intent.pk)
-  if (existing === undefined) {
-    throw new PlanningError(
-      `${intent.pk.chain}+${intent.pk.address} is not denylisted`,
-    )
+  // Entries are stored canonical (see planAddTokenToDenylist), so a
+  // pasted Address32 form must be normalized to find its entry.
+  const address = normalizeDenylistAddress(intent.pk.address)
+  if (address === undefined) {
+    throw new PlanningError(`${intent.pk.address} is not a valid token address`)
   }
-  // Removal only lifts the ban. The deleted token and relations are not
-  // restored automatically — ingestion re-creates them from live transfers,
-  // or a human re-adds them from history.
+  const pk = { chain: intent.pk.chain, address }
+  const existing = await db.tokenDenylist.findByChainAndAddress(pk)
+  if (existing === undefined) {
+    throw new PlanningError(`${pk.chain}+${pk.address} is not denylisted`)
+  }
+  // Removal only lifts the ban. The deleted token is not restored
+  // automatically — ingestion re-creates it from live transfers, or a human
+  // re-adds it from history. Relations were never deleted.
   return [
     {
-      type: 'DeleteTokenDenylistEntryCommand',
+      type: 'DeleteTokenFromDenylistCommand',
       pk: { chain: existing.chain, address: existing.address },
       existing,
     },
   ]
 }
 
-function compareTokenRelations(a: TokenRelationRecord, b: TokenRelationRecord) {
-  return (
-    a.plugin.localeCompare(b.plugin) ||
-    a.bridgeType.localeCompare(b.bridgeType) ||
-    a.tokenAChain.localeCompare(b.tokenAChain) ||
-    a.tokenAAddress.localeCompare(b.tokenAAddress) ||
-    a.tokenBChain.localeCompare(b.tokenBChain) ||
-    a.tokenBAddress.localeCompare(b.tokenBAddress)
-  )
+/**
+ * `normalizeInteropTokenAddress` throws on values that are not addresses at
+ * all (non-hex `0x…` strings); planning wants a clean error instead.
+ */
+function normalizeDenylistAddress(address: string): string | undefined {
+  try {
+    return normalizeInteropTokenAddress(address)
+  } catch {
+    return undefined
+  }
 }
 
 function mergeAdditionalCoingeckoEntries(

--- a/packages/token-backend/src/schemas/TokenDenylist.ts
+++ b/packages/token-backend/src/schemas/TokenDenylist.ts
@@ -1,0 +1,18 @@
+import { v } from '@l2beat/validate'
+
+/** What a denylist command plans to insert. `createdAt` is deliberately
+ * absent — the database fills it, keeping plan generation deterministic. */
+export type TokenDenylistEntryInsert = v.infer<typeof TokenDenylistEntryInsert>
+export const TokenDenylistEntryInsert = v.object({
+  chain: v.string(),
+  address: v.string(),
+  reason: v.string(),
+})
+
+export type TokenDenylistEntryRecord = v.infer<typeof TokenDenylistEntryRecord>
+export const TokenDenylistEntryRecord = v.object({
+  chain: v.string(),
+  address: v.string(),
+  reason: v.string(),
+  createdAt: v.number(),
+})

--- a/packages/token-backend/src/trpc/appRouter.ts
+++ b/packages/token-backend/src/trpc/appRouter.ts
@@ -6,6 +6,7 @@ import { deployedTokensRouter } from './routers/deployedTokens'
 import { planRouter } from './routers/plan'
 import { searchRouter } from './routers/search'
 import { tokenDbHistoryRouter } from './routers/tokenDbHistory'
+import { tokenDenylistRouter } from './routers/tokenDenylist'
 import { tokenIngestionQueueRouter } from './routers/tokenIngestionQueue'
 import { router } from './trpc'
 
@@ -25,6 +26,7 @@ export function createAppRouter({
     deployedTokens: deployedTokensRouter({ coingeckoClient, etherscanApiKey }),
     search: searchRouter,
     tokenDbHistory: tokenDbHistoryRouter,
+    tokenDenylist: tokenDenylistRouter,
     tokenIngestionQueue: tokenIngestionQueueRouter,
   })
 }

--- a/packages/token-backend/src/trpc/routers/deployedTokens/checkDeployedToken.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/checkDeployedToken.ts
@@ -34,6 +34,21 @@ export async function checkDeployedToken(
       }),
   } = deps
 
+  const denylisted = await tokenDb.tokenDenylist.findByChainAndAddress({
+    chain: input.chain,
+    address: input.address,
+  })
+  if (denylisted !== undefined) {
+    return {
+      error: {
+        type: 'denylisted' as const,
+        message: `This address is denylisted (${denylisted.reason}). Remove the denylist entry before adding it.`,
+      },
+      data: undefined,
+      warnings: [],
+    }
+  }
+
   const result = await tokenDb.deployedToken.findByChainAndAddress({
     chain: input.chain,
     address: input.address,

--- a/packages/token-backend/src/trpc/routers/deployedTokens/getCoingeckoSuggestions.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/getCoingeckoSuggestions.ts
@@ -20,15 +20,21 @@ export async function getCoingeckoSuggestions(
   coingeckoClient: CoingeckoClient,
   tokenDb: TokenDatabase,
 ): Promise<CoingeckoSuggestion[]> {
-  const [abstractTokens, deployedTokens, chains, coins] = await Promise.all([
-    tokenDb.abstractToken.getAll(),
-    tokenDb.deployedToken.getAll(),
-    tokenDb.chain.getAll(),
-    coingeckoClient.getCoinList({ includePlatform: true }),
-  ])
+  const [abstractTokens, deployedTokens, denylist, chains, coins] =
+    await Promise.all([
+      tokenDb.abstractToken.getAll(),
+      tokenDb.deployedToken.getAll(),
+      tokenDb.tokenDenylist.getAll(),
+      tokenDb.chain.getAll(),
+      coingeckoClient.getCoinList({ includePlatform: true }),
+    ])
 
+  // Denylisted addresses count as known: suggesting one would just funnel the
+  // user into the add form's refusal.
   const deployedTokenSet = new Set(
-    deployedTokens.map((t) => `${t.chain}:${t.address.toLowerCase()}`),
+    [...deployedTokens, ...denylist].map(
+      (t) => `${t.chain}:${t.address.toLowerCase()}`,
+    ),
   )
   const aliasToChain = buildAliasToChainMap(chains)
   const coinsById = new Map(coins.map((coin) => [coin.id, coin]))

--- a/packages/token-backend/src/trpc/routers/deployedTokens/getSuggestionsByCoingeckoId.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/getSuggestionsByCoingeckoId.ts
@@ -27,12 +27,26 @@ export async function getSuggestionsByCoingeckoId(
   const deployedTokens =
     await tokenDb.deployedToken.getByChainsAndAddresses(chainAddressPairs)
 
+  // Denylisted addresses must not resurface as suggestions — the add form
+  // would refuse them anyway.
+  const denylist = await tokenDb.tokenDenylist.getAll()
+  const denylisted = new Set(
+    denylist.map((entry) => `${entry.chain}:${entry.address.toLowerCase()}`),
+  )
+
   return findUnregisteredPlatformTokens(
     coin.platforms,
     deployedTokens,
     aliasToChain,
-  ).map((suggestion) => ({
-    ...suggestion,
-    isInterop: INTEROP_CHAIN_IDS.has(suggestion.chain),
-  }))
+  )
+    .filter(
+      (suggestion) =>
+        !denylisted.has(
+          `${suggestion.chain}:${suggestion.address.toLowerCase()}`,
+        ),
+    )
+    .map((suggestion) => ({
+      ...suggestion,
+      isInterop: INTEROP_CHAIN_IDS.has(suggestion.chain),
+    }))
 }

--- a/packages/token-backend/src/trpc/routers/deployedTokens/getSuggestionsByPartialTransfers.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/getSuggestionsByPartialTransfers.ts
@@ -39,9 +39,10 @@ export async function getSuggestionsByPartialTransfers(
     return []
   }
 
-  const [abstractTokens, deployedTokens, chains] = await Promise.all([
+  const [abstractTokens, deployedTokens, denylist, chains] = await Promise.all([
     tokenDb.abstractToken.getAll(),
     tokenDb.deployedToken.getAll(),
+    tokenDb.tokenDenylist.getAll(),
     tokenDb.chain.getAll(),
   ])
 
@@ -50,6 +51,9 @@ export async function getSuggestionsByPartialTransfers(
     abstractTokens,
     deployedTokens,
     chains,
+    // Denylisted addresses must not resurface as suggestions — the add form
+    // would refuse them anyway.
+    new Set(denylist.map((e) => `${e.chain}:${e.address.toLowerCase()}`)),
   )
 }
 
@@ -68,11 +72,14 @@ export async function getSuggestionsByPartialTransfersForToken(
 
   const abstractTokens = await tokenDb.abstractToken.getAll()
 
+  // No denylist filter: `checkDeployedToken` refuses denylisted addresses
+  // before ever asking for suggestions for one.
   return buildTransferSuggestionMap(
     transfersForSuggestions,
     abstractTokens,
     [],
     [],
+    new Set(),
   )
 }
 
@@ -89,6 +96,7 @@ function buildTransferSuggestionMap(
   abstractTokens: AbstractTokenRecord[],
   deployedTokens: DeployedTokenRecord[],
   chains: ChainRecord[],
+  denylisted: Set<string>,
 ): TransferSuggestion[] {
   const map = new Map<string, TransferSuggestion>()
   const abstractTokenMap = Object.fromEntries(
@@ -124,7 +132,7 @@ function buildTransferSuggestionMap(
       : tokenAddress
     const deployedToken = deployedTokenMap[`${chain}:${address.toLowerCase()}`]
 
-    if (deployedToken) {
+    if (deployedToken || denylisted.has(`${chain}:${address.toLowerCase()}`)) {
       return
     }
 

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
@@ -366,10 +366,81 @@ describe('deployedTokensRouter', () => {
         { plugin: 'd-plugin', role: 'minted', otherToken: null },
       ])
     })
+
+    it('marks relations whose other endpoint is denylisted instead of hiding them', async () => {
+      // The tab displays observations, so the relation stays visible — the
+      // banned counterparty is flagged so nobody mistakes it for a real
+      // asset. Only the graph drops such relations entirely.
+      const token = { chain: 'base', address: '0xbbb' }
+      const clean = {
+        ...tokenRelationRoute({
+          tokenAChain: 'base',
+          tokenAAddress: '0xbbb',
+          tokenBChain: 'ethereum',
+          tokenBAddress: '0xaaa',
+          plugin: 'a-plugin',
+          lockedToken: 'A',
+        }),
+        transfer: {},
+      } satisfies TokenRelationRecord
+      const banned = {
+        ...tokenRelationRoute({
+          tokenAChain: 'arbitrum',
+          tokenAAddress: '0xbad',
+          tokenBChain: 'base',
+          tokenBAddress: '0xbbb',
+          plugin: 'b-plugin',
+          lockedToken: 'A',
+        }),
+        transfer: {},
+      } satisfies TokenRelationRecord
+      const getByPrimaryKeys = mockFn().resolvesTo([])
+      const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
+          getAll: mockFn().resolvesTo([
+            {
+              chain: 'arbitrum',
+              address: '0xbad',
+              reason: 'test token',
+              createdAt: UnixTime(1),
+            },
+          ]),
+        }),
+        tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
+          getRelationsFor: mockFn().resolvesTo([clean, banned]),
+        }),
+        deployedToken: mockObject<TokenDatabase['deployedToken']>({
+          getByPrimaryKeys,
+        }),
+      })
+
+      const caller = createRouter(
+        mockTokenDb,
+        mockObject<Database>({}),
+        mockObject<CoingeckoClient>({}),
+      )
+      const result = await caller.getRelations(token)
+
+      expect(
+        result.map((entry) => ({
+          plugin: entry.relation.plugin,
+          denylisted: entry.otherEndpointDenylisted,
+        })),
+      ).toEqual([
+        { plugin: 'a-plugin', denylisted: false },
+        { plugin: 'b-plugin', denylisted: true },
+      ])
+      expect(getByPrimaryKeys).toHaveBeenCalledWith([
+        { chain: 'ethereum', address: '0xaaa' },
+        { chain: 'arbitrum', address: '0xbad' },
+      ])
+    })
   })
 
   describe('getMintingPlugins', () => {
     it('returns the plugin names straight from the repository', async () => {
+      // Deliberately not denylist-aware: a plugin observed minting this
+      // token minted it, whatever the counterparty was.
       const getMintingPluginsFor = mockFn().resolvesTo([
         'canonicalbridge',
         'superbridge',

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
@@ -20,6 +20,7 @@ describe('deployedTokensRouter', () => {
       const mockFindByChainAndAddress = mockFn().resolvesTo(undefined)
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFindByChainAndAddress,
         }),
@@ -63,6 +64,7 @@ describe('deployedTokensRouter', () => {
         },
       } satisfies DeployedTokenRecord
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(token),
         }),
@@ -83,6 +85,7 @@ describe('deployedTokensRouter', () => {
   describe('checkIfExists', () => {
     it('returns false when token does not exist', async () => {
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -106,6 +109,7 @@ describe('deployedTokensRouter', () => {
         address: '0x123',
       }
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(token),
         }),
@@ -174,6 +178,7 @@ describe('deployedTokensRouter', () => {
       }[]
       const mockGetByChainAndAddress = mockFn().resolvesTo(tokens)
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           getByChainAndAddress: mockGetByChainAndAddress,
         }),
@@ -219,6 +224,7 @@ describe('deployedTokensRouter', () => {
       const findDeployedToken = mockFn().resolvesTo(token)
       const findAbstractToken = mockFn().resolvesTo(abstractToken)
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: findDeployedToken,
         }),
@@ -244,6 +250,7 @@ describe('deployedTokensRouter', () => {
 
     it('returns null details for an uncatalogued endpoint', async () => {
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -317,6 +324,7 @@ describe('deployedTokensRouter', () => {
         symmetric,
       ])
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           getRelationsFor,
         }),
@@ -367,6 +375,7 @@ describe('deployedTokensRouter', () => {
         'superbridge',
       ])
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           getMintingPluginsFor,
         }),
@@ -408,6 +417,7 @@ describe('deployedTokensRouter', () => {
       } satisfies TokenRelationRecord
       const findRelation = mockFn().resolvesTo(relation)
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           findByPrimaryKey: findRelation,
         }),
@@ -460,6 +470,7 @@ describe('deployedTokensRouter', () => {
       const mockGetAllRelations = mockFn().resolvesTo(relations)
       const mockGetTokens = mockFn().resolvesTo(tokens)
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           getAllRoutes: mockGetAllRelations,
         }),
@@ -532,6 +543,7 @@ describe('deployedTokensRouter', () => {
         }),
       ]
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           getAllRoutes: mockFn().resolvesTo([conflict, unresolved]),
         }),
@@ -597,6 +609,7 @@ describe('deployedTokensRouter', () => {
       }
       const getTokens = mockFn().resolvesTo([])
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           getAllRoutes: mockFn().resolvesTo([supported, unsupported]),
         }),
@@ -645,6 +658,7 @@ describe('deployedTokensRouter', () => {
         address: '0x123',
       }
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(existingToken),
         }),
@@ -669,8 +683,40 @@ describe('deployedTokensRouter', () => {
       })
     })
 
+    it('returns denylisted error when the address is denylisted', async () => {
+      const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
+          findByChainAndAddress: mockFn().resolvesTo({
+            chain: 'ethereum',
+            address: '0x123',
+            reason: 'test token',
+            createdAt: 1,
+          }),
+        }),
+      })
+      const mockDb = mockObject<Database>({})
+      const mockCoingeckoClient = mockObject<CoingeckoClient>({})
+
+      const caller = createRouter(mockTokenDb, mockDb, mockCoingeckoClient)
+      const result = await caller.checks({
+        chain: 'ethereum',
+        address: '0x123',
+      })
+
+      expect(result).toEqual({
+        error: {
+          type: 'denylisted',
+          message:
+            'This address is denylisted (test token). Remove the denylist entry before adding it.',
+        },
+        data: undefined,
+        warnings: [],
+      })
+    })
+
     it('returns undefined error and data when address does not start with 0x', async () => {
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -693,6 +739,7 @@ describe('deployedTokensRouter', () => {
 
     it('returns chain-not-found error when chain does not exist', async () => {
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -736,6 +783,7 @@ describe('deployedTokensRouter', () => {
       const mockDb = mockObject<Database>({})
       const mockGetCoinList = mockFn().resolvesTo([])
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -789,6 +837,7 @@ describe('deployedTokensRouter', () => {
       })
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -860,6 +909,7 @@ describe('deployedTokensRouter', () => {
       })
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -929,6 +979,7 @@ describe('deployedTokensRouter', () => {
       })
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -994,6 +1045,7 @@ describe('deployedTokensRouter', () => {
       })
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -1046,6 +1098,7 @@ describe('deployedTokensRouter', () => {
       })
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -1098,6 +1151,7 @@ describe('deployedTokensRouter', () => {
       }
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -1195,6 +1249,7 @@ describe('deployedTokensRouter', () => {
         }),
       })
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -1283,6 +1338,7 @@ describe('deployedTokensRouter', () => {
       })
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -1321,6 +1377,7 @@ describe('deployedTokensRouter', () => {
       const mockGetAll = mockFn().resolvesTo([])
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -1399,6 +1456,7 @@ describe('deployedTokensRouter', () => {
         }),
       })
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -1465,6 +1523,7 @@ describe('deployedTokensRouter', () => {
       }
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -1535,6 +1594,7 @@ describe('deployedTokensRouter', () => {
       }
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -1596,6 +1656,7 @@ describe('deployedTokensRouter', () => {
       }
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -1649,6 +1710,7 @@ describe('deployedTokensRouter', () => {
       }
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn()
             .resolvesTo(undefined)
@@ -1730,6 +1792,7 @@ describe('deployedTokensRouter', () => {
       }
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
           getByChainsAndAddresses: mockFn().resolvesTo([]),
@@ -1776,7 +1839,9 @@ describe('deployedTokensRouter', () => {
 
   describe('getSuggestionsByCoingeckoId', () => {
     it('returns empty array when coin is not found', async () => {
-      const mockTokenDb = mockObject<TokenDatabase>({})
+      const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
+      })
       const mockCoingeckoClient = mockObject<CoingeckoClient>({
         getCoinDataById: mockFn().resolvesTo(null),
       })
@@ -1825,6 +1890,7 @@ describe('deployedTokensRouter', () => {
       ]
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         chain: mockObject<TokenDatabase['chain']>({
           getAll: mockFn().resolvesTo(chains),
         }),
@@ -1900,6 +1966,7 @@ describe('deployedTokensRouter', () => {
       ]
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         chain: mockObject<TokenDatabase['chain']>({
           getAll: mockFn().resolvesTo(chains),
         }),
@@ -1936,6 +2003,7 @@ describe('deployedTokensRouter', () => {
       ]
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         chain: mockObject<TokenDatabase['chain']>({
           getAll: mockFn().resolvesTo(chains),
         }),
@@ -1978,6 +2046,7 @@ describe('deployedTokensRouter', () => {
       ]
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         chain: mockObject<TokenDatabase['chain']>({
           getAll: mockFn().resolvesTo(chains),
         }),
@@ -2020,6 +2089,7 @@ describe('deployedTokensRouter', () => {
       ]
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         chain: mockObject<TokenDatabase['chain']>({
           getAll: mockFn().resolvesTo(chains),
         }),
@@ -2079,6 +2149,7 @@ describe('deployedTokensRouter', () => {
       ]
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         chain: mockObject<TokenDatabase['chain']>({
           getAll: mockFn().resolvesTo(chains),
         }),
@@ -2170,6 +2241,7 @@ describe('deployedTokensRouter', () => {
 
     const mockTokenDbForSuggestions = (abstractTokens: AbstractTokenRecord[]) =>
       mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         abstractToken: mockObject<TokenDatabase['abstractToken']>({
           getAll: mockFn().resolvesTo(abstractTokens),
         }),
@@ -2380,6 +2452,7 @@ describe('deployedTokensRouter', () => {
         }),
       })
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         abstractToken: mockObject<TokenDatabase['abstractToken']>({
           getAll: mockFn().resolvesTo([ABSTRACT_USDC]),
         }),
@@ -2523,6 +2596,7 @@ describe('deployedTokensRouter', () => {
 
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: emptyDenylist(),
         abstractToken: mockObject<TokenDatabase['abstractToken']>({
           getAll: mockFn().resolvesTo([
             usdc,
@@ -2695,5 +2769,12 @@ function createRouter(
     db,
     tokenDb: mockTokenDb,
     tokenIngestionProcessor: mockObject<TokenIngestionProcessor>({}),
+  })
+}
+
+function emptyDenylist() {
+  return mockObject<TokenDatabase['tokenDenylist']>({
+    findByChainAndAddress: mockFn().resolvesTo(undefined),
+    getAll: mockFn().resolvesTo([]),
   })
 }

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
@@ -20,7 +20,6 @@ describe('deployedTokensRouter', () => {
       const mockFindByChainAndAddress = mockFn().resolvesTo(undefined)
       const mockDb = mockObject<Database>({})
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFindByChainAndAddress,
         }),
@@ -64,7 +63,6 @@ describe('deployedTokensRouter', () => {
         },
       } satisfies DeployedTokenRecord
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(token),
         }),
@@ -85,7 +83,6 @@ describe('deployedTokensRouter', () => {
   describe('checkIfExists', () => {
     it('returns false when token does not exist', async () => {
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -109,7 +106,6 @@ describe('deployedTokensRouter', () => {
         address: '0x123',
       }
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(token),
         }),
@@ -178,7 +174,6 @@ describe('deployedTokensRouter', () => {
       }[]
       const mockGetByChainAndAddress = mockFn().resolvesTo(tokens)
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           getByChainAndAddress: mockGetByChainAndAddress,
         }),
@@ -224,7 +219,6 @@ describe('deployedTokensRouter', () => {
       const findDeployedToken = mockFn().resolvesTo(token)
       const findAbstractToken = mockFn().resolvesTo(abstractToken)
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: findDeployedToken,
         }),
@@ -250,7 +244,6 @@ describe('deployedTokensRouter', () => {
 
     it('returns null details for an uncatalogued endpoint', async () => {
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         deployedToken: mockObject<TokenDatabase['deployedToken']>({
           findByChainAndAddress: mockFn().resolvesTo(undefined),
         }),
@@ -440,13 +433,14 @@ describe('deployedTokensRouter', () => {
   describe('getMintingPlugins', () => {
     it('returns the plugin names straight from the repository', async () => {
       // Deliberately not denylist-aware: a plugin observed minting this
-      // token minted it, whatever the counterparty was.
+      // token minted it, whatever the counterparty was. No tokenDenylist
+      // mock exists on the database object — consulting it would make this
+      // test throw.
       const getMintingPluginsFor = mockFn().resolvesTo([
         'canonicalbridge',
         'superbridge',
       ])
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           getMintingPluginsFor,
         }),
@@ -488,7 +482,6 @@ describe('deployedTokensRouter', () => {
       } satisfies TokenRelationRecord
       const findRelation = mockFn().resolvesTo(relation)
       const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
         tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
           findByPrimaryKey: findRelation,
         }),
@@ -1964,9 +1957,7 @@ describe('deployedTokensRouter', () => {
 
   describe('getSuggestionsByCoingeckoId', () => {
     it('returns empty array when coin is not found', async () => {
-      const mockTokenDb = mockObject<TokenDatabase>({
-        tokenDenylist: emptyDenylist(),
-      })
+      const mockTokenDb = mockObject<TokenDatabase>({})
       const mockCoingeckoClient = mockObject<CoingeckoClient>({
         getCoinDataById: mockFn().resolvesTo(null),
       })

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.test.ts
@@ -7,7 +7,7 @@ import type {
   TokenRelationLockedToken,
   TokenRelationRecord,
 } from '@l2beat/database'
-import { Address32 } from '@l2beat/shared-pure'
+import { Address32, UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
 import type { CoingeckoClient } from '../../../chains/clients/coingecko/CoingeckoClient'
 import type { TokenIngestionProcessor } from '../../../ingestion/TokenIngestionProcessor'
@@ -646,6 +646,60 @@ describe('deployedTokensRouter', () => {
       expect(getTokens).toHaveBeenCalledWith([
         { chain: 'ethereum', address: '0xaaa' },
         { chain: 'base', address: '0xbbb' },
+      ])
+    })
+
+    it('excludes relations touching a denylisted address', async () => {
+      // The relation stays recorded (it is an observation), but the graph is
+      // an interpretation — drawing the banned endpoint would wire it back
+      // into a real cluster. This is the denylist's one read-side filter.
+      const clean = tokenRelationRoute({
+        tokenAChain: 'ethereum',
+        tokenAAddress: '0xaaa',
+        tokenBChain: 'base',
+        tokenBAddress: '0xbbb',
+        plugin: 'test-plugin',
+      })
+      const banned = tokenRelationRoute({
+        tokenAChain: 'arbitrum',
+        tokenAAddress: '0xbad',
+        tokenBChain: 'optimism',
+        tokenBAddress: '0xccc',
+        plugin: 'test-plugin',
+      })
+      const mockTokenDb = mockObject<TokenDatabase>({
+        tokenDenylist: mockObject<TokenDatabase['tokenDenylist']>({
+          getAll: mockFn().resolvesTo([
+            {
+              chain: 'arbitrum',
+              address: '0xbad',
+              reason: 'test token',
+              createdAt: UnixTime(1),
+            },
+          ]),
+        }),
+        tokenRelation: mockObject<TokenDatabase['tokenRelation']>({
+          getAllRoutes: mockFn().resolvesTo([clean, banned]),
+        }),
+        deployedToken: mockObject<TokenDatabase['deployedToken']>({
+          getByPrimaryKeys: mockFn().resolvesTo([]),
+        }),
+      })
+
+      const caller = createRouter(
+        mockTokenDb,
+        mockObject<Database>({}),
+        mockObject<CoingeckoClient>({}),
+      )
+
+      const result = await caller.getRelationsGraph()
+
+      expect(result.relations).toEqual([{ ...clean, isConflict: false }])
+      // The denylisted endpoint's counterparty vanishes with the relation —
+      // no orphan node is drawn.
+      expect(result.nodes.map((node) => node.id)).toEqual([
+        'ethereum:0xaaa',
+        'base:0xbbb',
       ])
     })
   })

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
@@ -106,9 +106,20 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
       }),
 
     getRelationsGraph: readOnlyProcedure.query(async ({ ctx }) => {
+      // Relations touching a denylisted address stay recorded — they are
+      // observations — but the graph is an interpretation of them, and
+      // drawing the banned endpoint would wire it back into a real cluster,
+      // which is exactly what the ban exists to prevent. Filtering here,
+      // where clusters are assembled, is the denylist's one read-side
+      // consult point.
+      const denylisted = new Set(
+        (await ctx.tokenDb.tokenDenylist.getAll()).map(tokenKey),
+      )
       const relations = sortRelations(
         (await ctx.tokenDb.tokenRelation.getAllRoutes()).filter(
-          isGraphRelation,
+          (relation) =>
+            isGraphRelation(relation) &&
+            !hasDenylistedEndpoint(relation, denylisted),
         ),
       )
       const tokenKeys = uniqueTokenKeys(
@@ -212,6 +223,31 @@ function isGraphRelation(relation: { bridgeType: string }): boolean {
   return (
     relation.bridgeType === 'burnAndMint' ||
     relation.bridgeType === 'lockAndMint'
+  )
+}
+
+function hasDenylistedEndpoint(
+  relation: {
+    tokenAChain: string
+    tokenAAddress: string
+    tokenBChain: string
+    tokenBAddress: string
+  },
+  denylisted: Set<string>,
+): boolean {
+  return (
+    denylisted.has(
+      tokenKey({
+        chain: relation.tokenAChain,
+        address: relation.tokenAAddress,
+      }),
+    ) ||
+    denylisted.has(
+      tokenKey({
+        chain: relation.tokenBChain,
+        address: relation.tokenBAddress,
+      }),
+    )
   )
 }
 

--- a/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
+++ b/packages/token-backend/src/trpc/routers/deployedTokens/index.ts
@@ -1,4 +1,4 @@
-import type { TokenRelationRoute } from '@l2beat/database'
+import type { TokenDatabase, TokenRelationRoute } from '@l2beat/database'
 import { v } from '@l2beat/validate'
 import { TokenRelationPrimaryKey } from '../../../schemas/TokenRelation'
 import { readOnlyProcedure } from '../../procedures'
@@ -39,9 +39,11 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
         // One list, not an inbound/outbound split: endpoint order is not a
         // direction. What differs between relations is this token's role, which
         // `lockedToken` answers.
-        const relations = sortRelations(
-          await ctx.tokenDb.tokenRelation.getRelationsFor(input),
-        )
+        const [allRelations, denylisted] = await Promise.all([
+          ctx.tokenDb.tokenRelation.getRelationsFor(input),
+          denylistedKeySet(ctx.tokenDb),
+        ])
+        const relations = sortRelations(allRelations)
         const otherTokenKeys = uniqueTokenKeys(
           relations.map((relation) => otherEndpoint(relation, input)),
         )
@@ -51,6 +53,9 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
           otherTokens.map((token) => [tokenKey(token), token]),
         )
 
+        // Relations to a denylisted address are shown, not hidden — the tab
+        // displays observations — but the banned counterparty is marked so
+        // nobody mistakes it for a real asset.
         return relations.map((relation) => {
           const other = otherEndpoint(relation, input)
           return {
@@ -58,12 +63,15 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
             role: tokenRelationRole(relation, input),
             otherEndpoint: other,
             otherToken: otherTokenMap.get(tokenKey(other)) ?? null,
+            otherEndpointDenylisted: denylisted.has(tokenKey(other)),
           }
         })
       }),
 
     // The same answer the Relations tab's role column gives, summarized: the
     // distinct plugins of the relations whose role for this token is `minted`.
+    // Deliberately not denylist-aware: a plugin observed minting this token
+    // minted it, whatever the counterparty was.
     getMintingPlugins: readOnlyProcedure
       .input(v.object({ chain: v.string(), address: v.string() }))
       .query(({ ctx, input }) =>
@@ -106,15 +114,9 @@ export const deployedTokensRouter = (deps: DeployedTokensRouterDeps) =>
       }),
 
     getRelationsGraph: readOnlyProcedure.query(async ({ ctx }) => {
-      // Relations touching a denylisted address stay recorded — they are
-      // observations — but the graph is an interpretation of them, and
-      // drawing the banned endpoint would wire it back into a real cluster,
-      // which is exactly what the ban exists to prevent. Filtering here,
-      // where clusters are assembled, is the denylist's one read-side
-      // consult point.
-      const denylisted = new Set(
-        (await ctx.tokenDb.tokenDenylist.getAll()).map(tokenKey),
-      )
+      // Drawing a denylisted endpoint would wire it back into a real
+      // cluster, which is exactly what the ban exists to prevent.
+      const denylisted = await denylistedKeySet(ctx.tokenDb)
       const relations = sortRelations(
         (await ctx.tokenDb.tokenRelation.getAllRoutes()).filter(
           (relation) =>
@@ -224,6 +226,17 @@ function isGraphRelation(relation: { bridgeType: string }): boolean {
     relation.bridgeType === 'burnAndMint' ||
     relation.bridgeType === 'lockAndMint'
   )
+}
+
+/**
+ * Relations touching a denylisted address stay recorded — they are
+ * observations. The relations graph drops them (a banned endpoint drawn
+ * into a cluster is exactly what the ban exists to prevent); the Relations
+ * tab shows them with the banned counterparty marked. These are the
+ * denylist's only read-side consult points.
+ */
+async function denylistedKeySet(db: TokenDatabase): Promise<Set<string>> {
+  return new Set((await db.tokenDenylist.getAll()).map(tokenKey))
 }
 
 function hasDenylistedEndpoint(

--- a/packages/token-backend/src/trpc/routers/tokenDenylist/index.ts
+++ b/packages/token-backend/src/trpc/routers/tokenDenylist/index.ts
@@ -1,0 +1,8 @@
+import { readOnlyProcedure } from '../../procedures'
+import { router } from '../../trpc'
+
+export const tokenDenylistRouter = router({
+  getAll: readOnlyProcedure.query(({ ctx }) =>
+    ctx.tokenDb.tokenDenylist.getAll(),
+  ),
+})

--- a/packages/token-ui/src/App.tsx
+++ b/packages/token-ui/src/App.tsx
@@ -13,6 +13,7 @@ import { SearchPage } from './pages/search/SearchPage'
 import { AbstractTokenPage } from './pages/tokens/AbstractTokenPage'
 import { AddTokensPage } from './pages/tokens/add-tokens/AddTokensPage'
 import { DeployedTokenPage } from './pages/tokens/DeployedTokenPage'
+import { TokenDenylistPage } from './pages/tokens/TokenDenylistPage'
 import { TokenHistoryPage } from './pages/tokens/TokenHistoryPage'
 import { TokenIngestionQueuePage } from './pages/tokens/TokenIngestionQueuePage'
 import { TokenSuggestionsPage } from './pages/tokens/TokenSuggestionsPage'
@@ -45,6 +46,7 @@ export function App() {
               element={<TokenIngestionQueuePage />}
             />
             <Route path="/tokens/history" element={<TokenHistoryPage />} />
+            <Route path="/tokens/denylist" element={<TokenDenylistPage />} />
             <Route
               path="/tokens/relations-graph"
               element={

--- a/packages/token-ui/src/components/AppSidebar.tsx
+++ b/packages/token-ui/src/components/AppSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  BanIcon,
   CirclePlusIcon,
   HistoryIcon,
   LightbulbIcon,
@@ -55,6 +56,11 @@ const items = [
         title: 'Graph',
         url: '/tokens/relations-graph',
         icon: NetworkIcon,
+      },
+      {
+        title: 'Denylist',
+        url: '/tokens/denylist',
+        icon: BanIcon,
       },
     ],
   },

--- a/packages/token-ui/src/components/PlanConfirmationDialog.tsx
+++ b/packages/token-ui/src/components/PlanConfirmationDialog.tsx
@@ -146,6 +146,21 @@ export function PlanConfirmationDialog({
             invalidateDeployedTokenQueries()
             navigate('/')
             break
+          case 'DenylistDeployedTokenIntent':
+            toast.success('Address denylisted successfully')
+            invalidateDeployedTokenQueries()
+            queryClient.invalidateQueries(
+              trpc.tokenDenylist.getAll.queryFilter(),
+            )
+            navigate('/tokens/denylist')
+            break
+          case 'RemoveTokenDenylistEntryIntent':
+            toast.success('Denylist entry removed successfully')
+            invalidateDeployedTokenQueries()
+            queryClient.invalidateQueries(
+              trpc.tokenDenylist.getAll.queryFilter(),
+            )
+            break
           case 'UpdateAbstractTokenIntent':
             toast.success('Abstract token updated successfully')
             invalidateAbstractTokenQueries()
@@ -373,6 +388,34 @@ function CommandItem({ command }: { command: Command }) {
             </TooltipContent>
           </Tooltip>{' '}
           will be deleted
+        </li>
+      )
+    case 'AddTokenDenylistEntryCommand':
+      return (
+        <li>
+          <Tooltip>
+            <TooltipTrigger className="underline">
+              Denylist entry
+            </TooltipTrigger>
+            <TooltipContent className="whitespace-pre">
+              {JSON.stringify(command.record, null, 2)}
+            </TooltipContent>
+          </Tooltip>{' '}
+          will be added — ingestion will refuse to observe this address
+        </li>
+      )
+    case 'DeleteTokenDenylistEntryCommand':
+      return (
+        <li>
+          <Tooltip>
+            <TooltipTrigger className="underline">
+              Denylist entry
+            </TooltipTrigger>
+            <TooltipContent className="whitespace-pre">
+              {JSON.stringify(command.existing, null, 2)}
+            </TooltipContent>
+          </Tooltip>{' '}
+          will be deleted — the address can be catalogued again
         </li>
       )
     default:

--- a/packages/token-ui/src/components/PlanConfirmationDialog.tsx
+++ b/packages/token-ui/src/components/PlanConfirmationDialog.tsx
@@ -146,7 +146,7 @@ export function PlanConfirmationDialog({
             invalidateDeployedTokenQueries()
             navigate('/')
             break
-          case 'DenylistDeployedTokenIntent':
+          case 'AddTokenToDenylistIntent':
             toast.success('Address denylisted successfully')
             invalidateDeployedTokenQueries()
             queryClient.invalidateQueries(
@@ -154,7 +154,7 @@ export function PlanConfirmationDialog({
             )
             navigate('/tokens/denylist')
             break
-          case 'RemoveTokenDenylistEntryIntent':
+          case 'DeleteTokenFromDenylistIntent':
             toast.success('Denylist entry removed successfully')
             invalidateDeployedTokenQueries()
             queryClient.invalidateQueries(
@@ -390,7 +390,7 @@ function CommandItem({ command }: { command: Command }) {
           will be deleted
         </li>
       )
-    case 'AddTokenDenylistEntryCommand':
+    case 'AddTokenToDenylistCommand':
       return (
         <li>
           <Tooltip>
@@ -401,10 +401,10 @@ function CommandItem({ command }: { command: Command }) {
               {JSON.stringify(command.record, null, 2)}
             </TooltipContent>
           </Tooltip>{' '}
-          will be added — ingestion will refuse to observe this address
+          will be added — ingestion will refuse to catalogue this address
         </li>
       )
-    case 'DeleteTokenDenylistEntryCommand':
+    case 'DeleteTokenFromDenylistCommand':
       return (
         <li>
           <Tooltip>

--- a/packages/token-ui/src/components/forms/DeployedTokenForm.tsx
+++ b/packages/token-ui/src/components/forms/DeployedTokenForm.tsx
@@ -175,7 +175,8 @@ export function DeployedTokenForm({
   const addressFieldSuccess =
     tokenDetails.data &&
     tokenDetails.data?.error?.type !== 'already-exists' &&
-    tokenDetails.data?.error?.type !== 'not-a-token'
+    tokenDetails.data?.error?.type !== 'not-a-token' &&
+    tokenDetails.data?.error?.type !== 'denylisted'
   const fetchedSymbol = tokenDetails.data?.data?.symbol
   const symbolSource = tokenDetails.data?.data?.symbolSource as
     | keyof typeof symbolSourceToLabel

--- a/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
+++ b/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
@@ -330,7 +330,8 @@ function DeployedTokenView({ token }: { token: DeployedToken }) {
  * Bans the token's address from TokenDB via `AddTokenToDenylistIntent` —
  * one plan that adds the denylist entry and deletes the token, so the blast
  * radius shows in the confirmation dialog. Relations stay recorded (they
- * are observations); the relations graph filters them out.
+ * are observations); the graph filters them out and the Relations tab
+ * marks the banned endpoint.
  */
 function DenylistTokenButton({
   isPending,

--- a/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
+++ b/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
@@ -297,7 +297,7 @@ function DeployedTokenView({ token }: { token: DeployedToken }) {
                 isPending={isPending}
                 onConfirm={(reason) => {
                   planMutate({
-                    type: 'DenylistDeployedTokenIntent',
+                    type: 'AddTokenToDenylistIntent',
                     pk: {
                       address: token.address,
                       chain: token.chain,
@@ -327,9 +327,10 @@ function DeployedTokenView({ token }: { token: DeployedToken }) {
 }
 
 /**
- * Bans the token's address from TokenDB via `DenylistDeployedTokenIntent` —
- * one plan that adds the denylist entry and deletes the token and all its
- * relations, so the blast radius shows in the confirmation dialog.
+ * Bans the token's address from TokenDB via `AddTokenToDenylistIntent` —
+ * one plan that adds the denylist entry and deletes the token, so the blast
+ * radius shows in the confirmation dialog. Relations stay recorded (they
+ * are observations); the relations graph filters them out.
  */
 function DenylistTokenButton({
   isPending,
@@ -354,8 +355,8 @@ function DenylistTokenButton({
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          Denylist — delete the token and its relations, and ban the address
-          from ever being re-ingested
+          Denylist — delete the token and ban the address from ever being
+          re-catalogued
         </TooltipContent>
       </Tooltip>
       <Dialog open={open} onOpenChange={setOpen}>
@@ -363,10 +364,10 @@ function DenylistTokenButton({
           <DialogHeader>
             <DialogTitle>Denylist this token?</DialogTitle>
             <DialogDescription>
-              The deployed token and every relation touching its address will be
-              deleted, and ingestion will refuse to observe the address again.
-              Deleted records stay recoverable from history. The ban can be
-              lifted on the Denylist page.
+              The deployed token will be deleted, ingestion will refuse to
+              catalogue the address again, and the relations graph will hide its
+              edges. The deleted record stays recoverable from history. The ban
+              can be lifted on the Denylist page.
             </DialogDescription>
           </DialogHeader>
           <div className="grid gap-1">

--- a/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
+++ b/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
@@ -1,13 +1,14 @@
 import { UnixTime } from '@l2beat/shared-pure'
 import type { Plan, RouterOutputs } from '@l2beat/token-backend'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { TrashIcon } from 'lucide-react'
+import { BanIcon, TrashIcon } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
 import { ButtonWithSpinner } from '~/components/ButtonWithSpinner'
 import { Badge } from '~/components/core/Badge'
+import { Button } from '~/components/core/Button'
 import {
   Card,
   CardContent,
@@ -15,6 +16,15 @@ import {
   CardHeader,
   CardTitle,
 } from '~/components/core/Card'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '~/components/core/Dialog'
+import { Label } from '~/components/core/Label'
 import {
   Table,
   TableBody,
@@ -29,6 +39,12 @@ import {
   TabsList,
   TabsTrigger,
 } from '~/components/core/Tabs'
+import { Textarea } from '~/components/core/TextArea'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '~/components/core/Tooltip'
 import {
   DeployedTokenForm,
   DeployedTokenSchema,
@@ -260,23 +276,37 @@ function DeployedTokenView({ token }: { token: DeployedToken }) {
                 </DeployedTokenForm>
               </CardContent>
             </Card>
-            <ButtonWithSpinner
-              variant="destructive"
-              className="mt-2"
-              size="icon"
-              onClick={() => {
-                planMutate({
-                  type: 'DeleteDeployedTokenIntent',
-                  pk: {
-                    address: token.address,
-                    chain: token.chain,
-                  },
-                })
-              }}
-              isLoading={isPending}
-            >
-              <TrashIcon />
-            </ButtonWithSpinner>
+            <div className="mt-2 flex flex-col gap-2">
+              <ButtonWithSpinner
+                variant="destructive"
+                size="icon"
+                onClick={() => {
+                  planMutate({
+                    type: 'DeleteDeployedTokenIntent',
+                    pk: {
+                      address: token.address,
+                      chain: token.chain,
+                    },
+                  })
+                }}
+                isLoading={isPending}
+              >
+                <TrashIcon />
+              </ButtonWithSpinner>
+              <DenylistTokenButton
+                isPending={isPending}
+                onConfirm={(reason) => {
+                  planMutate({
+                    type: 'DenylistDeployedTokenIntent',
+                    pk: {
+                      address: token.address,
+                      chain: token.chain,
+                    },
+                    reason,
+                  })
+                }}
+              />
+            </div>
           </div>
         </TabsContent>
         <TabsContent value="relations">
@@ -292,6 +322,80 @@ function DeployedTokenView({ token }: { token: DeployedToken }) {
           </div>
         </TabsContent>
       </Tabs>
+    </>
+  )
+}
+
+/**
+ * Bans the token's address from TokenDB via `DenylistDeployedTokenIntent` —
+ * one plan that adds the denylist entry and deletes the token and all its
+ * relations, so the blast radius shows in the confirmation dialog.
+ */
+function DenylistTokenButton({
+  isPending,
+  onConfirm,
+}: {
+  isPending: boolean
+  onConfirm: (reason: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [reason, setReason] = useState('')
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="destructive"
+            size="icon"
+            onClick={() => setOpen(true)}
+          >
+            <BanIcon />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          Denylist — delete the token and its relations, and ban the address
+          from ever being re-ingested
+        </TooltipContent>
+      </Tooltip>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Denylist this token?</DialogTitle>
+            <DialogDescription>
+              The deployed token and every relation touching its address will be
+              deleted, and ingestion will refuse to observe the address again.
+              Deleted records stay recoverable from history. The ban can be
+              lifted on the Denylist page.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-1">
+            <Label htmlFor="denylist-reason">Reason</Label>
+            <Textarea
+              id="denylist-reason"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder="Test token used by team X"
+            />
+          </div>
+          <DialogFooter>
+            <ButtonWithSpinner
+              variant="destructive"
+              isLoading={isPending}
+              disabled={!reason.trim()}
+              onClick={() => {
+                setOpen(false)
+                onConfirm(reason)
+              }}
+            >
+              Denylist
+            </ButtonWithSpinner>
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
+++ b/packages/token-ui/src/pages/tokens/DeployedTokenPage.tsx
@@ -488,56 +488,78 @@ function TokenRelationsSection({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {entries.map(({ relation, role, otherEndpoint, otherToken }) => (
-                <TableRow
-                  key={[
-                    relation.tokenAChain,
-                    relation.tokenAAddress,
-                    relation.tokenBChain,
-                    relation.tokenBAddress,
-                    relation.plugin,
-                    relation.bridgeType,
-                  ].join(':')}
-                >
-                  <TableCell className="min-w-56 whitespace-normal align-top">
-                    {otherToken ? (
-                      <Link
-                        to={`/tokens/${otherToken.chain}/${otherToken.address}`}
-                        className="font-medium underline"
-                      >
-                        {otherToken.symbol} on {otherToken.chain}
-                      </Link>
-                    ) : (
-                      <span className="font-medium">Missing token</span>
-                    )}
-                    <div className="break-all text-muted-foreground text-xs">
-                      {otherToken
-                        ? otherToken.address
-                        : `${otherEndpoint.chain}:${otherEndpoint.address}`}
-                    </div>
-                  </TableCell>
-                  <TableCell className="align-top">
-                    <div className="font-medium">{role}</div>
-                    <div className="text-muted-foreground text-xs">
-                      {RELATION_ROLE_DESCRIPTIONS[role]}
-                    </div>
-                  </TableCell>
-                  <TableCell className="align-top">{relation.plugin}</TableCell>
-                  <TableCell className="align-top">
-                    {relation.bridgeType}
-                  </TableCell>
-                  <TableCell className="whitespace-normal align-top">
-                    <details>
-                      <summary className="cursor-pointer text-muted-foreground text-xs">
-                        JSON
-                      </summary>
-                      <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-2 text-xs">
-                        {JSON.stringify(relation.transfer, null, 2)}
-                      </pre>
-                    </details>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {entries.map(
+                ({
+                  relation,
+                  role,
+                  otherEndpoint,
+                  otherToken,
+                  otherEndpointDenylisted,
+                }) => (
+                  <TableRow
+                    key={[
+                      relation.tokenAChain,
+                      relation.tokenAAddress,
+                      relation.tokenBChain,
+                      relation.tokenBAddress,
+                      relation.plugin,
+                      relation.bridgeType,
+                    ].join(':')}
+                  >
+                    <TableCell className="min-w-56 whitespace-normal align-top">
+                      {otherToken ? (
+                        <Link
+                          to={`/tokens/${otherToken.chain}/${otherToken.address}`}
+                          className="font-medium underline"
+                        >
+                          {otherToken.symbol} on {otherToken.chain}
+                        </Link>
+                      ) : (
+                        <span className="font-medium">
+                          {otherEndpointDenylisted
+                            ? 'Denylisted address'
+                            : 'Missing token'}
+                        </span>
+                      )}
+                      {otherEndpointDenylisted && (
+                        <span
+                          className="ml-1"
+                          title="This address is denylisted — the observed relation is shown, but the address is banned from TokenDB"
+                        >
+                          🚫
+                        </span>
+                      )}
+                      <div className="break-all text-muted-foreground text-xs">
+                        {otherToken
+                          ? otherToken.address
+                          : `${otherEndpoint.chain}:${otherEndpoint.address}`}
+                      </div>
+                    </TableCell>
+                    <TableCell className="align-top">
+                      <div className="font-medium">{role}</div>
+                      <div className="text-muted-foreground text-xs">
+                        {RELATION_ROLE_DESCRIPTIONS[role]}
+                      </div>
+                    </TableCell>
+                    <TableCell className="align-top">
+                      {relation.plugin}
+                    </TableCell>
+                    <TableCell className="align-top">
+                      {relation.bridgeType}
+                    </TableCell>
+                    <TableCell className="whitespace-normal align-top">
+                      <details>
+                        <summary className="cursor-pointer text-muted-foreground text-xs">
+                          JSON
+                        </summary>
+                        <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-2 text-xs">
+                          {JSON.stringify(relation.transfer, null, 2)}
+                        </pre>
+                      </details>
+                    </TableCell>
+                  </TableRow>
+                ),
+              )}
             </TableBody>
           </Table>
         )}

--- a/packages/token-ui/src/pages/tokens/TokenDenylistPage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenDenylistPage.tsx
@@ -1,0 +1,188 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { Plan } from '@l2beat/token-backend'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { TrashIcon } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { ButtonWithSpinner } from '~/components/ButtonWithSpinner'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/core/Card'
+import { Input } from '~/components/core/Input'
+import { Label } from '~/components/core/Label'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/core/Table'
+import { LoadingState } from '~/components/LoadingState'
+import { PlanConfirmationDialog } from '~/components/PlanConfirmationDialog'
+import { AppLayout } from '~/layouts/AppLayout'
+import { useTRPC } from '~/react-query/trpc'
+
+export function TokenDenylistPage() {
+  const trpc = useTRPC()
+  const [plan, setPlan] = useState<Plan | undefined>(undefined)
+  const [chain, setChain] = useState('')
+  const [address, setAddress] = useState('')
+  const [reason, setReason] = useState('')
+
+  const { data: entries, isLoading } = useQuery(
+    trpc.tokenDenylist.getAll.queryOptions(),
+  )
+
+  const { mutate: planMutate, isPending } = useMutation(
+    trpc.plan.generate.mutationOptions({
+      onSuccess: (data) => {
+        if (data.outcome === 'success') {
+          setPlan(data.plan)
+        } else {
+          toast.error(data.error)
+        }
+      },
+    }),
+  )
+
+  return (
+    <AppLayout>
+      <PlanConfirmationDialog
+        plan={plan}
+        setPlan={setPlan}
+        onSuccess={() => {
+          setChain('')
+          setAddress('')
+          setReason('')
+        }}
+      />
+      <div className="mx-auto w-full max-w-5xl space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Denylist an address</CardTitle>
+            <CardDescription>
+              Bans the address from TokenDB: the deployed token (if catalogued)
+              and every relation touching the address are deleted, and ingestion
+              refuses to observe it again. The address does not have to be
+              catalogued. Everything deleted stays recoverable from history.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap items-end gap-2">
+              <div className="grid gap-1">
+                <Label htmlFor="denylist-chain">Chain</Label>
+                <Input
+                  id="denylist-chain"
+                  value={chain}
+                  onChange={(e) => setChain(e.target.value)}
+                  placeholder="arbitrum"
+                />
+              </div>
+              <div className="grid min-w-96 gap-1">
+                <Label htmlFor="denylist-address">Address</Label>
+                <Input
+                  id="denylist-address"
+                  value={address}
+                  onChange={(e) => setAddress(e.target.value)}
+                  placeholder="0x…"
+                />
+              </div>
+              <div className="grid min-w-64 flex-1 gap-1">
+                <Label htmlFor="denylist-reason">Reason</Label>
+                <Input
+                  id="denylist-reason"
+                  value={reason}
+                  onChange={(e) => setReason(e.target.value)}
+                  placeholder="Test token used by team X"
+                />
+              </div>
+              <ButtonWithSpinner
+                isLoading={isPending}
+                disabled={!chain || !address || !reason.trim()}
+                onClick={() =>
+                  planMutate({
+                    type: 'DenylistDeployedTokenIntent',
+                    pk: { chain, address },
+                    reason,
+                  })
+                }
+              >
+                Denylist
+              </ButtonWithSpinner>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>Denylisted addresses</CardTitle>
+            <CardDescription>
+              Removing an entry only lifts the ban — deleted tokens and
+              relations are re-created by ingestion from live transfers, or
+              manually from history.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <LoadingState className="h-48" />
+            ) : !entries || entries.length === 0 ? (
+              <div className="text-muted-foreground text-sm">
+                No denylisted addresses.
+              </div>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Chain</TableHead>
+                    <TableHead>Address</TableHead>
+                    <TableHead>Reason</TableHead>
+                    <TableHead>Added</TableHead>
+                    <TableHead />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {entries.map((entry) => (
+                    <TableRow key={`${entry.chain}:${entry.address}`}>
+                      <TableCell className="align-top">{entry.chain}</TableCell>
+                      <TableCell className="break-all align-top">
+                        {entry.address}
+                      </TableCell>
+                      <TableCell className="whitespace-normal align-top">
+                        {entry.reason}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        {UnixTime.toYYYYMMDD(entry.createdAt)}
+                      </TableCell>
+                      <TableCell className="align-top">
+                        <ButtonWithSpinner
+                          variant="destructive"
+                          size="icon"
+                          isLoading={isPending}
+                          onClick={() =>
+                            planMutate({
+                              type: 'RemoveTokenDenylistEntryIntent',
+                              pk: {
+                                chain: entry.chain,
+                                address: entry.address,
+                              },
+                            })
+                          }
+                        >
+                          <TrashIcon />
+                        </ButtonWithSpinner>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </AppLayout>
+  )
+}

--- a/packages/token-ui/src/pages/tokens/TokenDenylistPage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenDenylistPage.tsx
@@ -67,9 +67,10 @@ export function TokenDenylistPage() {
             <CardTitle>Denylist an address</CardTitle>
             <CardDescription>
               Bans the address from TokenDB: the deployed token (if catalogued)
-              and every relation touching the address are deleted, and ingestion
-              refuses to observe it again. The address does not have to be
-              catalogued. Everything deleted stays recoverable from history.
+              is deleted, ingestion refuses to catalogue it again, and the
+              relations graph hides its edges. Relations stay recorded — they
+              are observations. The address does not have to be catalogued. The
+              deleted token stays recoverable from history.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -106,7 +107,7 @@ export function TokenDenylistPage() {
                 disabled={!chain || !address || !reason.trim()}
                 onClick={() =>
                   planMutate({
-                    type: 'DenylistDeployedTokenIntent',
+                    type: 'AddTokenToDenylistIntent',
                     pk: { chain, address },
                     reason,
                   })
@@ -121,9 +122,10 @@ export function TokenDenylistPage() {
           <CardHeader>
             <CardTitle>Denylisted addresses</CardTitle>
             <CardDescription>
-              Removing an entry only lifts the ban — deleted tokens and
-              relations are re-created by ingestion from live transfers, or
-              manually from history.
+              Removing an entry only lifts the ban — a deleted token is
+              re-created by ingestion from live transfers, or manually from
+              history. Relations were never deleted, so the graph shows the
+              address again immediately.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -164,7 +166,7 @@ export function TokenDenylistPage() {
                           isLoading={isPending}
                           onClick={() =>
                             planMutate({
-                              type: 'RemoveTokenDenylistEntryIntent',
+                              type: 'DeleteTokenFromDenylistIntent',
                               pk: {
                                 chain: entry.chain,
                                 address: entry.address,

--- a/packages/token-ui/src/pages/tokens/add-tokens/AddDeployedToken.tsx
+++ b/packages/token-ui/src/pages/tokens/add-tokens/AddDeployedToken.tsx
@@ -124,7 +124,8 @@ export function AddDeployedToken() {
     if (
       checks.error?.type === 'already-exists' ||
       checks.error?.type === 'not-found-on-coingecko' ||
-      checks.error?.type === 'not-a-token'
+      checks.error?.type === 'not-a-token' ||
+      checks.error?.type === 'denylisted'
     ) {
       form.setError('address', {
         type: checks.error.type,
@@ -185,7 +186,10 @@ export function AddDeployedToken() {
       setDeployedTokenExistsError(form)
       return
     }
-    if (checks?.error?.type === 'not-a-token') {
+    if (
+      checks?.error?.type === 'not-a-token' ||
+      checks?.error?.type === 'denylisted'
+    ) {
       form.setError('address', {
         type: checks.error.type,
         message: checks.error.message,


### PR DESCRIPTION
Resolves L2B-14529

Creates a separate Denylist (editable via UI) to prevent tokens (and relations including these tokens) to ever be ingested or added.

This is considered less brittle than adding some flag to existing, ingested tokens, and then remembering to filter them out for each new functionality.