### PR TITLE
Say when the TVL map failed instead of showing no value

### DIFF
--- a/packages/protocolbeat/src/apps/discovery/panel-tvl-map/TvlMapPanel.tsx
+++ b/packages/protocolbeat/src/apps/discovery/panel-tvl-map/TvlMapPanel.tsx
@@ -110,6 +110,13 @@ export function TvlMapPanel() {
   const holdings = toHoldings(holders, results, chainColors)
 
   if (swept === holders.length && holdings.length === 0) {
+    if (failed > 0) {
+      return (
+        <ActionNeededState
+          message={`Failed to value ${failed} of ${holders.length} addresses`}
+        />
+      )
+    }
     return <ActionNeededState message="No value held by this project" />
   }
 


### PR DESCRIPTION
A failed query is no longer pending, so when every address request fails `swept === holders.length` while `holdings` is empty. That fell into the no-value branch, which returned before `Summary` could ever show the failure count, so an unavailable estimate was reported as a successful zero.

The failure case is now handled first:

```tsx
if (swept === holders.length && holdings.length === 0) {
  if (failed > 0) {
    return <ActionNeededState message={`Failed to value ${failed} of ${holders.length} addresses`} />
  }
  return <ActionNeededState message="No value held by this project" />
}
```

The message counts failures rather than asserting that everything failed, so it stays true in the partial case too: some addresses failing while none of the rest hold value is still a broken estimate, not an empty one. When at least one address does hold value the map renders as before, with the failure count in the summary bar.

## Verified

Ran the discovery UI with `TOKEN_BACKEND_READONLY_AUTH_TOKEN` blanked, which is one of the conditions described:

```
addresses in project: 113
status codes for the first 5 sweeps: 500 500 500 500 500
```

Every sweep errors, which is exactly the state that used to render "No value held by this project".

🤖 Generated with [Claude Code](https://claude.com/claude-code)