### PR TITLE
Add privacy relayer activity migration

### DIFF
--- a/packages/database/prisma/migrations/20260805120000_add_privacy_relayer_activity/migration.sql
+++ b/packages/database/prisma/migrations/20260805120000_add_privacy_relayer_activity/migration.sql
@@ -8,7 +8,6 @@ CREATE TABLE "PrivacyRelayerActivity" (
     "txHash" VARCHAR(66) NOT NULL,
     "logIndex" INTEGER NOT NULL,
     "relayerAddress" VARCHAR(42) NOT NULL,
-    "recipientAddress" VARCHAR(42) NOT NULL,
 
     CONSTRAINT "PrivacyRelayerActivity_pkey" PRIMARY KEY ("configurationId", "txHash", "logIndex")
 );

--- a/packages/database/prisma/migrations/20260805120000_add_privacy_relayer_activity/migration.sql
+++ b/packages/database/prisma/migrations/20260805120000_add_privacy_relayer_activity/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "PrivacyRelayerActivity" (
+    "configurationId" CHAR(12) NOT NULL,
+    "projectId" VARCHAR(255) NOT NULL,
+    "chain" VARCHAR(32) NOT NULL,
+    "timestamp" TIMESTAMP(6) NOT NULL,
+    "blockNumber" INTEGER NOT NULL,
+    "txHash" VARCHAR(66) NOT NULL,
+    "logIndex" INTEGER NOT NULL,
+    "relayerAddress" VARCHAR(42) NOT NULL,
+    "recipientAddress" VARCHAR(42) NOT NULL,
+
+    CONSTRAINT "PrivacyRelayerActivity_pkey" PRIMARY KEY ("configurationId", "txHash", "logIndex")
+);
+
+-- CreateIndex
+CREATE INDEX "PrivacyRelayerActivity_projectId_timestamp_relayerAddress_idx" ON "PrivacyRelayerActivity"("projectId", "timestamp", "relayerAddress");
+
+-- CreateIndex
+CREATE INDEX "PrivacyRelayerActivity_configurationId_timestamp_idx" ON "PrivacyRelayerActivity"("configurationId", "timestamp");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -316,6 +316,21 @@ model PrivacyFlowEvent {
   @@index([configurationId, timestamp])
 }
 
+model PrivacyRelayerActivity {
+  configurationId String   @db.Char(12)
+  projectId       String   @db.VarChar(255)
+  chain           String   @db.VarChar(32)
+  timestamp       DateTime @db.Timestamp(6)
+  blockNumber     Int
+  txHash          String   @db.VarChar(66)
+  logIndex        Int
+  relayerAddress  String   @db.VarChar(42)
+
+  @@id([configurationId, txHash, logIndex])
+  @@index([projectId, timestamp, relayerAddress])
+  @@index([configurationId, timestamp])
+}
+
 model UpdateDiff {
   projectId         String   @db.VarChar(255)
   address           String   @db.VarChar(255)

--- a/packages/database/scripts/db-restore/db-restore.ts
+++ b/packages/database/scripts/db-restore/db-restore.ts
@@ -87,6 +87,7 @@ const FEATURES: Record<string, string[]> = {
     'PrivacyBlockTimestamp',
     'PrivacyFlowEvent',
     'PrivacyPrice',
+    'PrivacyRelayerActivity',
   ],
 }
 


### PR DESCRIPTION
## Summary

- Add the `PrivacyRelayerActivity` table.
- Add indexes for project relayer queries and configuration time-range queries.

## Why

This migration is isolated so the database change can land before the application code that starts using the table.

## Validation

- Applied the complete migration chain successfully to a fresh PostgreSQL 17 database.
- Verified the privacy relayer repositories against that database.