### PR TITLE
Fix Gnosis xDAI withdrawal relations

### DIFF
--- a/packages/backend/src/modules/interop/examples/examples.jsonc
+++ b/packages/backend/src/modules/interop/examples/examples.jsonc
@@ -6700,8 +6700,9 @@
             "event": { "type": "gnosisbridge.XdaiWithdrawalInitiated" }
           },
           "dst": {
+            "tokenAddress": "0x000000000000000000000000dc035d45d973e3ec169d2276ddab16f1e407384f",
             "tokenAmount": "120000000000000000000",
-            "wasMinted": true,
+            "wasMinted": false,
             "event": { "type": "gnosisbridge.XdaiWithdrawalFinalized" }
           }
         }

--- a/packages/backend/src/modules/interop/plugins/gnosisbridge.ts
+++ b/packages/backend/src/modules/interop/plugins/gnosisbridge.ts
@@ -58,6 +58,11 @@ const FOREIGN_XDAI_BRIDGE = ChainSpecificAddress(
 const HOME_XDAI_BRIDGE = ChainSpecificAddress(
   'gno:0x7301CFA0e1756B71869E93d4e4Dca5c7d0eb0AA6',
 )
+// XDaiForeignBridge.erc20token() returns USDS. Requests for DAI are fulfilled
+// by a destination-side conversion and do not change the backing asset.
+const XDAI_BRIDGE_BACKING_TOKEN = Address32.from(
+  '0xdc035d45d973e3ec169d2276ddab16f1e407384f',
+)
 
 type GnosisBridgeChain = 'ethereum' | 'gnosis'
 
@@ -78,9 +83,7 @@ interface XdaiTransferFinalizedArgs {
 
 interface XdaiWithdrawalFinalizedArgs {
   nonce: `0x${string}`
-  token: Address32 | undefined
   amount: bigint
-  wasMinted: boolean | undefined
 }
 
 const AmbMessageRequested = createInteropEventType<AmbMessageRequestedArgs>(
@@ -305,15 +308,10 @@ export class GnosisBridgePlugin implements InteropPluginResyncable {
         ChainSpecificAddress.address(FOREIGN_XDAI_BRIDGE),
       ])
       if (xdaiFinalized) {
-        const transfer = findTokenTransferBefore(input, xdaiFinalized.value, {
-          boundary: (log) => parseXdaiRelayedMessage(log, null) !== undefined,
-        })
         return [
           XdaiWithdrawalFinalized.create(input, {
             nonce: xdaiFinalized.transactionHash,
-            token: transfer?.token,
             amount: xdaiFinalized.value,
-            wasMinted: transfer?.wasMinted,
           }),
         ]
       }
@@ -515,11 +513,6 @@ export class GnosisBridgePlugin implements InteropPluginResyncable {
     })
     if (!initiated) return
 
-    const wasMinted =
-      event.args.token === initiated.args.token
-        ? event.args.wasMinted
-        : undefined
-
     return [
       Result.Message('gnosisbridge.Message', {
         app: 'xdai-bridge',
@@ -532,9 +525,9 @@ export class GnosisBridgePlugin implements InteropPluginResyncable {
         srcAmount: initiated.args.amount,
         srcWasBurned: true,
         dstEvent: event,
-        dstTokenAddress: initiated.args.token,
+        dstTokenAddress: XDAI_BRIDGE_BACKING_TOKEN,
         dstAmount: event.args.amount,
-        dstWasMinted: wasMinted,
+        dstWasMinted: false,
       }),
     ]
   }


### PR DESCRIPTION
## Summary

- model USDS as the Ethereum backing token for native xDAI withdrawals
- exclude the destination-side USDS-to-DAI conversion from crosschain transfer classification
- update the Gnosis bridge example to assert USDS is released rather than DAI being minted

## Root cause

The withdrawal matcher used the token requested by the Gnosis message and inferred minting from transaction transfer logs. The current `XDaiForeignBridge` implementation defines `erc20token()` as USDS and only converts USDS to DAI locally when DAI is requested. Treating that local DAI mint as part of the bridge produced an incorrect DAI/xDAI relation.

## Impact

Gnosis native xDAI withdrawals are classified as burning xDAI on Gnosis and releasing USDS on Ethereum. The local USDS-to-DAI conversion no longer creates a crosschain token relation.

## Validation

- `pnpm interop:example gnosisbridge --simple` — 24 expectations passed
- `pnpm interop:example gnosisbridge-paid-interest --simple` — 4 expectations passed
- `pnpm exec biome check packages/backend/src/modules/interop/plugins/gnosisbridge.ts packages/backend/src/modules/interop/examples/examples.jsonc`
- `pnpm --filter @l2beat/backend typecheck`
