### PR TITLE
Verify node_modules matches lockfile before running scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,16 @@
 packages:
   - 'packages/*'
 
+# Before running any script (pnpm run/exec/<bin>, including turbo tasks) check
+# that node_modules matches pnpm-lock.yaml. In a terminal this offers to run
+# `pnpm install`; in non-interactive contexts (CI, turbo children, IDE tasks) it
+# fails with a clear "run pnpm install" error instead of obscure module errors.
+verifyDepsBeforeRun: prompt
+# pnpm 11 defaults this differently with and without CI=true; pin it so the
+# check above does not fail when installs and script runs happen in different
+# environments (e.g. `pnpm install` locally, then `CI=true pnpm test`).
+enableGlobalVirtualStore: false
+
 overrides:
   'form-data@^2': 2.5.4
   'form-data@^4': 4.0.4


### PR DESCRIPTION
## Summary

Sets `verifyDepsBeforeRun: prompt` (pnpm ≥10) in `pnpm-workspace.yaml`. Before running any script — `pnpm run`, `pnpm exec`, `pnpm <bin>`, `--filter`, and therefore every turbo task — pnpm checks that `node_modules` is in sync with `pnpm-lock.yaml`.

- **In a terminal:** offers to run `pnpm install` (`Y/n`). This is the "I pulled and forgot to install" case that currently ends in cryptic `Cannot find module` / stale-build errors.
- **Non-interactive** (turbo children, CI, IDE task runners): fails fast with `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN … Run "pnpm install"` instead of running against stale deps.
- **In sync:** silent, ~ms hash comparison against `node_modules/.pnpm-workspace-state-v1.json`.

Also pins `enableGlobalVirtualStore: false`. pnpm 11 defaults it differently depending on whether `CI` is set, and the verification compares it against the install-time snapshot — without the pin, `pnpm install` locally followed by `CI=true pnpm test` (or vice versa) reports a bogus "setting has changed" mismatch. Verified both directions after pinning.

## Verified

- Stale manifest → prompt in TTY / hard error in non-TTY, for `pnpm run`, `pnpm exec turbo`, `pnpm turbo`, `pnpm --filter … run`.
- In-sync → no output. Install with and without `CI=true`, run with the other → no false positive.
- Backend container image builds unchanged (`pnpm install --frozen-lockfile` → `pnpm build:backend` → turbo children all pass the check).
- CI: every workflow installs before running scripts; Coolify/nixpacks and Docker do the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)