### PR TITLE
Ship only production dependencies in service container images

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -29,6 +29,12 @@ RUN --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN \
   --mount=type=secret,id=TURBO_API,env=TURBO_API \
   pnpm build:backend
 
+# Replace node_modules with production dependencies only. Switching dev -> prod
+# in place does not garbage-collect the virtual store, so purge and reinstall
+# offline from the local store (cached native builds are reused).
+RUN rm -rf node_modules packages/*/node_modules && \
+  CI=true pnpm install --prod --frozen-lockfile --offline
+
 RUN mkdir /dist/ && \
   cd /dist/ && \
   wget -q https://github.com/Wilfred/difftastic/releases/download/0.57.0/difft-$ARCH-unknown-linux-gnu.tar.gz && \

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,15 +31,15 @@
   },
   "dependencies": {
     "@l2beat/discovery": "workspace:*",
+    "@l2beat/shared": "workspace:*",
     "@l2beat/shared-pure": "workspace:*",
+    "@l2beat/validate": "workspace:*",
     "ethers": "^5.7.2",
     "lodash": "^4.17.21",
     "sqlite3": "5.1.7"
   },
   "devDependencies": {
-    "@l2beat/validate": "workspace:*",
     "@l2beat/backend-tools": "workspace:*",
-    "@l2beat/shared": "workspace:*",
     "@l2beat/typescript-config": "workspace:*",
     "@types/diff": "^7.0.2",
     "@types/lodash": "^4.17.12",

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -27,6 +27,12 @@ RUN --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN \
   --mount=type=secret,id=TURBO_API,env=TURBO_API \
   pnpm build:frontend
 
+# Replace node_modules with production dependencies only. Switching dev -> prod
+# in place does not garbage-collect the virtual store, so purge and reinstall
+# offline from the local store (cached native builds are reused).
+RUN rm -rf node_modules packages/*/node_modules && \
+  CI=true pnpm install --prod --frozen-lockfile --offline
+
 FROM node:22.22.0-slim AS release
 
 # Install curl for healthcheck and create non-root user

--- a/packages/public-api/Dockerfile
+++ b/packages/public-api/Dockerfile
@@ -29,6 +29,12 @@ RUN --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN \
   --mount=type=secret,id=TURBO_API,env=TURBO_API \
   pnpm build:public-api
 
+# Replace node_modules with production dependencies only. Switching dev -> prod
+# in place does not garbage-collect the virtual store, so purge and reinstall
+# offline from the local store (cached native builds are reused).
+RUN rm -rf node_modules packages/*/node_modules && \
+  CI=true pnpm install --prod --frozen-lockfile --offline
+
 RUN mkdir /dist/ && \
   cd /dist/ && \
   wget -q https://github.com/Wilfred/difftastic/releases/download/0.57.0/difft-$ARCH-unknown-linux-gnu.tar.gz && \

--- a/packages/public-api/package.json
+++ b/packages/public-api/package.json
@@ -17,15 +17,15 @@
   },
   "dependencies": {
     "@l2beat/backend-tools": "workspace:*",
+    "@l2beat/config": "workspace:*",
     "@l2beat/database": "workspace:*",
+    "@l2beat/shared-pure": "workspace:*",
     "@l2beat/validate": "workspace:*",
     "express": "^5.0.0",
     "lodash": "^4.17.21",
     "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
-    "@l2beat/config": "workspace:*",
-    "@l2beat/shared-pure": "workspace:*",
     "@l2beat/typescript-config": "workspace:*",
     "@types/express": "^5.0.0",
     "@types/lodash": "^4.17.4",

--- a/packages/shared-pure/biome.json
+++ b/packages/shared-pure/biome.json
@@ -59,5 +59,57 @@
         }
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/test/**/*.ts", "**/*.test.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "assert": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "buffer": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "child_process": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "cluster": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "crypto": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "dgram": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "dns": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "domain": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "events": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "ethers": "Do not use node dependencies inside this package as it can be used in frontend code which increases bundle size. Use @l2beat/shared instead.",
+                  "freelist": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "fs": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "http": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "https": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "module": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "net": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "os": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "path": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "punycode": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "querystring": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "readline": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "repl": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "smalloc": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "stream": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "string_decoder": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "sys": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "timers": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "tls": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "tracing": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "tty": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "url": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "util": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "vm": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "zlib": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/token-backend/Dockerfile
+++ b/packages/token-backend/Dockerfile
@@ -29,6 +29,12 @@ RUN --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN \
   --mount=type=secret,id=TURBO_API,env=TURBO_API \
   pnpm build:token-backend
 
+# Replace node_modules with production dependencies only. Switching dev -> prod
+# in place does not garbage-collect the virtual store, so purge and reinstall
+# offline from the local store (cached native builds are reused).
+RUN rm -rf node_modules packages/*/node_modules && \
+  CI=true pnpm install --prod --frozen-lockfile --offline
+
 RUN mkdir /dist/ && \
   cd /dist/ && \
   wget -q https://github.com/Wilfred/difftastic/releases/download/0.57.0/difft-$ARCH-unknown-linux-gnu.tar.gz && \

--- a/packages/token-backend/package.json
+++ b/packages/token-backend/package.json
@@ -38,19 +38,19 @@
     "@l2beat/shared-pure": "workspace:*",
     "@l2beat/typescript-config": "workspace:*",
     "@l2beat/validate": "workspace:*",
+    "@trpc/client": "11.17.0",
     "@trpc/server": "11.17.0",
+    "dotenv": "^17.2.3",
+    "express": "^5.1.0",
     "fuzzysort": "3.1.0",
     "jose": "^6.1.0",
     "viem": "^2.31.6"
   },
   "devDependencies": {
     "@l2beat/typescript-config": "workspace:*",
-    "@trpc/client": "11.17.0",
     "@types/express": "^5.0.0",
     "@types/mocha": "^10.0.6",
-    "dotenv": "^17.2.3",
     "earl": "^1.1.0",
-    "express": "^5.1.0",
     "mocha": "^10.2.0",
     "tsx": "^4.9.3"
   }

--- a/packages/tools-api/Dockerfile
+++ b/packages/tools-api/Dockerfile
@@ -27,6 +27,12 @@ RUN --mount=type=secret,id=TURBO_TOKEN,env=TURBO_TOKEN \
   --mount=type=secret,id=TURBO_API,env=TURBO_API \
   pnpm build:tools-api
 
+# Replace node_modules with production dependencies only. Switching dev -> prod
+# in place does not garbage-collect the virtual store, so purge and reinstall
+# offline from the local store (cached native builds are reused).
+RUN rm -rf node_modules packages/*/node_modules && \
+  CI=true pnpm install --prod --frozen-lockfile --offline
+
 FROM node:22.22.0-slim AS release
 
 # Install curl for healthcheck and create non-root user

--- a/packages/validate/biome.json
+++ b/packages/validate/biome.json
@@ -59,5 +59,57 @@
         }
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/test/**/*.ts", "**/*.test.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "assert": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "buffer": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "child_process": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "cluster": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "crypto": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "dgram": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "dns": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "domain": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "events": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "ethers": "Do not use node dependencies inside this package as it can be used in frontend code which increases bundle size. Use @l2beat/shared instead.",
+                  "freelist": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "fs": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "http": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "https": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "module": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "net": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "os": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "path": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "punycode": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "querystring": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "readline": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "repl": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "smalloc": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "stream": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "string_decoder": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "sys": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "timers": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "tls": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "tracing": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "tty": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "url": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "util": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "vm": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+                  "zlib": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,9 +366,15 @@ importers:
       '@l2beat/discovery':
         specifier: workspace:*
         version: link:../discovery
+      '@l2beat/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@l2beat/shared-pure':
         specifier: workspace:*
         version: link:../shared-pure
+      '@l2beat/validate':
+        specifier: workspace:*
+        version: link:../validate
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -382,15 +388,9 @@ importers:
       '@l2beat/backend-tools':
         specifier: workspace:*
         version: link:../backend-tools
-      '@l2beat/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@l2beat/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
-      '@l2beat/validate':
-        specifier: workspace:*
-        version: link:../validate
       '@types/diff':
         specifier: ^7.0.2
         version: 7.0.2
@@ -996,9 +996,15 @@ importers:
       '@l2beat/backend-tools':
         specifier: workspace:*
         version: link:../backend-tools
+      '@l2beat/config':
+        specifier: workspace:*
+        version: link:../config
       '@l2beat/database':
         specifier: workspace:*
         version: link:../database
+      '@l2beat/shared-pure':
+        specifier: workspace:*
+        version: link:../shared-pure
       '@l2beat/validate':
         specifier: workspace:*
         version: link:../validate
@@ -1012,12 +1018,6 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(express@5.0.1)
     devDependencies:
-      '@l2beat/config':
-        specifier: workspace:*
-        version: link:../config
-      '@l2beat/shared-pure':
-        specifier: workspace:*
-        version: link:../shared-pure
       '@l2beat/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -1125,9 +1125,18 @@ importers:
       '@l2beat/validate':
         specifier: workspace:*
         version: link:../validate
+      '@trpc/client':
+        specifier: 11.17.0
+        version: 11.17.0(@trpc/server@11.17.0(typescript@7.0.2))(typescript@7.0.2)
       '@trpc/server':
         specifier: 11.17.0
         version: 11.17.0(typescript@7.0.2)
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
       fuzzysort:
         specifier: 3.1.0
         version: 3.1.0
@@ -1138,24 +1147,15 @@ importers:
         specifier: ^2.31.6
         version: 2.31.6(typescript@7.0.2)(zod@3.24.1)
     devDependencies:
-      '@trpc/client':
-        specifier: 11.17.0
-        version: 11.17.0(@trpc/server@11.17.0(typescript@7.0.2))(typescript@7.0.2)
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.0
       '@types/mocha':
         specifier: ^10.0.6
         version: 10.0.9
-      dotenv:
-        specifier: ^17.2.3
-        version: 17.2.3
       earl:
         specifier: ^1.1.0
         version: 1.3.0
-      express:
-        specifier: ^5.1.0
-        version: 5.1.0
       mocha:
         specifier: ^10.2.0
         version: 10.7.3


### PR DESCRIPTION
> **Stacked on #12600** (forbid `earl` outside tests) — the backend's production interop code imported `isEqual` from `earl`, which only worked because dev tooling shipped in the image. This PR must not merge before #12600; the base retargets to `main` automatically once it does.

## Summary

The release stages of our service images copy the whole built monorepo, including every workspace's devDependencies. In the backend image that was 572 MB of `node_modules`, of which biome, turbo, prisma + engines, typescript ×2, esbuild ×2, mocha, tsx… never run in prod.

This adds one step to the builder stage of `backend`, `token-backend`, `public-api`, `tools-api` and `frontend` (disco-ui already did this):

```dockerfile
RUN rm -rf node_modules packages/*/node_modules && \
  CI=true pnpm install --prod --frozen-lockfile --offline
```

- Fresh install rather than in-place `--prod`: pnpm switches dev→prod without garbage-collecting the virtual store (measured: 0 MB saved in place; 572 → 315 MB after purge).
- `--offline` from the store populated by the first install (~2 s); native builds (sqlite3, sharp…) come back from pnpm's side-effects cache without re-running install scripts.
- Layout is unchanged (`/app/packages/...`, `.discovery.json`, `packages/config/src/projects`) so nothing about how the services locate discovery data / `db.sqlite` changes.

### Image sizes, before → after

Built locally from `origin/main` vs this branch, same machine and arch (linux/arm64), measured with `docker images` and `du -sm` inside the running image.

| Image | Image size | `/app` | `node_modules` |
|---|---|---|---|
| backend | 947 MB → **704 MB** (−243 MB, −26 %) | 730 → 477 MB | 572 → 318 MB |
| token-backend | 907 MB → **661 MB** (−246 MB, −27 %) | 670 → 412 MB | 530 → 273 MB |
| public-api | 915 MB → **669 MB** (−246 MB, −27 %) | 676 → 419 MB | 538 → 281 MB |
| tools-api | 673 MB → **569 MB** (−104 MB, −15 %) | 508 → 398 MB | 374 → 264 MB |
| frontend | 1.37 GB → **1.04 GB** (−330 MB, −24 %) | 1260 → 913 MB | 762 → 416 MB |
| **total** | 4.81 GB → **3.64 GB** (−1.17 GB, −24 %) | | |

The remainder is dominated by things the services genuinely need at runtime: `packages/config/src/projects` (89 MB of discovery data), built outputs, and prod deps such as `viem` (41 MB) and `@polkadot/*` (29 MB). `typescript@7` (26 MB) still lands in the backend image as an auto-installed optional peer of `viem` — a possible follow-up, not touched here.

### Why not `pnpm deploy`

`pnpm deploy` relocates a single package into a self-contained directory. All four Node services read the monorepo tree at runtime — `getDiscoveryPaths()` walks up to `.discovery.json` and `ConfigReader`/`TemplateService` read `packages/config/src/projects`; `ProjectService` reads config's built `db.sqlite` — so relocating breaks them without code changes. Prod-only pruning gets most of the win with none of that risk.

### Latent bugs this exposed (and fixes)

Booting the pruned images surfaced runtime imports that only worked because dev tooling shipped in the image:

- **backend**: production interop code imported `isEqual` from `earl` → fixed in #12600 (with a lint guard).
- **token-backend**: `dotenv`, `express`, `@trpc/client` are used by `server.ts` / `client.ts` at runtime → moved to `dependencies`.
- **public-api**: `@l2beat/config`, `@l2beat/shared-pure` used at runtime → `dependencies`.
- **config**: `@l2beat/shared`, `@l2beat/validate` are value-imported by non-test code → `dependencies` (no workspace cycle; turbo graph builds).

Found via boot tests plus a static scan of every non-test import in the five services' workspace closures against `dependencies`/`devDependencies`; the remaining dev-listed imports are script-only (`interop/examples/*`, `config/src/tokens/*`, frontend dev middleware) and not reachable from the runtime entrypoints.

## Verified

- All five images built locally; each booted with no env: backend / public-api / tools-api fail on the first missing env var (module graph fully loaded), token-backend and frontend start listening. Zero `Cannot find module`.
- `require('@l2beat/config' | shared | discovery | database | token-backend)` from the pruned backend image resolves.
- Only lazy loads in the runtime graph are `@polkadot/api` (shared) and `clingo-wasm` (discovery), both prod deps; non-top-level `require`s are Node built-ins / relative.
- Backend typecheck, biome, interop test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
