### PR TITLE
Move compare page controls out of the primary card

### DIFF
--- a/packages/frontend/src/components/core/DashedButton.tsx
+++ b/packages/frontend/src/components/core/DashedButton.tsx
@@ -1,0 +1,24 @@
+import type { ComponentProps } from 'react'
+import { cn } from '~/utils/cn'
+
+export function DashedButton({
+  className,
+  ...props
+}: ComponentProps<'button'>) {
+  const isDisabled =
+    props['aria-disabled'] === true || props['aria-disabled'] === 'true'
+  return (
+    <button
+      type="button"
+      {...props}
+      className={cn(
+        'flex items-center justify-center gap-1.5 border border-divider border-dashed font-medium text-secondary text-sm leading-none transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand',
+        isDisabled
+          ? 'cursor-not-allowed opacity-50'
+          : 'cursor-pointer hover:bg-surface-primary',
+        className,
+      )}
+    />
+  )
+}

--- a/packages/frontend/src/components/core/Select.tsx
+++ b/packages/frontend/src/components/core/Select.tsx
@@ -130,7 +130,10 @@ const SelectLabel = ({
 }: React.ComponentProps<typeof SelectPrimitive.Label>) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('py-1.5 pr-2 pl-8 font-medium text-xs md:text-sm', className)}
+    className={cn(
+      'px-2.5 pt-2 pb-1 text-secondary text-subtitle-10 uppercase tracking-[0.04em] md:text-subtitle-11',
+      className,
+    )}
     {...props}
   />
 )
@@ -167,7 +170,7 @@ const SelectSeparator = ({
 }: React.ComponentProps<typeof SelectPrimitive.Separator>) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-gray-200 dark:bg-zinc-700', className)}
+    className={cn('-mx-1 my-1 h-px bg-divider', className)}
     {...props}
   />
 )

--- a/packages/frontend/src/pages/scaling/compare/ScalingComparePage.tsx
+++ b/packages/frontend/src/pages/scaling/compare/ScalingComparePage.tsx
@@ -30,9 +30,7 @@ export function ScalingComparePage({
     <AppLayout {...props}>
       <HydrationBoundary state={queryState}>
         <SideNavLayout>
-          <MainPageHeader description="Compare Ethereum scaling projects across metrics. Add charts to see value secured, activity, costs, and data posted side by side, and share the exact view with a link.">
-            Compare Projects
-          </MainPageHeader>
+          <MainPageHeader>Compare Projects</MainPageHeader>
           <ScalingCompareCharts
             allProjects={allProjects}
             initialState={initialState}

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
@@ -127,7 +127,7 @@ export function CompareProjectPicker({
                 onMouseLeave={() => setHoveredProjectId(undefined)}
                 onFocus={() => setHoveredProjectId(project.id)}
                 onBlur={() => setHoveredProjectId(undefined)}
-                className="flex h-7 items-center gap-1.5 rounded-full border border-divider bg-surface-primary primary-card:bg-surface-secondary py-1 pr-1.5 pl-1"
+                className="flex h-7 items-center gap-1.5 rounded-full border border-divider bg-surface-primary py-1 pr-1.5 pl-1"
                 // The ring makes the chip strip double as the charts' color key,
                 // so it must show exactly the series color the charts use - and
                 // no color at all when no chart has a series for the project.
@@ -173,7 +173,7 @@ export function CompareProjectPicker({
           setPinnedSlugs(selectedSlugs)
           setOpen(true)
         }}
-        className="flex h-7 cursor-pointer items-center gap-1.5 rounded-full border border-divider border-dashed py-1 pr-2.5 pl-1.5 font-medium text-secondary text-sm leading-none hover:bg-surface-secondary primary-card:hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        className="flex h-7 cursor-pointer items-center gap-1.5 rounded-full border border-divider border-dashed py-1 pr-2.5 pl-1.5 font-medium text-secondary text-sm leading-none hover:bg-surface-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
       >
         <PlusIcon className="size-4" />
         Add project

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectPicker.tsx
@@ -8,6 +8,7 @@ import {
   CommandItem,
   CommandList,
 } from '~/components/core/Command'
+import { DashedButton } from '~/components/core/DashedButton'
 import {
   Tooltip,
   TooltipContent,
@@ -127,7 +128,7 @@ export function CompareProjectPicker({
                 onMouseLeave={() => setHoveredProjectId(undefined)}
                 onFocus={() => setHoveredProjectId(project.id)}
                 onBlur={() => setHoveredProjectId(undefined)}
-                className="flex h-7 items-center gap-1.5 rounded-full border border-divider bg-surface-primary py-1 pr-1.5 pl-1"
+                className="flex h-7 items-center gap-1.5 rounded-lg border border-divider bg-surface-primary py-1 pr-1.5 pl-1"
                 // The ring makes the chip strip double as the charts' color key,
                 // so it must show exactly the series color the charts use - and
                 // no color at all when no chart has a series for the project.
@@ -167,17 +168,16 @@ export function CompareProjectPicker({
           </Tooltip>
         )
       })}
-      <button
-        type="button"
+      <DashedButton
         onClick={() => {
           setPinnedSlugs(selectedSlugs)
           setOpen(true)
         }}
-        className="flex h-7 cursor-pointer items-center gap-1.5 rounded-full border border-divider border-dashed py-1 pr-2.5 pl-1.5 font-medium text-secondary text-sm leading-none hover:bg-surface-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        className="h-7 rounded-lg py-1 pr-2.5 pl-1.5"
       >
         <PlusIcon className="size-4" />
         Add project
-      </button>
+      </DashedButton>
       {isDefaultSelection && (
         <p className="w-full font-medium text-2xs text-secondary">
           Showing top projects by default. Add or remove projects to build your

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareCharts.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareCharts.tsx
@@ -135,44 +135,41 @@ export function ScalingCompareCharts({
     <section className="flex flex-col gap-2 max-md:mt-4 md:mt-2">
       <CompareSeriesProvider projects={selectedProjects}>
         <CompareChartHoverProvider>
-          <PrimaryCard>
-            <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
-              <CompareProjectPicker
-                allProjects={allProjects}
-                metrics={displayedMetrics}
-                selectedProjects={selectedProjects}
-                isDefaultSelection={state.projects.length === 0}
-                onChange={(projects) =>
-                  setState((prev) => ({ ...prev, projects }))
+          <div className="flex flex-col gap-3 max-md:px-4 lg:px-2">
+            <CompareProjectPicker
+              allProjects={allProjects}
+              metrics={displayedMetrics}
+              selectedProjects={selectedProjects}
+              isDefaultSelection={state.projects.length === 0}
+              onChange={(projects) =>
+                setState((prev) => ({ ...prev, projects }))
+              }
+            />
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <CopyLinkButton
+                // Serialized on click from the live state, because the
+                // address bar only catches up after the URL-sync debounce.
+                getShareUrl={() =>
+                  window.location.origin +
+                  buildCompareUrl(
+                    window.location.pathname,
+                    toCompareUrlState(state),
+                  )
                 }
-                className="min-w-0 flex-1 basis-80"
               />
-              <div className="flex flex-wrap items-center gap-2">
-                <ChartRangeControls
-                  name="compareChart"
-                  value={state.chartRange}
-                  setValue={(chartRange) =>
-                    setState((prev) => ({ ...prev, chartRange }))
-                  }
-                  options={COMPARE_RANGE_OPTIONS.map((value) => ({
-                    value,
-                    label: value.toUpperCase(),
-                  }))}
-                />
-                <CopyLinkButton
-                  // Serialized on click from the live state, because the
-                  // address bar only catches up after the URL-sync debounce.
-                  getShareUrl={() =>
-                    window.location.origin +
-                    buildCompareUrl(
-                      window.location.pathname,
-                      toCompareUrlState(state),
-                    )
-                  }
-                />
-              </div>
+              <ChartRangeControls
+                name="compareChart"
+                value={state.chartRange}
+                setValue={(chartRange) =>
+                  setState((prev) => ({ ...prev, chartRange }))
+                }
+                options={COMPARE_RANGE_OPTIONS.map((value) => ({
+                  value,
+                  label: value.toUpperCase(),
+                }))}
+              />
             </div>
-          </PrimaryCard>
+          </div>
           {state.charts.map((config, index) => (
             <CompareChartCard
               // Charts carry no identity of their own in the URL, so the
@@ -364,7 +361,7 @@ function CopyLinkButton({ getShareUrl }: { getShareUrl: () => string }) {
       onClick={() => void copy(getShareUrl()).then(setCopied)}
       className={cn(
         'inline-flex h-8 items-center gap-1.5 rounded-lg px-2 font-medium text-xs md:text-sm',
-        'bg-surface-primary primary-card:bg-surface-secondary',
+        'bg-surface-primary hover:bg-surface-primary-hover',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
       )}
     >

--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareCharts.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareCharts.tsx
@@ -6,6 +6,7 @@ import {
   useState,
 } from 'react'
 import { ChartRangeControls } from '~/components/core/chart/ChartRangeControls'
+import { DashedButton } from '~/components/core/DashedButton'
 import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
 import { Skeleton } from '~/components/core/Skeleton'
 import {
@@ -220,27 +221,22 @@ function CompareChartCard({
 
   return (
     <PrimaryCard>
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+      <div className="flex items-center justify-between gap-x-2 md:gap-x-4">
         <MetricSwitcher
           name={`compareMetric-${chartId}`}
           value={config.metric}
           onValueChange={(metric) => setConfig((prev) => ({ ...prev, metric }))}
         />
-        <div className="flex items-center gap-1">
-          {metric.Controls && (
-            <metric.Controls state={config} setState={setConfig} />
-          )}
-          {onRemove && (
-            <button
-              type="button"
-              aria-label="Remove chart"
-              onClick={onRemove}
-              className="ml-1 flex size-7 cursor-pointer items-center justify-center rounded-lg hover:bg-surface-secondary primary-card:hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
-            >
-              <CloseIcon className="size-2.5 fill-secondary" aria-hidden />
-            </button>
-          )}
-        </div>
+        {onRemove && (
+          <button
+            type="button"
+            aria-label="Remove chart"
+            onClick={onRemove}
+            className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-lg hover:bg-surface-secondary primary-card:hover:bg-surface-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+          >
+            <CloseIcon className="size-2.5 fill-secondary" aria-hidden />
+          </button>
+        )}
       </div>
       <CompareChartIdProvider chartId={chartId}>
         <div
@@ -250,6 +246,11 @@ function CompareChartCard({
           <metric.Chart projects={projects} state={chartState} />
         </div>
       </CompareChartIdProvider>
+      {metric.Controls && (
+        <div className="mt-3 flex flex-wrap items-center gap-1">
+          <metric.Controls state={config} setState={setConfig} />
+        </div>
+      )}
     </PrimaryCard>
   )
 }
@@ -269,7 +270,7 @@ function MetricSwitcher({
 }) {
   const isClient = useIsClient()
   if (!isClient) {
-    return <Skeleton className="h-9 w-[340px]" />
+    return <Skeleton className="h-9 w-[300px] md:w-[340px]" />
   }
   return (
     <RadioGroup
@@ -278,13 +279,13 @@ function MetricSwitcher({
       value={value}
       onValueChange={(value) => onValueChange(value as CompareMetricId)}
       variant="highlighted"
-      className="h-9"
+      className="h-9 max-w-full overflow-x-auto"
     >
       {Object.values(COMPARE_METRICS).map((metric) => (
         <RadioGroupItem
           key={metric.id}
           value={metric.id}
-          className="h-full px-2 text-sm"
+          className="h-full whitespace-nowrap px-1.5 text-xs md:px-2 md:text-sm"
         >
           {metric.label}
         </RadioGroupItem>
@@ -306,21 +307,14 @@ function AddChartButton({
     // enabled element so the tooltip still receives pointer events.
     <Tooltip>
       <TooltipTrigger asChild disabled={!atCap}>
-        <button
-          type="button"
+        <DashedButton
           aria-disabled={atCap}
           onClick={atCap ? undefined : onClick}
-          className={cn(
-            'flex h-12 w-full items-center justify-center gap-1.5 rounded-xl border border-divider border-dashed font-medium text-secondary text-sm',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand',
-            atCap
-              ? 'cursor-not-allowed opacity-50'
-              : 'cursor-pointer hover:bg-surface-secondary',
-          )}
+          className="h-12 w-full rounded-xl"
         >
           <PlusIcon className="size-4" />
           Add chart
-        </button>
+        </DashedButton>
       </TooltipTrigger>
       <TooltipContent>
         Maximum of {MAX_COMPARE_CHARTS} charts reached
@@ -361,7 +355,7 @@ function CopyLinkButton({ getShareUrl }: { getShareUrl: () => string }) {
       onClick={() => void copy(getShareUrl()).then(setCopied)}
       className={cn(
         'inline-flex h-8 items-center gap-1.5 rounded-lg px-2 font-medium text-xs md:text-sm',
-        'bg-surface-primary hover:bg-surface-primary-hover',
+        'bg-surface-primary',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
       )}
     >

--- a/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
+++ b/packages/frontend/src/pages/scaling/compare/metrics/tvs/TvsCompareControls.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from '~/components/core/Checkbox'
 import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
 import {
   Select,
@@ -5,12 +6,23 @@ import {
   SelectGroup,
   SelectItem,
   SelectLabel,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from '~/components/core/Select'
 import { Skeleton } from '~/components/core/Skeleton'
-import { DisplayControls } from '~/components/table/display/DisplayControls'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '~/components/core/tooltip/Tooltip'
+import {
+  DISPLAY_OPTIONS,
+  type DisplayOption,
+  type DisplayOptionsKey,
+} from '~/components/table/display/displayOptions'
 import { useIsClient } from '~/hooks/useIsClient'
+import { InfoIcon } from '~/icons/Info'
 import {
   COMPARE_TVS_ASSET_CATEGORIES,
   COMPARE_TVS_BRIDGE_TYPES,
@@ -48,43 +60,7 @@ export function TvsCompareControls({
   }
   const restrictedRwaFilterActive = state.tvsFilter === 'rwaRestricted'
   return (
-    <div className="flex items-center gap-1">
-      <Select
-        value={state.tvsFilter}
-        onValueChange={(value) =>
-          setState((prev) => ({
-            ...prev,
-            tvsFilter: value as CompareTvsFilter,
-          }))
-        }
-      >
-        <SelectTrigger className="h-9" aria-label="Filter the compared value">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent align="end">
-          <SelectItem value="all">All</SelectItem>
-          <SelectGroup>
-            <SelectLabel className="pl-2.5 text-secondary">
-              Bridge type
-            </SelectLabel>
-            {COMPARE_TVS_BRIDGE_TYPES.map((bridgeType) => (
-              <SelectItem key={bridgeType} value={bridgeType}>
-                {TVS_BRIDGE_TYPE_LABELS[bridgeType]}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-          <SelectGroup>
-            <SelectLabel className="pl-2.5 text-secondary">
-              Asset category
-            </SelectLabel>
-            {COMPARE_TVS_ASSET_CATEGORIES.map((assetCategory) => (
-              <SelectItem key={assetCategory} value={assetCategory}>
-                {TVS_ASSET_CATEGORY_LABELS[assetCategory]}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+    <div className="flex flex-wrap items-center gap-1">
       <RadioGroup
         name="compareTvsUnit"
         value={state.tvsUnit}
@@ -101,27 +77,106 @@ export function TvsCompareControls({
           ETH
         </RadioGroupItem>
       </RadioGroup>
-      <DisplayControls
-        display={{
-          // Show the effective value: the toggle is overridden to false
-          // while the Restricted RWAs filter is active, because excluding
-          // restricted RWAs while comparing them would zero the chart.
-          excludeRwaRestrictedTokens:
-            effectiveExcludeRwaRestrictedTokens(state),
-          excludeAssociatedTokens: state.excludeAssociatedTokens,
-        }}
-        disabled={
+      <Select
+        value={state.tvsFilter}
+        onValueChange={(value) =>
+          setState((prev) => ({
+            ...prev,
+            tvsFilter: value as CompareTvsFilter,
+          }))
+        }
+      >
+        <SelectTrigger
+          className="h-9 primary-card:bg-surface-secondary"
+          aria-label="Filter the compared value"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent
+          align="end"
+          // Sized to the viewport instead of the default cap so the whole
+          // list is visible without scrolling wherever it fits.
+          className="max-h-(--radix-select-content-available-height)"
+        >
+          <SelectItem value="all">All</SelectItem>
+          <SelectSeparator />
+          <SelectGroup>
+            <SelectLabel>Bridge type</SelectLabel>
+            {COMPARE_TVS_BRIDGE_TYPES.map((bridgeType) => (
+              <SelectItem key={bridgeType} value={bridgeType}>
+                {TVS_BRIDGE_TYPE_LABELS[bridgeType]}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+          <SelectSeparator />
+          <SelectGroup>
+            <SelectLabel>Asset category</SelectLabel>
+            {COMPARE_TVS_ASSET_CATEGORIES.map((assetCategory) => (
+              <SelectItem key={assetCategory} value={assetCategory}>
+                {TVS_ASSET_CATEGORY_LABELS[assetCategory]}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      <DisplayCheckbox
+        optionKey="excludeRwaRestrictedTokens"
+        // Show the effective value: the toggle is overridden to false while
+        // the Restricted RWAs filter is active, because excluding restricted
+        // RWAs while comparing them would zero the chart.
+        checked={effectiveExcludeRwaRestrictedTokens(state)}
+        disabledReason={
           restrictedRwaFilterActive
-            ? {
-                excludeRwaRestrictedTokens:
-                  'Unavailable while comparing restricted RWAs - it would exclude the very tokens being compared.',
-              }
+            ? 'Unavailable while comparing restricted RWAs - it would exclude the very tokens being compared.'
             : undefined
         }
-        setDisplay={(key, value) =>
-          setState((prev) => ({ ...prev, [key]: value }))
+        onCheckedChange={(excludeRwaRestrictedTokens) =>
+          setState((prev) => ({ ...prev, excludeRwaRestrictedTokens }))
+        }
+      />
+      <DisplayCheckbox
+        optionKey="excludeAssociatedTokens"
+        checked={state.excludeAssociatedTokens}
+        onCheckedChange={(excludeAssociatedTokens) =>
+          setState((prev) => ({ ...prev, excludeAssociatedTokens }))
         }
       />
     </div>
+  )
+}
+
+function DisplayCheckbox({
+  optionKey,
+  checked,
+  disabledReason,
+  onCheckedChange,
+}: {
+  optionKey: DisplayOptionsKey
+  checked: boolean
+  disabledReason?: string
+  onCheckedChange: (checked: boolean) => void
+}) {
+  const option: DisplayOption = DISPLAY_OPTIONS[optionKey]
+  const tooltip = disabledReason ?? option.tooltip
+  return (
+    <Checkbox
+      name={`compareTvs-${optionKey}`}
+      checked={checked}
+      disabled={disabledReason !== undefined}
+      onCheckedChange={(checked) => onCheckedChange(!!checked)}
+      className="h-9"
+    >
+      <div className="flex items-center gap-1">
+        {option.label}
+        {tooltip && (
+          <Tooltip>
+            <TooltipTrigger>
+              <InfoIcon className="size-3.5" />
+            </TooltipTrigger>
+            <TooltipContent>{tooltip}</TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    </Checkbox>
   )
 }


### PR DESCRIPTION
## Summary

- Drop the `PrimaryCard` wrapper around the scaling compare page controls and lay the project picker, copy-link button and range controls out directly on the page background
- Stack the controls vertically: picker on top, then a row with the copy-link button on the left and the range controls on the right
- Remove the now-unneeded `primary-card:` background variants from the project chips, the "Add project" button and the copy-link button, and give the latter two plain hover states

## Testing

- Not run — visual-only change; worth a quick check of the compare page in light and dark mode at mobile, md and lg widths