### PR TITLE
Filter interop token deployments by active chains

### DIFF
--- a/packages/frontend/src/server/features/scaling/interop/token/getInteropTokenOnchainDeployments.ts
+++ b/packages/frontend/src/server/features/scaling/interop/token/getInteropTokenOnchainDeployments.ts
@@ -25,14 +25,18 @@ export async function getInteropTokenOnchainDeployments(
   tokenId: string,
   supportedChainIds: string[],
 ): Promise<InteropTokenOnchainDeployment[]> {
+  const supportedChains = new Set(supportedChainIds)
   if (env.MOCK) {
-    return MOCK_INTEROP_TOKEN_DEPLOYMENTS
+    return MOCK_INTEROP_TOKEN_DEPLOYMENTS.filter((deployment) =>
+      supportedChains.has(deployment.chain),
+    )
   }
   const db = getDb()
   const tokenDb = getTokenDb()
 
-  const deployedTokens =
+  const deployedTokens = (
     await tokenDb.deployedToken.getByAbstractTokenId(tokenId)
+  ).filter((token) => supportedChains.has(token.chain))
   if (deployedTokens.length === 0) return []
 
   // Aggregates store token addresses in Address32 format,
@@ -68,8 +72,6 @@ export async function getInteropTokenOnchainDeployments(
     plugins.push({ plugin: row.plugin, bridgeType: row.bridgeType })
     mintingPluginsMap.set(key, plugins)
   }
-  const supportedChains = new Set(supportedChainIds)
-
   const deployments = deployedTokens.map((token) => {
     const tokenAddress = Address32.fromOrUndefined(token.address)
     const stat = tokenAddress


### PR DESCRIPTION
## Summary

- filter onchain token deployments to the active interop chain IDs already supplied by the token page
- apply the filter before aggregate-stat and minting-plugin queries

## Why

The token database also contains deployments on disabled and upcoming chains. The deployments loader previously returned all of them and only marked unsupported rows after running its downstream queries, which produced a long table with mostly missing data.

This is stacked on #12542 so its CI preview shows the minters column with the filtered deployment set.

## Validation

- `pnpm --filter @l2beat/frontend typecheck`
- `pnpm --filter @l2beat/frontend lint`
- `git diff --check`