### PR TITLE
Fix Coolify builds after pnpm 11 bump

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+# pnpm 9 (e.g. the version bundled by nixpacks on Coolify) does not switch to the
+# version from package.json#packageManager unless told to. pnpm >=10 does this by default.
+manage-package-manager-versions=true


### PR DESCRIPTION
## Problem
Since #12592 the Coolify (nixpacks) deployments of the uops dashboard, token frontend, backoffice and tools UI fail with:

```
ERR_PNPM_UNSUPPORTED_ENGINE Unsupported environment (bad pnpm and/or Node.js version)
Expected version: >=11
Got: 9.15.9
```

nixpacks picks its pnpm from nixpkgs based on the lockfile version (`9.0` → `pnpm-9_x` = 9.15.9), and Coolify's `--install-cmd` override replaces nixpacks' own `corepack enable` step, so `package.json#packageManager` was never honoured.

## Fix
Add a root `.npmrc` with `manage-package-manager-versions=true`. pnpm 9.7+ then installs and re-execs the version from `packageManager` (11.22.0) *before* the engines / packageManager-strict checks run, so the existing Coolify config keeps working unchanged. pnpm ≥10 already does this by default, so it is a no-op for developers, CI and the Dockerfile-based services.

Verified locally: `npx pnpm@9.15.9 install --frozen-lockfile` from `packages/uops-dashboard` now finishes with `Done ... using pnpm v11.22.0` (fails with the same engine error without the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)