### PR TITLE
Add compare page entry points to the sidebar, metric pages and project sections

### DIFF
--- a/packages/frontend/src/components/chart/activity/ScalingActivityChart.tsx
+++ b/packages/frontend/src/components/chart/activity/ScalingActivityChart.tsx
@@ -10,6 +10,8 @@ import { Skeleton } from '~/components/core/Skeleton'
 import { useIsClient } from '~/hooks/useIsClient'
 import { useActivityChartRangeContext } from '~/pages/scaling/activity/components/ActivityChartRangeContext'
 import { ActivityChartRangeControls } from '~/pages/scaling/activity/components/ActivityChartRangeControls'
+import { CompareProjectsLink } from '~/pages/scaling/compare/components/CompareProjectsLink'
+import { getCompareEntryUrl } from '~/pages/scaling/compare/utils/getCompareEntryUrl'
 import type { ScalingActivityEntry } from '~/server/features/scaling/activity/getScalingActivityEntries'
 import { useTRPC } from '~/trpc/React'
 import type { ChartRange } from '~/utils/range/range'
@@ -102,7 +104,7 @@ function Controls({ scale, setScale, range, setRange }: ControlsProps) {
   const isClient = useIsClient()
   return (
     <ChartControlsWrapper>
-      <div className="flex gap-1">
+      <div className="flex flex-wrap items-center gap-2">
         {isClient ? (
           <RadioGroup
             name="activityChartScale"
@@ -115,6 +117,9 @@ function Controls({ scale, setScale, range, setRange }: ControlsProps) {
         ) : (
           <Skeleton className="h-8 w-[91px] md:w-[95px]" />
         )}
+        <CompareProjectsLink
+          href={getCompareEntryUrl({ metric: 'activity' })}
+        />
       </div>
       <ActivityChartRangeControls range={range} setRange={setRange} />
     </ChartControlsWrapper>

--- a/packages/frontend/src/components/chart/costs/ScalingCostsChart.tsx
+++ b/packages/frontend/src/components/chart/costs/ScalingCostsChart.tsx
@@ -4,6 +4,8 @@ import { useMemo } from 'react'
 import { RadioGroup, RadioGroupItem } from '~/components/core/RadioGroup'
 import { Skeleton } from '~/components/core/Skeleton'
 import { useTableFilterContext } from '~/components/table/filters/TableFilterContext'
+import { CompareProjectsLink } from '~/pages/scaling/compare/components/CompareProjectsLink'
+import { getCompareEntryUrl } from '~/pages/scaling/compare/utils/getCompareEntryUrl'
 import {
   type CostsMetric,
   useCostsMetricContext,
@@ -135,9 +137,10 @@ export function ScalingCostsChart({ tab, milestones, entries }: Props) {
         />
       </div>
       <ChartControlsWrapper>
-        <div className="flex flex-wrap gap-1">
+        <div className="flex flex-wrap items-center gap-1">
           <UnitControls unit={unit} setUnit={setUnit} isLoading={isLoading} />
           <CostsMetricControls value={metric} onValueChange={onMetricChange} />
+          <CompareProjectsLink href={getCompareEntryUrl({ metric: 'costs' })} />
         </div>
         <CostsChartRangeControls
           range={range}

--- a/packages/frontend/src/components/projects/sections/ActivitySection.tsx
+++ b/packages/frontend/src/components/projects/sections/ActivitySection.tsx
@@ -34,7 +34,11 @@ export function ActivitySection({
       {...sectionProps}
       headerAccessory={
         compareUrl && (
-          <CompareProjectsLink href={compareUrl} className="max-md:hidden">
+          <CompareProjectsLink
+            variant="section"
+            href={compareUrl}
+            className="max-md:hidden"
+          >
             Compare
           </CompareProjectsLink>
         )
@@ -58,8 +62,9 @@ export function ActivitySection({
       )}
       {compareUrl && (
         <CompareProjectsLink
+          variant="section"
           href={compareUrl}
-          className="mt-4 h-10 w-full md:hidden"
+          className="mt-4 md:hidden"
         >
           Compare with other projects
         </CompareProjectsLink>

--- a/packages/frontend/src/components/projects/sections/ActivitySection.tsx
+++ b/packages/frontend/src/components/projects/sections/ActivitySection.tsx
@@ -3,6 +3,7 @@ import { ProjectId } from '@l2beat/shared-pure'
 import { EthereumActivityChart } from '~/components/chart/activity/EthereumActivityChart'
 import { ChartDataSourceInfo } from '~/components/chart/ChartDataSourceInfo'
 import type { ChartProject } from '~/components/core/chart/Chart'
+import { CompareProjectsLink } from '~/pages/scaling/compare/components/CompareProjectsLink'
 import type { ChartRange } from '~/utils/range/range'
 import { ProjectActivityChart } from '../../chart/activity/ProjectActivityChart'
 import { ProjectSection } from './ProjectSection'
@@ -15,6 +16,8 @@ export interface ActivitySectionProps extends ProjectSectionProps {
   category?: ProjectScalingCategory
   defaultRange: ChartRange
   dataSource: string | undefined
+  /** Entry to the compare page with this project pre-selected. */
+  compareUrl?: string
 }
 
 export function ActivitySection({
@@ -23,10 +26,20 @@ export function ActivitySection({
   category,
   defaultRange,
   dataSource,
+  compareUrl,
   ...sectionProps
 }: ActivitySectionProps) {
   return (
-    <ProjectSection {...sectionProps}>
+    <ProjectSection
+      {...sectionProps}
+      headerAccessory={
+        compareUrl && (
+          <CompareProjectsLink href={compareUrl} className="max-md:hidden">
+            Compare
+          </CompareProjectsLink>
+        )
+      }
+    >
       {dataSource && <ChartDataSourceInfo dataSource={dataSource} />}
       {project.id === ProjectId.ETHEREUM ? (
         <EthereumActivityChart
@@ -42,6 +55,14 @@ export function ActivitySection({
           category={category}
           defaultRange={defaultRange}
         />
+      )}
+      {compareUrl && (
+        <CompareProjectsLink
+          href={compareUrl}
+          className="mt-4 h-10 w-full md:hidden"
+        >
+          Compare with other projects
+        </CompareProjectsLink>
       )}
     </ProjectSection>
   )

--- a/packages/frontend/src/components/projects/sections/ActivitySection.tsx
+++ b/packages/frontend/src/components/projects/sections/ActivitySection.tsx
@@ -16,7 +16,6 @@ export interface ActivitySectionProps extends ProjectSectionProps {
   category?: ProjectScalingCategory
   defaultRange: ChartRange
   dataSource: string | undefined
-  /** Entry to the compare page with this project pre-selected. */
   compareUrl?: string
 }
 

--- a/packages/frontend/src/components/projects/sections/costs/CostsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/costs/CostsSection.tsx
@@ -16,7 +16,6 @@ export interface CostsSectionProps extends ProjectSectionProps {
   milestones: Milestone[]
   trackedTransactions: TrackedTransactionsByType
   defaultRange: ChartRange
-  /** Entry to the compare page with this project pre-selected. */
   compareUrl?: string
 }
 

--- a/packages/frontend/src/components/projects/sections/costs/CostsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/costs/CostsSection.tsx
@@ -4,6 +4,7 @@ import type { ChartProject } from '~/components/core/chart/Chart'
 import { HorizontalSeparator } from '~/components/core/HorizontalSeparator'
 import { TrackedTxsOutageNotice } from '~/components/TrackedTxsOutageNotice'
 import { env } from '~/env'
+import { CompareProjectsLink } from '~/pages/scaling/compare/components/CompareProjectsLink'
 import type { TrackedTransactionsByType } from '~/utils/project/tracked-txs/getTrackedTransactions'
 import type { ChartRange } from '~/utils/range/range'
 import { ProjectSection } from '../ProjectSection'
@@ -15,6 +16,8 @@ export interface CostsSectionProps extends ProjectSectionProps {
   milestones: Milestone[]
   trackedTransactions: TrackedTransactionsByType
   defaultRange: ChartRange
+  /** Entry to the compare page with this project pre-selected. */
+  compareUrl?: string
 }
 
 export function CostsSection({
@@ -22,10 +25,24 @@ export function CostsSection({
   milestones,
   trackedTransactions,
   defaultRange,
+  compareUrl,
   ...sectionProps
 }: CostsSectionProps) {
   return (
-    <ProjectSection {...sectionProps}>
+    <ProjectSection
+      {...sectionProps}
+      headerAccessory={
+        compareUrl && (
+          <CompareProjectsLink
+            variant="section"
+            href={compareUrl}
+            className="max-md:hidden"
+          >
+            Compare
+          </CompareProjectsLink>
+        )
+      }
+    >
       <p className="text-paragraph-15 md:text-paragraph-16">
         The section shows the operating costs that L2s pay to Ethereum.
       </p>
@@ -40,6 +57,15 @@ export function CostsSection({
       />
       <HorizontalSeparator className="my-4" />
       <TrackedTransactions {...trackedTransactions} />
+      {compareUrl && (
+        <CompareProjectsLink
+          variant="section"
+          href={compareUrl}
+          className="mt-4 md:hidden"
+        >
+          Compare with other projects
+        </CompareProjectsLink>
+      )}
     </ProjectSection>
   )
 }

--- a/packages/frontend/src/components/projects/sections/data-posted/DataPostedSection.tsx
+++ b/packages/frontend/src/components/projects/sections/data-posted/DataPostedSection.tsx
@@ -4,6 +4,7 @@ import { ProjectDataPostedChart } from '~/components/chart/data-posted/ProjectDa
 import type { ChartProject } from '~/components/core/chart/Chart'
 import { HorizontalSeparator } from '~/components/core/HorizontalSeparator'
 import { CustomLink } from '~/components/link/CustomLink'
+import { CompareProjectsLink } from '~/pages/scaling/compare/components/CompareProjectsLink'
 import type { ChartRange } from '~/utils/range/range'
 import { ProjectSection } from '../ProjectSection'
 import type { ProjectSectionProps } from '../types'
@@ -26,6 +27,8 @@ export interface DataPostedSectionProps extends ProjectSectionProps {
   daTrackingConfig: (ProjectDaTrackingConfig & {
     daLayerName: string
   })[]
+  /** Entry to the compare page with this project pre-selected. */
+  compareUrl?: string
 }
 
 export function DataPostedSection({
@@ -35,10 +38,24 @@ export function DataPostedSection({
   milestones,
   defaultRange,
   daTrackingConfig,
+  compareUrl,
   ...sectionProps
 }: DataPostedSectionProps) {
   return (
-    <ProjectSection {...sectionProps}>
+    <ProjectSection
+      {...sectionProps}
+      headerAccessory={
+        compareUrl && (
+          <CompareProjectsLink
+            variant="section"
+            href={compareUrl}
+            className="max-md:hidden"
+          >
+            Compare
+          </CompareProjectsLink>
+        )
+      }
+    >
       <p className="text-paragraph-15 md:text-paragraph-16">
         This section shows how much data the project publishes to its
         data-availability (DA) layer over time. The project currently posts data
@@ -87,6 +104,15 @@ export function DataPostedSection({
       />
       <HorizontalSeparator className="my-4" />
       <DataPostedTrackedTransactions daTrackingConfig={daTrackingConfig} />
+      {compareUrl && (
+        <CompareProjectsLink
+          variant="section"
+          href={compareUrl}
+          className="mt-4 md:hidden"
+        >
+          Compare with other projects
+        </CompareProjectsLink>
+      )}
     </ProjectSection>
   )
 }

--- a/packages/frontend/src/components/projects/sections/data-posted/DataPostedSection.tsx
+++ b/packages/frontend/src/components/projects/sections/data-posted/DataPostedSection.tsx
@@ -27,7 +27,6 @@ export interface DataPostedSectionProps extends ProjectSectionProps {
   daTrackingConfig: (ProjectDaTrackingConfig & {
     daLayerName: string
   })[]
-  /** Entry to the compare page with this project pre-selected. */
   compareUrl?: string
 }
 

--- a/packages/frontend/src/components/projects/sections/tvs/ScalingTvsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/tvs/ScalingTvsSection.tsx
@@ -3,6 +3,7 @@ import { ProjectAssetCategoryTvsChart } from '~/components/chart/tvs/stacked/Pro
 import { ProjectBridgeTypeTvsChart } from '~/components/chart/tvs/stacked/ProjectBridgeTypeTvsChart'
 import { SelectedTokenContextProvider } from '~/components/chart/tvs/token/SelectedTokenContext'
 import type { ChartProject } from '~/components/core/chart/Chart'
+import { CompareProjectsLink } from '~/pages/scaling/compare/components/CompareProjectsLink'
 import { ScalingRwaRestrictedTokensContextProvider } from '~/pages/scaling/components/ScalingRwaRestrictedTokensContext'
 import type { ProjectToken } from '~/server/features/scaling/tvs/tokens/getTokensForProject'
 import type { ChartRange } from '~/utils/range/range'
@@ -22,6 +23,8 @@ export interface ScalingTvsSectionProps extends ProjectSectionProps {
   milestones: Milestone[]
   tvsInfo: ProjectTvsInfo
   tvsBreakdownUrl?: string
+  /** Entry to the compare page with this project pre-selected. */
+  compareUrl?: string
   defaultRange: ChartRange
 }
 
@@ -31,6 +34,7 @@ export function ScalingTvsSection({
   tokens,
   tvsInfo,
   tvsBreakdownUrl,
+  compareUrl,
   defaultRange,
   ...sectionProps
 }: ScalingTvsSectionProps) {
@@ -38,12 +42,14 @@ export function ScalingTvsSection({
     <ProjectSection
       {...sectionProps}
       headerAccessory={
-        tvsBreakdownUrl && (
-          <TvsBreakdownButton
-            tvsBreakdownUrl={tvsBreakdownUrl}
-            className="max-md:hidden"
-          />
-        )
+        <div className="flex items-center gap-2 max-md:hidden">
+          {compareUrl && (
+            <CompareProjectsLink href={compareUrl}>Compare</CompareProjectsLink>
+          )}
+          {tvsBreakdownUrl && (
+            <TvsBreakdownButton tvsBreakdownUrl={tvsBreakdownUrl} />
+          )}
+        </div>
       }
     >
       <ScalingRwaRestrictedTokensContextProvider>
@@ -67,6 +73,14 @@ export function ScalingTvsSection({
               tvsBreakdownUrl={tvsBreakdownUrl}
               tvsInfo={tvsInfo}
             />
+            {compareUrl && (
+              <CompareProjectsLink
+                href={compareUrl}
+                className="mt-3 h-10 w-full md:hidden"
+              >
+                Compare with other projects
+              </CompareProjectsLink>
+            )}
           </SelectedTokenContextProvider>
         </TvsChartControlsContextProvider>
       </ScalingRwaRestrictedTokensContextProvider>

--- a/packages/frontend/src/components/projects/sections/tvs/ScalingTvsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/tvs/ScalingTvsSection.tsx
@@ -44,7 +44,9 @@ export function ScalingTvsSection({
       headerAccessory={
         <div className="flex items-center gap-2 max-md:hidden">
           {compareUrl && (
-            <CompareProjectsLink href={compareUrl}>Compare</CompareProjectsLink>
+            <CompareProjectsLink variant="section" href={compareUrl}>
+              Compare
+            </CompareProjectsLink>
           )}
           {tvsBreakdownUrl && (
             <TvsBreakdownButton tvsBreakdownUrl={tvsBreakdownUrl} />
@@ -75,8 +77,9 @@ export function ScalingTvsSection({
             />
             {compareUrl && (
               <CompareProjectsLink
+                variant="section"
                 href={compareUrl}
-                className="mt-3 h-10 w-full md:hidden"
+                className="mt-3 md:hidden"
               >
                 Compare with other projects
               </CompareProjectsLink>

--- a/packages/frontend/src/components/projects/sections/tvs/ScalingTvsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/tvs/ScalingTvsSection.tsx
@@ -23,7 +23,6 @@ export interface ScalingTvsSectionProps extends ProjectSectionProps {
   milestones: Milestone[]
   tvsInfo: ProjectTvsInfo
   tvsBreakdownUrl?: string
-  /** Entry to the compare page with this project pre-selected. */
   compareUrl?: string
   defaultRange: ChartRange
 }

--- a/packages/frontend/src/components/search-bar/searchBarPages.ts
+++ b/packages/frontend/src/components/search-bar/searchBarPages.ts
@@ -36,7 +36,7 @@ export const searchBarPages = withIndex([
     tags: ['pages', 'scaling'],
     href: '/scaling/activity',
   },
-  ...(env.FEATURE_FLAG_COMPARE_PROJECTS
+  ...(env.CLIENT_SIDE_COMPARE_PROJECTS
     ? [
         {
           category: 'scaling' as const,

--- a/packages/frontend/src/components/search-bar/searchBarPages.ts
+++ b/packages/frontend/src/components/search-bar/searchBarPages.ts
@@ -36,6 +36,16 @@ export const searchBarPages = withIndex([
     tags: ['pages', 'scaling'],
     href: '/scaling/activity',
   },
+  ...(env.FEATURE_FLAG_COMPARE_PROJECTS
+    ? [
+        {
+          category: 'scaling' as const,
+          name: 'Compare Projects',
+          tags: ['pages', 'scaling', 'compare'],
+          href: '/scaling/compare',
+        },
+      ]
+    : []),
   {
     category: 'scaling',
     name: 'Data Availability',

--- a/packages/frontend/src/consts/navGroups.tsx
+++ b/packages/frontend/src/consts/navGroups.tsx
@@ -75,7 +75,7 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
         title: 'Costs',
         href: '/scaling/costs',
       },
-      env.FEATURE_FLAG_COMPARE_PROJECTS && {
+      env.CLIENT_SIDE_COMPARE_PROJECTS && {
         title: 'Compare',
         href: '/scaling/compare',
       },

--- a/packages/frontend/src/consts/navGroups.tsx
+++ b/packages/frontend/src/consts/navGroups.tsx
@@ -1,5 +1,5 @@
 import compact from 'lodash/compact'
-import type { NavGroup } from '~/components/nav/types'
+import type { NavGroup, NavLink } from '~/components/nav/types'
 import { PARTNERS_ORDER } from '~/consts/partnersOrder'
 import { env } from '~/env'
 import { BridgesIcon } from '~/icons/pages/Bridges'
@@ -28,7 +28,7 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
     icon: (
       <ScalingIcon className="transition-colors duration-300 group-data-[active=true]:stroke-brand" />
     ),
-    links: [
+    links: compact<NavLink>([
       {
         title: 'Summary',
         href: '/scaling/summary',
@@ -75,7 +75,11 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
         title: 'Costs',
         href: '/scaling/costs',
       },
-    ],
+      env.FEATURE_FLAG_COMPARE_PROJECTS && {
+        title: 'Compare',
+        href: '/scaling/compare',
+      },
+    ]),
     secondaryLinks: [
       {
         title: 'Archived',

--- a/packages/frontend/src/env.ts
+++ b/packages/frontend/src/env.ts
@@ -22,12 +22,9 @@ const CLIENT_CONFIG = {
   CLIENT_SIDE_SHOW_HIRING_BADGE: featureFlag.default(false),
   CLIENT_SIDE_TRACKED_TXS_OUTAGE: featureFlag.default(false),
   CLIENT_SIDE_OPENPANEL_CLIENT_ID: z.string().optional(),
-  // Client-side because the compare entry points (sidebar, chart buttons)
-  // are rendered by client components and must hydrate identically.
-  FEATURE_FLAG_COMPARE_PROJECTS: featureFlag.default(false),
+  CLIENT_SIDE_COMPARE_PROJECTS: featureFlag.default(false),
 }
 const ClientEnv = z.object(CLIENT_CONFIG)
-/** The env keys safe to embed in the HTML for the browser bundle. */
 export const CLIENT_ENV_KEYS = Object.keys(CLIENT_CONFIG)
 
 const SERVER_CONFIG = {
@@ -140,6 +137,6 @@ function getRawEnv(): Record<
     CLIENT_SIDE_TRACKED_TXS_OUTAGE: process.env.CLIENT_SIDE_TRACKED_TXS_OUTAGE,
     CLIENT_SIDE_OPENPANEL_CLIENT_ID:
       process.env.CLIENT_SIDE_OPENPANEL_CLIENT_ID,
-    FEATURE_FLAG_COMPARE_PROJECTS: process.env.FEATURE_FLAG_COMPARE_PROJECTS,
+    CLIENT_SIDE_COMPARE_PROJECTS: process.env.CLIENT_SIDE_COMPARE_PROJECTS,
   }
 }

--- a/packages/frontend/src/env.ts
+++ b/packages/frontend/src/env.ts
@@ -22,8 +22,13 @@ const CLIENT_CONFIG = {
   CLIENT_SIDE_SHOW_HIRING_BADGE: featureFlag.default(false),
   CLIENT_SIDE_TRACKED_TXS_OUTAGE: featureFlag.default(false),
   CLIENT_SIDE_OPENPANEL_CLIENT_ID: z.string().optional(),
+  // Client-side because the compare entry points (sidebar, chart buttons)
+  // are rendered by client components and must hydrate identically.
+  FEATURE_FLAG_COMPARE_PROJECTS: featureFlag.default(false),
 }
 const ClientEnv = z.object(CLIENT_CONFIG)
+/** The env keys safe to embed in the HTML for the browser bundle. */
+export const CLIENT_ENV_KEYS = Object.keys(CLIENT_CONFIG)
 
 const SERVER_CONFIG = {
   ...CLIENT_CONFIG,
@@ -66,7 +71,6 @@ const SERVER_CONFIG = {
     .optional(),
   INTEROP_CHAINS: stringArray.optional(),
   INTEROP_UPCOMING_CHAINS: stringArray.optional(),
-  FEATURE_FLAG_COMPARE_PROJECTS: featureFlag.default(false),
 }
 const ServerEnv = z.object(SERVER_CONFIG)
 
@@ -129,7 +133,6 @@ function getRawEnv(): Record<
     LOG_LEVEL: process.env.LOG_LEVEL,
     INTEROP_CHAINS: process.env.INTEROP_CHAINS,
     INTEROP_UPCOMING_CHAINS: process.env.INTEROP_UPCOMING_CHAINS,
-    FEATURE_FLAG_COMPARE_PROJECTS: process.env.FEATURE_FLAG_COMPARE_PROJECTS,
     // Client
     CLIENT_SIDE_GITCOIN_ROUND_LIVE: process.env.CLIENT_SIDE_GITCOIN_ROUND_LIVE,
     CLIENT_SIDE_HOME_PAGE: process.env.CLIENT_SIDE_HOME_PAGE,
@@ -137,5 +140,6 @@ function getRawEnv(): Record<
     CLIENT_SIDE_TRACKED_TXS_OUTAGE: process.env.CLIENT_SIDE_TRACKED_TXS_OUTAGE,
     CLIENT_SIDE_OPENPANEL_CLIENT_ID:
       process.env.CLIENT_SIDE_OPENPANEL_CLIENT_ID,
+    FEATURE_FLAG_COMPARE_PROJECTS: process.env.FEATURE_FLAG_COMPARE_PROJECTS,
   }
 }

--- a/packages/frontend/src/pages/scaling/ScalingRouter.ts
+++ b/packages/frontend/src/pages/scaling/ScalingRouter.ts
@@ -66,7 +66,7 @@ export function createScalingRouter(
     res.status(200).send(html)
   })
 
-  if (env.FEATURE_FLAG_COMPARE_PROJECTS) {
+  if (env.CLIENT_SIDE_COMPARE_PROJECTS) {
     // No validateRoute: the compare page parses and sanitizes its query
     // params itself (unknown values fall back to defaults, never 400).
     router.get('/scaling/compare', async (req, res) => {

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
@@ -6,17 +6,35 @@ import { cn } from '~/utils/cn'
 interface Props {
   /** A URL from `getCompareEntryUrl`. */
   href: string
+  /**
+   * `controls` sits inline among chart controls, so it is a compact gradient
+   * pill at every breakpoint. `section` mirrors `TvsBreakdownButton` in a
+   * project section: a full-width outline button on mobile and a gradient
+   * one on desktop.
+   */
+  variant?: 'controls' | 'section'
   className?: string
   children?: ReactNode
 }
 
+const VARIANT_CLASSES = {
+  controls:
+    'inline-flex h-8 w-fit rounded-md bg-linear-to-r from-purple-100 to-pink-100 px-3 text-white',
+  section: cn(
+    'flex w-full rounded-md border border-brand bg-transparent from-purple-100 to-pink-100 p-3 text-primary',
+    'md:w-fit md:border-0 md:bg-linear-to-r md:py-2 md:text-white',
+  ),
+}
+
 /**
- * An entry point to the compare page, styled to sit among chart controls.
- * Renders nothing while `FEATURE_FLAG_COMPARE_PROJECTS` is off, so callers
- * can place it unconditionally.
+ * An entry point to the compare page, highlighted like the other promoted
+ * links (`TvsBreakdownButton`). Renders nothing while
+ * `FEATURE_FLAG_COMPARE_PROJECTS` is off, so callers can place it
+ * unconditionally.
  */
 export function CompareProjectsLink({
   href,
+  variant = 'controls',
   className,
   children = 'Compare projects',
 }: Props) {
@@ -25,13 +43,15 @@ export function CompareProjectsLink({
     <a
       href={href}
       className={cn(
-        'inline-flex h-8 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-2 font-medium text-xs md:px-3 md:text-sm',
-        'bg-surface-primary primary-card:bg-surface-secondary hover:bg-surface-secondary primary-card:hover:bg-surface-tertiary',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
+        'items-center justify-center gap-1.5 whitespace-nowrap font-bold text-xs leading-none',
+        'ring-brand ring-offset-1 ring-offset-background focus:outline-none focus:ring-2',
+        VARIANT_CLASSES[variant],
         className,
       )}
     >
-      <LineChartIcon className="size-4 shrink-0 fill-current" aria-hidden />
+      {/* Sized to the text so the button height matches its icon-less
+          siblings (e.g. TvsBreakdownButton). */}
+      <LineChartIcon className="size-3 shrink-0 fill-current" aria-hidden />
       {children}
     </a>
   )

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
@@ -3,14 +3,7 @@ import { env } from '~/env'
 import { cn } from '~/utils/cn'
 
 interface Props {
-  /** A URL from `getCompareEntryUrl`. */
   href: string
-  /**
-   * `controls` sits inline among chart controls, so it is a compact gradient
-   * pill at every breakpoint. `section` mirrors `TvsBreakdownButton` in a
-   * project section: a full-width outline button on mobile and a gradient
-   * one on desktop.
-   */
   variant?: 'controls' | 'section'
   className?: string
   children?: ReactNode
@@ -25,12 +18,6 @@ const VARIANT_CLASSES = {
   ),
 }
 
-/**
- * An entry point to the compare page, highlighted like the other promoted
- * links (`TvsBreakdownButton`). Renders nothing while
- * `CLIENT_SIDE_COMPARE_PROJECTS` is off, so callers can place it
- * unconditionally.
- */
 export function CompareProjectsLink({
   href,
   variant = 'controls',

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from 'react'
+import { env } from '~/env'
+import { LineChartIcon } from '~/icons/LineChart'
+import { cn } from '~/utils/cn'
+
+interface Props {
+  /** A URL from `getCompareEntryUrl`. */
+  href: string
+  className?: string
+  children?: ReactNode
+}
+
+/**
+ * An entry point to the compare page, styled to sit among chart controls.
+ * Renders nothing while `FEATURE_FLAG_COMPARE_PROJECTS` is off, so callers
+ * can place it unconditionally.
+ */
+export function CompareProjectsLink({
+  href,
+  className,
+  children = 'Compare projects',
+}: Props) {
+  if (!env.FEATURE_FLAG_COMPARE_PROJECTS) return null
+  return (
+    <a
+      href={href}
+      className={cn(
+        'inline-flex h-8 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-2 font-medium text-xs md:px-3 md:text-sm',
+        'bg-surface-primary primary-card:bg-surface-secondary hover:bg-surface-secondary primary-card:hover:bg-surface-tertiary',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-1 focus-visible:ring-offset-transparent',
+        className,
+      )}
+    >
+      <LineChartIcon className="size-4 shrink-0 fill-current" aria-hidden />
+      {children}
+    </a>
+  )
+}

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
 import { env } from '~/env'
-import { LineChartIcon } from '~/icons/LineChart'
 import { cn } from '~/utils/cn'
 
 interface Props {
@@ -43,15 +42,12 @@ export function CompareProjectsLink({
     <a
       href={href}
       className={cn(
-        'items-center justify-center gap-1.5 whitespace-nowrap font-bold text-xs leading-none',
+        'items-center justify-center whitespace-nowrap font-bold text-xs leading-none',
         'ring-brand ring-offset-1 ring-offset-background focus:outline-none focus:ring-2',
         VARIANT_CLASSES[variant],
         className,
       )}
     >
-      {/* Sized to the text so the button height matches its icon-less
-          siblings (e.g. TvsBreakdownButton). */}
-      <LineChartIcon className="size-3 shrink-0 fill-current" aria-hidden />
       {children}
     </a>
   )

--- a/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
+++ b/packages/frontend/src/pages/scaling/compare/components/CompareProjectsLink.tsx
@@ -28,7 +28,7 @@ const VARIANT_CLASSES = {
 /**
  * An entry point to the compare page, highlighted like the other promoted
  * links (`TvsBreakdownButton`). Renders nothing while
- * `FEATURE_FLAG_COMPARE_PROJECTS` is off, so callers can place it
+ * `CLIENT_SIDE_COMPARE_PROJECTS` is off, so callers can place it
  * unconditionally.
  */
 export function CompareProjectsLink({
@@ -37,7 +37,7 @@ export function CompareProjectsLink({
   className,
   children = 'Compare projects',
 }: Props) {
-  if (!env.FEATURE_FLAG_COMPARE_PROJECTS) return null
+  if (!env.CLIENT_SIDE_COMPARE_PROJECTS) return null
   return (
     <a
       href={href}

--- a/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
+++ b/packages/frontend/src/pages/scaling/compare/getScalingCompareData.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_COMPARE_PROJECTS_COUNT,
   toCompareClientState,
 } from './utils/compareChartState'
+import { COMPARE_PAGE_PATH } from './utils/getCompareEntryUrl'
 import { parseCompareStateFromSearchParams } from './utils/parseCompareStateFromSearchParams'
 
 export async function getScalingCompareData(
@@ -76,7 +77,7 @@ async function getCompareData(originalUrl: string, cache: InMemoryCache) {
   // customized URL renders with client-side loading states instead. The
   // canonical-URL check collapses garbage params into the default view.
   const isDefaultView =
-    buildCompareUrl('/scaling/compare', initialState) === '/scaling/compare'
+    buildCompareUrl(COMPARE_PAGE_PATH, initialState) === COMPARE_PAGE_PATH
   if (!isDefaultView) {
     return {
       allProjects,

--- a/packages/frontend/src/pages/scaling/compare/utils/getCompareEntryUrl.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/getCompareEntryUrl.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'earl'
+import { getCompareEntryUrl } from './getCompareEntryUrl'
+
+describe(getCompareEntryUrl.name, () => {
+  it('returns the bare path for the default TVS entry', () => {
+    expect(getCompareEntryUrl()).toEqual('/scaling/compare')
+    expect(getCompareEntryUrl({ metric: 'tvs' })).toEqual('/scaling/compare')
+  })
+
+  it('encodes a non-default metric', () => {
+    expect(getCompareEntryUrl({ metric: 'activity' })).toEqual(
+      '/scaling/compare?charts=activity',
+    )
+  })
+
+  it('pre-selects a project', () => {
+    expect(getCompareEntryUrl({ projectSlug: 'arbitrum' })).toEqual(
+      '/scaling/compare?projects=arbitrum',
+    )
+    expect(
+      getCompareEntryUrl({ metric: 'activity', projectSlug: 'arbitrum' }),
+    ).toEqual('/scaling/compare?projects=arbitrum&charts=activity')
+  })
+})

--- a/packages/frontend/src/pages/scaling/compare/utils/getCompareEntryUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/getCompareEntryUrl.ts
@@ -8,13 +8,6 @@ import {
 
 export const COMPARE_PAGE_PATH = '/scaling/compare'
 
-/**
- * The URL an entry point (sidebar, metric page button, project section link)
- * sends the user to: the compare page with a single chart of `metric` and
- * `projectSlug` (if any) pre-selected, so they only have to add comparators.
- * Built with `buildCompareUrl` so defaults are omitted and the bare TVS entry
- * stays `/scaling/compare`.
- */
 export function getCompareEntryUrl({
   metric = DEFAULT_COMPARE_METRIC,
   projectSlug,

--- a/packages/frontend/src/pages/scaling/compare/utils/getCompareEntryUrl.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/getCompareEntryUrl.ts
@@ -1,0 +1,30 @@
+import { buildCompareUrl } from './buildCompareUrl'
+import {
+  type CompareMetricId,
+  createDefaultChartConfig,
+  DEFAULT_COMPARE_METRIC,
+  DEFAULT_COMPARE_RANGE,
+} from './compareChartState'
+
+export const COMPARE_PAGE_PATH = '/scaling/compare'
+
+/**
+ * The URL an entry point (sidebar, metric page button, project section link)
+ * sends the user to: the compare page with a single chart of `metric` and
+ * `projectSlug` (if any) pre-selected, so they only have to add comparators.
+ * Built with `buildCompareUrl` so defaults are omitted and the bare TVS entry
+ * stays `/scaling/compare`.
+ */
+export function getCompareEntryUrl({
+  metric = DEFAULT_COMPARE_METRIC,
+  projectSlug,
+}: {
+  metric?: CompareMetricId
+  projectSlug?: string
+} = {}): string {
+  return buildCompareUrl(COMPARE_PAGE_PATH, {
+    projects: projectSlug ? [projectSlug] : [],
+    range: DEFAULT_COMPARE_RANGE,
+    charts: [createDefaultChartConfig(metric)],
+  })
+}

--- a/packages/frontend/src/pages/scaling/compare/utils/getCompareSeriesColors.test.ts
+++ b/packages/frontend/src/pages/scaling/compare/utils/getCompareSeriesColors.test.ts
@@ -20,7 +20,11 @@ describe(getCompareSeriesColors.name, () => {
 
   it('gives Ethereum its fixed chart color without taking a palette slot', () => {
     const without = getCompareSeriesColors(['arbitrum', 'base'])
-    const withEthereum = getCompareSeriesColors(['arbitrum', 'ethereum', 'base'])
+    const withEthereum = getCompareSeriesColors([
+      'arbitrum',
+      'ethereum',
+      'base',
+    ])
 
     expect(withEthereum.ethereum).toEqual('var(--chart-ethereum)')
     expect(withEthereum.arbitrum).toEqual(without.arbitrum)

--- a/packages/frontend/src/pages/scaling/tvs/components/ScalingTvsCharts.tsx
+++ b/packages/frontend/src/pages/scaling/tvs/components/ScalingTvsCharts.tsx
@@ -10,6 +10,8 @@ import type { ChartUnit } from '~/components/chart/types'
 import { ChartControlsWrapper } from '~/components/core/chart/ChartControlsWrapper'
 import { getChartTimeRangeFromData } from '~/components/core/chart/utils/getChartTimeRangeFromData'
 import { useTvsDisplayControlsContext } from '~/components/table/display/contexts/TvsDisplayControlsContext'
+import { CompareProjectsLink } from '~/pages/scaling/compare/components/CompareProjectsLink'
+import { getCompareEntryUrl } from '~/pages/scaling/compare/utils/getCompareEntryUrl'
 import type { ScalingTvsEntry } from '~/server/features/scaling/tvs/getScalingTvsEntries'
 import type { TvsProjectFilter } from '~/server/features/scaling/tvs/utils/projectFilterUtils'
 import { useTRPC } from '~/trpc/React'
@@ -90,7 +92,10 @@ export function ScalingTvsCharts({ entries, milestones }: Props) {
         charts={[byBridgeTypeChart, byAssetSourceChart]}
       />
       <ChartControlsWrapper>
-        <TvsChartUnitControls unit={unit} setUnit={setUnit} />
+        <div className="flex flex-wrap items-center gap-2">
+          <TvsChartUnitControls unit={unit} setUnit={setUnit} />
+          <CompareProjectsLink href={getCompareEntryUrl({ metric: 'tvs' })} />
+        </div>
         <TvsChartRangeControls range={range} setRange={setRange} />
       </ChartControlsWrapper>
     </div>

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -796,10 +796,6 @@ export async function getScalingProjectEntry(
   return { ...common, sections }
 }
 
-/**
- * The compare page only lists live scaling projects, so archived ones get
- * no entry link. Undefined while the compare page is behind its flag.
- */
 function getProjectCompareUrl(
   project: Project<never, 'archivedAt'>,
   metric: CompareMetricId,

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -449,6 +449,7 @@ export async function getScalingProjectEntry(
         title: 'Onchain costs',
         milestones: sortedMilestones,
         project: projectWithIcon,
+        compareUrl: getProjectCompareUrl(project, 'costs'),
         ...costsSection,
       },
     })
@@ -462,6 +463,7 @@ export async function getScalingProjectEntry(
         title: 'Data posted',
         milestones: sortedMilestones,
         project: projectWithIcon,
+        compareUrl: getProjectCompareUrl(project, 'data-posted'),
         ...dataPostedSection,
       },
     })

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -19,6 +19,8 @@ import {
   WALK_AWAY_PASSED_PROJECTS,
 } from '~/consts/walkAwayProjects'
 import { env } from '~/env'
+import type { CompareMetricId } from '~/pages/scaling/compare/utils/compareChartState'
+import { getCompareEntryUrl } from '~/pages/scaling/compare/utils/getCompareEntryUrl'
 import {
   countRecentDiscoveryUpdates,
   getDiscoveryUpdates,
@@ -399,6 +401,7 @@ export async function getScalingProjectEntry(
         id: 'tvs',
         title: 'Value Secured',
         tvsBreakdownUrl: `/scaling/projects/${project.slug}/tvs-breakdown`,
+        compareUrl: getProjectCompareUrl(project, 'tvs'),
         milestones: sortedMilestones,
         tokens,
         tvsInfo: project.tvsInfo,
@@ -432,6 +435,7 @@ export async function getScalingProjectEntry(
         milestones: sortedMilestones,
         category: project.scalingInfo.type,
         project: projectWithIcon,
+        compareUrl: getProjectCompareUrl(project, 'activity'),
         ...activitySection,
       },
     })
@@ -788,4 +792,18 @@ export async function getScalingProjectEntry(
   }
 
   return { ...common, sections }
+}
+
+/**
+ * The compare page only lists live scaling projects, so archived ones get
+ * no entry link. Undefined while the compare page is behind its flag.
+ */
+function getProjectCompareUrl(
+  project: Project<never, 'archivedAt'>,
+  metric: CompareMetricId,
+): string | undefined {
+  if (!env.FEATURE_FLAG_COMPARE_PROJECTS || project.archivedAt) {
+    return undefined
+  }
+  return getCompareEntryUrl({ metric, projectSlug: project.slug })
 }

--- a/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
+++ b/packages/frontend/src/server/features/scaling/project/getScalingProjectEntry.ts
@@ -804,7 +804,7 @@ function getProjectCompareUrl(
   project: Project<never, 'archivedAt'>,
   metric: CompareMetricId,
 ): string | undefined {
-  if (!env.FEATURE_FLAG_COMPARE_PROJECTS || project.archivedAt) {
+  if (!env.CLIENT_SIDE_COMPARE_PROJECTS || project.archivedAt) {
     return undefined
   }
   return getCompareEntryUrl({ metric, projectSlug: project.slug })

--- a/packages/frontend/src/server/pagePaths.ts
+++ b/packages/frontend/src/server/pagePaths.ts
@@ -48,7 +48,7 @@ export const STATIC_PAGE_PATHS = [
 ] as const satisfies PagePath[]
 
 export async function getPagePaths(): Promise<PagePath[]> {
-  const flaggedPaths: PagePath[] = env.FEATURE_FLAG_COMPARE_PROJECTS
+  const flaggedPaths: PagePath[] = env.CLIENT_SIDE_COMPARE_PROJECTS
     ? ['/scaling/compare']
     : []
   return [

--- a/packages/frontend/src/server/server.ts
+++ b/packages/frontend/src/server/server.ts
@@ -6,7 +6,7 @@ import type { NextFunction, Request, Response } from 'express'
 import express from 'express'
 import sirv from 'sirv'
 import type { ViteDevServer } from 'vite'
-import { rawEnv } from '~/env'
+import { CLIENT_ENV_KEYS, rawEnv } from '~/env'
 import { createServerPageRouter } from '../pages/ServerPageRouter'
 import {
   CLIENT_ASSETS_OUTPUT_DIR,
@@ -178,18 +178,6 @@ function jsonForInlineScript(value: unknown): string {
 
 function getClientEnvData() {
   return Object.fromEntries(
-    Object.entries(rawEnv)
-      .map(([key, value]) => {
-        if (
-          !key.startsWith('CLIENT_SIDE_') &&
-          key !== 'NODE_ENV' &&
-          key !== 'DEPLOYMENT_ENV'
-        ) {
-          return undefined
-        }
-
-        return [key, value] as const
-      })
-      .filter((x) => x !== undefined),
+    Object.entries(rawEnv).filter(([key]) => CLIENT_ENV_KEYS.includes(key)),
   )
 }


### PR DESCRIPTION
Resolves L2B-14551

Based on #12504 (`project-compare-feature`) — merge that first.

## Summary

- Add a "Compare" entry to the Scaling nav group (desktop sidebar + mobile tabs) and to the search bar pages, linking to the bare `/scaling/compare`
- Add a highlighted (gradient) "Compare projects" button next to the chart controls on `/scaling/tvs` (clean `/scaling/compare`), `/scaling/activity` (`?charts=activity`) and `/scaling/costs` (`?charts=costs`)
- Add a "Compare" link to the Value Secured, Activity, Onchain costs and Data posted sections of scaling project pages, landing on compare with that project pre-selected (`?projects=<slug>` plus the matching `charts=` metric). Styled like `TvsBreakdownButton`: a gradient header-accessory button on desktop and a full-width outline button below the section on mobile
- Move `FEATURE_FLAG_COMPARE_PROJECTS` to the client env config so the client-rendered entry points hydrate identically; `getClientEnvData` now embeds exactly the client schema keys instead of matching a name prefix
- Add `getCompareEntryUrl` (built on `buildCompareUrl`, so defaults are omitted) and a shared `CompareProjectsLink` with `controls`/`section` variants that renders nothing while the flag is off

With the flag off no entry point renders anywhere: sidebar, metric pages and project pages are unchanged. Archived projects (not in the compare universe) get no project-page link.

## Testing

- `pnpm test` — new unit tests for `getCompareEntryUrl` (clean default URL, metric encoding, project pre-selection)
- Manual with `MOCK=true`: with the flag on, links render with the expected hrefs on `/scaling/tvs`, `/scaling/activity`, `/scaling/costs` and `/scaling/projects/arbitrum` (all four sections) on desktop and iPhone-width viewports; section buttons match `TvsBreakdownButton` styling and height exactly
- Manual: with the flag off, no `/scaling/compare` link is emitted on any of those pages and the route 404s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
