### PR TITLE
DA tracking guard: check ranges and coverage gaps, freeze recipe in errors (L2B-14746)

### DIFF
--- a/docs/da-tracking.md
+++ b/docs/da-tracking.md
@@ -87,20 +87,36 @@ enforces it and fails when:
 - a new identity is **not yet in the snapshot** - harmless, just regenerate;
 - two configs **hash to the same id**.
 
-### Range changes: freeze, don't regenerate
+### Don't just regenerate
 
-When the guard reports a removed identity or a moved range, regenerating the
-snapshot only silences the alarm - the data is still lost on deploy. Instead:
+Regenerating the snapshot only silences the alarm - the data is still lost on
+deploy. Which fix applies depends on what changed, because `createDaTrackingId`
+hashes the **identity fields only** (inbox, sequencers, topics, namespace,
+appIds, customerId) and deliberately **not** the range. The guard error spells
+out the applicable recipe; the short version:
 
-1. In the project's config, replace the changed entry's discovered values with
-   the literals from the snapshot, so the old identity and its `since` stay
-   exactly as they were.
-2. Close that entry with `untilBlock` (`untilTimestamp` for eigen-da) at the
-   last block/timestamp the old configuration was live.
+**The range moved, the id is the same.** Same configuration, moved window -
+usually discovery drift on a `sinceBlock`. Freezing the entry and adding a
+second one here would produce two entries with the same id, which the guard's
+duplicate check rejects. Either pin the range (write the snapshot's literal
+`since`/`until` into the project's config instead of the discovered value), or,
+if the move is intended, accept it knowingly: raising `since` or lowering
+`until` trims the data outside the new range, and lowering `since` makes the
+backend re-index the configuration from scratch.
+
+**The id disappeared.** The identity fields changed, so it is a different
+configuration and the old one must be frozen, not edited (see the two ethereum
+entries in `packages/config/src/projects/ink/ink.ts`, a sequencer rotation):
+
+1. Replace the old entry's discovered values with the literals from the
+   snapshot, so its id stays exactly as it is.
+2. Close it with `untilBlock` (`untilTimestamp` for eigen-da) at the last
+   block/timestamp the old configuration was live.
 3. Add a new entry with the new values, starting where the old one ended. For
    the lower bound of the change bracket use the previous discovery run's
    `usedBlockNumbers[<chain>]` from the pre-change `discovered.json`.
-4. Only then, after verifying with `pnpm da:preview`, accept the change:
+
+Only then, after verifying with `pnpm da:preview`, accept the change:
 
 ```bash
 cd packages/config

--- a/docs/da-tracking.md
+++ b/docs/da-tracking.md
@@ -73,13 +73,55 @@ few hours. EigenDA per-project data is published as daily files starting
 
 ## Guarding against silent data wipes
 
-The committed snapshot is enforced by
-`packages/config/src/snapshots/guard.test.ts`: it fails when an identity
-disappears or the snapshot is stale, so identity changes are always explicit.
-After verifying your change with `pnpm da:preview`, regenerate the snapshot to
-accept it:
+`packages/config/src/snapshots/daTracking/snapshot.json` pins every backend DA
+configuration - its id, its label and its `since`/`until` range - for every
+project, sovereign projects included. `packages/config/src/snapshots/guard.test.ts`
+enforces it and fails when:
+
+- an identity **disappears** - the backend deletes configurations whose id is
+  gone and wipes all data indexed under them;
+- an identity's **range changed** - equally destructive, the backend re-syncs
+  the configuration from the new `since` and drops what falls outside the new
+  range. This is the case that used to pass silently: `sinceBlock` values come
+  from discovery, so a re-discovery can move one without anyone typing it;
+- a new identity is **not yet in the snapshot** - harmless, just regenerate;
+- two configs **hash to the same id**.
+
+### Range changes: freeze, don't regenerate
+
+When the guard reports a removed identity or a moved range, regenerating the
+snapshot only silences the alarm - the data is still lost on deploy. Instead:
+
+1. In the project's config, replace the changed entry's discovered values with
+   the literals from the snapshot, so the old identity and its `since` stay
+   exactly as they were.
+2. Close that entry with `untilBlock` (`untilTimestamp` for eigen-da) at the
+   last block/timestamp the old configuration was live.
+3. Add a new entry with the new values, starting where the old one ended. For
+   the lower bound of the change bracket use the previous discovery run's
+   `usedBlockNumbers[<chain>]` from the pre-change `discovered.json`.
+4. Only then, after verifying with `pnpm da:preview`, accept the change:
 
 ```bash
 cd packages/config
 pnpm snapshots:generate
 ```
+
+### No gaps
+
+The guard also checks the configs themselves (not the snapshot file): within a
+project and a single DA layer, the entries must cover a continuous range.
+
+- Ranges are inclusive on both ends and compared in the layer's native unit -
+  blocks, or unix seconds for eigen-da. A layer never mixes the two.
+- **Overlaps are allowed** on purpose, e.g. a delta sequencer tracked next to
+  the main one.
+- `next.since <= prev.until + 1` counts as adjacency, not a gap. Both the
+  existing convention (`next.since === prev.until`, the handover block counted
+  by both entries) and a strict `prev.until + 1` handover pass.
+- A **trailing closed entry** is fine - the project simply left the layer.
+- A closed entry whose `until` leaves a hole before the next entry's `since`
+  **fails**. Fix it by adding a config entry covering the missing range, never
+  by widening an existing one - that changes its range and re-syncs it. A gap
+  that is real and accepted goes into `LEGACY_COVERAGE_GAPS` in
+  `packages/config/src/snapshots/daTracking/gaps.ts` with a comment.

--- a/packages/backend/scripts/da/diffSnapshot.ts
+++ b/packages/backend/scripts/da/diffSnapshot.ts
@@ -1,4 +1,8 @@
-/** Structurally compatible with Snapshot from @l2beat/config snapshots. */
+/**
+ * Structurally compatible with Snapshot from @l2beat/config snapshots. Only
+ * the identity is diffed here - since/until changes are caught by the guard
+ * test in packages/config, which knows how to explain them.
+ */
 export type IdentitySnapshot = Record<string, { id: string; label: string }[]>
 
 export interface SnapshotDiffEntry {

--- a/packages/config/src/snapshots/daTracking/gaps.test.ts
+++ b/packages/config/src/snapshots/daTracking/gaps.test.ts
@@ -1,0 +1,130 @@
+import { expect } from 'earl'
+import { findCoverageGaps, type TrackedRange } from './gaps'
+
+describe(findCoverageGaps.name, () => {
+  const entry = (
+    since: number,
+    until?: number,
+    daLayer = 'ethereum',
+  ): TrackedRange => ({
+    daLayer,
+    label: `${daLayer} ${since}`,
+    since,
+    until,
+  })
+
+  it('accepts a single open entry', () => {
+    expect(findCoverageGaps([entry(100)])).toEqual([])
+  })
+
+  it('accepts a trailing closed entry', () => {
+    expect(findCoverageGaps([entry(100, 200)])).toEqual([])
+    expect(findCoverageGaps([entry(100, 200), entry(201, 300)])).toEqual([])
+  })
+
+  it('accepts touching entries', () => {
+    expect(findCoverageGaps([entry(100, 200), entry(200)])).toEqual([])
+  })
+
+  it('accepts adjacent entries (next.since === prev.until + 1)', () => {
+    expect(findCoverageGaps([entry(100, 200), entry(201)])).toEqual([])
+  })
+
+  it('accepts overlapping entries', () => {
+    expect(findCoverageGaps([entry(100, 250), entry(150)])).toEqual([])
+  })
+
+  it('accepts an entry fully contained in another', () => {
+    expect(
+      findCoverageGaps([entry(100), entry(150, 160), entry(170, 180)]),
+    ).toEqual([])
+  })
+
+  it('reports a hole between a closed entry and its successor', () => {
+    expect(findCoverageGaps([entry(100, 200), entry(202)])).toEqual([
+      {
+        daLayer: 'ethereum',
+        from: 201,
+        to: 201,
+        before: entry(100, 200),
+        after: entry(202),
+      },
+    ])
+  })
+
+  it('reports the hole after the furthest reaching entry, not the last one', () => {
+    // The overlapping entry ends earlier than the first one - the frontier
+    // must not go backwards.
+    expect(
+      findCoverageGaps([entry(100, 500), entry(200, 300), entry(600)]),
+    ).toEqual([
+      {
+        daLayer: 'ethereum',
+        from: 501,
+        to: 599,
+        before: entry(100, 500),
+        after: entry(600),
+      },
+    ])
+  })
+
+  it('reports multiple holes', () => {
+    expect(
+      findCoverageGaps([entry(100, 200), entry(300, 400), entry(500)]),
+    ).toEqual([
+      {
+        daLayer: 'ethereum',
+        from: 201,
+        to: 299,
+        before: entry(100, 200),
+        after: entry(300, 400),
+      },
+      {
+        daLayer: 'ethereum',
+        from: 401,
+        to: 499,
+        before: entry(300, 400),
+        after: entry(500),
+      },
+    ])
+  })
+
+  it('is not confused by unsorted input', () => {
+    expect(findCoverageGaps([entry(300), entry(100, 200)])).toEqual([
+      {
+        daLayer: 'ethereum',
+        from: 201,
+        to: 299,
+        before: entry(100, 200),
+        after: entry(300),
+      },
+    ])
+  })
+
+  it('compares entries per DA layer', () => {
+    // A closed ethereum range followed by a celestia range is a layer switch,
+    // not a hole - the layers have unrelated units.
+    expect(
+      findCoverageGaps([entry(100, 200), entry(5, undefined, 'celestia')]),
+    ).toEqual([])
+  })
+
+  it('applies the same rules to eigen-da timestamps', () => {
+    const eigen = (since: number, until?: number) =>
+      entry(since, until, 'eigenda')
+    expect(
+      findCoverageGaps([eigen(1700000000, 1700003600), eigen(1700003601)]),
+    ).toEqual([])
+    expect(
+      findCoverageGaps([eigen(1700000000, 1700003600), eigen(1700007200)]),
+    ).toEqual([
+      {
+        daLayer: 'eigenda',
+        from: 1700003601,
+        to: 1700007199,
+        before: eigen(1700000000, 1700003600),
+        after: eigen(1700007200),
+      },
+    ])
+  })
+})

--- a/packages/config/src/snapshots/daTracking/gaps.test.ts
+++ b/packages/config/src/snapshots/daTracking/gaps.test.ts
@@ -1,5 +1,7 @@
+import { ProjectId } from '@l2beat/shared-pure'
 import { expect } from 'earl'
-import { findCoverageGaps, type TrackedRange } from './gaps'
+import type { BaseProject } from '../../types'
+import { findCoverageGaps, findDaTrackingGaps, type TrackedRange } from './gaps'
 
 describe(findCoverageGaps.name, () => {
   const entry = (
@@ -126,5 +128,45 @@ describe(findCoverageGaps.name, () => {
         after: eigen(1700007200),
       },
     ])
+  })
+})
+
+describe(findDaTrackingGaps.name, () => {
+  const project = (id: string, ...ranges: [number, number?][]): BaseProject =>
+    ({
+      id: ProjectId(id),
+      daTrackingConfig: ranges.map(([sinceBlock, untilBlock]) => ({
+        type: 'ethereum' as const,
+        daLayer: ProjectId('ethereum'),
+        inbox: '0xInbox',
+        sinceBlock,
+        untilBlock,
+      })),
+    }) as BaseProject
+
+  it('reports a gap between two config entries', () => {
+    const violations = findDaTrackingGaps([project('taiko', [100, 200], [300])])
+
+    expect(violations.length).toEqual(1)
+    expect(violations[0].projectId).toEqual('taiko')
+    expect(violations[0].message).toInclude('taiko/ethereum/201-299')
+  })
+
+  it('skips a gap listed in the legacy exclusions', () => {
+    const violations = findDaTrackingGaps(
+      [project('taiko', [100, 200], [300])],
+      ['taiko/ethereum/201-299'],
+    )
+
+    expect(violations).toEqual([])
+  })
+
+  it('only excludes the exact gap that is listed', () => {
+    const violations = findDaTrackingGaps(
+      [project('taiko', [100, 200], [300])],
+      ['taiko/ethereum/201-298'],
+    )
+
+    expect(violations.length).toEqual(1)
   })
 })

--- a/packages/config/src/snapshots/daTracking/gaps.ts
+++ b/packages/config/src/snapshots/daTracking/gaps.ts
@@ -1,0 +1,128 @@
+import type { BaseProject } from '../../types'
+import { formatRange } from '../ranges'
+import type { ConfigViolation } from '../types'
+import {
+  createLabel,
+  forEachDaTrackingConfig,
+  getConfigRange,
+} from './identities'
+
+export interface TrackedRange {
+  daLayer: string
+  label: string
+  since: number
+  /** Absent means the range is still open, i.e. it covers everything after. */
+  until?: number
+}
+
+export interface CoverageGap {
+  daLayer: string
+  /** First uncovered point, in the layer's native unit. */
+  from: number
+  /** Last uncovered point. */
+  to: number
+  before: TrackedRange
+  after: TrackedRange
+}
+
+/**
+ * Gaps a project's DA tracking leaves on a single DA layer.
+ *
+ * Ranges are inclusive on both ends and compared in the layer's native unit
+ * (blocks, or unix seconds for eigen-da) - a layer never mixes the two.
+ *
+ * Rules:
+ * - overlaps are allowed on purpose (e.g. a delta sequencer tracked next to
+ *   the main one), so only the covered frontier matters, not pairwise order
+ * - `next.since <= prev.until + 1` is adjacency, not a gap: closing an entry
+ *   at the last block it was live and starting the next one at the following
+ *   block is the intended way to hand over
+ * - a trailing closed entry is fine - the project simply left the layer
+ */
+export function findCoverageGaps(entries: TrackedRange[]): CoverageGap[] {
+  const gaps: CoverageGap[] = []
+  for (const [daLayer, layerEntries] of groupByLayer(entries)) {
+    const sorted = [...layerEntries].sort((a, b) => a.since - b.since)
+    let frontier = sorted[0].since - 1
+    let last = sorted[0]
+    for (const entry of sorted) {
+      if (frontier === Number.POSITIVE_INFINITY) {
+        break
+      }
+      if (entry.since > frontier + 1) {
+        gaps.push({
+          daLayer,
+          from: frontier + 1,
+          to: entry.since - 1,
+          before: last,
+          after: entry,
+        })
+      }
+      const until = entry.until ?? Number.POSITIVE_INFINITY
+      if (until > frontier) {
+        frontier = until
+        last = entry
+      }
+    }
+  }
+  return gaps
+}
+
+function groupByLayer(entries: TrackedRange[]): Map<string, TrackedRange[]> {
+  const byLayer = new Map<string, TrackedRange[]>()
+  for (const entry of entries) {
+    byLayer.set(entry.daLayer, [...(byLayer.get(entry.daLayer) ?? []), entry])
+  }
+  return byLayer
+}
+
+/**
+ * Gaps that predate this check. They are not fixed by editing ranges - moving
+ * a since/until makes the backend re-sync and wipe the affected configuration.
+ * Closing one means backfilling the missing range with a new config entry,
+ * which is a deliberate, data-affecting decision.
+ *
+ * Format: `${projectId}/${daLayer}/${from}-${to}`.
+ */
+export const LEGACY_COVERAGE_GAPS: string[] = []
+
+/** Coverage gaps across all projects, minus the accepted legacy ones. */
+export function findDaTrackingGaps(projects: BaseProject[]): ConfigViolation[] {
+  const byProject = new Map<string, TrackedRange[]>()
+  forEachDaTrackingConfig(projects, (projectId, config) => {
+    byProject.set(projectId, [
+      ...(byProject.get(projectId) ?? []),
+      {
+        daLayer: config.daLayer,
+        label: createLabel(config),
+        ...getConfigRange(config),
+      },
+    ])
+  })
+
+  const legacy = new Set(LEGACY_COVERAGE_GAPS)
+  const violations: ConfigViolation[] = []
+  for (const [projectId, entries] of byProject) {
+    for (const gap of findCoverageGaps(entries)) {
+      if (legacy.has(gapKey(projectId, gap))) {
+        continue
+      }
+      violations.push({
+        projectId,
+        message:
+          `${projectId} is not tracked on ${gap.daLayer} between ${gap.from} and ${gap.to} [${gapKey(projectId, gap)}]:\n` +
+          `- ends: ${describe(gap.before)}\n` +
+          `- resumes: ${describe(gap.after)}`,
+      })
+    }
+  }
+  return violations
+}
+
+export function gapKey(projectId: string, gap: CoverageGap): string {
+  return `${projectId}/${gap.daLayer}/${gap.from}-${gap.to}`
+}
+
+function describe(entry: TrackedRange): string {
+  return `${entry.label} [${formatRange(entry)}]`
+}

--- a/packages/config/src/snapshots/daTracking/gaps.ts
+++ b/packages/config/src/snapshots/daTracking/gaps.ts
@@ -1,18 +1,16 @@
+import groupBy from 'lodash/groupBy'
 import type { BaseProject } from '../../types'
 import { formatRange } from '../ranges'
-import type { ConfigViolation } from '../types'
+import type { ConfigViolation, Range } from '../types'
 import {
   createLabel,
   forEachDaTrackingConfig,
   getConfigRange,
 } from './identities'
 
-export interface TrackedRange {
+export interface TrackedRange extends Range {
   daLayer: string
   label: string
-  since: number
-  /** Absent means the range is still open, i.e. it covers everything after. */
-  until?: number
 }
 
 export interface CoverageGap {
@@ -41,7 +39,9 @@ export interface CoverageGap {
  */
 export function findCoverageGaps(entries: TrackedRange[]): CoverageGap[] {
   const gaps: CoverageGap[] = []
-  for (const [daLayer, layerEntries] of groupByLayer(entries)) {
+  for (const [daLayer, layerEntries] of Object.entries(
+    groupBy(entries, (e) => e.daLayer),
+  )) {
     const sorted = [...layerEntries].sort((a, b) => a.since - b.since)
     let frontier = sorted[0].since - 1
     let last = sorted[0]
@@ -68,14 +68,6 @@ export function findCoverageGaps(entries: TrackedRange[]): CoverageGap[] {
   return gaps
 }
 
-function groupByLayer(entries: TrackedRange[]): Map<string, TrackedRange[]> {
-  const byLayer = new Map<string, TrackedRange[]>()
-  for (const entry of entries) {
-    byLayer.set(entry.daLayer, [...(byLayer.get(entry.daLayer) ?? []), entry])
-  }
-  return byLayer
-}
-
 /**
  * Gaps that predate this check. They are not fixed by editing ranges - moving
  * a since/until makes the backend re-sync and wipe the affected configuration.
@@ -87,22 +79,25 @@ function groupByLayer(entries: TrackedRange[]): Map<string, TrackedRange[]> {
 export const LEGACY_COVERAGE_GAPS: string[] = []
 
 /** Coverage gaps across all projects, minus the accepted legacy ones. */
-export function findDaTrackingGaps(projects: BaseProject[]): ConfigViolation[] {
-  const byProject = new Map<string, TrackedRange[]>()
+export function findDaTrackingGaps(
+  projects: BaseProject[],
+  legacyGaps: string[] = LEGACY_COVERAGE_GAPS,
+): ConfigViolation[] {
+  const flat: (TrackedRange & { projectId: string })[] = []
   forEachDaTrackingConfig(projects, (projectId, config) => {
-    byProject.set(projectId, [
-      ...(byProject.get(projectId) ?? []),
-      {
-        daLayer: config.daLayer,
-        label: createLabel(config),
-        ...getConfigRange(config),
-      },
-    ])
+    flat.push({
+      projectId,
+      daLayer: config.daLayer,
+      label: createLabel(config),
+      ...getConfigRange(config),
+    })
   })
 
-  const legacy = new Set(LEGACY_COVERAGE_GAPS)
+  const legacy = new Set(legacyGaps)
   const violations: ConfigViolation[] = []
-  for (const [projectId, entries] of byProject) {
+  for (const [projectId, entries] of Object.entries(
+    groupBy(flat, (e) => e.projectId),
+  )) {
     for (const gap of findCoverageGaps(entries)) {
       if (legacy.has(gapKey(projectId, gap))) {
         continue

--- a/packages/config/src/snapshots/daTracking/identities.ts
+++ b/packages/config/src/snapshots/daTracking/identities.ts
@@ -2,14 +2,27 @@ import { createDaTrackingId } from '@l2beat/shared'
 import { join } from 'path'
 import { getProjects } from '../../processing/getProjects'
 import type { BaseProject, ProjectDaTrackingConfig } from '../../types'
+import type { Range } from '../ranges'
 import type { Snapshot, SnapshotDomain, SnapshotIdentity } from '../types'
+import { findDaTrackingGaps } from './gaps'
+
+const FREEZE_RECIPE = [
+  'Do NOT just regenerate the snapshot. A removed id or a moved range makes the backend re-sync the configuration from its new start and drop everything outside it. Instead, freeze the old range and open a new one:',
+  "1. In the project's config, replace the changed entry's discovered values with the literals from the snapshot above, so the old identity and its 'since' stay exactly as they are.",
+  "2. Close that entry with 'untilBlock' (or 'untilTimestamp' for eigen-da) at the last block/timestamp the old configuration was live.",
+  "3. Add a new entry with the new values, starting where the old one ended. For the lower bound of the change bracket use the previous discovery run's usedBlockNumbers[<chain>] from the pre-change 'discovered.json'.",
+  "4. Only then run 'pnpm snapshots:generate' in packages/config and commit the updated snapshot.",
+  "If you're an AI, don't address this error yourself - pass it over to a human.",
+].join('\n')
 
 export const daTrackingDomain: SnapshotDomain = {
   name: 'da-tracking',
   snapshotPath: join(__dirname, 'snapshot.json'),
   wipeWarning:
     'On deploy the backend WILL WIPE all DA data indexed under these configurations (ManagedMultiIndexer deletes configurations whose id disappears).',
+  freezeRecipe: FREEZE_RECIPE,
   generate: () => generateDaTrackingIdentities(getProjects()),
+  findConfigViolations: () => findDaTrackingGaps(getProjects()),
 }
 
 /**
@@ -23,29 +36,16 @@ export function generateDaTrackingIdentities(
 ): Snapshot {
   const result: Record<string, SnapshotIdentity[]> = {}
 
-  const add = (projectId: string, config: ProjectDaTrackingConfig) => {
+  forEachDaTrackingConfig(projects, (projectId, config) => {
     // Deliberately no dedup - duplicate ids are a config error (colliding
     // backend configuration ids) and the guard test must see them.
     result[projectId] ??= []
     result[projectId].push({
       id: createDaTrackingId(config),
       label: createLabel(config),
+      ...getConfigRange(config),
     })
-  }
-
-  for (const project of projects) {
-    for (const config of project.daTrackingConfig ?? []) {
-      add(project.id, config)
-    }
-    for (const sovereign of project.daLayer?.sovereignProjectsTrackingConfig ??
-      []) {
-      for (const config of sovereign.daTrackingConfig) {
-        // The backend attaches the DA layer's project id before hashing
-        // (getBlockDaTrackingSovereignProjects in backend da.ts).
-        add(sovereign.projectId, { daLayer: project.id, ...config })
-      }
-    }
-  }
+  })
 
   return Object.fromEntries(
     Object.entries(result)
@@ -57,7 +57,42 @@ export function generateDaTrackingIdentities(
   )
 }
 
-function createLabel(config: ProjectDaTrackingConfig): string {
+/**
+ * Single walk over every DA tracking configuration in the config, used by both
+ * the identity snapshot and the config invariants, so they can never disagree
+ * on which configs exist.
+ */
+export function forEachDaTrackingConfig(
+  projects: BaseProject[],
+  callback: (projectId: string, config: ProjectDaTrackingConfig) => void,
+): void {
+  for (const project of projects) {
+    for (const config of project.daTrackingConfig ?? []) {
+      callback(project.id, config)
+    }
+    for (const sovereign of project.daLayer?.sovereignProjectsTrackingConfig ??
+      []) {
+      for (const config of sovereign.daTrackingConfig) {
+        // The backend attaches the DA layer's project id before hashing
+        // (getBlockDaTrackingSovereignProjects in backend da.ts).
+        callback(sovereign.projectId, { daLayer: project.id, ...config })
+      }
+    }
+  }
+}
+
+/**
+ * The range in the config's native unit - blocks for the block-based layers,
+ * unix seconds for eigen-da. Ranges are only ever compared within a single DA
+ * layer, and a layer never mixes the two kinds.
+ */
+export function getConfigRange(config: ProjectDaTrackingConfig): Range {
+  return config.type === 'eigen-da'
+    ? { since: config.sinceTimestamp, until: config.untilTimestamp }
+    : { since: config.sinceBlock, until: config.untilBlock }
+}
+
+export function createLabel(config: ProjectDaTrackingConfig): string {
   switch (config.type) {
     case 'ethereum': {
       const sequencers = config.sequencers

--- a/packages/config/src/snapshots/daTracking/identities.ts
+++ b/packages/config/src/snapshots/daTracking/identities.ts
@@ -1,18 +1,38 @@
 import { createDaTrackingId } from '@l2beat/shared'
+import groupBy from 'lodash/groupBy'
 import { join } from 'path'
 import { getProjects } from '../../processing/getProjects'
 import type { BaseProject, ProjectDaTrackingConfig } from '../../types'
-import type { Range } from '../ranges'
-import type { Snapshot, SnapshotDomain, SnapshotIdentity } from '../types'
+import type {
+  Range,
+  Snapshot,
+  SnapshotDomain,
+  SnapshotIdentity,
+} from '../types'
 import { findDaTrackingGaps } from './gaps'
 
+/**
+ * For a config whose identity fields changed - the old id is gone for good, so
+ * the old entry has to be frozen instead of edited. See the two ethereum
+ * entries in projects/ink/ink.ts for a worked example (sequencer rotation).
+ */
 const FREEZE_RECIPE = [
-  'Do NOT just regenerate the snapshot. A removed id or a moved range makes the backend re-sync the configuration from its new start and drop everything outside it. Instead, freeze the old range and open a new one:',
-  "1. In the project's config, replace the changed entry's discovered values with the literals from the snapshot above, so the old identity and its 'since' stay exactly as they are.",
+  'Freeze the old configuration, do not let it disappear:',
+  "1. In the project's config, replace the old entry's discovered values with the literals from the snapshot above, so its id stays exactly as it is.",
   "2. Close that entry with 'untilBlock' (or 'untilTimestamp' for eigen-da) at the last block/timestamp the old configuration was live.",
   "3. Add a new entry with the new values, starting where the old one ended. For the lower bound of the change bracket use the previous discovery run's usedBlockNumbers[<chain>] from the pre-change 'discovered.json'.",
   "4. Only then run 'pnpm snapshots:generate' in packages/config and commit the updated snapshot.",
-  "If you're an AI, don't address this error yourself - pass it over to a human.",
+].join('\n')
+
+/**
+ * For a config whose identity is unchanged but whose range moved. The id is a
+ * hash of the identity fields only, so the "freeze and add a new entry" recipe
+ * does not apply here - it would produce two entries with the same id.
+ */
+const RANGE_CHANGE_RECIPE = [
+  'The id hashes the identity fields (inbox, sequencers, topics, namespace, appIds, customerId) and NOT the range, so this is the same configuration with a moved window. Do not freeze it and add a second entry - the two would collide on the id.',
+  "If the move is unintended (usually discovery drift on a sinceBlock): pin the range by writing the snapshot's literal since/until into the project's config instead of the discovered values, and leave the snapshot alone.",
+  "If the move is intended: accept it knowingly, then run 'pnpm snapshots:generate' in packages/config. Raising 'since' or lowering 'until' TRIMS the data outside the new range; lowering 'since' makes the backend re-index the configuration from scratch.",
 ].join('\n')
 
 export const daTrackingDomain: SnapshotDomain = {
@@ -21,6 +41,7 @@ export const daTrackingDomain: SnapshotDomain = {
   wipeWarning:
     'On deploy the backend WILL WIPE all DA data indexed under these configurations (ManagedMultiIndexer deletes configurations whose id disappears).',
   freezeRecipe: FREEZE_RECIPE,
+  rangeChangeRecipe: RANGE_CHANGE_RECIPE,
   generate: () => generateDaTrackingIdentities(getProjects()),
   findConfigViolations: () => findDaTrackingGaps(getProjects()),
 }
@@ -34,13 +55,12 @@ export const daTrackingDomain: SnapshotDomain = {
 export function generateDaTrackingIdentities(
   projects: BaseProject[],
 ): Snapshot {
-  const result: Record<string, SnapshotIdentity[]> = {}
-
+  // Deliberately no dedup - duplicate ids are a config error (colliding
+  // backend configuration ids) and the guard test must see them.
+  const flat: (SnapshotIdentity & { projectId: string })[] = []
   forEachDaTrackingConfig(projects, (projectId, config) => {
-    // Deliberately no dedup - duplicate ids are a config error (colliding
-    // backend configuration ids) and the guard test must see them.
-    result[projectId] ??= []
-    result[projectId].push({
+    flat.push({
+      projectId,
       id: createDaTrackingId(config),
       label: createLabel(config),
       ...getConfigRange(config),
@@ -48,11 +68,13 @@ export function generateDaTrackingIdentities(
   })
 
   return Object.fromEntries(
-    Object.entries(result)
+    Object.entries(groupBy(flat, (e) => e.projectId))
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([projectId, identities]) => [
         projectId,
-        identities.sort((a, b) => a.id.localeCompare(b.id)),
+        identities
+          .map(({ projectId: _, ...identity }) => identity)
+          .sort((a, b) => a.id.localeCompare(b.id)),
       ]),
   )
 }

--- a/packages/config/src/snapshots/daTracking/snapshot.json
+++ b/packages/config/src/snapshots/daTracking/snapshot.json
@@ -2,1145 +2,1378 @@
   "170889": [
     {
       "id": "dc83c4b90647",
-      "label": "avail appIds [18] since 0"
+      "label": "avail appIds [18] since 0",
+      "since": 0
     }
   ],
   "0x84e96bb748abb8a16c28ecc": [
     {
       "id": "318cb6ce5b8b",
-      "label": "avail appIds [10] since 0"
+      "label": "avail appIds [10] since 0",
+      "since": 0
     }
   ],
   "527d69c3": [
     {
       "id": "ba28e866fe8e",
-      "label": "avail appIds [25] since 0"
+      "label": "avail appIds [25] since 0",
+      "since": 0
     }
   ],
   "abstract": [
     {
       "id": "277c1f08ed30",
-      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[4] since 21809364"
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[4] since 21809364",
+      "since": 21809364,
+      "until": 23671537
     },
     {
       "id": "86008db656ff",
-      "label": "ethereum inbox 0xC62BDE55caaB102714c6b9F7e29e05D9237EfD83 sequencers[2] since 25424362"
+      "label": "ethereum inbox 0xC62BDE55caaB102714c6b9F7e29e05D9237EfD83 sequencers[2] since 25424362",
+      "since": 25424362
     },
     {
       "id": "900f9962e673",
-      "label": "ethereum inbox 0x2e5110cF18678Ec99818bFAa849B8C881744b776 sequencers[4] since 23671537"
+      "label": "ethereum inbox 0x2e5110cF18678Ec99818bFAa849B8C881744b776 sequencers[4] since 23671537",
+      "since": 23671537,
+      "until": 25424362
     }
   ],
   "adi": [
     {
       "id": "a8d364734186",
-      "label": "ethereum inbox 0xE28cAc160C2a79dFA1fbd2169AC5fa5d061cf186 sequencers[4] since 23874833"
+      "label": "ethereum inbox 0xE28cAc160C2a79dFA1fbd2169AC5fa5d061cf186 sequencers[4] since 23874833",
+      "since": 23874833
     }
   ],
   "aevo": [
     {
       "id": "22bdf46cb00a",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADBuw7+PjGs8= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADBuw7+PjGs8= since 0",
+      "since": 0,
+      "until": 3538077
     },
     {
       "id": "50220521c4e9",
-      "label": "ethereum inbox 0x253887577420Cb7e7418cD4d50147743c8041b28 sequencers[1] since 16858818"
+      "label": "ethereum inbox 0x253887577420Cb7e7418cD4d50147743c8041b28 sequencers[1] since 16858818",
+      "since": 16858818
     },
     {
       "id": "c7f9dcc291d2",
-      "label": "eigen-da customer 0x2dc71dbd1cf713e70f939346317bf93a2e62cfee since 1753437600"
+      "label": "eigen-da customer 0x2dc71dbd1cf713e70f939346317bf93a2e62cfee since 1753437600",
+      "since": 1753437600
     }
   ],
   "alchemy-production": [
     {
       "id": "f8bd5e57d72c",
-      "label": "eigen-da customer 0x3ba8c28a0209dea4d0502031f83d09a17a389fb0 since 1753833600"
+      "label": "eigen-da customer 0x3ba8c28a0209dea4d0502031f83d09a17a389fb0 since 1753833600",
+      "since": 1753833600
     }
   ],
   "altlayer": [
     {
       "id": "c7e0fd43ca7f",
-      "label": "eigen-da customer 0x4fdbd273b8d2c1c429a7e3078063c49528aa8264 since 0"
+      "label": "eigen-da customer 0x4fdbd273b8d2c1c429a7e3078063c49528aa8264 since 0",
+      "since": 0
     }
   ],
   "altlayer-2": [
     {
       "id": "42fe3a8bc92f",
-      "label": "eigen-da customer 0x1359fbd4b9bc9441a90436719426157526742c9a since 0"
+      "label": "eigen-da customer 0x1359fbd4b9bc9441a90436719426157526742c9a since 0",
+      "since": 0
     }
   ],
   "altlayer-cyber": [
     {
       "id": "3f3602df41c1",
-      "label": "eigen-da customer 35.167.254.127 since 0"
+      "label": "eigen-da customer 35.167.254.127 since 0",
+      "since": 0
     }
   ],
   "ancient": [
     {
       "id": "a3be402c9fca",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADE4vVvVyRsg= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADE4vVvVyRsg= since 0",
+      "since": 0
     }
   ],
   "antonio": [
     {
       "id": "7bfa73ca443c",
-      "label": "avail appIds [23] since 0"
+      "label": "avail appIds [23] since 0",
+      "since": 0
     }
   ],
   "arbitrum": [
     {
       "id": "f2eb27779e5d",
-      "label": "ethereum inbox 0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6 sequencers[3] since 15411056"
+      "label": "ethereum inbox 0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6 sequencers[3] since 15411056",
+      "since": 15411056
     }
   ],
   "arenaz": [
     {
       "id": "5f18f8f53116",
-      "label": "ethereum inbox 0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0 sequencers[1] since 24776391"
+      "label": "ethereum inbox 0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0 sequencers[1] since 24776391",
+      "since": 24776391,
+      "until": 25228892
     },
     {
       "id": "f21be91c0dea",
-      "label": "ethereum inbox 0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0 sequencers[1] since 21169100"
+      "label": "ethereum inbox 0x00f9BCEe08DCe4F0e7906c1f6cFb10c77802EEd0 sequencers[1] since 21169100",
+      "since": 21169100,
+      "until": 24776391
     }
   ],
   "art-peace": [
     {
       "id": "4f301127be05",
-      "label": "avail appIds [35] since 0"
+      "label": "avail appIds [35] since 0",
+      "since": 0
     }
   ],
   "avail-main": [
     {
       "id": "cfc04769ab1c",
-      "label": "avail appIds [0] since 0"
+      "label": "avail appIds [0] since 0",
+      "since": 0
     }
   ],
   "azeazeqsdhfgkjkk": [
     {
       "id": "be2895d872d6",
-      "label": "avail appIds [14] since 0"
+      "label": "avail appIds [14] since 0",
+      "since": 0
     }
   ],
   "aztecnetwork": [
     {
       "id": "7926e2fc5a89",
-      "label": "ethereum inbox 0x0000000000000000000000000000000000000000 since 25533241"
+      "label": "ethereum inbox 0x0000000000000000000000000000000000000000 since 25533241",
+      "since": 25533241
     }
   ],
   "b3": [
     {
       "id": "c1602abf682d",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SqMAivUaAM= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SqMAivUaAM= since 0",
+      "since": 0
     }
   ],
   "base": [
     {
       "id": "6d60c3b4b32e",
-      "label": "ethereum inbox 0xFf00000000000000000000000000000000008453 sequencers[1] since 0"
+      "label": "ethereum inbox 0xFf00000000000000000000000000000000008453 sequencers[1] since 0",
+      "since": 0
     }
   ],
   "battle-for-blockchain": [
     {
       "id": "f93c143823f1",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAKzFLTn1xOipecg= since 5047670"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAKzFLTn1xOipecg= since 5047670",
+      "since": 5047670
     }
   ],
   "blast": [
     {
       "id": "576440a9a827",
-      "label": "ethereum inbox 0xFf00000000000000000000000000000000081457 sequencers[1] since 19300387"
+      "label": "ethereum inbox 0xFf00000000000000000000000000000000081457 sequencers[1] since 19300387",
+      "since": 19300387
     }
   ],
   "bling": [
     {
       "id": "92c6fe63c620",
-      "label": "avail appIds [12] since 0"
+      "label": "avail appIds [12] since 0",
+      "since": 0
     }
   ],
   "bob": [
     {
       "id": "67159dd176aa",
-      "label": "ethereum inbox 0x3A75346f81302aAc0333FB5DCDD407e12A6CfA83 sequencers[1] since 19634330"
+      "label": "ethereum inbox 0x3A75346f81302aAc0333FB5DCDD407e12A6CfA83 sequencers[1] since 19634330",
+      "since": 19634330
     }
   ],
   "bobanetwork": [
     {
       "id": "85bcc630ded4",
-      "label": "ethereum inbox 0xfFF0000000000000000000000000000000000288 sequencers[1] since 22790097"
+      "label": "ethereum inbox 0xfFF0000000000000000000000000000000000288 sequencers[1] since 22790097",
+      "since": 22790097
     },
     {
       "id": "e541e8f08f5f",
-      "label": "ethereum inbox 0xfFF0000000000000000000000000000000000288 sequencers[1] since 19671339"
+      "label": "ethereum inbox 0xfFF0000000000000000000000000000000000288 sequencers[1] since 19671339",
+      "since": 19671339,
+      "until": 22790097
     }
   ],
   "bullet": [
     {
       "id": "10fa01449fd7",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAGJsdGJhdGNoLXQ= since 10183821"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAGJsdGJhdGNoLXQ= since 10183821",
+      "since": 10183821
     },
     {
       "id": "5c366a7c0a51",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAGJsdGJhdGNoLWw= since 10168980"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAGJsdGJhdGNoLWw= since 10168980",
+      "since": 10168980
     },
     {
       "id": "b1411081b4fa",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAGJsdGJhdGNoLXo= since 10456208"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAGJsdGJhdGNoLXo= since 10456208",
+      "since": 10456208
     }
   ],
   "camp": [
     {
       "id": "00be395010a6",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAB7AAAAAAAAAeQ= since 6459709"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAB7AAAAAAAAAeQ= since 6459709",
+      "since": 6459709
     }
   ],
   "celo": [
     {
       "id": "7c329e9319ea",
-      "label": "ethereum inbox 0xff00000000000000000000000000000000042220 sequencers[1] since 22038831"
+      "label": "ethereum inbox 0xff00000000000000000000000000000000042220 sequencers[1] since 22038831",
+      "since": 22038831
     },
     {
       "id": "d7534d04c245",
-      "label": "eigen-da customer 0xecf08b0a4f196e06e9aece95d5dd724bc121f09c since 1741806000"
+      "label": "eigen-da customer 0xecf08b0a4f196e06e9aece95d5dd724bc121f09c since 1741806000",
+      "since": 1741806000
     }
   ],
   "civitia": [
     {
       "id": "73be28c3fbaa",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAEwLOhV+kOUlUq4= since 4492300"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAEwLOhV+kOUlUq4= since 4492300",
+      "since": 4492300
     }
   ],
   "clique": [
     {
       "id": "d6028e9615e0",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAARQV7t6sd4A= since 3161819"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAARQV7t6sd4A= since 3161819",
+      "since": 3161819
     }
   ],
   "codex": [
     {
       "id": "29bbe6e797bd",
-      "label": "ethereum inbox 0x8c12f051c161c2cda736f3b3fa1c4bdd35b7922c sequencers[1] since 20953494"
+      "label": "ethereum inbox 0x8c12f051c161c2cda736f3b3fa1c4bdd35b7922c sequencers[1] since 20953494",
+      "since": 20953494
     }
   ],
   "conduit": [
     {
       "id": "0e12a4598e33",
-      "label": "eigen-da customer 0x8dc6f0bd2ce3c40d633f5541e21e7574598f7c75 since 0"
+      "label": "eigen-da customer 0x8dc6f0bd2ce3c40d633f5541e21e7574598f7c75 since 0",
+      "since": 0
     }
   ],
   "conduit-2": [
     {
       "id": "9b293cd2e4d8",
-      "label": "eigen-da customer 34.145.120.220 since 1719266400"
+      "label": "eigen-da customer 34.145.120.220 since 1719266400",
+      "since": 1719266400
     }
   ],
   "conduit-3": [
     {
       "id": "c988d5341c99",
-      "label": "eigen-da customer 34.168.104.248 since 1719262800"
+      "label": "eigen-da customer 34.168.104.248 since 1719262800",
+      "since": 1719262800
     }
   ],
   "creator": [
     {
       "id": "54f3f96071b1",
-      "label": "ethereum inbox 0x18cc381705761aa2d2e8ea62888a4029a0fad3ab sequencers[2] since 23869474"
+      "label": "ethereum inbox 0x18cc381705761aa2d2e8ea62888a4029a0fad3ab sequencers[2] since 23869474",
+      "since": 23869474
     }
   ],
   "crestal": [
     {
       "id": "21dc3b98a724",
-      "label": "avail appIds [16] since 0"
+      "label": "avail appIds [16] since 0",
+      "since": 0
     },
     {
       "id": "89d8398a1ace",
-      "label": "eigen-da customer 0x2659d4555e482ec4131a493def0770a922c75de3 since 1728399600"
+      "label": "eigen-da customer 0x2659d4555e482ec4131a493def0770a922c75de3 since 1728399600",
+      "since": 1728399600
     }
   ],
   "dans-awesome-app": [
     {
       "id": "258ece60d579",
-      "label": "avail appIds [29] since 0"
+      "label": "avail appIds [29] since 0",
+      "since": 0
     }
   ],
   "dbk": [
     {
       "id": "0be222b43a67",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000020240603 sequencers[1] since 20015025"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000020240603 sequencers[1] since 20015025",
+      "since": 20015025
     }
   ],
   "dragonft": [
     {
       "id": "3d11dac766ac",
-      "label": "avail appIds [21] since 0"
+      "label": "avail appIds [21] since 0",
+      "since": 0
     }
   ],
   "echelon": [
     {
       "id": "601354221be6",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAItyY42OaTC/skE= since 5659637"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAItyY42OaTC/skE= since 5659637",
+      "since": 5659637
     }
   ],
   "echos": [
     {
       "id": "c4682102bddf",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAA/cZMN1XLG8= since 3161819"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAA/cZMN1XLG8= since 3161819",
+      "since": 3161819
     }
   ],
   "eclipse": [
     {
       "id": "630dbcf6c9c5",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAGVjbGlwc2U= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAGVjbGlwc2U= since 0",
+      "since": 0
     }
   ],
   "eden": [
     {
       "id": "62eb20f5e97e",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAoxK5AW18ozObY= since 9413424"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAoxK5AW18ozObY= since 9413424",
+      "since": 9413424
     },
     {
       "id": "fcb367b41b8e",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAORr5sRrVhwIjmU= since 9409947"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAORr5sRrVhwIjmU= since 9409947",
+      "since": 9409947
     }
   ],
   "embr-fun": [
     {
       "id": "86f0b7d8e667",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMbONmnisjTDz4I= since 5954601"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMbONmnisjTDz4I= since 5954601",
+      "since": 5954601
     }
   ],
   "ethernity": [
     {
       "id": "69534074e040",
-      "label": "ethereum inbox 0xfF00000000000000000000000000000000000183 sequencers[1] since 20519438"
+      "label": "ethereum inbox 0xfF00000000000000000000000000000000000183 sequencers[1] since 20519438",
+      "since": 20519438
     }
   ],
   "flame": [
     {
       "id": "9090bf154b79",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAL2dxfeNrJ+tg6Y= since 3161819"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAL2dxfeNrJ+tg6Y= since 3161819",
+      "since": 3161819
     }
   ],
   "flynet": [
     {
       "id": "ef648acaf8f9",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAACyPE7Ql9zwA= since 5188001"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAACyPE7Ql9zwA= since 5188001",
+      "since": 5188001
     }
   ],
   "forknet": [
     {
       "id": "fa508c38e45a",
-      "label": "ethereum inbox 0x003FBC27c32dBE174A7BB1EfdD49da79C6Ea1774 sequencers[1] since 23281847"
+      "label": "ethereum inbox 0x003FBC27c32dBE174A7BB1EfdD49da79C6Ea1774 sequencers[1] since 23281847",
+      "since": 23281847
     }
   ],
   "form": [
     {
       "id": "70a7244f9daf",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SpR3bjJQT0= since 2943925"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SpR3bjJQT0= since 2943925",
+      "since": 2943925
     }
   ],
   "forma": [
     {
       "id": "c27254593410",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAKKnitomrCy/HoY= since 3161819"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAKKnitomrCy/HoY= since 3161819",
+      "since": 3161819
     }
   ],
   "foundation-network": [
     {
       "id": "27a6c76de4df",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAN/xAxpagCrjLVQ= since 3667737"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAN/xAxpagCrjLVQ= since 3667737",
+      "since": 3667737
     }
   ],
   "fuel": [
     {
       "id": "0e8ec8be6a50",
-      "label": "eigen-da customer 0xea0337efc12e98ab118948da570c07691e8e4b37 since 1751526000"
+      "label": "eigen-da customer 0xea0337efc12e98ab118948da570c07691e8e4b37 since 1751526000",
+      "since": 1751526000
     },
     {
       "id": "9f8a5f377b9d",
-      "label": "ethereum inbox 0xEA0337EFC12e98AB118948dA570C07691E8E4b37 sequencers[1] since 20915271"
+      "label": "ethereum inbox 0xEA0337EFC12e98AB118948dA570C07691E8E4b37 sequencers[1] since 20915271",
+      "since": 20915271,
+      "until": 22837254
     }
   ],
   "fuse-l2": [
     {
       "id": "c14af5db5ed3",
-      "label": "avail appIds [22] since 0"
+      "label": "avail appIds [22] since 0",
+      "since": 0
     }
   ],
   "galxegravity": [
     {
       "id": "2b42cc2008b7",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABH1QsY4w6WU= since 5169794"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABH1QsY4w6WU= since 5169794",
+      "since": 5169794
     }
   ],
   "ham": [
     {
       "id": "b82f9418c0a1",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SpeLVvrm6k= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SpeLVvrm6k= since 0",
+      "since": 0
     }
   ],
   "hashkey": [
     {
       "id": "11c7a388565a",
-      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 24582182"
+      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 24582182",
+      "since": 24582182
     },
     {
       "id": "374bf6c1c013",
-      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 22237008"
+      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 22237008",
+      "since": 22237008,
+      "until": 24324263
     },
     {
       "id": "bcad13fb47dc",
-      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 24324263"
+      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 24324263",
+      "since": 24324263,
+      "until": 24582182
     },
     {
       "id": "e11269b4d577",
-      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 21414884"
+      "label": "ethereum inbox 0x0004cb44C80b6Fbf8ceb1d80AF688C9f7C0b2aB5 sequencers[1] since 21414884",
+      "since": 21414884,
+      "until": 22237008
     }
   ],
   "hello-world": [
     {
       "id": "03cb1ce906bd",
-      "label": "avail appIds [13] since 0"
+      "label": "avail appIds [13] since 0",
+      "since": 0
     }
   ],
   "hemi": [
     {
       "id": "58512485ccc1",
-      "label": "ethereum inbox 0xfF00000000000000000000000000000000043111 sequencers[1] since 20711665"
+      "label": "ethereum inbox 0xfF00000000000000000000000000000000043111 sequencers[1] since 20711665",
+      "since": 20711665
     }
   ],
   "hibachi": [
     {
       "id": "7bbe2b7034e0",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAABoaWJhY2hpLXM= since 5979823"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAABoaWJhY2hpLXM= since 5979823",
+      "since": 5979823
     },
     {
       "id": "dfefb8bddfee",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAGhpYmFjaGk= since 5981133"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAGhpYmFjaGk= since 5981133",
+      "since": 5981133
     }
   ],
   "hypr": [
     {
       "id": "44b9bc7dd0a3",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABqVjuNvNnoE= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABqVjuNvNnoE= since 0",
+      "since": 0
     }
   ],
   "inertia": [
     {
       "id": "ad5b898564ce",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAEg2If2QGyq4ZRQ= since 5941532"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAEg2If2QGyq4ZRQ= since 5941532",
+      "since": 5941532
     }
   ],
   "ing": [
     {
       "id": "a48ebe34cd2d",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAALdhUSKgKHU0Zx0= since 5945453"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAALdhUSKgKHU0Zx0= since 5945453",
+      "since": 5945453
     }
   ],
   "ink": [
     {
       "id": "43b77e5a5d4a",
-      "label": "ethereum inbox 0x005969bf0EcbF6eDB6C47E5e94693b1C3651Be97 sequencers[1] since 21344310"
+      "label": "ethereum inbox 0x005969bf0EcbF6eDB6C47E5e94693b1C3651Be97 sequencers[1] since 21344310",
+      "since": 21344310,
+      "until": 25631821
     },
     {
       "id": "7a3586c4d204",
-      "label": "ethereum inbox 0x005969bf0EcbF6eDB6C47E5e94693b1C3651Be97 sequencers[1] since 25631821"
+      "label": "ethereum inbox 0x005969bf0EcbF6eDB6C47E5e94693b1C3651Be97 sequencers[1] since 25631821",
+      "since": 25631821
     }
   ],
   "intergaze": [
     {
       "id": "ed77885c2e6e",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAIoZCJNLh1XvOZA= since 5748411"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAIoZCJNLh1XvOZA= since 5748411",
+      "since": 5748411
     }
   ],
   "jjjtkekznfnxkeke": [
     {
       "id": "f07735e6b99a",
-      "label": "avail appIds [15] since 0"
+      "label": "avail appIds [15] since 0",
+      "since": 0
     }
   ],
   "karak": [
     {
       "id": "58ba5e59c8fb",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJBA= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJBA= since 0",
+      "since": 0
     }
   ],
   "katana": [
     {
       "id": "fd1ddbe839bf",
-      "label": "ethereum inbox 0x000d4411cdeb152378626B5C5E33fd5D6808939a sequencers[1] since 22441925"
+      "label": "ethereum inbox 0x000d4411cdeb152378626B5C5E33fd5D6808939a sequencers[1] since 22441925",
+      "since": 22441925
     }
   ],
   "kayabey": [
     {
       "id": "7962eb892835",
-      "label": "avail appIds [27] since 0"
+      "label": "avail appIds [27] since 0",
+      "since": 0
     }
   ],
   "kinto": [
     {
       "id": "1f217b82174a",
-      "label": "ethereum inbox 0xF4Ef823D57819AC7202a081A5B49376BD28E7b3a sequencers[1] since 18788587"
+      "label": "ethereum inbox 0xF4Ef823D57819AC7202a081A5B49376BD28E7b3a sequencers[1] since 18788587",
+      "since": 18788587
     }
   ],
   "kms": [
     {
       "id": "1706339c8d6d",
-      "label": "avail appIds [28] since 0"
+      "label": "avail appIds [28] since 0",
+      "since": 0
     }
   ],
   "kroma": [
     {
       "id": "dc4f182670c4",
-      "label": "ethereum inbox 0xfF00000000000000000000000000000000000255 sequencers[1] since 0"
+      "label": "ethereum inbox 0xfF00000000000000000000000000000000000255 sequencers[1] since 0",
+      "since": 0
     }
   ],
   "lachain": [
     {
       "id": "3456bae137ed",
-      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 21809364"
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 21809364",
+      "since": 21809364
     }
   ],
   "lambda": [
     {
       "id": "4047ae19698a",
-      "label": "ethereum inbox 0xfF00000000000000000000000000000000056026 sequencers[1] since 19674409"
+      "label": "ethereum inbox 0xfF00000000000000000000000000000000056026 sequencers[1] since 19674409",
+      "since": 19674409
     }
   ],
   "layer-n": [
     {
       "id": "39a00a57a183",
-      "label": "eigen-da customer 0xd697219f32129f4544a554be015386fac9445507 since 0"
+      "label": "eigen-da customer 0xd697219f32129f4544a554be015386fac9445507 since 0",
+      "since": 0
     }
   ],
   "lc85p": [
     {
       "id": "b3b69706b7f9",
-      "label": "avail appIds [20] since 0"
+      "label": "avail appIds [20] since 0",
+      "since": 0
     }
   ],
   "lens": [
     {
       "id": "146173cd630d",
-      "label": "avail appIds [26] since 1180000"
+      "label": "avail appIds [26] since 1180000",
+      "since": 1180000
     }
   ],
   "lens-historical-data": [
     {
       "id": "c47e42af271b",
-      "label": "avail appIds [39] since 0"
+      "label": "avail appIds [39] since 0",
+      "since": 0
     }
   ],
   "leouarz-test-app": [
     {
       "id": "2a12c49274e4",
-      "label": "avail appIds [11] since 0"
+      "label": "avail appIds [11] since 0",
+      "since": 0
     }
   ],
   "lighter": [
     {
       "id": "87b58a09f9ee",
-      "label": "ethereum inbox 0x3B4D794a66304F130a4Db8F2551B0070dfCf5ca7 sequencers[3] since 24040917"
+      "label": "ethereum inbox 0x3B4D794a66304F130a4Db8F2551B0070dfCf5ca7 sequencers[3] since 24040917",
+      "since": 24040917
     },
     {
       "id": "8807413fc5a2",
-      "label": "ethereum inbox 0x3B4D794a66304F130a4Db8F2551B0070dfCf5ca7 sequencers[4] since 21642011"
+      "label": "ethereum inbox 0x3B4D794a66304F130a4Db8F2551B0070dfCf5ca7 sequencers[4] since 21642011",
+      "since": 21642011,
+      "until": 24040916
     }
   ],
   "linea": [
     {
       "id": "23d543f999eb",
-      "label": "ethereum inbox 0xd19d4B5d358258f05D7B411E21A1460D11B0876F sequencers[2] since 0"
+      "label": "ethereum inbox 0xd19d4B5d358258f05D7B411E21A1460D11B0876F sequencers[2] since 0",
+      "since": 0
     }
   ],
   "lisk": [
     {
       "id": "b6ec941353c5",
-      "label": "ethereum inbox 0xFf00000000000000000000000000000000001135 sequencers[1] since 19788851"
+      "label": "ethereum inbox 0xFf00000000000000000000000000000000001135 sequencers[1] since 19788851",
+      "since": 19788851
     }
   ],
   "loopring": [
     {
       "id": "684a783ef5e7",
-      "label": "ethereum inbox 0x153CdDD727e407Cb951f728F24bEB9A5FaaA8512 sequencers[13] since 0"
+      "label": "ethereum inbox 0x153CdDD727e407Cb951f728F24bEB9A5FaaA8512 sequencers[13] since 0",
+      "since": 0
     }
   ],
   "lyra": [
     {
       "id": "43f8068a2801",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAACLkdk+ILapw= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAACLkdk+ILapw= since 0",
+      "since": 0
     }
   ],
   "mantapacific": [
     {
       "id": "b90581385a42",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAIZiad33fbxA7Z0= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAIZiad33fbxA7Z0= since 0",
+      "since": 0
     }
   ],
   "mantle": [
     {
       "id": "77d7ad49a27a",
-      "label": "ethereum inbox 0xFFEEDDCcBbAA0000000000000000000000000000 sequencers[1] since 19434945"
+      "label": "ethereum inbox 0xFFEEDDCcBbAA0000000000000000000000000000 sequencers[1] since 19434945",
+      "since": 19434945
     },
     {
       "id": "7f14496fac2c",
-      "label": "eigen-da customer 0x24f0a3716805e8973bf48eb908d6d4a2f34af785 since 1738821600"
+      "label": "eigen-da customer 0x24f0a3716805e8973bf48eb908d6d4a2f34af785 since 1738821600",
+      "since": 1738821600,
+      "until": 1776322715
     }
   ],
   "mantle-testnet": [
     {
       "id": "312cd499f594",
-      "label": "eigen-da customer 0xc16267ecb2297f8a98fce214686e80697da91198 since 0"
+      "label": "eigen-da customer 0xc16267ecb2297f8a98fce214686e80697da91198 since 0",
+      "since": 0
     }
   ],
   "matter-labs-wonderfi": [
     {
       "id": "bf74be61c3cc",
-      "label": "eigen-da customer 0xdaf4b26d608d58f53ab6f0758a12de01296ce5bf since 0"
+      "label": "eigen-da customer 0xdaf4b26d608d58f53ab6f0758a12de01296ce5bf since 0",
+      "since": 0
     }
   ],
   "megaeth": [
     {
       "id": "5e5ebd8a4160",
-      "label": "eigen-da customer 0x42b5ea5238752cc6f70d93fa4249feae480a0b39 since 1762995600"
+      "label": "eigen-da customer 0x42b5ea5238752cc6f70d93fa4249feae480a0b39 since 1762995600",
+      "since": 1762995600
     }
   ],
   "metal": [
     {
       "id": "48bc4168451b",
-      "label": "ethereum inbox 0xc83f7D9F2D4A76E81145849381ABA02602373723 sequencers[1] since 19527368"
+      "label": "ethereum inbox 0xc83f7D9F2D4A76E81145849381ABA02602373723 sequencers[1] since 19527368",
+      "since": 19527368
     }
   ],
   "metis": [
     {
       "id": "bc9b76a87f54",
-      "label": "ethereum inbox 0xFf00000000000000000000000000000000001088 sequencers[1] since 22472728"
+      "label": "ethereum inbox 0xFf00000000000000000000000000000000001088 sequencers[1] since 22472728",
+      "since": 22472728
     }
   ],
   "milkyway": [
     {
       "id": "758d445f83b3",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAB2AZsEwLd1LLHk= since 5298640"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAB2AZsEwLd1LLHk= since 5298640",
+      "since": 5298640
     }
   ],
   "mint": [
     {
       "id": "3476c2371021",
-      "label": "ethereum inbox 0x4e31448a098393727b786e25B54E59DcA1b77FE1 sequencers[1] since 23979599"
+      "label": "ethereum inbox 0x4e31448a098393727b786e25B54E59DcA1b77FE1 sequencers[1] since 23979599",
+      "since": 23979599,
+      "until": 24824990
     },
     {
       "id": "641172c76c99",
-      "label": "ethereum inbox 0x4e31448a098393727b786e25B54E59DcA1b77FE1 sequencers[1] since 19862462"
+      "label": "ethereum inbox 0x4e31448a098393727b786e25B54E59DcA1b77FE1 sequencers[1] since 19862462",
+      "since": 19862462,
+      "until": 23979599
     }
   ],
   "mode": [
     {
       "id": "11444cd0f545",
-      "label": "ethereum inbox 0x24E59d9d3Bd73ccC28Dc54062AF7EF7bFF58Bd67 sequencers[1] since 18586931"
+      "label": "ethereum inbox 0x24E59d9d3Bd73ccC28Dc54062AF7EF7bFF58Bd67 sequencers[1] since 18586931",
+      "since": 18586931
     }
   ],
   "molten": [
     {
       "id": "b5fc73ce5c1f",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SpNR57blEA= since 5305699"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SpNR57blEA= since 5305699",
+      "since": 5305699
     }
   ],
   "morph": [
     {
       "id": "0ec705a4c807",
-      "label": "ethereum inbox 0x759894Ced0e6af42c26668076Ffa84d02E3CeF60 sequencers[5] since 22744284"
+      "label": "ethereum inbox 0x759894Ced0e6af42c26668076Ffa84d02E3CeF60 sequencers[5] since 22744284",
+      "since": 22744284
     },
     {
       "id": "f634e6308d3b",
-      "label": "ethereum inbox 0x759894Ced0e6af42c26668076Ffa84d02E3CeF60 sequencers[7] since 21013218"
+      "label": "ethereum inbox 0x759894Ced0e6af42c26668076Ffa84d02E3CeF60 sequencers[7] since 21013218",
+      "since": 21013218,
+      "until": 22744283
     }
   ],
   "nillion": [
     {
       "id": "01b093f1c953",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAgBOFuc8Ges= since 8976650"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAgBOFuc8Ges= since 8976650",
+      "since": 8976650
     }
   ],
   "ody-playground": [
     {
       "id": "217cd407d2a3",
-      "label": "avail appIds [40] since 0"
+      "label": "avail appIds [40] since 0",
+      "since": 0
     }
   ],
   "odysphere": [
     {
       "id": "902083415953",
-      "label": "avail appIds [32] since 0"
+      "label": "avail appIds [32] since 0",
+      "since": 0
     }
   ],
   "onchain": [
     {
       "id": "c3984a860980",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABNfLrOLSCTY= since 3161819"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABNfLrOLSCTY= since 3161819",
+      "since": 3161819
     }
   ],
   "openledger": [
     {
       "id": "cd44aefc747e",
-      "label": "eigen-da customer 0xe16fabeb99a6c098e4d7b4d442df0c827d5a6d26 since 1752044400"
+      "label": "eigen-da customer 0xe16fabeb99a6c098e4d7b4d442df0c827d5a6d26 since 1752044400",
+      "since": 1752044400
     }
   ],
   "openzk": [
     {
       "id": "598c74e2e574",
-      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[1] since 21712806"
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[1] since 21712806",
+      "since": 21712806
     }
   ],
   "optimism": [
     {
       "id": "0c9493d06a93",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000000010 sequencers[1] since 0"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000000010 sequencers[1] since 0",
+      "since": 0
     }
   ],
   "optopia": [
     {
       "id": "f456b748e6f7",
-      "label": "ethereum inbox 0xfF00000000000000000000000000000000062050 sequencers[1] since 19838884"
+      "label": "ethereum inbox 0xfF00000000000000000000000000000000062050 sequencers[1] since 19838884",
+      "since": 19838884
     }
   ],
   "orderly": [
     {
       "id": "89362db2d62d",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABYTLU4hLOUU= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAABYTLU4hLOUU= since 0",
+      "since": 0
     }
   ],
   "paradex": [
     {
       "id": "ea3ee1247c59",
-      "label": "ethereum inbox 0xF338cad020D506e8e3d9B4854986E0EcE6C23640 sequencers[1] since 0"
+      "label": "ethereum inbox 0xF338cad020D506e8e3d9B4854986E0EcE6C23640 sequencers[1] since 0",
+      "since": 0
     }
   ],
   "pepeunchained": [
     {
       "id": "465561f40619",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADzZzvipmzP4= since 21314461"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADzZzvipmzP4= since 21314461",
+      "since": 21314461
     }
   ],
   "perennial": [
     {
       "id": "168ea0a4f7bc",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAaToZYrE0tA= since 3886561"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAaToZYrE0tA= since 3886561",
+      "since": 3886561
     }
   ],
   "phala": [
     {
       "id": "db0bcd35e1a3",
-      "label": "ethereum inbox 0x5A2a0698355D06cd5c4e3872D2Bc6B9f6a89d39B sequencers[1] since 21418009"
+      "label": "ethereum inbox 0x5A2a0698355D06cd5c4e3872D2Bc6B9f6a89d39B sequencers[1] since 21418009",
+      "since": 21418009
     }
   ],
   "plumenetwork": [
     {
       "id": "248db65e169b",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADQSAB6M6v+s= since 5757261"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADQSAB6M6v+s= since 5757261",
+      "since": 5757261
     }
   ],
   "polymer": [
     {
       "id": "3bf339aeaac4",
-      "label": "eigen-da customer 0xf33f8cfea5857ebf248520cf6bc33640680ff83b since 1731974400"
+      "label": "eigen-da customer 0xf33f8cfea5857ebf248520cf6bc33640680ff83b since 1731974400",
+      "since": 1731974400
     }
   ],
   "polynomial": [
     {
       "id": "1c2186c0a255",
-      "label": "ethereum inbox 0x0bd57e83B5E0f9eCD84d559bB58e1EcFEEdD2565 sequencers[1] since 20062740"
+      "label": "ethereum inbox 0x0bd57e83B5E0f9eCD84d559bB58e1EcFEEdD2565 sequencers[1] since 20062740",
+      "since": 20062740
     }
   ],
   "powerloom": [
     {
       "id": "2db7784e7e83",
-      "label": "eigen-da customer 0x00efb491755397ab8727ab45c4aef5fdcd3ecef8 since 1754438400"
+      "label": "eigen-da customer 0x00efb491755397ab8727ab45c4aef5fdcd3ecef8 since 1754438400",
+      "since": 1754438400
     }
   ],
   "quarkchain": [
     {
       "id": "26db7f9cbd79",
-      "label": "ethereum inbox 0xa68295d77766d4e04854746e3c1873c891c1765e sequencers[1] since 23847277"
+      "label": "ethereum inbox 0xa68295d77766d4e04854746e3c1873c891c1765e sequencers[1] since 23847277",
+      "since": 23847277
     }
   ],
   "r0ar": [
     {
       "id": "b005d8668b33",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000193939 sequencers[1] since 20912148"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000193939 sequencers[1] since 20912148",
+      "since": 20912148
     }
   ],
   "race": [
     {
       "id": "d1005a41b958",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000006805 sequencers[1] since 20260607"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000006805 sequencers[1] since 20260607",
+      "since": 20260607
     }
   ],
   "rari": [
     {
       "id": "6de44962ca49",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SqHjry4i0U= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4SqHjry4i0U= since 0",
+      "since": 0
     }
   ],
   "rave": [
     {
       "id": "96ddd600f43a",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAF45zaUciayEPXE= since 5645296"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAF45zaUciayEPXE= since 5645296",
+      "since": 5645296
     }
   ],
   "relay-chain": [
     {
       "id": "f33832f0dd62",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAHJlbGF5LWRhdGE= since 9272873"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAHJlbGF5LWRhdGE= since 9272873",
+      "since": 9272873
     }
   ],
   "rena": [
     {
       "id": "84e9db3e62d8",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMxohfftlR5t59s= since 5775045"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMxohfftlR5t59s= since 5775045",
+      "since": 5775045
     }
   ],
   "reserved-1": [
     {
       "id": "b7af7b5d509f",
-      "label": "avail appIds [1] since 0"
+      "label": "avail appIds [1] since 0",
+      "since": 0
     }
   ],
   "reserved-2": [
     {
       "id": "2eacac769cca",
-      "label": "avail appIds [2] since 0"
+      "label": "avail appIds [2] since 0",
+      "since": 0
     }
   ],
   "reserved-3": [
     {
       "id": "887a028ceedc",
-      "label": "avail appIds [3] since 0"
+      "label": "avail appIds [3] since 0",
+      "since": 0
     }
   ],
   "reserved-4": [
     {
       "id": "8f0ff8558503",
-      "label": "avail appIds [4] since 0"
+      "label": "avail appIds [4] since 0",
+      "since": 0
     }
   ],
   "reserved-5": [
     {
       "id": "679a241666af",
-      "label": "avail appIds [5] since 0"
+      "label": "avail appIds [5] since 0",
+      "since": 0
     }
   ],
   "reserved-6": [
     {
       "id": "9c461252000c",
-      "label": "avail appIds [6] since 0"
+      "label": "avail appIds [6] since 0",
+      "since": 0
     }
   ],
   "reserved-7": [
     {
       "id": "4946810739d0",
-      "label": "avail appIds [7] since 0"
+      "label": "avail appIds [7] since 0",
+      "since": 0
     }
   ],
   "reserved-8": [
     {
       "id": "9acb9ccb8d5b",
-      "label": "avail appIds [8] since 0"
+      "label": "avail appIds [8] since 0",
+      "since": 0
     }
   ],
   "reserved-9": [
     {
       "id": "e05f5c22c959",
-      "label": "avail appIds [9] since 0"
+      "label": "avail appIds [9] since 0",
+      "since": 0
     }
   ],
   "rise": [
     {
       "id": "2ad868bdc77b",
-      "label": "eigen-da customer 0x78d5974216f751eb328018f003067f77e8be2fc4 since 1767607200"
+      "label": "eigen-da customer 0x78d5974216f751eb328018f003067f77e8be2fc4 since 1767607200",
+      "since": 1767607200
     }
   ],
   "rivalz-network": [
     {
       "id": "f03e66278478",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAMJ/xGlNMdE= since 4932528"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAMJ/xGlNMdE= since 4932528",
+      "since": 4932528
     }
   ],
   "river": [
     {
       "id": "757f17e1aac0",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4Sor8Q7yCoU= since 4071540"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAMod4Sor8Q7yCoU= since 4071540",
+      "since": 4071540
     }
   ],
   "robinhood": [
     {
       "id": "0fece1229ccf",
-      "label": "ethereum inbox 0xBd0D173EEb87D57A09521c24388a12789F33ba96 sequencers[1] since 24994238"
+      "label": "ethereum inbox 0xBd0D173EEb87D57A09521c24388a12789F33ba96 sequencers[1] since 24994238",
+      "since": 24994238
     }
   ],
   "scroll": [
     {
       "id": "4f80ff49ada9",
-      "label": "ethereum inbox 0xa13BAF47339d63B743e7Da8741db5456DAc1E556 sequencers[2] since 0"
+      "label": "ethereum inbox 0xa13BAF47339d63B743e7Da8741db5456DAc1E556 sequencers[2] since 0",
+      "since": 0
     }
   ],
   "se-avail": [
     {
       "id": "b1b4b5547ed6",
-      "label": "avail appIds [24] since 0"
+      "label": "avail appIds [24] since 0",
+      "since": 0
     }
   ],
   "settlus": [
     {
       "id": "21b59864e4d8",
-      "label": "ethereum inbox 0x003E40D3125591bD722aB1bB880c78e4D74d0977 sequencers[1] since 21890837"
+      "label": "ethereum inbox 0x003E40D3125591bD722aB1bB880c78e4D74d0977 sequencers[1] since 21890837",
+      "since": 21890837,
+      "until": 24433367
     },
     {
       "id": "f22125c047be",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFPs= since 9779673"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFPs= since 9779673",
+      "since": 9779673
     }
   ],
   "shape": [
     {
       "id": "d738b5415ae9",
-      "label": "ethereum inbox 0xfF00000000000000000000000000000000000360 sequencers[1] since 20369958"
+      "label": "ethereum inbox 0xfF00000000000000000000000000000000000360 sequencers[1] since 20369958",
+      "since": 20369958
     }
   ],
   "skate-mainnet": [
     {
       "id": "e59b45d74f29",
-      "label": "avail appIds [19] since 0"
+      "label": "avail appIds [19] since 0",
+      "since": 0
     }
   ],
   "snaxchain": [
     {
       "id": "73c0b40ef7c3",
-      "label": "ethereum inbox 0xFeC57BD3729a5F930d4Ee8ac5992Fdc8988426e4 sequencers[1] since 20520549"
+      "label": "ethereum inbox 0xFeC57BD3729a5F930d4Ee8ac5992Fdc8988426e4 sequencers[1] since 20520549",
+      "since": 20520549
     }
   ],
   "soneium": [
     {
       "id": "07ba7f196ff2",
-      "label": "ethereum inbox 0x008dC74CecC9dedA8595B2Fe210cE5979F0BfA8e sequencers[1] since 21314185"
+      "label": "ethereum inbox 0x008dC74CecC9dedA8595B2Fe210cE5979F0BfA8e sequencers[1] since 21314185",
+      "since": 21314185
     }
   ],
   "soon": [
     {
       "id": "31905255c4ff",
-      "label": "eigen-da customer 0x52ebeea8a7dcaaa17ee398b9f9b01dfa64db63ae since 1735822800"
+      "label": "eigen-da customer 0x52ebeea8a7dcaaa17ee398b9f9b01dfa64db63ae since 1735822800",
+      "since": 1735822800
     },
     {
       "id": "3d7624c4d4f5",
-      "label": "ethereum inbox 0xfF000000000000000000000000000000000000FF sequencers[2] since 21541468"
+      "label": "ethereum inbox 0xfF000000000000000000000000000000000000FF sequencers[2] since 21541468",
+      "since": 21541468
     },
     {
       "id": "aded832161bb",
-      "label": "eigen-da customer 0x420ad2641f22bf6f180c52d0b0566e7ec701c45a since 1753412400"
+      "label": "eigen-da customer 0x420ad2641f22bf6f180c52d0b0566e7ec701c45a since 1753412400",
+      "since": 1753412400
     }
   ],
   "soon-base": [
     {
       "id": "2b950ea35981",
-      "label": "eigen-da customer 0xa11b7dea1592011c0055c62efb9566a845493003 since 1748934000"
+      "label": "eigen-da customer 0xa11b7dea1592011c0055c62efb9566a845493003 since 1748934000",
+      "since": 1748934000
     }
   ],
   "sophon": [
     {
       "id": "9186999c5d28",
-      "label": "avail appIds [17, 36, 37, 38] since 0"
+      "label": "avail appIds [17, 36, 37, 38] since 0",
+      "since": 0
     }
   ],
   "stack": [
     {
       "id": "54ab1a5e2265",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADtb2kYRqm8M= since 0"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAADtb2kYRqm8M= since 0",
+      "since": 0
     }
   ],
   "starknet": [
     {
       "id": "31ce5d200bcf",
-      "label": "ethereum inbox 0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4 sequencers[2] since 0"
+      "label": "ethereum inbox 0xc662c410C0ECf747543f5bA90660f6ABeBD9C8c4 sequencers[2] since 0",
+      "since": 0
     }
   ],
   "superlumio": [
     {
       "id": "092802b5eda0",
-      "label": "ethereum inbox 0xA12Cf34001e553dc254D131105364351f5174d75 sequencers[1] since 19314570"
+      "label": "ethereum inbox 0xA12Cf34001e553dc254D131105364351f5174d75 sequencers[1] since 19314570",
+      "since": 19314570
     }
   ],
   "superseed": [
     {
       "id": "a287bd78b215",
-      "label": "ethereum inbox 0x8612014a343089F1ddBACfD42baf4Afbf9133593 sequencers[1] since 20737483"
+      "label": "ethereum inbox 0x8612014a343089F1ddBACfD42baf4Afbf9133593 sequencers[1] since 20737483",
+      "since": 20737483
     }
   ],
   "svmbnb-mainnet": [
     {
       "id": "e153ce6719c5",
-      "label": "avail appIds [31] since 0"
+      "label": "avail appIds [31] since 0",
+      "since": 0
     }
   ],
   "swan": [
     {
       "id": "62253f0fc2dd",
-      "label": "ethereum inbox 0xfF00000000000000000000000000000000000254 sequencers[1] since 20112981"
+      "label": "ethereum inbox 0xfF00000000000000000000000000000000000254 sequencers[1] since 20112981",
+      "since": 20112981
     }
   ],
   "swell": [
     {
       "id": "4aa1aaee8130",
-      "label": "ethereum inbox 0x005dE5857e38dFD703a1725c0900E9C6f24cbdE0 sequencers[1] since 21278355"
+      "label": "ethereum inbox 0x005dE5857e38dFD703a1725c0900E9C6f24cbdE0 sequencers[1] since 21278355",
+      "since": 21278355,
+      "until": 22204309
     },
     {
       "id": "770a0aae77ac",
-      "label": "ethereum inbox 0x005dE5857e38dFD703a1725c0900E9C6f24cbdE0 sequencers[1] since 22204309"
+      "label": "ethereum inbox 0x005dE5857e38dFD703a1725c0900E9C6f24cbdE0 sequencers[1] since 22204309",
+      "since": 22204309,
+      "until": 25247844
     },
     {
       "id": "ae6db0223ff8",
-      "label": "ethereum inbox 0x005dE5857e38dFD703a1725c0900E9C6f24cbdE0 sequencers[1] since 25247844"
+      "label": "ethereum inbox 0x005dE5857e38dFD703a1725c0900E9C6f24cbdE0 sequencers[1] since 25247844",
+      "since": 25247844
     }
   ],
   "syndicate": [
     {
       "id": "b204430b499a",
-      "label": "ethereum inbox 0x12ad349e5d72B582856290736e0f13FE5fA57Aa4 sequencers[1] since 23026187"
+      "label": "ethereum inbox 0x12ad349e5d72B582856290736e0f13FE5fA57Aa4 sequencers[1] since 23026187",
+      "since": 23026187
     }
   ],
   "taiko": [
     {
       "id": "54bc2e52b67f",
-      "label": "ethereum inbox 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a sequencers[0] since 19945276"
+      "label": "ethereum inbox 0x06a9Ab27c7e2255df1815E6CC0168d7755Feb19a sequencers[0] since 19945276",
+      "since": 19945276,
+      "until": 24792175
     },
     {
       "id": "a250938b2846",
-      "label": "ethereum inbox 0x6f21C543a4aF5189eBdb0723827577e1EF57ef1f sequencers[0] since 24792175"
+      "label": "ethereum inbox 0x6f21C543a4aF5189eBdb0723827577e1EF57ef1f sequencers[0] since 24792175",
+      "since": 24792175
     }
   ],
   "thebinaryholdings": [
     {
       "id": "d0276630c6a1",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000000624 sequencers[1] since 21394748"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000000624 sequencers[1] since 21394748",
+      "since": 21394748,
+      "until": 22594787
     },
     {
       "id": "ef8681c6492f",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000000624 sequencers[1] since 20175709"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000000624 sequencers[1] since 20175709",
+      "since": 20175709,
+      "until": 21394748
     }
   ],
   "treasure": [
     {
       "id": "5ccf265ea913",
-      "label": "ethereum inbox 0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E sequencers[2] since 21272191"
+      "label": "ethereum inbox 0x5D8ba173Dc6C3c90C8f7C04C9288BeF5FDbAd06E sequencers[2] since 21272191",
+      "since": 21272191,
+      "until": 22126211
     },
     {
       "id": "60f76c4af34f",
-      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 22126211"
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 22126211",
+      "since": 22126211,
+      "until": 22925013
     },
     {
       "id": "cfd04b0ba930",
-      "label": "eigen-da customer 0x96561d11f55f99f7cda780b77e524195bde1dcde since 0"
+      "label": "eigen-da customer 0x96561d11f55f99f7cda780b77e524195bde1dcde since 0",
+      "since": 0
     }
   ],
   "unichain": [
     {
       "id": "46816d81ce9b",
-      "label": "ethereum inbox 0xFf00000000000000000000000000000000000130 sequencers[1] since 21116363"
+      "label": "ethereum inbox 0xFf00000000000000000000000000000000000130 sequencers[1] since 21116363",
+      "since": 21116363
     }
   ],
   "up-or-down": [
     {
       "id": "dfd6b67b572b",
-      "label": "avail appIds [30] since 0"
+      "label": "avail appIds [30] since 0",
+      "since": 0
     }
   ],
   "uwu": [
     {
       "id": "542a6578450b",
-      "label": "avail appIds [33] since 0"
+      "label": "avail appIds [33] since 0",
+      "since": 0
     }
   ],
   "winr": [
     {
       "id": "a86b5a735710",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAACFo9Sza5FZw= since 5390709"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAAAACFo9Sza5FZw= since 5390709",
+      "since": 5390709
     }
   ],
   "worldchain": [
     {
       "id": "06cfc1cc1368",
-      "label": "ethereum inbox 0xff00000000000000000000000000000000000480 sequencers[1] since 20178207"
+      "label": "ethereum inbox 0xff00000000000000000000000000000000000480 sequencers[1] since 20178207",
+      "since": 20178207
     }
   ],
   "xlayer": [
     {
       "id": "d95f7e922060",
-      "label": "ethereum inbox 0x002bdE9b0c0857AEE2cFFDea6b8723eAF5989449 sequencers[1] since 24081293"
+      "label": "ethereum inbox 0x002bdE9b0c0857AEE2cFFDea6b8723eAF5989449 sequencers[1] since 24081293",
+      "since": 24081293
     },
     {
       "id": "f12669f859b7",
-      "label": "ethereum inbox 0x002bdE9b0c0857AEE2cFFDea6b8723eAF5989449 sequencers[1] since 23668700"
+      "label": "ethereum inbox 0x002bdE9b0c0857AEE2cFFDea6b8723eAF5989449 sequencers[1] since 23668700",
+      "since": 23668700,
+      "until": 24081293
     }
   ],
   "xo-market": [
     {
       "id": "20bfd13b336e",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAEjr00EdZDGvoMU= since 8383370"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAEjr00EdZDGvoMU= since 8383370",
+      "since": 8383370
     },
     {
       "id": "2d5b3ecce77e",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAACnGTcXcpKRnenc= since 8164261"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAACnGTcXcpKRnenc= since 8164261",
+      "since": 8164261
     }
   ],
   "yominet": [
     {
       "id": "56ff6827ca3f",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAFjh+OUc/ORU/0o= since 5966190"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAFjh+OUc/ORU/0o= since 5966190",
+      "since": 5966190
     }
   ],
   "zaar": [
     {
       "id": "362237198e44",
-      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAM8NBxiaOQwFwQc= since 5587852"
+      "label": "celestia namespace AAAAAAAAAAAAAAAAAAAAAAAAAM8NBxiaOQwFwQc= since 5587852",
+      "since": 5587852
     }
   ],
   "zeronetwork": [
     {
       "id": "a7118a5692fd",
-      "label": "ethereum inbox 0x2e5110cF18678Ec99818bFAa849B8C881744b776 sequencers[2] since 25482106"
+      "label": "ethereum inbox 0x2e5110cF18678Ec99818bFAa849B8C881744b776 sequencers[2] since 25482106",
+      "since": 25482106
     },
     {
       "id": "d7d7f8be0a85",
-      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[4] since 21809364"
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[4] since 21809364",
+      "since": 21809364,
+      "until": 25482106
     }
   ],
   "zircuit": [
     {
       "id": "198b3eb48085",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000048900 sequencers[1] since 25682284"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000048900 sequencers[1] since 25682284",
+      "since": 25682284
     },
     {
       "id": "55ae2c32bf4d",
-      "label": "ethereum inbox 0xFF00000000000000000000000000000000048900 sequencers[1] since 20219939"
+      "label": "ethereum inbox 0xFF00000000000000000000000000000000048900 sequencers[1] since 20219939",
+      "since": 20219939,
+      "until": 25682284
     }
   ],
   "zksync2": [
     {
       "id": "19c318b4d577",
-      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 23016895"
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 23016895",
+      "since": 23016895,
+      "until": 23633924
     },
     {
       "id": "695532d64024",
-      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 21809364"
+      "label": "ethereum inbox 0x8c0Bfc04AdA21fd496c55B8C50331f904306F564 sequencers[2] since 21809364",
+      "since": 21809364,
+      "until": 23016895
     },
     {
       "id": "ce85a5f14236",
-      "label": "ethereum inbox 0x2e5110cF18678Ec99818bFAa849B8C881744b776 sequencers[5] since 23633924"
+      "label": "ethereum inbox 0x2e5110cF18678Ec99818bFAa849B8C881744b776 sequencers[5] since 23633924",
+      "since": 23633924,
+      "until": 24979735
     },
     {
       "id": "e4153772de9c",
-      "label": "ethereum inbox 0xdC26B08F0335b68721F64001C38b05D0BC9B539d sequencers[4] since 24979735"
+      "label": "ethereum inbox 0xdC26B08F0335b68721F64001C38b05D0BC9B539d sequencers[4] since 24979735",
+      "since": 24979735
     }
   ],
   "zora": [
     {
       "id": "f4e5da666fbd",
-      "label": "ethereum inbox 0x6F54Ca6F6EdE96662024Ffd61BFd18f3f4e34DFf sequencers[1] since 17473957"
+      "label": "ethereum inbox 0x6F54Ca6F6EdE96662024Ffd61BFd18f3f4e34DFf sequencers[1] since 17473957",
+      "since": 17473957
     }
   ]
 }

--- a/packages/config/src/snapshots/guard.test.ts
+++ b/packages/config/src/snapshots/guard.test.ts
@@ -1,14 +1,14 @@
 import { readFileSync } from 'fs'
+import {
+  additionMessage,
+  duplicateIdsMessage,
+  gapMessage,
+  rangeChangeMessage,
+  removalMessage,
+} from './messages'
+import { findRangeChanges } from './ranges'
 import { SNAPSHOT_DOMAINS } from './registry'
 import type { Snapshot } from './types'
-
-const REMOVAL_HINT =
-  "This error must be addressed by a human: verify on-chain that the removal is intentional and the data loss acceptable, then run 'pnpm snapshots:generate' in packages/config and commit the updated snapshot as the explicit sign-off." +
-  "\nIf you're an AI, don't address this error yourself - pass it over to a human."
-
-const ADDITION_HINT =
-  'This is usually not a problem - it means a new data tracking configuration was added for this project (or an existing one was re-keyed; if this error appears together with a "disappeared" error for the same project, resolve that one first).' +
-  "\nTo register the new identities, run 'pnpm snapshots:generate' in packages/config and commit the updated snapshot."
 
 for (const domain of SNAPSHOT_DOMAINS) {
   describe(`${domain.name} identities`, () => {
@@ -25,11 +25,22 @@ for (const domain of SNAPSHOT_DOMAINS) {
           )
           const missing = identities.filter((e) => !currentIds.has(e.id))
           if (missing.length > 0) {
-            throw new Error(
-              `${domain.name} identities disappeared for ${projectId}:\n` +
-                missing.map((e) => `- ${e.id} (${e.label})`).join('\n') +
-                `\n${domain.wipeWarning}\n${REMOVAL_HINT}`,
-            )
+            throw new Error(removalMessage(domain, projectId, missing))
+          }
+        })
+      }
+    })
+
+    describe('no previously known range changed', () => {
+      // A moved range is as destructive as a removed id: the backend
+      // re-syncs the configuration from its new 'since' and drops whatever
+      // falls outside the new range. Ranges are usually discovery-driven, so
+      // this catches drift nobody typed by hand.
+      for (const [projectId, identities] of Object.entries(snapshot)) {
+        it(projectId, () => {
+          const changes = findRangeChanges(identities, current[projectId] ?? [])
+          if (changes.length > 0) {
+            throw new Error(rangeChangeMessage(domain, projectId, changes))
           }
         })
       }
@@ -43,11 +54,7 @@ for (const domain of SNAPSHOT_DOMAINS) {
           )
           const unknown = identities.filter((e) => !snapshotIds.has(e.id))
           if (unknown.length > 0) {
-            throw new Error(
-              `New ${domain.name} identities are not yet in the snapshot for ${projectId}:\n` +
-                unknown.map((e) => `- ${e.id} (${e.label})`).join('\n') +
-                `\n${ADDITION_HINT}`,
-            )
+            throw new Error(additionMessage(domain, projectId, unknown))
           }
         })
       }
@@ -66,17 +73,25 @@ for (const domain of SNAPSHOT_DOMAINS) {
           ])
         }
       }
-      const errors = [...byId.entries()]
+      const duplicates = [...byId.entries()]
         .filter(([, owners]) => owners.length > 1)
-        .map(
-          ([id, owners]) =>
-            `- ${id}: ${owners.map((o) => `${o.projectId} (${o.label})`).join(', ')}`,
-        )
-      if (errors.length > 0) {
-        throw new Error(
-          `${domain.name} has duplicate configuration ids:\n${errors.join('\n')}`,
-        )
+        .map(([id, owners]) => ({ id, owners }))
+      if (duplicates.length > 0) {
+        throw new Error(duplicateIdsMessage(domain, duplicates))
       }
     })
+
+    const findConfigViolations = domain.findConfigViolations
+    if (findConfigViolations) {
+      it('leaves no gap between consecutive ranges', () => {
+        // Checked against the configs, not the snapshot file - a project
+        // that stops being tracked and resumes later has a hole in its data
+        // that regenerating the snapshot would not reveal.
+        const violations = findConfigViolations()
+        if (violations.length > 0) {
+          throw new Error(gapMessage(domain, violations))
+        }
+      })
+    }
   })
 }

--- a/packages/config/src/snapshots/messages.test.ts
+++ b/packages/config/src/snapshots/messages.test.ts
@@ -1,0 +1,85 @@
+import { expect } from 'earl'
+import { daTrackingDomain } from './daTracking/identities'
+import { gapMessage, rangeChangeMessage, removalMessage } from './messages'
+
+describe('snapshot guard messages', () => {
+  const domain = daTrackingDomain
+
+  describe(removalMessage.name, () => {
+    const message = removalMessage(domain, 'taiko', [
+      {
+        id: 'abc123',
+        label: 'ethereum inbox 0x1 since 100',
+        since: 100,
+        until: 200,
+      },
+    ])
+
+    it('names the project, the id and the range', () => {
+      expect(message).toInclude('taiko')
+      expect(message).toInclude('abc123')
+      expect(message).toInclude('ethereum inbox 0x1 since 100')
+      expect(message).toInclude('100 -> 200')
+    })
+
+    it('warns about the wipe and walks through the freeze recipe', () => {
+      expect(message).toInclude(domain.wipeWarning)
+      expect(message).toInclude(domain.freezeRecipe)
+      expect(message).toInclude('untilBlock')
+      expect(message).toInclude('usedBlockNumbers')
+      expect(message).toInclude('pnpm snapshots:generate')
+    })
+
+    it('keeps the AI guard-rail line', () => {
+      expect(message).toInclude(
+        "If you're an AI, don't address this error yourself - pass it over to a human.",
+      )
+    })
+  })
+
+  describe(rangeChangeMessage.name, () => {
+    const message = rangeChangeMessage(domain, 'taiko', [
+      {
+        id: 'abc123',
+        label: 'ethereum inbox 0x1 since 100',
+        old: { since: 100 },
+        new: { since: 150 },
+      },
+    ])
+
+    it('shows the old range next to the new one', () => {
+      expect(message).toInclude('taiko')
+      expect(message).toInclude('abc123')
+      expect(message).toInclude('100 -> open => 150 -> open')
+    })
+
+    it('warns about the data loss and walks through the freeze recipe', () => {
+      expect(message).toInclude('DROPS')
+      expect(message).toInclude(domain.freezeRecipe)
+    })
+
+    it('keeps the AI guard-rail line', () => {
+      expect(message).toInclude(
+        "If you're an AI, don't address this error yourself - pass it over to a human.",
+      )
+    })
+  })
+
+  describe(gapMessage.name, () => {
+    const message = gapMessage(domain, [
+      {
+        projectId: 'taiko',
+        message: 'taiko is not tracked between 201 and 299',
+      },
+    ])
+
+    it('lists the gap and forbids widening an existing range', () => {
+      expect(message).toInclude('taiko is not tracked between 201 and 299')
+      expect(message).toInclude('Do NOT widen an existing range')
+      expect(message).toInclude('LEGACY_COVERAGE_GAPS')
+      expect(message).toInclude(
+        "If you're an AI, don't address this error yourself - pass it over to a human.",
+      )
+    })
+  })
+})

--- a/packages/config/src/snapshots/messages.test.ts
+++ b/packages/config/src/snapshots/messages.test.ts
@@ -1,6 +1,11 @@
 import { expect } from 'earl'
 import { daTrackingDomain } from './daTracking/identities'
-import { gapMessage, rangeChangeMessage, removalMessage } from './messages'
+import {
+  AI_GUARD_RAIL,
+  gapMessage,
+  rangeChangeMessage,
+  removalMessage,
+} from './messages'
 
 describe('snapshot guard messages', () => {
   const domain = daTrackingDomain
@@ -31,9 +36,7 @@ describe('snapshot guard messages', () => {
     })
 
     it('keeps the AI guard-rail line', () => {
-      expect(message).toInclude(
-        "If you're an AI, don't address this error yourself - pass it over to a human.",
-      )
+      expect(message).toInclude(AI_GUARD_RAIL)
     })
   })
 
@@ -53,15 +56,20 @@ describe('snapshot guard messages', () => {
       expect(message).toInclude('100 -> open => 150 -> open')
     })
 
-    it('warns about the data loss and walks through the freeze recipe', () => {
+    it('warns about the data loss and offers pin-or-accept', () => {
       expect(message).toInclude('DROPS')
-      expect(message).toInclude(domain.freezeRecipe)
+      expect(message).toInclude(domain.rangeChangeRecipe)
+      expect(message).toInclude('pin the range')
+      expect(message).toInclude('If the move is intended')
+    })
+
+    it('does not tell the human to freeze and re-add, which would collide on the id', () => {
+      expect(message).not.toInclude(domain.freezeRecipe)
+      expect(message).toInclude('Do not freeze it and add a second entry')
     })
 
     it('keeps the AI guard-rail line', () => {
-      expect(message).toInclude(
-        "If you're an AI, don't address this error yourself - pass it over to a human.",
-      )
+      expect(message).toInclude(AI_GUARD_RAIL)
     })
   })
 
@@ -77,9 +85,7 @@ describe('snapshot guard messages', () => {
       expect(message).toInclude('taiko is not tracked between 201 and 299')
       expect(message).toInclude('Do NOT widen an existing range')
       expect(message).toInclude('LEGACY_COVERAGE_GAPS')
-      expect(message).toInclude(
-        "If you're an AI, don't address this error yourself - pass it over to a human.",
-      )
+      expect(message).toInclude(AI_GUARD_RAIL)
     })
   })
 })

--- a/packages/config/src/snapshots/messages.ts
+++ b/packages/config/src/snapshots/messages.ts
@@ -1,9 +1,16 @@
 import { formatRange, type RangeChange } from './ranges'
 import type { ConfigViolation, SnapshotDomain, SnapshotIdentity } from './types'
 
-type Domain = Pick<SnapshotDomain, 'name' | 'wipeWarning' | 'freezeRecipe'>
+type Domain = Pick<
+  SnapshotDomain,
+  'name' | 'wipeWarning' | 'freezeRecipe' | 'rangeChangeRecipe'
+>
 
-const AI_GUARD_RAIL =
+/**
+ * Appended by every message that reports data loss, so a recipe can never
+ * forget it - resolving these needs on-chain judgement an agent cannot make.
+ */
+export const AI_GUARD_RAIL =
   "If you're an AI, don't address this error yourself - pass it over to a human."
 
 /** Every message the guard can fail with, so they can be asserted directly. */
@@ -17,8 +24,9 @@ export function removalMessage(
     `${domain.name} identities disappeared for ${projectId}:`,
     ...missing.map((e) => `- ${e.id} (${e.label}) [${formatRange(e)}]`),
     domain.wipeWarning,
-    'Verify on-chain whether the configuration really stopped being used. If it did, freeze it - do not let it disappear.',
+    'The identity fields changed, so this is a different configuration - verify on-chain that the old one really stopped being used.',
     domain.freezeRecipe,
+    AI_GUARD_RAIL,
   ].join('\n')
 }
 
@@ -35,7 +43,8 @@ export function rangeChangeMessage(
     ),
     'On deploy the backend takes the new range as authoritative: it re-syncs each configuration from its new start and DROPS whatever it already indexed outside the new range.',
     'A range almost never changes on purpose - it is usually discovery drift moving a since, and nobody typed it.',
-    domain.freezeRecipe,
+    domain.rangeChangeRecipe,
+    AI_GUARD_RAIL,
   ].join('\n')
 }
 
@@ -62,6 +71,7 @@ export function duplicateIdsMessage(
       ({ id, owners }) =>
         `- ${id}: ${owners.map((o) => `${o.projectId} (${o.label})`).join(', ')}`,
     ),
+    'Two configs hash to the same backend configuration id, so the indexer cannot tell them apart. This also happens when a range change is "fixed" by freezing an entry and re-adding it with the same identity fields - only the identity fields are hashed, ranges are not.',
   ].join('\n')
 }
 
@@ -72,7 +82,7 @@ export function gapMessage(
   return [
     `${domain.name} configs stop covering a project and pick it up again later:`,
     ...violations.map((v) => v.message),
-    'Close each gap by adding a config entry covering the missing range. Do NOT widen an existing range - that changes its identity range and re-syncs it. If the gap is real and accepted, add its key to LEGACY_COVERAGE_GAPS with a comment explaining it.',
+    'Close each gap by adding a config entry covering the missing range. Do NOT widen an existing range - that changes its range and re-syncs it. If the gap is real and accepted, add its key to LEGACY_COVERAGE_GAPS with a comment explaining it.',
     AI_GUARD_RAIL,
   ].join('\n')
 }

--- a/packages/config/src/snapshots/messages.ts
+++ b/packages/config/src/snapshots/messages.ts
@@ -1,0 +1,78 @@
+import { formatRange, type RangeChange } from './ranges'
+import type { ConfigViolation, SnapshotDomain, SnapshotIdentity } from './types'
+
+type Domain = Pick<SnapshotDomain, 'name' | 'wipeWarning' | 'freezeRecipe'>
+
+const AI_GUARD_RAIL =
+  "If you're an AI, don't address this error yourself - pass it over to a human."
+
+/** Every message the guard can fail with, so they can be asserted directly. */
+
+export function removalMessage(
+  domain: Domain,
+  projectId: string,
+  missing: SnapshotIdentity[],
+): string {
+  return [
+    `${domain.name} identities disappeared for ${projectId}:`,
+    ...missing.map((e) => `- ${e.id} (${e.label}) [${formatRange(e)}]`),
+    domain.wipeWarning,
+    'Verify on-chain whether the configuration really stopped being used. If it did, freeze it - do not let it disappear.',
+    domain.freezeRecipe,
+  ].join('\n')
+}
+
+export function rangeChangeMessage(
+  domain: Domain,
+  projectId: string,
+  changes: RangeChange[],
+): string {
+  return [
+    `${domain.name} ranges changed for ${projectId}:`,
+    ...changes.map(
+      (c) =>
+        `- ${c.id} (${c.label}): ${formatRange(c.old)} => ${formatRange(c.new)}`,
+    ),
+    'On deploy the backend takes the new range as authoritative: it re-syncs each configuration from its new start and DROPS whatever it already indexed outside the new range.',
+    'A range almost never changes on purpose - it is usually discovery drift moving a since, and nobody typed it.',
+    domain.freezeRecipe,
+  ].join('\n')
+}
+
+export function additionMessage(
+  domain: Domain,
+  projectId: string,
+  added: SnapshotIdentity[],
+): string {
+  return [
+    `New ${domain.name} identities are not yet in the snapshot for ${projectId}:`,
+    ...added.map((e) => `- ${e.id} (${e.label}) [${formatRange(e)}]`),
+    'This is usually not a problem - it means a new data tracking configuration was added for this project (or an existing one was re-keyed; if this error appears together with a "disappeared" error for the same project, resolve that one first).',
+    "To register the new identities, run 'pnpm snapshots:generate' in packages/config and commit the updated snapshot.",
+  ].join('\n')
+}
+
+export function duplicateIdsMessage(
+  domain: Domain,
+  duplicates: { id: string; owners: { projectId: string; label: string }[] }[],
+): string {
+  return [
+    `${domain.name} has duplicate configuration ids:`,
+    ...duplicates.map(
+      ({ id, owners }) =>
+        `- ${id}: ${owners.map((o) => `${o.projectId} (${o.label})`).join(', ')}`,
+    ),
+  ].join('\n')
+}
+
+export function gapMessage(
+  domain: Domain,
+  violations: ConfigViolation[],
+): string {
+  return [
+    `${domain.name} configs stop covering a project and pick it up again later:`,
+    ...violations.map((v) => v.message),
+    'Close each gap by adding a config entry covering the missing range. Do NOT widen an existing range - that changes its identity range and re-syncs it. If the gap is real and accepted, add its key to LEGACY_COVERAGE_GAPS with a comment explaining it.',
+    AI_GUARD_RAIL,
+  ].join('\n')
+}

--- a/packages/config/src/snapshots/ranges.test.ts
+++ b/packages/config/src/snapshots/ranges.test.ts
@@ -1,0 +1,73 @@
+import { expect } from 'earl'
+import { findRangeChanges, formatRange } from './ranges'
+
+describe(findRangeChanges.name, () => {
+  const identity = (id: string, since: number, until?: number) => ({
+    id,
+    label: `label ${id}`,
+    since,
+    until,
+  })
+
+  it('reports a changed since', () => {
+    expect(
+      findRangeChanges([identity('a', 100)], [identity('a', 120)]),
+    ).toEqual([
+      {
+        id: 'a',
+        label: 'label a',
+        old: { since: 100, until: undefined },
+        new: { since: 120, until: undefined },
+      },
+    ])
+  })
+
+  it('reports a range that got closed', () => {
+    expect(
+      findRangeChanges([identity('a', 100)], [identity('a', 100, 200)]),
+    ).toEqual([
+      {
+        id: 'a',
+        label: 'label a',
+        old: { since: 100, until: undefined },
+        new: { since: 100, until: 200 },
+      },
+    ])
+  })
+
+  it('reports a changed until', () => {
+    expect(
+      findRangeChanges([identity('a', 100, 200)], [identity('a', 100, 250)]),
+    ).toEqual([
+      {
+        id: 'a',
+        label: 'label a',
+        old: { since: 100, until: 200 },
+        new: { since: 100, until: 250 },
+      },
+    ])
+  })
+
+  it('ignores unchanged ranges and label-only changes', () => {
+    const committed = [identity('a', 100, 200), identity('b', 5)]
+    const current = [
+      { ...identity('a', 100, 200), label: 'renamed' },
+      identity('b', 5),
+    ]
+    expect(findRangeChanges(committed, current)).toEqual([])
+  })
+
+  it('ignores identities missing on either side', () => {
+    expect(findRangeChanges([identity('a', 1)], [identity('b', 2)])).toEqual([])
+  })
+})
+
+describe(formatRange.name, () => {
+  it('formats an open range', () => {
+    expect(formatRange({ since: 100 })).toEqual('100 -> open')
+  })
+
+  it('formats a closed range', () => {
+    expect(formatRange({ since: 100, until: 200 })).toEqual('100 -> 200')
+  })
+})

--- a/packages/config/src/snapshots/ranges.ts
+++ b/packages/config/src/snapshots/ranges.ts
@@ -1,9 +1,4 @@
-import type { SnapshotIdentity } from './types'
-
-export interface Range {
-  since: number
-  until?: number
-}
+import type { Range, SnapshotIdentity } from './types'
 
 export interface RangeChange {
   id: string

--- a/packages/config/src/snapshots/ranges.ts
+++ b/packages/config/src/snapshots/ranges.ts
@@ -1,0 +1,47 @@
+import type { SnapshotIdentity } from './types'
+
+export interface Range {
+  since: number
+  until?: number
+}
+
+export interface RangeChange {
+  id: string
+  /** Label as committed in the snapshot, i.e. the old one. */
+  label: string
+  old: Range
+  new: Range
+}
+
+/**
+ * Compares the ranges of identities present in both snapshots. Identities that
+ * only exist on one side are not reported here - the disappeared / not yet in
+ * the snapshot checks own those.
+ *
+ * A changed range is never harmless: the backend re-syncs the configuration
+ * from the new 'since' and drops everything indexed outside the new range.
+ */
+export function findRangeChanges(
+  committed: SnapshotIdentity[],
+  current: SnapshotIdentity[],
+): RangeChange[] {
+  const currentById = new Map(current.map((e) => [e.id, e]))
+  const changes: RangeChange[] = []
+  for (const old of committed) {
+    const now = currentById.get(old.id)
+    if (!now || (old.since === now.since && old.until === now.until)) {
+      continue
+    }
+    changes.push({
+      id: old.id,
+      label: old.label,
+      old: { since: old.since, until: old.until },
+      new: { since: now.since, until: now.until },
+    })
+  }
+  return changes
+}
+
+export function formatRange(range: Range): string {
+  return `${range.since} -> ${range.until ?? 'open'}`
+}

--- a/packages/config/src/snapshots/types.ts
+++ b/packages/config/src/snapshots/types.ts
@@ -1,16 +1,34 @@
 export interface SnapshotIdentity {
   id: string
   label: string
+  /**
+   * Start of the tracked range. Blocks or unix seconds depending on the
+   * config the identity was built from - the unit is implied by the config
+   * type, both sides of a comparison always come from the same config.
+   */
+  since: number
+  /**
+   * Last covered point, inclusive (it becomes the indexer's maxHeight).
+   * Absent means the range is still open.
+   */
+  until?: number
 }
 
 /** Project id -> identities, sorted by key and id for stable diffs. */
 export type Snapshot = Record<string, SnapshotIdentity[]>
 
+/** A config-level invariant violation, reported per project by the guard. */
+export interface ConfigViolation {
+  projectId: string
+  message: string
+}
+
 /**
  * A guarded family of backend configuration identities. The committed
- * snapshot pins every identity; the guard test fails when one disappears
- * or when the snapshot is stale, so identity changes are always an
- * explicit, reviewed decision (regenerate via 'pnpm snapshots:generate').
+ * snapshot pins every identity; the guard test fails when one disappears,
+ * when its range changed or when the snapshot is stale, so identity changes
+ * are always an explicit, reviewed decision (regenerate via
+ * 'pnpm snapshots:generate').
  */
 export interface SnapshotDomain {
   /** Kebab-case name used in CLI args and test titles, e.g. 'da-tracking' */
@@ -19,5 +37,17 @@ export interface SnapshotDomain {
   snapshotPath: string
   /** What the backend destroys when an identity disappears */
   wipeWarning: string
+  /**
+   * Multi-line, human-facing instructions for resolving a removed identity or
+   * a changed range without losing data. Must end with the "if you're an AI"
+   * guard-rail line - blind snapshot regeneration is the failure mode this
+   * whole guard exists to prevent.
+   */
+  freezeRecipe: string
   generate: () => Snapshot
+  /**
+   * Optional invariants checked against the runtime configs (not the
+   * snapshot file), e.g. coverage gaps between consecutive entries.
+   */
+  findConfigViolations?: () => ConfigViolation[]
 }

--- a/packages/config/src/snapshots/types.ts
+++ b/packages/config/src/snapshots/types.ts
@@ -1,9 +1,7 @@
-export interface SnapshotIdentity {
-  id: string
-  label: string
+export interface Range {
   /**
    * Start of the tracked range. Blocks or unix seconds depending on the
-   * config the identity was built from - the unit is implied by the config
+   * config the range was built from - the unit is implied by the config
    * type, both sides of a comparison always come from the same config.
    */
   since: number
@@ -12,6 +10,11 @@ export interface SnapshotIdentity {
    * Absent means the range is still open.
    */
   until?: number
+}
+
+export interface SnapshotIdentity extends Range {
+  id: string
+  label: string
 }
 
 /** Project id -> identities, sorted by key and id for stable diffs. */
@@ -38,12 +41,18 @@ export interface SnapshotDomain {
   /** What the backend destroys when an identity disappears */
   wipeWarning: string
   /**
-   * Multi-line, human-facing instructions for resolving a removed identity or
-   * a changed range without losing data. Must end with the "if you're an AI"
-   * guard-rail line - blind snapshot regeneration is the failure mode this
-   * whole guard exists to prevent.
+   * Multi-line, human-facing instructions for an identity that disappeared,
+   * i.e. a config whose identity fields changed and that must be frozen
+   * rather than edited in place.
    */
   freezeRecipe: string
+  /**
+   * Multi-line, human-facing instructions for a config whose identity is
+   * unchanged but whose range moved. Deliberately different from
+   * freezeRecipe: the id does not depend on the range, so "freeze and re-add"
+   * would produce two entries with the same id.
+   */
+  rangeChangeRecipe: string
   generate: () => Snapshot
   /**
    * Optional invariants checked against the runtime configs (not the


### PR DESCRIPTION
## Motivation

The daTracking snapshot guard only compared configuration **ids**, so a discovery-driven `sinceBlock`/`untilBlock` drift passed CI while the backend wiped that configuration's whole history on deploy (see #12434, #12464). Its error also invited the wrong fix — blindly regenerating the snapshot.

Part of the [daTracking config store](https://linear.app/l2beat/project/datracking-config-store-59c4257b58d0) project. Fixes L2B-14746.

## Changes

- **Ranges in the snapshot**: identities are now `{id, label, since, until?}` and the guard fails on any range change, printing `old -> new`. Snapshot regenerated (format only — same 203 identities across 166 projects).
- **No-gaps check**: per project + daLayer, a closed entry may not leave a hole before the next entry's `since`. Overlaps and trailing closed entries pass; adjacency rule is `next.since <= prev.until + 1` (superset of the existing `next.since === prev.until` handover convention — all current configs pass; `LEGACY_COVERAGE_GAPS` committed empty).
- **Freeze recipe**: disappeared-identity and range-change errors now walk through the correct resolution (freeze old entry to literals + `until`, add new entry starting where the old ended, then regenerate) and keep the "If you're an AI, don't address this error yourself" guard-rail. All guard messages extracted to pure, unit-tested builders.
- `docs/da-tracking.md` "Guarding against silent data wipes" rewritten; `diffSnapshot.ts` untouched behaviorally (structurally compatible, dropped in a later ticket).

## Testing

- `packages/config` suite: 23 971 passing (+166 range checks, +1 gap check, + unit tests for gaps/ranges/messages)
- Red-test verified: tampering a snapshot `since` fails with the old→new range and the full recipe
- Backend `diffSnapshots` tests and typecheck green; lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)