### PR TITLE
Lower min particle value on embedded flow graphs

### DIFF
--- a/packages/frontend/src/pages/interop/components/flows/FlowsParticleLegend.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/FlowsParticleLegend.tsx
@@ -32,7 +32,10 @@ export function FlowsParticleLegend({
     <>
       <span className="size-1.5 rounded-full bg-brand" />1 particle ≈{' '}
       <span className="font-bold text-brand">
-        {formatCurrency(dollarsPerParticle, 'usd', { decimals: 0 })}
+        {formatCurrency(dollarsPerParticle, 'usd', {
+          // sub-dollar values ($0.1, $0.5) need a decimal to not render as "<$1"
+          decimals: dollarsPerParticle < 1 ? 1 : 0,
+        })}
       </span>
     </>
   ) : null

--- a/packages/frontend/src/pages/interop/components/flows/consts.ts
+++ b/packages/frontend/src/pages/interop/components/flows/consts.ts
@@ -6,9 +6,11 @@ export const MIN_SELECTED_PROTOCOLS = 1
 export const DOLLARS_PER_PARTICLE = 50
 // Lower base for embedded volume graphs (token page, project sections) —
 // kept very low so graphs of low-volume tokens still show movement
-export const EMBEDDED_FLOWS_DOLLARS_PER_PARTICLE = 1
-// Scaled-up particle values are rounded to a multiple of this step
-export const DOLLARS_PER_PARTICLE_STEP = 5
+export const EMBEDDED_FLOWS_DOLLARS_PER_PARTICLE = 0.1
+// Allowed particle values — scaling picks the lowest one satisfying the caps
+export const DOLLARS_PER_PARTICLE_OPTIONS = [0.1, 0.5, 1, 5, 10, 20, 50, 100]
+// Beyond the last option, values continue in multiples of this step (150, 200, ...)
+export const DOLLARS_PER_PARTICLE_EXTENSION_STEP = 50
 // Travel time (seconds) for the longest path — shorter paths take proportionally less
 export const BASE_DURATION_S = 6
 // Per-flow upper bound to avoid excessive DOM nodes

--- a/packages/frontend/src/pages/interop/components/flows/consts.ts
+++ b/packages/frontend/src/pages/interop/components/flows/consts.ts
@@ -4,8 +4,9 @@ export const MIN_SELECTED_PROTOCOLS = 1
 
 // Base particle value — each particle starts at 50 USD of volume per second
 export const DOLLARS_PER_PARTICLE = 50
-// Lower base for embedded volume graphs (token page, project sections)
-export const EMBEDDED_FLOWS_DOLLARS_PER_PARTICLE = 25
+// Lower base for embedded volume graphs (token page, project sections) —
+// kept very low so graphs of low-volume tokens still show movement
+export const EMBEDDED_FLOWS_DOLLARS_PER_PARTICLE = 1
 // Step size when increasing particle value to satisfy constraints
 export const DOLLARS_PER_PARTICLE_STEP = 25
 // Travel time (seconds) for the longest path — shorter paths take proportionally less

--- a/packages/frontend/src/pages/interop/components/flows/consts.ts
+++ b/packages/frontend/src/pages/interop/components/flows/consts.ts
@@ -7,8 +7,8 @@ export const DOLLARS_PER_PARTICLE = 50
 // Lower base for embedded volume graphs (token page, project sections) —
 // kept very low so graphs of low-volume tokens still show movement
 export const EMBEDDED_FLOWS_DOLLARS_PER_PARTICLE = 1
-// Step size when increasing particle value to satisfy constraints
-export const DOLLARS_PER_PARTICLE_STEP = 25
+// Scaled-up particle values are rounded to a multiple of this step
+export const DOLLARS_PER_PARTICLE_STEP = 5
 // Travel time (seconds) for the longest path — shorter paths take proportionally less
 export const BASE_DURATION_S = 6
 // Per-flow upper bound to avoid excessive DOM nodes

--- a/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.test.ts
+++ b/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.test.ts
@@ -8,21 +8,48 @@ describe(getScaledParticleCounts.name, () => {
     expect(result.dollarsPerParticle).toEqual(50)
   })
 
-  it('increases dollars per particle in $5 steps when per-flow cap is exceeded', () => {
-    // base counts [100, 70, 10] — max=100 > 60, need to step up
-    // minByMax = 100*50/60 ≈ 83.33, rounded up to $85
+  it('steps up to the next allowed value when per-flow cap is exceeded', () => {
+    // base counts [100, 70, 10] — max=100 > 60
+    // minByMax = 100*50/60 ≈ 83.33 → next allowed value is $100
     const result = getScaledParticleCounts([100, 70, 10])
-    expect(result.dollarsPerParticle).toEqual(85)
-    expect(Math.max(...result.counts) <= 60).toEqual(true)
-    expect(result.counts.reduce((s, c) => s + c, 0) <= 700).toEqual(true)
+    expect(result.counts).toEqual([50, 35, 5])
+    expect(result.dollarsPerParticle).toEqual(100)
   })
 
-  it('increases dollars per particle when global cap is exceeded', () => {
+  it('steps up to the next allowed value when global cap is exceeded', () => {
     // 20 flows of 60 each — total=1200 > 700
-    // minByTotal = 1200*50/700 ≈ 85.71, rounded up to $90
+    // minByTotal = 1200*50/700 ≈ 85.71 → next allowed value is $100
     const result = getScaledParticleCounts(Array.from({ length: 20 }, () => 60))
-    expect(result.dollarsPerParticle).toEqual(90)
+    expect(result.counts).toEqual(Array.from({ length: 20 }, () => 30))
+    expect(result.dollarsPerParticle).toEqual(100)
+  })
+
+  it('continues in $50 multiples beyond the last fixed option', () => {
+    // base 100, minByMax = 100*100/60 ≈ 166.67 → 200
+    const result = getScaledParticleCounts([100, 70, 10], 100)
+    expect(Math.max(...result.counts) <= 60).toEqual(true)
     expect(result.counts.reduce((s, c) => s + c, 0) <= 700).toEqual(true)
+    expect(result.dollarsPerParticle).toEqual(200)
+  })
+
+  it('scales a low base up through the fixed options', () => {
+    // base 1, max=100 > 60 → minByMax = 100*1/60 ≈ 1.67 → next option is 5
+    const result = getScaledParticleCounts([100, 70, 10], 1)
+    expect(result.dollarsPerParticle).toEqual(5)
+    expect(result.counts).toEqual([20, 14, 2])
+  })
+
+  it('keeps a sub-dollar base when caps are satisfied', () => {
+    const result = getScaledParticleCounts([3, 1], 0.1)
+    expect(result.counts).toEqual([3, 1])
+    expect(result.dollarsPerParticle).toEqual(0.1)
+  })
+
+  it('scales a sub-dollar base to the next sub-dollar option', () => {
+    // base 0.1, max=200 > 60 → minByMax = 200*0.1/60 ≈ 0.33 → next option is 0.5
+    const result = getScaledParticleCounts([200], 0.1)
+    expect(result.dollarsPerParticle).toEqual(0.5)
+    expect(result.counts).toEqual([40])
   })
 
   it('returns empty counts for empty input', () => {
@@ -44,25 +71,9 @@ describe(getScaledParticleCounts.name, () => {
   it('honors caps when the closed-form result lands at a step boundary', () => {
     // maxBase=600 → minByMax = 600*50/60 = 500, dpp = 500, scale = 0.1.
     // 0.1 is not exact in floating point, so 600*0.1 can land just above 60.
-    // The re-check should bump one step if so.
+    // The re-check should bump to the next allowed value if so.
     const result = getScaledParticleCounts([600])
     expect(Math.max(...result.counts) <= 60).toEqual(true)
-  })
-
-  it('respects a custom baseDollarsPerParticle', () => {
-    // Same shape as the per-flow-cap test but starting at $100.
-    // minByMax = 100*100/60 ≈ 166.67, rounded up to $170.
-    const result = getScaledParticleCounts([100, 70, 10], 100)
-    expect(Math.max(...result.counts) <= 60).toEqual(true)
-    expect(result.counts.reduce((s, c) => s + c, 0) <= 700).toEqual(true)
-    expect(result.dollarsPerParticle).toEqual(170)
-  })
-
-  it('scales a low base up to a clean step multiple', () => {
-    // base 1, max=100 > 60 → minByMax = 100*1/60 ≈ 1.67, rounded up to 5
-    const result = getScaledParticleCounts([100, 70, 10], 1)
-    expect(result.dollarsPerParticle).toEqual(5)
-    expect(result.counts).toEqual([20, 14, 2])
   })
 
   it('handles a single flow exactly at the per-flow cap', () => {

--- a/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.test.ts
+++ b/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.test.ts
@@ -59,6 +59,15 @@ describe(getScaledParticleCounts.name, () => {
     expect(result.dollarsPerParticle).toEqual(175)
   })
 
+  it('scales a low base up to a clean step multiple', () => {
+    // base 1, max=100 > 60 → minByMax = 100*1/60 ≈ 1.67, rounded up to 25
+    const result = getScaledParticleCounts([100, 70, 10], 1)
+    expect(result.dollarsPerParticle).toEqual(25)
+    expect(result.counts.map((c) => Math.round(c * 10) / 10)).toEqual([
+      4, 2.8, 0.4,
+    ])
+  })
+
   it('handles a single flow exactly at the per-flow cap', () => {
     const result = getScaledParticleCounts([60])
     expect(result.counts).toEqual([60])

--- a/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.test.ts
+++ b/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.test.ts
@@ -8,22 +8,21 @@ describe(getScaledParticleCounts.name, () => {
     expect(result.dollarsPerParticle).toEqual(50)
   })
 
-  it('increases dollars per particle in $25 steps when per-flow cap is exceeded', () => {
+  it('increases dollars per particle in $5 steps when per-flow cap is exceeded', () => {
     // base counts [100, 70, 10] — max=100 > 60, need to step up
-    // $75: 100*(50/75)=66.67 > 60, fail
-    // $100: 100*(50/100)=50 ≤ 60, total=90 ≤ 700, pass
+    // minByMax = 100*50/60 ≈ 83.33, rounded up to $85
     const result = getScaledParticleCounts([100, 70, 10])
-    expect(result.counts).toEqual([50, 35, 5])
-    expect(result.dollarsPerParticle).toEqual(100)
+    expect(result.dollarsPerParticle).toEqual(85)
+    expect(Math.max(...result.counts) <= 60).toEqual(true)
+    expect(result.counts.reduce((s, c) => s + c, 0) <= 700).toEqual(true)
   })
 
   it('increases dollars per particle when global cap is exceeded', () => {
     // 20 flows of 60 each — total=1200 > 700
-    // $75: 60*(50/75)=40, total=800 > 700, fail
-    // $100: 60*(50/100)=30, total=600 ≤ 700, pass
+    // minByTotal = 1200*50/700 ≈ 85.71, rounded up to $90
     const result = getScaledParticleCounts(Array.from({ length: 20 }, () => 60))
-    expect(result.counts).toEqual(Array.from({ length: 20 }, () => 30))
-    expect(result.dollarsPerParticle).toEqual(100)
+    expect(result.dollarsPerParticle).toEqual(90)
+    expect(result.counts.reduce((s, c) => s + c, 0) <= 700).toEqual(true)
   })
 
   it('returns empty counts for empty input', () => {
@@ -52,20 +51,18 @@ describe(getScaledParticleCounts.name, () => {
 
   it('respects a custom baseDollarsPerParticle', () => {
     // Same shape as the per-flow-cap test but starting at $100.
-    // minByMax = 100*100/60 ≈ 166.67, step up from 100 in $25s → 175.
+    // minByMax = 100*100/60 ≈ 166.67, rounded up to $170.
     const result = getScaledParticleCounts([100, 70, 10], 100)
     expect(Math.max(...result.counts) <= 60).toEqual(true)
     expect(result.counts.reduce((s, c) => s + c, 0) <= 700).toEqual(true)
-    expect(result.dollarsPerParticle).toEqual(175)
+    expect(result.dollarsPerParticle).toEqual(170)
   })
 
   it('scales a low base up to a clean step multiple', () => {
-    // base 1, max=100 > 60 → minByMax = 100*1/60 ≈ 1.67, rounded up to 25
+    // base 1, max=100 > 60 → minByMax = 100*1/60 ≈ 1.67, rounded up to 5
     const result = getScaledParticleCounts([100, 70, 10], 1)
-    expect(result.dollarsPerParticle).toEqual(25)
-    expect(result.counts.map((c) => Math.round(c * 10) / 10)).toEqual([
-      4, 2.8, 0.4,
-    ])
+    expect(result.dollarsPerParticle).toEqual(5)
+    expect(result.counts).toEqual([20, 14, 2])
   })
 
   it('handles a single flow exactly at the per-flow cap', () => {

--- a/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.ts
+++ b/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.ts
@@ -1,6 +1,7 @@
 import {
   DOLLARS_PER_PARTICLE,
-  DOLLARS_PER_PARTICLE_STEP,
+  DOLLARS_PER_PARTICLE_EXTENSION_STEP,
+  DOLLARS_PER_PARTICLE_OPTIONS,
   MAX_PARTICLES_PER_FLOW,
   MAX_TOTAL_PARTICLES,
 } from '../../consts'
@@ -12,8 +13,9 @@ interface ScaledParticleResult {
 
 /**
  * Given base particle counts (computed at baseDollarsPerParticle), finds the
- * lowest dollars-per-particle value (a multiple of DOLLARS_PER_PARTICLE_STEP,
- * or the base itself) where both constraints are satisfied:
+ * lowest allowed dollars-per-particle value (one of
+ * DOLLARS_PER_PARTICLE_OPTIONS, or beyond the last option a multiple of
+ * DOLLARS_PER_PARTICLE_EXTENSION_STEP) where both constraints are satisfied:
  *   - no single flow exceeds MAX_PARTICLES_PER_FLOW
  *   - total across all flows does not exceed MAX_TOTAL_PARTICLES
  */
@@ -33,26 +35,43 @@ export function getScaledParticleCounts(
     (totalBaseCount * baseDollarsPerParticle) / MAX_TOTAL_PARTICLES
   const minRequiredDpp = Math.max(minDppForPerFlowCap, minDppForTotalCap)
 
-  // Round up to a step multiple so the legend shows clean values even when
-  // the base itself is not a multiple of the step
   let dollarsPerParticle = Math.max(
     baseDollarsPerParticle,
-    Math.ceil(minRequiredDpp / DOLLARS_PER_PARTICLE_STEP) *
-      DOLLARS_PER_PARTICLE_STEP,
+    nextAllowedDpp(minRequiredDpp),
   )
 
   let scale = baseDollarsPerParticle / dollarsPerParticle
   let counts = baseExactCounts.map((c) => c * scale)
 
   // Closed-form math can land a hair above the caps due to floating-point
-  // rounding (e.g. total = 700.0000000003). Re-verify and bump one step if so.
+  // rounding (e.g. total = 700.0000000003). Re-verify and bump one value if so.
   const maxCount = Math.max(...counts)
   const totalCount = counts.reduce((sum, c) => sum + c, 0)
   if (maxCount > MAX_PARTICLES_PER_FLOW || totalCount > MAX_TOTAL_PARTICLES) {
-    dollarsPerParticle += DOLLARS_PER_PARTICLE_STEP
+    dollarsPerParticle = nextAllowedDppAbove(dollarsPerParticle)
     scale = baseDollarsPerParticle / dollarsPerParticle
     counts = baseExactCounts.map((c) => c * scale)
   }
 
   return { counts, dollarsPerParticle }
+}
+
+/** The smallest allowed dollars-per-particle value that is >= min */
+function nextAllowedDpp(min: number): number {
+  const option = DOLLARS_PER_PARTICLE_OPTIONS.find((o) => o >= min)
+  if (option !== undefined) return option
+  return (
+    Math.ceil(min / DOLLARS_PER_PARTICLE_EXTENSION_STEP) *
+    DOLLARS_PER_PARTICLE_EXTENSION_STEP
+  )
+}
+
+/** The smallest allowed dollars-per-particle value that is strictly > value */
+function nextAllowedDppAbove(value: number): number {
+  const option = DOLLARS_PER_PARTICLE_OPTIONS.find((o) => o > value)
+  if (option !== undefined) return option
+  return (
+    (Math.floor(value / DOLLARS_PER_PARTICLE_EXTENSION_STEP) + 1) *
+    DOLLARS_PER_PARTICLE_EXTENSION_STEP
+  )
 }

--- a/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.ts
+++ b/packages/frontend/src/pages/interop/components/flows/graph/utils/getScaledParticleCounts.ts
@@ -12,8 +12,8 @@ interface ScaledParticleResult {
 
 /**
  * Given base particle counts (computed at baseDollarsPerParticle), finds the
- * lowest dollars-per-particle value (in DOLLARS_PER_PARTICLE_STEP increments)
- * where both constraints are satisfied:
+ * lowest dollars-per-particle value (a multiple of DOLLARS_PER_PARTICLE_STEP,
+ * or the base itself) where both constraints are satisfied:
  *   - no single flow exceeds MAX_PARTICLES_PER_FLOW
  *   - total across all flows does not exceed MAX_TOTAL_PARTICLES
  */
@@ -31,20 +31,15 @@ export function getScaledParticleCounts(
     (maxBaseCount * baseDollarsPerParticle) / MAX_PARTICLES_PER_FLOW
   const minDppForTotalCap =
     (totalBaseCount * baseDollarsPerParticle) / MAX_TOTAL_PARTICLES
-  const minRequiredDpp = Math.max(
-    baseDollarsPerParticle,
-    minDppForPerFlowCap,
-    minDppForTotalCap,
-  )
+  const minRequiredDpp = Math.max(minDppForPerFlowCap, minDppForTotalCap)
 
-  const stepsNeeded = Math.max(
-    0,
-    Math.ceil(
-      (minRequiredDpp - baseDollarsPerParticle) / DOLLARS_PER_PARTICLE_STEP,
-    ),
+  // Round up to a step multiple so the legend shows clean values even when
+  // the base itself is not a multiple of the step
+  let dollarsPerParticle = Math.max(
+    baseDollarsPerParticle,
+    Math.ceil(minRequiredDpp / DOLLARS_PER_PARTICLE_STEP) *
+      DOLLARS_PER_PARTICLE_STEP,
   )
-  let dollarsPerParticle =
-    baseDollarsPerParticle + stepsNeeded * DOLLARS_PER_PARTICLE_STEP
 
   let scale = baseDollarsPerParticle / dollarsPerParticle
   let counts = baseExactCounts.map((c) => c * scale)


### PR DESCRIPTION
## Summary

Token pages with low-volume tokens (e.g. `/interop/tokens/op`, ~$4.6k/day on its biggest flow) rendered effectively empty flow graphs — at the previous $25-per-particle floor the busiest flow emitted one particle every ~8 minutes.

- Lower `EMBEDDED_FLOWS_DOLLARS_PER_PARTICLE` from 25 to 0.1 so embedded volume graphs (token page, project sections) of low-volume tokens still show visible movement.
- Replace the fixed $25 scaling step in `getScaledParticleCounts` with a ladder of allowed values: **0.1, 0.5, 1, 5, 10, 20, 50, 100**, then multiples of 50 (150, 200, ...). Scaling picks the lowest allowed value that satisfies the per-flow (60) and total (700) particle caps.
- The main interop page keeps its $50 base and now scales through 100, 150, 200, ...
- Fix `FlowsParticleLegend` formatting for sub-dollar values — with `decimals: 0` a $0.1 particle value rendered as "<$1"; sub-dollar values now show one decimal ("1 particle ≈ $0.1").

## Testing

- Extended `getScaledParticleCounts` unit tests to cover the value ladder: stepping to the next allowed option under both caps, continuing in $50 multiples beyond $100, and sub-dollar bases staying put / scaling 0.1 → 0.5. 12 tests passing.
- Manual browser check of the embedded graphs — Not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)