### PR TITLE
Render the copy button tooltip in a portal

### DIFF
--- a/packages/frontend/src/components/CopyButton.tsx
+++ b/packages/frontend/src/components/CopyButton.tsx
@@ -5,7 +5,12 @@ import { useTimeout } from '~/hooks/useTimeout'
 import { CopyIcon } from '~/icons/Copy'
 import { SatisfiedIcon } from '~/icons/Satisfied'
 import { cn } from '~/utils/cn'
-import { Tooltip, TooltipContent, TooltipTrigger } from './core/tooltip/Tooltip'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
+} from './core/tooltip/Tooltip'
 
 interface CopyButtonProps {
   toCopy: string | (() => string)
@@ -49,12 +54,14 @@ export function CopyButton({
           <CopyIcon className={cn('fill-current', iconClassName)} />
         )}
       </TooltipTrigger>
-      <TooltipContent
-        hideWhenDetached
-        onPointerDownOutside={(event) => event.preventDefault()}
-      >
-        {copied ? 'Copied!' : copyText}
-      </TooltipContent>
+      <TooltipPortal>
+        <TooltipContent
+          hideWhenDetached
+          onPointerDownOutside={(event) => event.preventDefault()}
+        >
+          {copied ? 'Copied!' : copyText}
+        </TooltipContent>
+      </TooltipPortal>
     </Tooltip>
   )
 }

--- a/packages/frontend/src/components/CopyButton.tsx
+++ b/packages/frontend/src/components/CopyButton.tsx
@@ -56,6 +56,7 @@ export function CopyButton({
       </TooltipTrigger>
       <TooltipPortal>
         <TooltipContent
+          className="z-1000"
           hideWhenDetached
           onPointerDownOutside={(event) => event.preventDefault()}
         >


### PR DESCRIPTION
The copy-link button inside the home page "Recent changes" modal rendered its tooltip inline, so it got clipped by the dialog's scroll container.

Wraps `CopyButton`'s `TooltipContent` in `TooltipPortal`, matching how tooltips are rendered elsewhere (`TableTooltip`, `ProjectBadge`, `ProjectNameCell`). This applies to every `CopyButton` usage, not just the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)