### PR TITLE
Require 7-day minimum release age for pnpm installs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - 'packages/*'
 
+# Only install package versions published at least a week ago, to reduce
+# exposure to supply chain attacks in freshly published releases.
+minimumReleaseAge: 10080
+
 overrides:
   'form-data@^2': 2.5.4
   'form-data@^4': 4.0.4


### PR DESCRIPTION
Sets `minimumReleaseAge: 10080` (minutes = 7 days) in `pnpm-workspace.yaml`, so pnpm will not resolve package versions published within the last week.

Most supply chain attacks via npm are caught and the malicious version yanked within a couple of days. Refusing to install anything fresher than a week means those releases expire before they can reach our lockfile.

**Scope of the change:**
- The existing `pnpm-lock.yaml` is untouched — already-locked versions install exactly as before. The setting only kicks in when resolving new or updated versions (`pnpm add`, `pnpm update`, Renovate/Dependabot bumps).
- Workspace `@l2beat/*` links use `workspace:` and are unaffected.
- If a security patch ever has to land immediately, that package can be exempted with `minimumReleaseAgeExclude` rather than dropping the setting.

Requires pnpm >= 10.16; the repo is on 11.22.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)