### PR TITLE
Housekeeping: Single discovery remap func

### DIFF
--- a/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
+++ b/packages/backend/src/modules/update-monitor/DiscoveryRunner.ts
@@ -1,7 +1,6 @@
 import { Logger } from '@l2beat/backend-tools'
 import {
   type AllProviders,
-  type Analysis,
   ConfigReader,
   type ConfigRegistry,
   combinePermissionsIntoDiscovery,
@@ -12,6 +11,7 @@ import {
   getDependenciesToDiscoverForProject,
   getDiscoveryPaths,
   modelPermissions,
+  remapDiscoverySourceNames,
   type TemplateService,
   toRawDiscoveryOutput,
 } from '@l2beat/discovery'
@@ -94,8 +94,7 @@ export class DiscoveryRunner {
     // TODO: Should not be here - drop it and use implementation name once it's ready
     // if somebody changes the name and decides to re-colorize
     // then .flat folder will be incorrect
-    // Duplicated from saveDiscoveryResult.ts
-    const remappedResults = remapNames(
+    const remappedResults = remapDiscoverySourceNames(
       projectDiscovery.analysis,
       projectDiscovery.discoveryOutput,
     )
@@ -171,30 +170,4 @@ export class DiscoveryRunner {
       throw err
     }
   }
-}
-
-function remapNames(
-  results: Analysis[],
-  discoveryOutput: DiscoveryOutput,
-): Analysis[] {
-  return results.map((entry) => {
-    if (entry.type === 'EOA' || entry.type === 'Reference') {
-      return entry
-    }
-
-    const matchingEntry = discoveryOutput.entries.find(
-      (e) => e.address === entry.address,
-    )
-
-    if (!matchingEntry) {
-      return entry
-    }
-
-    const newName = matchingEntry.name ?? entry.name
-
-    return {
-      ...entry,
-      name: newName,
-    }
-  })
 }

--- a/packages/discovery/src/discovery/output/remapDiscoverySourceNames.test.ts
+++ b/packages/discovery/src/discovery/output/remapDiscoverySourceNames.test.ts
@@ -1,0 +1,74 @@
+import { ChainSpecificAddress, Hash256 } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import type { Analysis, AnalyzedContract } from '../analysis/AddressAnalyzer'
+import { EMPTY_ANALYZED_CONTRACT, EMPTY_ANALYZED_EOA } from '../utils/testUtils'
+import { remapDiscoverySourceNames } from './remapDiscoverySourceNames'
+import type { DiscoveryOutput } from './types'
+
+describe(remapDiscoverySourceNames.name, () => {
+  it('uses output names only for matching contracts', () => {
+    const renamedContract = contract('Original')
+    const unnamedContract = contract('Fallback')
+    const eoa = {
+      ...EMPTY_ANALYZED_EOA,
+      address: ChainSpecificAddress.random('eth'),
+      name: 'EOA',
+    }
+    const reference: Analysis = {
+      type: 'Reference',
+      address: ChainSpecificAddress.random('eth'),
+      name: 'Reference',
+      targetType: 'Contract',
+      targetProject: 'shared',
+    }
+    const output: DiscoveryOutput = {
+      name: 'project',
+      timestamp: 0,
+      configHash: Hash256.ZERO,
+      entries: [
+        {
+          type: 'Contract',
+          address: renamedContract.address,
+          name: 'Remapped',
+        },
+        {
+          type: 'Contract',
+          address: unnamedContract.address,
+        },
+        {
+          type: 'EOA',
+          address: eoa.address,
+          name: 'Ignored EOA name',
+        },
+        {
+          type: 'Reference',
+          address: reference.address,
+          name: 'Ignored reference name',
+        },
+      ],
+      abis: {},
+      usedTemplates: {},
+      usedBlockNumbers: {},
+    }
+
+    const result = remapDiscoverySourceNames(
+      [renamedContract, unnamedContract, eoa, reference],
+      output,
+    )
+
+    expect(result).toEqual([
+      { ...renamedContract, name: 'Remapped' },
+      unnamedContract,
+      eoa,
+      reference,
+    ])
+  })
+})
+
+function contract(name: string): AnalyzedContract {
+  return {
+    ...EMPTY_ANALYZED_CONTRACT,
+    address: ChainSpecificAddress.random('eth'),
+    name,
+  }
+}

--- a/packages/discovery/src/discovery/output/remapDiscoverySourceNames.ts
+++ b/packages/discovery/src/discovery/output/remapDiscoverySourceNames.ts
@@ -1,0 +1,26 @@
+import type { Analysis } from '../analysis/AddressAnalyzer'
+import type { DiscoveryOutput } from './types'
+
+export function remapDiscoverySourceNames(
+  results: Analysis[],
+  discoveryOutput: DiscoveryOutput,
+): Analysis[] {
+  return results.map((entry) => {
+    if (entry.type === 'EOA' || entry.type === 'Reference') {
+      return entry
+    }
+
+    const matchingEntry = discoveryOutput.entries.find(
+      (e) => e.address === entry.address,
+    )
+
+    if (!matchingEntry) {
+      return entry
+    }
+
+    return {
+      ...entry,
+      name: matchingEntry.name ?? entry.name,
+    }
+  })
+}

--- a/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
+++ b/packages/discovery/src/discovery/output/saveDiscoveryResult.ts
@@ -16,6 +16,7 @@ import type { ConfigRegistry } from '../config/ConfigRegistry'
 import type { DiscoveryPaths } from '../config/getDiscoveryPaths'
 import { removeSharedNesting } from '../source/removeSharedNesting'
 import { flattenDiscoveredSources } from './flattenDiscoveredSource'
+import { remapDiscoverySourceNames } from './remapDiscoverySourceNames'
 import { toDiscoveryOutput } from './toDiscoveryOutput'
 import type { DiscoveryOutput } from './types'
 
@@ -60,7 +61,7 @@ export async function saveDiscoveryResult(
   // TODO: Should not be here - drop it and use implementation name once it's ready
   // if somebody changes the name and decides to re-colorize
   // then .flat folder will be incorrect
-  const remappedResults = remapNames(results, discoveryOutput)
+  const remappedResults = remapDiscoverySourceNames(results, discoveryOutput)
 
   await saveDiscoveredJson(
     discoveryOutput,
@@ -199,30 +200,4 @@ function getImplementationFolder(i: number, sourcesCount: number): string {
     name = `/${name}`
   }
   return name
-}
-
-function remapNames(
-  results: Analysis[],
-  discoveryOutput: DiscoveryOutput,
-): Analysis[] {
-  return results.map((entry) => {
-    if (entry.type === 'EOA' || entry.type === 'Reference') {
-      return entry
-    }
-
-    const matchingEntry = discoveryOutput.entries.find(
-      (e) => e.address === entry.address,
-    )
-
-    if (!matchingEntry) {
-      return entry
-    }
-
-    const newName = matchingEntry.name ?? entry.name
-
-    return {
-      ...entry,
-      name: newName,
-    }
-  })
 }

--- a/packages/discovery/src/index.ts
+++ b/packages/discovery/src/index.ts
@@ -78,6 +78,7 @@ export {
 } from './discovery/output/diffToMarkdown'
 export { neuterErrors } from './discovery/output/errors'
 export { flattenDiscoveredSources } from './discovery/output/flattenDiscoveredSource'
+export { remapDiscoverySourceNames } from './discovery/output/remapDiscoverySourceNames'
 export { saveDiscoveredJson } from './discovery/output/saveDiscoveryResult'
 export { generateStructureHash } from './discovery/output/structureOutput'
 export {


### PR DESCRIPTION
@codex review
Resolves L2B-14704

This PR extracts `remapDiscoverySourceNames` as the single Discovery-owned implementation for source-name remapping. Both `saveDiscoveryResult` and Backend's `DiscoveryRunner` now use it, with focused coverage for contracts, EOAs, references, and missing output names.