### PR TITLE
Skip tokens the backend cannot price

### DIFF
--- a/packages/l2b/src/implementations/discovery-ui/tokenBackend.test.ts
+++ b/packages/l2b/src/implementations/discovery-ui/tokenBackend.test.ts
@@ -1,0 +1,85 @@
+import { expect } from 'earl'
+import { parseTokens } from './tokenBackend'
+
+interface TestAbstractToken {
+  symbol: string
+  iconUrl: string | null
+  coingeckoId: string | null
+  deployedTokens: {
+    chain: string
+    address: string
+    symbol: string
+    decimals: number
+  }[]
+}
+
+// The second entry is the chains procedure of the tRPC batch, which is ignored.
+function toBody(abstractTokens: TestAbstractToken[]) {
+  return [{ result: { data: { abstractTokens } } }, { result: { data: [] } }]
+}
+
+const ETHER: TestAbstractToken = {
+  symbol: 'ETH',
+  iconUrl: 'https://example.com/eth.png',
+  coingeckoId: 'ethereum',
+  deployedTokens: [
+    { chain: 'ethereum', address: 'native', symbol: 'ETH', decimals: 18 },
+    { chain: 'base', address: 'native', symbol: 'ETH', decimals: 18 },
+  ],
+}
+
+const UNPRICED: TestAbstractToken = {
+  symbol: 'NOPRICE',
+  iconUrl: null,
+  coingeckoId: null,
+  deployedTokens: [
+    { chain: 'ethereum', address: '0xabc', symbol: 'NOPRICE', decimals: 6 },
+  ],
+}
+
+describe('parseTokens', () => {
+  it('flattens deployed tokens onto their abstract token', () => {
+    const tokens = parseTokens(toBody([ETHER]))
+
+    expect(tokens).toEqual([
+      {
+        chain: 'ethereum',
+        address: 'native',
+        symbol: 'ETH',
+        decimals: 18,
+        coingeckoId: 'ethereum',
+        iconUrl: 'https://example.com/eth.png',
+      },
+      {
+        chain: 'base',
+        address: 'native',
+        symbol: 'ETH',
+        decimals: 18,
+        coingeckoId: 'ethereum',
+        iconUrl: 'https://example.com/eth.png',
+      },
+    ])
+  })
+
+  // A token the backend cannot price is unusable here, but it must not cost us
+  // every other token in the response.
+  it('skips a token without a coingecko id and keeps the rest', () => {
+    const tokens = parseTokens(toBody([UNPRICED, ETHER]))
+
+    expect(tokens.map((token) => token.symbol)).toEqual(['ETH', 'ETH'])
+  })
+
+  it('reads an absent icon as undefined', () => {
+    const priced = { ...UNPRICED, coingeckoId: 'no-price' }
+    const tokens = parseTokens(toBody([priced]))
+
+    expect(tokens.map((token) => token.iconUrl)).toEqual([undefined])
+  })
+
+  it('rejects a response it cannot read', () => {
+    expect(() => parseTokens({ result: 'not a batch' })).toThrow()
+    expect(() =>
+      parseTokens(toBody([{ ...ETHER, symbol: 1 } as never])),
+    ).toThrow()
+  })
+})

--- a/packages/l2b/src/implementations/discovery-ui/tokenBackend.ts
+++ b/packages/l2b/src/implementations/discovery-ui/tokenBackend.ts
@@ -25,7 +25,7 @@ const DeployedToken = v.object({
 const AbstractToken = v.object({
   symbol: v.string(),
   iconUrl: v.union([v.string(), v.null()]),
-  coingeckoId: v.string(),
+  coingeckoId: v.union([v.string(), v.null()]),
   deployedTokens: v.array(DeployedToken),
 })
 
@@ -56,17 +56,25 @@ export async function fetchTokens(): Promise<BackendToken[]> {
     `Token backend responded with ${response.status}`,
   )
 
-  const [tokens] = TokensResponse.parse(await response.json())
-  return tokens.result.data.abstractTokens.flatMap((abstractToken) =>
-    abstractToken.deployedTokens.map(
+  return parseTokens(await response.json())
+}
+
+export function parseTokens(body: unknown): BackendToken[] {
+  const [tokens] = TokensResponse.parse(body)
+  return tokens.result.data.abstractTokens.flatMap((abstractToken) => {
+    const coingeckoId = abstractToken.coingeckoId
+    if (coingeckoId === null) {
+      return []
+    }
+    return abstractToken.deployedTokens.map(
       (deployed): BackendToken => ({
         chain: deployed.chain,
         address: deployed.address,
         symbol: deployed.symbol,
         decimals: deployed.decimals,
-        coingeckoId: abstractToken.coingeckoId,
+        coingeckoId,
         iconUrl: abstractToken.iconUrl ?? undefined,
       }),
-    ),
-  )
+    )
+  })
 }


### PR DESCRIPTION
`AbstractToken.coingeckoId` is nullable, both in the schema (`packages/database/src/kysely/generated/types.ts:13`) and in `AbstractTokenRepository`'s record type, and `abstractTokens.getAllWithDeployedTokens` returns every abstract token including unpriced ones. The validator here declared `coingeckoId: v.string()`, so a single `null` would reject the whole batch response, `fetchTokens()` would throw, and every TVL request would return 500.

The field is now parsed as nullable and records that cannot be priced are dropped, so one unpriceable token costs us that token instead of the entire list. `BackendToken.coingeckoId` stays a plain `string`, so nothing downstream has to think about the nullable case.

Parsing moved out of `fetchTokens` into an exported `parseTokens`, which gives the behaviour a test seam that does not need `fetch` stubbed. Four tests cover the flattening, the skip, the absent icon, and a malformed body.

## Status

Latent, not currently firing: **0 of 5,964** live abstract tokens have a null `coingeckoId` today, which is why the panel works. It breaks the moment an unpriced token is added upstream.

Verified against the real payload with a null injected into a token that has deployed tokens:

```
unmodified payload parses to 9644 tokens
nulling "ICCM" which has 1 deployed tokens
with a null id it parses to 9643 tokens
```

One token dropped rather than the whole list rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)