### PR TITLE
Pan relation graph at overview zoom

### DIFF
--- a/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenRelationsGraph.tsx
@@ -8,6 +8,10 @@ import {
   type RelationGraphTheme,
 } from './relationGraphCanvas'
 import {
+  findDraggableNodeAt,
+  nodeDraggingIsEnabled,
+} from './relationGraphInteraction'
+import {
   getRelationGraphFocus,
   type RelationGraph,
   type RelationGraphSelection,
@@ -168,6 +172,16 @@ export function TokenRelationsGraph({
       return findNodeAt(scene, x, y, radius / scale)
     }
 
+    function pickDraggableNode(pointer: [number, number]) {
+      const [x, y] = toWorld(pointer)
+      const scale = cameraTransform.k
+      const radius = Math.max(
+        NODE_RING_RADIUS * nodeVisualScreenScale(scale),
+        MIN_NODE_HIT_RADIUS,
+      )
+      return findDraggableNodeAt(scene, x, y, radius / scale, scale)
+    }
+
     function pickLink(pointer: [number, number]) {
       const [x, y] = toWorld(pointer)
       const scale = cameraTransform.k
@@ -239,10 +253,17 @@ export function TokenRelationsGraph({
         }
         // No pan while a node drag is active (a later touch joining it) or
         // when the gesture itself grabs a node (the primary pointer).
-        return allowed && !drag && pickNode(eventPoint(event)) === undefined
+        return (
+          allowed && !drag && pickDraggableNode(eventPoint(event)) === undefined
+        )
       })
       .on('start', (event: d3.D3ZoomEvent<HTMLCanvasElement, unknown>) => {
-        if (event.sourceEvent && !hovered) canvas.style.cursor = 'grabbing'
+        if (
+          event.sourceEvent &&
+          (!hovered || !nodeDraggingIsEnabled(cameraTransform.k))
+        ) {
+          canvas.style.cursor = 'grabbing'
+        }
       })
       .on('zoom', (event: d3.D3ZoomEvent<HTMLCanvasElement, unknown>) => {
         cameraTransform = event.transform
@@ -261,7 +282,7 @@ export function TokenRelationsGraph({
       .on('pointerdown.graph', (event: PointerEvent) => {
         suppressNextClick = false
         if (!event.isPrimary || event.button !== 0) return
-        const node = pickNode(eventPoint(event))
+        const node = pickDraggableNode(eventPoint(event))
         if (node === undefined) return
         const [x, y] = toWorld(eventPoint(event))
         drag = { node, offsetX: node.x - x, offsetY: node.y - y, moved: false }

--- a/packages/token-ui/src/pages/tokens/relationGraphCanvas.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphCanvas.test.ts
@@ -36,6 +36,19 @@ describe(drawRelationGraph.name, () => {
     ])
   })
 
+  it('does not draw token or chain labels at overview zoom', () => {
+    const node = sceneNode('unichain', '0xaaa')
+    node.x = 50
+    node.y = 50
+    const drawnText: { text: string; x: number; y: number }[] = []
+    const view = viewState()
+    view.camera.k = 0.5
+
+    drawRelationGraph(recordingContext(drawnText), sceneWith(node), view)
+
+    expect(drawnText).toEqual([])
+  })
+
   it('keeps the cluster heading above a focused symbol when zoomed out', () => {
     const node = sceneNode('unichain', '0xaaa')
     node.x = 50

--- a/packages/token-ui/src/pages/tokens/relationGraphCanvas.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphCanvas.ts
@@ -341,7 +341,7 @@ function getNodeLabelLayout(scale: number) {
   const symbolLabelOffsetY = chainLabelOffsetY - chainFontSize - labelScale
 
   return {
-    showAll: naturalSymbolFontSize >= NODE_LABEL_MIN_FONT_SIZE,
+    showAll: nodeLabelsAreVisible(scale),
     labelScale,
     symbolFontSize,
     chainFontSize,
@@ -351,6 +351,14 @@ function getNodeLabelLayout(scale: number) {
     // approximate em box plus the same gap used between the two node lines.
     clusterClearance: -symbolLabelOffsetY + symbolFontSize + labelScale,
   }
+}
+
+/** Whether every node's token and chain labels are visible at this zoom. */
+export function nodeLabelsAreVisible(scale: number) {
+  return (
+    NODE_LABEL_FONT_SIZE * nodeVisualScreenScale(scale) >=
+    NODE_LABEL_MIN_FONT_SIZE
+  )
 }
 
 function drawClusterLabels(

--- a/packages/token-ui/src/pages/tokens/relationGraphInteraction.test.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphInteraction.test.ts
@@ -1,0 +1,48 @@
+import { expect } from 'earl'
+import { findDraggableNodeAt } from './relationGraphInteraction'
+import type { RelationGraphNode } from './relationGraphModel'
+import type { RelationGraphScene, SceneNode } from './relationGraphScene'
+
+describe(findDraggableNodeAt.name, () => {
+  const node = sceneNode()
+  const scene = sceneWith(node)
+
+  it('returns undefined while node labels are hidden', () => {
+    expect(findDraggableNodeAt(scene, node.x, node.y, 10, 0.5)).toEqual(
+      undefined,
+    )
+  })
+
+  it('returns the node once node labels are visible', () => {
+    expect(
+      found(findDraggableNodeAt(scene, node.x, node.y, 10, 1)),
+    ).toExactlyEqual(node)
+  })
+})
+
+function found<T>(value: T | undefined): T {
+  if (value === undefined) throw new Error('Expected the hit test to hit')
+  return value
+}
+
+function sceneNode(): SceneNode {
+  const data: RelationGraphNode = {
+    id: 'unichain:0xaaa',
+    chain: 'unichain',
+    address: '0xaaa',
+    symbol: 'TOKEN',
+    isDeployed: true,
+  }
+  return { data, label: 'TOKEN', x: 50, y: 50 }
+}
+
+function sceneWith(node: SceneNode): RelationGraphScene {
+  return {
+    nodes: [node],
+    links: [],
+    clusterLabels: [],
+    nodeById: new Map([[node.data.id, node]]),
+    width: 100,
+    height: 100,
+  }
+}

--- a/packages/token-ui/src/pages/tokens/relationGraphInteraction.ts
+++ b/packages/token-ui/src/pages/tokens/relationGraphInteraction.ts
@@ -1,0 +1,26 @@
+import { nodeLabelsAreVisible } from './relationGraphCanvas'
+import {
+  findNodeAt,
+  type RelationGraphScene,
+  type SceneNode,
+} from './relationGraphScene'
+
+/**
+ * At overview zoom, every drag pans even if it starts on a node. Individual
+ * node dragging starts with the zoom level that reveals token and chain labels.
+ */
+export function nodeDraggingIsEnabled(scale: number) {
+  return nodeLabelsAreVisible(scale)
+}
+
+/** A missing drag target leaves the pointer gesture to the pan behavior. */
+export function findDraggableNodeAt(
+  scene: RelationGraphScene,
+  x: number,
+  y: number,
+  radius: number,
+  scale: number,
+): SceneNode | undefined {
+  if (!nodeDraggingIsEnabled(scale)) return undefined
+  return findNodeAt(scene, x, y, radius)
+}


### PR DESCRIPTION
## Summary

- disable node dragging while per-node token and chain labels are hidden
- let drags that start over a node pan the overview, while preserving node dragging at detail zoom
- share the label visibility threshold with interaction hit testing and add behavioral coverage

## Testing

- `pnpm --filter @l2beat/token-ui exec mocha src/pages/tokens/relationGraphInteraction.test.ts` (82 passing)
- `pnpm --filter @l2beat/token-ui typecheck`
- `pnpm --filter @l2beat/token-ui lint`
- `git diff --check`
- manual browser test: overview drag pans over nodes; detailed zoom allows node dragging