### PR TITLE
Fix Rollup Stage tests

### DIFF
--- a/packages/config/src/common/stages/getRollupStage.test.ts
+++ b/packages/config/src/common/stages/getRollupStage.test.ts
@@ -1,42 +1,56 @@
+import { UnixTime } from '@l2beat/shared-pure'
 import { expect } from 'earl'
 
-import { getRollupStage } from './getRollupStage'
+import { getRollupStage, UPCOMING_STAGE_1_ITEMS } from './getRollupStage'
+import type { UpcomingStageRequirements } from './stage'
+
+const PAST_TIME = UnixTime.now() - 30 * UnixTime.DAY
+const FUTURE_TIME = UnixTime.now() + 30 * UnixTime.DAY
+
+const upcomingExpiringAt = (expiresAt: number): UpcomingStageRequirements => ({
+  stage1: { expiresAt, items: UPCOMING_STAGE_1_ITEMS },
+})
+
+const FULLY_SATISFIED_CHECKLIST = {
+  stage0: {
+    callsItselfRollup: true,
+    stateRootsPostedToL1: true,
+    dataAvailabilityOnL1: true,
+    rollupNodeSourceAvailable: true,
+    stateVerificationOnL1: true,
+    fraudProofSystemAtLeast5Outsiders: true,
+  },
+  stage1: {
+    principle: true,
+    usersHave7DaysToExit: true,
+    usersCanExitWithoutCooperation: true,
+    securityCouncilProperlySetUp: true,
+    noRedTrustedSetups: true,
+    proverSourcePublished: true,
+    verifierContractsReproducible: true,
+    programHashesReproducible: true,
+  },
+  stage2: {
+    proofSystemOverriddenOnlyInCaseOfABug: false,
+    fraudProofSystemIsPermissionless: false,
+    delayWith30DExitWindow: false,
+  },
+} as const
+
+const OPTS = {
+  rollupNodeLink: 'randomlink',
+  additionalConsiderations: {
+    short: 'short notice',
+    long: 'long notice',
+  },
+}
 
 describe(getRollupStage.name, () => {
   it('should return stage object', () => {
     const result = getRollupStage(
-      {
-        stage0: {
-          callsItselfRollup: true,
-          stateRootsPostedToL1: true,
-          dataAvailabilityOnL1: true,
-          rollupNodeSourceAvailable: true,
-          stateVerificationOnL1: true,
-          fraudProofSystemAtLeast5Outsiders: true,
-        },
-        stage1: {
-          principle: true,
-          usersHave7DaysToExit: true,
-          usersCanExitWithoutCooperation: true,
-          securityCouncilProperlySetUp: true,
-          noRedTrustedSetups: true,
-          proverSourcePublished: true,
-          verifierContractsReproducible: true,
-          programHashesReproducible: true,
-        },
-        stage2: {
-          proofSystemOverriddenOnlyInCaseOfABug: false,
-          fraudProofSystemIsPermissionless: false,
-          delayWith30DExitWindow: false,
-        },
-      },
-      {
-        rollupNodeLink: 'randomlink',
-        additionalConsiderations: {
-          short: 'short notice',
-          long: 'long notice',
-        },
-      },
+      FULLY_SATISFIED_CHECKLIST,
+      OPTS,
+      upcomingExpiringAt(PAST_TIME),
     )
     expect(result).toEqual({
       message: undefined,
@@ -111,24 +125,20 @@ describe(getRollupStage.name, () => {
               description:
                 'The proof system meets the minimum trusted setup requirements defined in the L2BEAT [trusted setup assessment framework](https://forum.l2beat.com/t/the-trusted-setups-framework-for-zk-catalog/381).',
               satisfied: true,
-              upcoming: true,
             },
             {
               description: 'Prover source code is published.',
               satisfied: true,
-              upcoming: true,
             },
             {
               description:
                 "Onchain verifiers' smart contracts can be independently regenerated from the verifier source code.",
               satisfied: true,
-              upcoming: true,
             },
             {
               description:
                 'The sources of all programs used are public and program hashes can be independently regenerated.',
               satisfied: true,
-              upcoming: true,
             },
           ],
           stage: 'Stage 1',
@@ -164,32 +174,67 @@ describe(getRollupStage.name, () => {
   })
 
   it('should throw error if no rollup node link is present and rollupNodeSourceAvailable is satisfied', () => {
-    expect(() =>
-      getRollupStage({
-        stage0: {
-          callsItselfRollup: true,
-          stateRootsPostedToL1: true,
-          dataAvailabilityOnL1: true,
-          rollupNodeSourceAvailable: true,
-          stateVerificationOnL1: true,
-          fraudProofSystemAtLeast5Outsiders: true,
+    expect(() => getRollupStage(FULLY_SATISFIED_CHECKLIST)).toThrow(
+      'Rollup node link is required',
+    )
+  })
+
+  describe('upcoming Stage 1 requirements', () => {
+    it('flags them as upcoming while the countdown is still running', () => {
+      const result = getRollupStage(
+        FULLY_SATISFIED_CHECKLIST,
+        OPTS,
+        upcomingExpiringAt(FUTURE_TIME),
+      )
+
+      const stage1 = result.summary.find((s) => s.stage === 'Stage 1')
+      expect(
+        stage1?.requirements.filter((r) => r.upcoming === true).length,
+      ).toEqual(UPCOMING_STAGE_1_ITEMS.length)
+      expect(result.stage).toEqual('Stage 1')
+    })
+
+    it('keeps Stage 1 but marks a downgrade as pending when an upcoming requirement fails before expiry', () => {
+      const result = getRollupStage(
+        {
+          ...FULLY_SATISFIED_CHECKLIST,
+          stage1: {
+            ...FULLY_SATISFIED_CHECKLIST.stage1,
+            proverSourcePublished: false,
+          },
         },
-        stage1: {
-          principle: true,
-          usersHave7DaysToExit: true,
-          usersCanExitWithoutCooperation: true,
-          securityCouncilProperlySetUp: true,
-          noRedTrustedSetups: true,
-          proverSourcePublished: true,
-          verifierContractsReproducible: true,
-          programHashesReproducible: true,
+        OPTS,
+        upcomingExpiringAt(FUTURE_TIME),
+      )
+
+      expect(result.stage).toEqual('Stage 1')
+      // Stage 1 itself is not missing anything yet - only Stage 2 is.
+      expect(result.missing?.nextStage).toEqual('Stage 2')
+      expect(result.downgradePending).toEqual({
+        expiresAt: FUTURE_TIME,
+        reasons: ['Prover source code is not published.'],
+        toStage: 'Stage 0',
+      })
+    })
+
+    it('downgrades to Stage 0 once the countdown has expired', () => {
+      const result = getRollupStage(
+        {
+          ...FULLY_SATISFIED_CHECKLIST,
+          stage1: {
+            ...FULLY_SATISFIED_CHECKLIST.stage1,
+            proverSourcePublished: false,
+          },
         },
-        stage2: {
-          proofSystemOverriddenOnlyInCaseOfABug: false,
-          fraudProofSystemIsPermissionless: false,
-          delayWith30DExitWindow: false,
-        },
-      }),
-    ).toThrow('Rollup node link is required')
+        OPTS,
+        upcomingExpiringAt(PAST_TIME),
+      )
+
+      expect(result.stage).toEqual('Stage 0')
+      expect(result.downgradePending).toEqual(undefined)
+      expect(result.missing?.requirements).toEqual([
+        'Prover source code is not published.',
+      ])
+    })
   })
 })

--- a/packages/config/src/common/stages/getRollupStage.ts
+++ b/packages/config/src/common/stages/getRollupStage.ts
@@ -19,21 +19,27 @@ interface GetRollupStageOptions {
 type Blueprint = ReturnType<typeof getBlueprint>
 type BlueprintChecklist = ChecklistTemplate<Blueprint>
 
+export const UPCOMING_STAGE_1_ITEMS = [
+  'noRedTrustedSetups',
+  'proverSourcePublished',
+  'verifierContractsReproducible',
+  'programHashesReproducible',
+]
+
 const UPCOMING_STAGE_REQUIREMENTS: UpcomingStageRequirements = {
   stage1: {
     expiresAt: PROJECT_COUNTDOWNS.stageChanges,
-    items: [
-      'noRedTrustedSetups',
-      'proverSourcePublished',
-      'verifierContractsReproducible',
-      'programHashesReproducible',
-    ],
+    items: UPCOMING_STAGE_1_ITEMS,
   },
 }
 
 export const getRollupStage = (
   blueprintChecklist: BlueprintChecklist,
   opts?: GetRollupStageOptions,
+  // Injectable so tests can pin the countdown instead of depending on the
+  // real PROJECT_COUNTDOWNS.stageChanges date, which would make them change
+  // behaviour the moment that deadline passes.
+  upcoming: UpcomingStageRequirements = UPCOMING_STAGE_REQUIREMENTS,
 ) => {
   const rollupNode = isSatisfied(
     blueprintChecklist.stage0.rollupNodeSourceAvailable,
@@ -45,10 +51,7 @@ export const getRollupStage = (
   const blueprint = getBlueprint(opts)
 
   return {
-    ...createGetStage(
-      blueprint,
-      UPCOMING_STAGE_REQUIREMENTS,
-    )(blueprintChecklist),
+    ...createGetStage(blueprint, upcoming)(blueprintChecklist),
     additionalConsiderations: opts?.additionalConsiderations,
     stage1PrincipleDescription: opts?.stage1PrincipleDescription,
   }


### PR DESCRIPTION
## Fix time-dependent test in getRollupStage

### Problem

`getRollupStage.test.ts` hardcoded `upcoming: true` on the four new Stage 1
requirements. `stage.ts` only attaches that flag while the countdown is unexpired:

```ts
...(isUpcoming && !upcomingCountdownExpired ? { upcoming: true } : {})
```

`PROJECT_COUNTDOWNS.stageChanges` expired on **2026-08-17 12:00 UTC**, so the test
started failing on `main` for everyone from that moment — a latent time bomb, not a
regression. `stage.test.ts` already avoided this by deriving its expiry from
`UnixTime.now()`; `getRollupStage.test.ts` was missed when the timer landed in #10959.

### Changes

- `getRollupStage` takes an optional third `upcoming` param, defaulting to the real
  `UPCOMING_STAGE_REQUIREMENTS`. All existing call sites unchanged.
- Exported `UPCOMING_STAGE_1_ITEMS` so test and production share one list.
- The test pins its own expiry relative to `now` instead of reading the production
  constant; the duplicated checklist literal moved into a shared fixture.

### New coverage

Three cases now exercise the countdown through the **real** rollup blueprint
(previously only tested against a synthetic one):

- requirements flagged `upcoming` while the countdown runs
- `downgradePending` set, Stage 1 retained, when an upcoming requirement fails
  before expiry
- downgrade to Stage 0 once the countdown has expired

### Impact

No production behaviour change — the default argument preserves the existing wiring.

The expiry itself changed **no project stages**. All 13 projects failing one of the
four new requirements also fail a regular Stage 1 requirement (every one has
`principle: false`), and `downgradePending` is only set when `!missing` — so none
ever showed the countdown banner and none moved. Enforcement is live going forward
though: a project that would otherwise qualify for Stage 1 but fails one of these
four is now downgraded immediately, with no grace period.
