### PR TITLE
Compare page: mobile layout polish and Ethereum as a selectable baseline

### DIFF
--- a/packages/frontend/src/pages/scaling/compare/components/ScalingCompareCharts.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/ScalingCompareCharts.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react'
 import { ChartRangeControls } from '~/components/core/chart/ChartRangeControls'
 import { DashedButton } from '~/components/core/DashedButton'
+import { OverflowWrapper } from '~/components/core/OverflowWrapper'
 import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
 import { Skeleton } from '~/components/core/Skeleton'
 import {
@@ -171,22 +172,24 @@ export function ScalingCompareCharts({
               />
             </div>
           </div>
-          {state.charts.map((config, index) => (
-            <CompareChartCard
-              // Charts carry no identity of their own in the URL, so the
-              // index is the only stable key; card-local state is limited
-              // to hydration skeletons, so remounts on removal are cheap.
-              key={index}
-              chartId={index}
-              config={config}
-              chartRange={state.chartRange}
-              projects={selectedProjects}
-              setConfig={setChartConfig(index)}
-              onRemove={
-                state.charts.length > 1 ? () => removeChart(index) : undefined
-              }
-            />
-          ))}
+          <div className="flex flex-col md:gap-2">
+            {state.charts.map((config, index) => (
+              <CompareChartCard
+                // Charts carry no identity of their own in the URL, so the
+                // index is the only stable key; card-local state is limited
+                // to hydration skeletons, so remounts on removal are cheap.
+                key={index}
+                chartId={index}
+                config={config}
+                chartRange={state.chartRange}
+                projects={selectedProjects}
+                setConfig={setChartConfig(index)}
+                onRemove={
+                  state.charts.length > 1 ? () => removeChart(index) : undefined
+                }
+              />
+            ))}
+          </div>
           <AddChartButton
             onClick={addChart}
             atCap={state.charts.length >= MAX_COMPARE_CHARTS}
@@ -273,24 +276,26 @@ function MetricSwitcher({
     return <Skeleton className="h-9 w-[300px] md:w-[340px]" />
   }
   return (
-    <RadioGroup
-      name={name}
-      aria-label="Chart metric"
-      value={value}
-      onValueChange={(value) => onValueChange(value as CompareMetricId)}
-      variant="highlighted"
-      className="h-9 max-w-full overflow-x-auto"
-    >
-      {Object.values(COMPARE_METRICS).map((metric) => (
-        <RadioGroupItem
-          key={metric.id}
-          value={metric.id}
-          className="h-full whitespace-nowrap px-1.5 text-xs md:px-2 md:text-sm"
-        >
-          {metric.label}
-        </RadioGroupItem>
-      ))}
-    </RadioGroup>
+    <OverflowWrapper className="min-w-0">
+      <RadioGroup
+        name={name}
+        aria-label="Chart metric"
+        value={value}
+        onValueChange={(value) => onValueChange(value as CompareMetricId)}
+        variant="highlighted"
+        className="h-9"
+      >
+        {Object.values(COMPARE_METRICS).map((metric) => (
+          <RadioGroupItem
+            key={metric.id}
+            value={metric.id}
+            className="h-full whitespace-nowrap px-1.5 text-xs md:px-2 md:text-sm"
+          >
+            {metric.label}
+          </RadioGroupItem>
+        ))}
+      </RadioGroup>
+    </OverflowWrapper>
   )
 }
 
@@ -305,21 +310,23 @@ function AddChartButton({
     // The button stays visible (not hidden) at the cap: a vanishing button
     // reads as a bug, while the tooltip teaches the limit. It stays a real
     // enabled element so the tooltip still receives pointer events.
-    <Tooltip>
-      <TooltipTrigger asChild disabled={!atCap}>
-        <DashedButton
-          aria-disabled={atCap}
-          onClick={atCap ? undefined : onClick}
-          className="h-12 w-full rounded-xl"
-        >
-          <PlusIcon className="size-4" />
-          Add chart
-        </DashedButton>
-      </TooltipTrigger>
-      <TooltipContent>
-        Maximum of {MAX_COMPARE_CHARTS} charts reached
-      </TooltipContent>
-    </Tooltip>
+    <div className="max-md:px-4">
+      <Tooltip>
+        <TooltipTrigger asChild disabled={!atCap}>
+          <DashedButton
+            aria-disabled={atCap}
+            onClick={atCap ? undefined : onClick}
+            className="h-12 w-full rounded-xl"
+          >
+            <PlusIcon className="size-4" />
+            Add chart
+          </DashedButton>
+        </TooltipTrigger>
+        <TooltipContent>
+          Maximum of {MAX_COMPARE_CHARTS} charts reached
+        </TooltipContent>
+      </Tooltip>
+    </div>
   )
 }
 

--- a/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
+++ b/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
@@ -1,4 +1,4 @@
-import type { InMemoryCache } from '@l2beat/shared-pure'
+import { type InMemoryCache, ProjectId } from '@l2beat/shared-pure'
 import type { Request } from 'express'
 import { getAppLayoutProps } from '~/common/getAppLayoutProps'
 import type { CompareProjectEntry } from '~/server/features/scaling/compare/getCompareProjectEntries'
@@ -65,8 +65,11 @@ async function getCompareData(originalUrl: string, cache: InMemoryCache) {
     validSlugs: allProjects.map((project) => project.slug),
   })
   // Always ranked by TVS regardless of chart metrics - the universe is
-  // already ordered by TVS descending.
-  const defaultProjects = allProjects.slice(0, DEFAULT_COMPARE_PROJECTS_COUNT)
+  // already ordered by TVS descending. Ethereum is a baseline to opt into,
+  // never a default.
+  const defaultProjects = allProjects
+    .filter((project) => project.id !== ProjectId.ETHEREUM)
+    .slice(0, DEFAULT_COMPARE_PROJECTS_COUNT)
   const defaultProjectSlugs = defaultProjects.map((project) => project.slug)
 
   // Chart data is only prefetched for the pristine default view; every

--- a/packages/frontend/src/pages/scaling/compare/utils/getCompareSeriesColors.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/getCompareSeriesColors.test.ts
@@ -17,4 +17,19 @@ describe(getCompareSeriesColors.name, () => {
     expect(three.arbitrum).toEqual(two.arbitrum)
     expect(three.base).toEqual(two.base)
   })
+
+  it('gives Ethereum its fixed chart color without taking a palette slot', () => {
+    const without = getCompareSeriesColors(['arbitrum', 'base'])
+    const withEthereum = getCompareSeriesColors(['arbitrum', 'ethereum', 'base'])
+
+    expect(withEthereum.ethereum).toEqual('var(--chart-ethereum)')
+    expect(withEthereum.arbitrum).toEqual(without.arbitrum)
+    expect(withEthereum.base).toEqual(without.base)
+  })
+
+  it('does not map Ethereum when it is not selected', () => {
+    const colors = getCompareSeriesColors(['arbitrum'])
+
+    expect(colors.ethereum).toEqual(undefined)
+  })
 })

--- a/packages/frontend/src/pages/scaling/compare/utils/getCompareSeriesColors.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/getCompareSeriesColors.ts
@@ -1,15 +1,28 @@
+import { ProjectId } from '@l2beat/shared-pure'
 import { generateAccessibleColors } from '~/utils/generateColors'
+
+const ETHEREUM_COLOR = 'var(--chart-ethereum)'
 
 /**
  * The single source of the compare page per-series color mapping, assigned
  * by selection order. The selection chips, chart lines, legend and tooltip
  * must all read colors from this mapping so they always agree.
+ *
+ * Ethereum always gets the site-wide Ethereum chart color and takes no
+ * palette slot, so the projects around it keep the colors they would have
+ * without it.
  */
 export function getCompareSeriesColors(
   projectIds: string[],
 ): Record<string, string> {
-  const colors = generateAccessibleColors(projectIds.length)
-  return Object.fromEntries(
-    projectIds.map((id, index) => [id, colors[index] ?? 'var(--secondary)']),
-  )
+  const paletteIds = projectIds.filter((id) => id !== ProjectId.ETHEREUM)
+  const colors = generateAccessibleColors(paletteIds.length)
+  return {
+    ...Object.fromEntries(
+      paletteIds.map((id, index) => [id, colors[index] ?? 'var(--secondary)']),
+    ),
+    ...(projectIds.includes(ProjectId.ETHEREUM)
+      ? { [ProjectId.ETHEREUM]: ETHEREUM_COLOR }
+      : {}),
+  }
 }

--- a/packages/frontend/src/server/features/scaling/compare/getCompareProjectEntries.ts
+++ b/packages/frontend/src/server/features/scaling/compare/getCompareProjectEntries.ts
@@ -5,7 +5,7 @@ import type {
   TvsToken,
   ValueFormula,
 } from '@l2beat/config'
-import type { ProjectId } from '@l2beat/shared-pure'
+import { ProjectId } from '@l2beat/shared-pure'
 import { ps } from '~/server/projects'
 import { manifest } from '~/utils/Manifest'
 import { get7dTvsBreakdown } from '../tvs/get7dTvsBreakdown'
@@ -33,10 +33,11 @@ export interface CompareProjectEntry {
 }
 
 /**
- * The selectable universe of the compare page: live scaling projects only
- * (rollups, validiums & optimiums, others) - no archived, no upcoming,
- * no Ethereum. Ordered by TVS descending, which is the order the picker
- * shows them in.
+ * The selectable universe of the compare page: Ethereum as the baseline,
+ * then live scaling projects only (rollups, validiums & optimiums, others) -
+ * no archived, no upcoming. Projects are ordered by TVS descending, which is
+ * the order the picker shows them in; Ethereum is pinned first so the
+ * baseline is easy to find rather than buried among 0-TVS projects.
  */
 export async function getCompareProjectEntries(): Promise<
   CompareProjectEntry[]
@@ -51,7 +52,7 @@ export async function getCompareProjectEntries(): Promise<
     get7dTvsBreakdown({ type: 'layer2' }),
   ])
 
-  return projects
+  const entries = projects
     .map((project) => ({
       id: project.id,
       slug: project.slug,
@@ -64,6 +65,25 @@ export async function getCompareProjectEntries(): Promise<
       hasDaTracking: (project.daTrackingConfig?.length ?? 0) > 0,
     }))
     .sort((a, b) => b.tvs - a.tvs || a.name.localeCompare(b.name))
+  return [getEthereumEntry(), ...entries]
+}
+
+/**
+ * Ethereum as a compare entry. Only activity tracks it, so on every other
+ * metric it is marked "no data" like any project without that tracking.
+ */
+function getEthereumEntry(): CompareProjectEntry {
+  return {
+    id: ProjectId.ETHEREUM,
+    slug: 'ethereum',
+    name: 'Ethereum',
+    shortName: undefined,
+    iconUrl: manifest.getUrl('/icons/ethereum.png'),
+    tvsSinceTimestamp: undefined,
+    costsSinceTimestamp: undefined,
+    tvs: 0,
+    hasDaTracking: false,
+  }
 }
 
 function getCostsSinceTimestamp(


### PR DESCRIPTION
## Summary

Two small compare-page changes, stacked on \`project-compare-feature\`.

### Mobile layout polish
- Chart cards stack without a gap on mobile (the \`gap-2\` stays on \`md+\`)
- The "Add chart" button gets side padding on mobile so it no longer touches the screen edges
- The metric switcher (Value Secured / Activity / Costs / Data posted) is wrapped in the shared \`OverflowWrapper\` (hidden scrollbar, edge fade, scroll arrows) instead of a raw \`overflow-x-auto\`

### Ethereum as a selectable baseline
Rather than a metric-specific "Show Ethereum" toggle, Ethereum simply joins the compare universe as a regular \`CompareProjectEntry\`:
- Pinned first in the "Add project" picker so the baseline is easy to find (it would otherwise sit at the bottom among 0-TVS projects)
- Never part of the top-N default selection
- Only activity tracks it, so on TVS / costs / data-posted it is marked "no data" through the existing \`hasData\` machinery, exactly like any project without that tracking
- Always renders in the site-wide \`--chart-ethereum\` color, and takes no palette slot — the other selected projects keep the colors they'd have without it

Selecting it is just \`?projects=arbitrum,base,ethereum\`; no new state, URL fields, or props.

## Test plan
- [x] \`tsc --noEmit\`, biome, and \`mocha\` (394 passing; 2 new tests for the Ethereum color rule)
- [x] Mock server: default view has no Ethereum chip; picker lists Ethereum first after the pinned selection with "No TVS data" while a TVS chart is shown; selecting it adds a chip and an Ethereum-blue line on the activity chart
- [ ] Eyeball mobile spacing on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)