### PR TITLE
Identify Stargate burn-and-mint relations

### DIFF
--- a/packages/config/src/projects/stargate/stargate.ts
+++ b/packages/config/src/projects/stargate/stargate.ts
@@ -49,6 +49,16 @@ export const stargate: BaseProject = {
       },
     ],
     durationSplit: {
+      burnAndMint: [
+        {
+          label: 'Bus',
+          transferTypes: ['stargate-v2-bus.Transfer'],
+        },
+        {
+          label: 'Taxi',
+          transferTypes: ['stargate-v2-taxi.Transfer'],
+        },
+      ],
       lockAndMint: [
         {
           label: 'Bus',

--- a/packages/config/src/projects/stargate/stargate.ts
+++ b/packages/config/src/projects/stargate/stargate.ts
@@ -43,6 +43,10 @@ export const stargate: BaseProject = {
         plugin: 'stargate',
         bridgeType: 'lockAndMint',
       },
+      {
+        plugin: 'stargate',
+        bridgeType: 'burnAndMint',
+      },
     ],
     durationSplit: {
       lockAndMint: [


### PR DESCRIPTION
## Summary

Configure the Stargate interop project to claim `burnAndMint` observations in addition to its existing non-minting and lock-and-mint routes.

This lets consumers such as the token-relations graph attribute full Hydra clusters to Stargate instead of displaying them as unidentified.

## Root cause

The Stargate plugin classifies Hydra-to-Hydra transfers as `burnAndMint`, but the project configuration only claimed `nonMinting` and `lockAndMint` observations.

## Verification

Checked an Abstract-to-Ink USDC.e transfer directly with `cast`:

- the Abstract token emitted a transfer to the zero address
- the Ink token emitted a transfer from the zero address
- the Stargate `OFTSent` and `OFTReceived` events shared the same GUID
- both event emitters match configured Stargate pools

Also ran:

- `pnpm --filter @l2beat/config build`
- `git diff --check`
- production-backed token graph lookup, which resolves the Abstract/Ink cluster to Stargate after rebuilding config