### PR TITLE
Forbid importing earl outside test files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -95,7 +95,8 @@
               "assert": "Use assert from @l2beat/shared-pure",
               "node:assert": "Use assert from @l2beat/shared-pure",
               "lodash": "Use lodash/{module}",
-              "process": "Do not use process"
+              "process": "Do not use process",
+              "earl": "earl is a test-only dependency. Use lodash/isEqual for deep equality or move this file under a test/ directory."
             }
           }
         }
@@ -170,7 +171,20 @@
       "linter": {
         "rules": {
           "style": {
-            "noNonNullAssertion": "off"
+            "noNonNullAssertion": "off",
+            "noRestrictedImports": {
+              "level": "error",
+              "options": {
+                "paths": {
+                  "console": "Do not use console",
+                  "node:console": "Do not use console",
+                  "assert": "Use assert from @l2beat/shared-pure",
+                  "node:assert": "Use assert from @l2beat/shared-pure",
+                  "lodash": "Use lodash/{module}",
+                  "process": "Do not use process"
+                }
+              }
+            }
           },
           "suspicious": {
             "noExplicitAny": "off",

--- a/packages/backend/src/modules/interop/engine/config/reconcileNetworks.ts
+++ b/packages/backend/src/modules/interop/engine/config/reconcileNetworks.ts
@@ -1,4 +1,4 @@
-import { isEqual } from 'earl'
+import isEqual from 'lodash/isEqual'
 
 export function reconcileNetworks<T extends { chain: string }>(
   previousNetworks: T[] | undefined,

--- a/packages/backend/src/modules/interop/plugins/polygon/polygon.config.ts
+++ b/packages/backend/src/modules/interop/plugins/polygon/polygon.config.ts
@@ -11,7 +11,7 @@
 import type { Logger } from '@l2beat/backend-tools'
 import type { EVMLog, IRpcClient } from '@l2beat/shared'
 import { Address32, EthereumAddress } from '@l2beat/shared-pure'
-import { isEqual } from 'earl'
+import isEqual from 'lodash/isEqual'
 import { decodeEventLog, encodeEventTopics, type Hex, parseAbi } from 'viem'
 import { TimeLoop } from '../../../../tools/TimeLoop'
 import {

--- a/packages/backend/src/modules/interop/plugins/zkstack/zkstack.config.ts
+++ b/packages/backend/src/modules/interop/plugins/zkstack/zkstack.config.ts
@@ -23,7 +23,7 @@ import {
   EthereumAddress,
 } from '@l2beat/shared-pure'
 import type { TokenDbClient } from '@l2beat/token-backend'
-import { isEqual } from 'earl'
+import isEqual from 'lodash/isEqual'
 import {
   decodeFunctionResult,
   encodeFunctionData,

--- a/packages/config/src/tokens/getTokenData.ts
+++ b/packages/config/src/tokens/getTokenData.ts
@@ -12,8 +12,8 @@ import {
   type EthereumAddress,
   type UnixTime,
 } from '@l2beat/shared-pure'
-import { isEqual } from 'earl'
 import { providers } from 'ethers'
+import isEqual from 'lodash/isEqual'
 import { ProjectService } from '../ProjectService'
 import type { ChainConfig } from '../types'
 import type { GeneratedToken, Output, SourceEntry } from './types'

--- a/packages/shared-pure/biome.json
+++ b/packages/shared-pure/biome.json
@@ -52,7 +52,8 @@
               "url": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
               "util": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
               "vm": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
-              "zlib": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead."
+              "zlib": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+              "earl": "earl is a test-only dependency. Use lodash/isEqual for deep equality or move this file under a test/ directory."
             }
           }
         }

--- a/packages/validate/biome.json
+++ b/packages/validate/biome.json
@@ -52,7 +52,8 @@
               "url": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
               "util": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
               "vm": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
-              "zlib": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead."
+              "zlib": "Do not use node dependencies inside this package as it can be used in frontend code. Use @l2beat/shared instead.",
+              "earl": "earl is a test-only dependency. Use lodash/isEqual for deep equality or move this file under a test/ directory."
             }
           }
         }


### PR DESCRIPTION
## Summary

`earl` is our test assertion library, but four non-test modules imported `isEqual` from it:

- `packages/backend/src/modules/interop/engine/config/reconcileNetworks.ts`
- `packages/backend/src/modules/interop/plugins/polygon/polygon.config.ts`
- `packages/backend/src/modules/interop/plugins/zkstack/zkstack.config.ts`
- `packages/config/src/tokens/getTokenData.ts`

In the backend `earl` isn't even a declared dependency — it only resolved because root devDependencies are hoisted. That means production interop code depends on dev tooling being present at runtime (surfaced while pruning devDependencies from container images in #12599, which now stacks on this PR).

### Changes

- Replace with `import isEqual from 'lodash/isEqual'` — the idiom already used in frontend and public-api; both packages depend on lodash. Plain deep equality on config/data objects, same semantics for these call sites.
- **Guard:** add `earl` to Biome's `style/noRestrictedImports` so any future non-test import fails lint. `**/test/**/*.ts` and `**/*.test.ts` keep access through the existing test override, which re-lists the root map without `earl` — unavoidable, since Biome overrides *replace* rule options rather than merge them (6 lines).
- `packages/validate` and `packages/shared-pure` maintain their own restricted-imports map (no Node built-ins, since they can end up in frontend bundles) that shadows the root entry, so `earl` is added to their maps too (one line each). Side effect, accepted deliberately: in those two packages' *test files* the root test override now takes precedence, so the built-ins rule no longer applies there. Test files are never bundled, so nothing shipped changes; the alternative was restating their 30-entry map per package.

### Verified

- Probes: `earl` in a prod file (backend and validate) → lint error; `earl` in `*.test.ts` / `test/**` → allowed; `lodash` root import in a test file → still flagged.
- `pnpm lint` at root and per-package lint in backend/config/validate/shared-pure clean.
- backend + config typecheck clean; interop test suite 1332 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
