### PR TITLE
EigenDA indexers trim data instead of wiping on range edits (L2B-14742)

### DIFF
--- a/docs/da-tracking.md
+++ b/docs/da-tracking.md
@@ -83,3 +83,29 @@ accept it:
 cd packages/config
 pnpm snapshots:generate
 ```
+
+## Editing since/until of an EigenDA configuration
+
+The EigenDA indexers (`EigenDaLayerIndexer`, `EigenDaProjectsIndexer`) are
+timestamp based - their indexer heights ARE unix timestamps - and they implement
+`trimData`. Editing `sinceTimestamp` or `untilTimestamp` of an existing
+`eigen-da` entry (same configuration id) therefore trims the configuration's
+`DataAvailability` rows to the new range instead of wiping its whole history.
+Lowering `sinceTimestamp` still wipes and re-indexes, because gaps in downloaded
+data are not allowed.
+
+Rows are hourly buckets holding the data of the whole hour they start, so a
+bucket can straddle the edge of the new range. Only buckets lying ENTIRELY
+outside the retained range are deleted - **the straddling hour is KEPT**:
+
+- deleting it would leave a permanent hole, because after a trim the
+  configuration's `currentHeight` stays where it was and nothing would ever
+  re-index that hour,
+- keeping it cannot double count if the range is extended again later:
+  `DataAvailability` rows are upserted by overwriting `totalSize`, never by
+  accumulating it.
+
+The trim deletes only the range the indexer framework asks for, not everything
+outside the configuration range: `EigenDaProjectsIndexer` writes the rows of the
+previous day at every 02:00 height, so rows legitimately exist below
+`sinceTimestamp`.

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.test.ts
@@ -7,7 +7,10 @@ import type { TimestampDaIndexedConfig } from '../../../../config/Config'
 import { mockDatabase } from '../../../../test/database'
 import type { IndexerService } from '../../../../tools/uif/IndexerService'
 import { _TEST_ONLY_resetUniqueIds } from '../../../../tools/uif/ids'
-import type { Configuration } from '../../../../tools/uif/multi/types'
+import type {
+  Configuration,
+  SavedConfiguration,
+} from '../../../../tools/uif/multi/types'
 import { EigenDaLayerIndexer } from './EigenDaLayerIndexer'
 
 const DA_LAYER = 'eigen-da'
@@ -205,16 +208,261 @@ describe(EigenDaLayerIndexer.name, () => {
       ])
     })
   })
+
+  describe(EigenDaLayerIndexer.prototype.trimData.name, () => {
+    const START = UnixTime.fromDate(new Date('2022-01-01T00:00:00Z'))
+
+    it('deletes records before the new minHeight, keeping its bucket', async () => {
+      // minHeight is raised into the middle of the 05:00 bucket
+      const newMinHeight = START + 5 * UnixTime.HOUR + 30 * UnixTime.MINUTE
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, { minHeight: newMinHeight }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [START, newMinHeight - 1] },
+      ])
+
+      // the 05:00 bucket is kept - it holds the data of the whole hour and
+      // nothing would ever re-index it
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        START,
+        START + 5 * UnixTime.HOUR - 1,
+      )
+    })
+
+    it('deletes all records before an hour aligned minHeight', async () => {
+      const newMinHeight = START + 5 * UnixTime.HOUR
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, { minHeight: newMinHeight }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [START, newMinHeight - 1] },
+      ])
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenOnlyCalledWith(configurations[0].id, START, newMinHeight - 1)
+    })
+
+    it('does not delete anything when the trim stays within one bucket', async () => {
+      const newMinHeight = START + 30 * UnixTime.MINUTE
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, { minHeight: newMinHeight }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [START, newMinHeight - 1] },
+      ])
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).not.toHaveBeenCalled()
+    })
+
+    it('deletes records after the new maxHeight, keeping its bucket', async () => {
+      // maxHeight is lowered into the middle of the 10:00 bucket
+      const newMaxHeight = START + 10 * UnixTime.HOUR + 30 * UnixTime.MINUTE
+      const currentHeight = START + 20 * UnixTime.HOUR
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, {
+          minHeight: START,
+          maxHeight: newMaxHeight,
+        }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [newMaxHeight + 1, currentHeight] },
+      ])
+
+      // records are hour aligned, so the 10:00 bucket is not in the range
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        newMaxHeight + 1,
+        currentHeight,
+      )
+    })
+
+    it('trims every configuration', async () => {
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, {
+          minHeight: START + 5 * UnixTime.HOUR,
+        }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        {
+          id: configurations[0].id,
+          range: [START, START + 5 * UnixTime.HOUR - 1],
+        },
+        {
+          id: configurations[0].id,
+          range: [START + 30 * UnixTime.HOUR, START + 40 * UnixTime.HOUR],
+        },
+      ])
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('range edits', () => {
+    const START = UnixTime.fromDate(new Date('2022-01-01T00:00:00Z'))
+    const MAX_HEIGHT = START + 10 * UnixTime.HOUR + 30 * UnixTime.MINUTE
+    const CURRENT_HEIGHT = START + 20 * UnixTime.HOUR
+
+    it('trims instead of wiping when untilTimestamp is lowered', async () => {
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, {
+          minHeight: START,
+          maxHeight: MAX_HEIGHT,
+        }),
+      ]
+
+      const { indexer, repository, indexerService } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+        savedConfigurations: [
+          savedConfiguration(configurations[0], {
+            maxHeight: null,
+            currentHeight: CURRENT_HEIGHT,
+          }),
+        ],
+      })
+
+      const { safeHeight } = await indexer.initialize()
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        MAX_HEIGHT + 1,
+        CURRENT_HEIGHT,
+      )
+      expect(repository.deleteByConfigIds).not.toHaveBeenCalled()
+      expect(indexerService.upsertConfigurations).toHaveBeenCalledTimes(1)
+      expect(safeHeight).toEqual(MAX_HEIGHT)
+    })
+
+    it('wipes when sinceTimestamp is lowered - gaps are not allowed', async () => {
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, { minHeight: START }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+        savedConfigurations: [
+          {
+            ...savedConfiguration(configurations[0], {
+              currentHeight: CURRENT_HEIGHT,
+            }),
+            minHeight: START + 5 * UnixTime.HOUR,
+          },
+        ],
+      })
+
+      const { safeHeight } = await indexer.initialize()
+
+      expect(repository.deleteByConfigIds).toHaveBeenOnlyCalledWith([
+        configurations[0].id,
+      ])
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).not.toHaveBeenCalled()
+      expect(safeHeight).toEqual(START - 1)
+    })
+
+    it('does not double count when untilTimestamp is extended again', async () => {
+      const throughput = 1_000_000
+      const configurations = [
+        createConfiguration(DA_LAYER, DA_LAYER, { minHeight: START }),
+      ]
+
+      // the trim above left currentHeight at the (kept) 10:00 bucket
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+        throughput,
+        savedConfigurations: [
+          savedConfiguration(configurations[0], {
+            maxHeight: MAX_HEIGHT,
+            currentHeight: MAX_HEIGHT,
+          }),
+        ],
+      })
+
+      await indexer.initialize()
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).not.toHaveBeenCalled()
+      expect(repository.deleteByConfigIds).not.toHaveBeenCalled()
+
+      const updateCallback = await indexer.multiUpdate(
+        MAX_HEIGHT + 1,
+        CURRENT_HEIGHT,
+        configurations,
+      )
+      await updateCallback()
+
+      // the kept bucket is fetched for the whole hour again and upserted with
+      // an overwrite of totalSize, so its value does not accumulate
+      expect(repository.upsertMany).toHaveBeenOnlyCalledWith([
+        {
+          timestamp: START + 10 * UnixTime.HOUR,
+          totalSize: BigInt(throughput),
+          projectId: 'eigenda',
+          daLayer: DA_LAYER,
+          configurationId: configurations[0].id,
+        },
+      ])
+    })
+  })
 })
 
 function mockIndexer($: {
   configurations: Configuration<TimestampDaIndexedConfig>[]
   daLayer: string
   throughput?: number
+  savedConfigurations?: SavedConfiguration<string>[]
 }) {
   const repository = mockObject<Database['dataAvailability']>({
     deleteByConfigIds: mockFn().resolvesTo(10),
     deleteByConfigurationId: mockFn().resolvesTo(10),
+    deleteByConfigurationIdInTimeRange: mockFn().resolvesTo(10),
     upsertMany: mockFn().resolvesTo(undefined),
   })
 
@@ -229,7 +477,7 @@ function mockIndexer($: {
   })
 
   const indexerService = mockObject<IndexerService>({
-    getSavedConfigurations: mockFn().resolvesTo([]),
+    getSavedConfigurations: mockFn().resolvesTo($.savedConfigurations ?? []),
     insertConfigurations: mockFn().resolvesTo(undefined),
     upsertConfigurations: mockFn().resolvesTo(undefined),
     deleteConfigurations: mockFn().resolvesTo(undefined),
@@ -270,11 +518,12 @@ function mockIndexer($: {
 function createConfiguration(
   projectId: string,
   daLayer: string,
+  range?: { minHeight?: number; maxHeight?: number | null },
 ): Configuration<TimestampDaIndexedConfig> {
   return {
     id: `config-${projectId}`,
-    minHeight: 1640995200, // 2022-01-01 00:00:00 UTC
-    maxHeight: null,
+    minHeight: range?.minHeight ?? 1640995200, // 2022-01-01 00:00:00 UTC
+    maxHeight: range?.maxHeight ?? null,
     properties: {
       configurationId: `config-${projectId}`,
       projectId: ProjectId(projectId),
@@ -282,5 +531,21 @@ function createConfiguration(
       daLayer,
       sinceTimestamp: UnixTime.fromDate(new Date('2022-01-01T00:00:00Z')),
     },
+  }
+}
+
+function savedConfiguration(
+  configuration: Configuration<TimestampDaIndexedConfig>,
+  overrides: { maxHeight?: number | null; currentHeight: number },
+): SavedConfiguration<string> {
+  return {
+    id: configuration.id,
+    properties: JSON.stringify(configuration.properties),
+    minHeight: configuration.minHeight,
+    maxHeight:
+      overrides.maxHeight === undefined
+        ? configuration.maxHeight
+        : overrides.maxHeight,
+    currentHeight: overrides.currentHeight,
   }
 }

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.test.ts
@@ -4,8 +4,8 @@ import type { EigenApiClient } from '@l2beat/shared'
 import { ProjectId, UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
 import type { TimestampDaIndexedConfig } from '../../../../config/Config'
-import { mockDatabase } from '../../../../test/database'
-import type { IndexerService } from '../../../../tools/uif/IndexerService'
+import { describeDatabase, mockDatabase } from '../../../../test/database'
+import { IndexerService } from '../../../../tools/uif/IndexerService'
 import { _TEST_ONLY_resetUniqueIds } from '../../../../tools/uif/ids'
 import type {
   Configuration,
@@ -230,9 +230,7 @@ describe(EigenDaLayerIndexer.name, () => {
 
       // the 05:00 bucket is kept - it holds the data of the whole hour and
       // nothing would ever re-index it
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenOnlyCalledWith(
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
         configurations[0].id,
         START,
         START + 5 * UnixTime.HOUR - 1,
@@ -254,9 +252,11 @@ describe(EigenDaLayerIndexer.name, () => {
         { id: configurations[0].id, range: [START, newMinHeight - 1] },
       ])
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenOnlyCalledWith(configurations[0].id, START, newMinHeight - 1)
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        START,
+        newMinHeight - 1,
+      )
     })
 
     it('does not delete anything when the trim stays within one bucket', async () => {
@@ -274,9 +274,7 @@ describe(EigenDaLayerIndexer.name, () => {
         { id: configurations[0].id, range: [START, newMinHeight - 1] },
       ])
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).not.toHaveBeenCalled()
+      expect(repository.deleteByConfigInTimeRange).not.toHaveBeenCalled()
     })
 
     it('deletes records after the new maxHeight, keeping its bucket', async () => {
@@ -300,16 +298,14 @@ describe(EigenDaLayerIndexer.name, () => {
       ])
 
       // records are hour aligned, so the 10:00 bucket is not in the range
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenOnlyCalledWith(
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
         configurations[0].id,
         newMaxHeight + 1,
         currentHeight,
       )
     })
 
-    it('trims every configuration', async () => {
+    it('trims every requested range', async () => {
       const configurations = [
         createConfiguration(DA_LAYER, DA_LAYER, {
           minHeight: START + 5 * UnixTime.HOUR,
@@ -332,9 +328,7 @@ describe(EigenDaLayerIndexer.name, () => {
         },
       ])
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenCalledTimes(2)
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -364,9 +358,7 @@ describe(EigenDaLayerIndexer.name, () => {
 
       const { safeHeight } = await indexer.initialize()
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenOnlyCalledWith(
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
         configurations[0].id,
         MAX_HEIGHT + 1,
         CURRENT_HEIGHT,
@@ -399,9 +391,7 @@ describe(EigenDaLayerIndexer.name, () => {
       expect(repository.deleteByConfigIds).toHaveBeenOnlyCalledWith([
         configurations[0].id,
       ])
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).not.toHaveBeenCalled()
+      expect(repository.deleteByConfigInTimeRange).not.toHaveBeenCalled()
       expect(safeHeight).toEqual(START - 1)
     })
 
@@ -426,9 +416,7 @@ describe(EigenDaLayerIndexer.name, () => {
 
       await indexer.initialize()
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).not.toHaveBeenCalled()
+      expect(repository.deleteByConfigInTimeRange).not.toHaveBeenCalled()
       expect(repository.deleteByConfigIds).not.toHaveBeenCalled()
 
       const updateCallback = await indexer.multiUpdate(
@@ -462,7 +450,7 @@ function mockIndexer($: {
   const repository = mockObject<Database['dataAvailability']>({
     deleteByConfigIds: mockFn().resolvesTo(10),
     deleteByConfigurationId: mockFn().resolvesTo(10),
-    deleteByConfigurationIdInTimeRange: mockFn().resolvesTo(10),
+    deleteByConfigInTimeRange: mockFn().resolvesTo(10),
     upsertMany: mockFn().resolvesTo(undefined),
   })
 
@@ -549,3 +537,109 @@ function savedConfiguration(
     currentHeight: overrides.currentHeight,
   }
 }
+
+describeDatabase(`${EigenDaLayerIndexer.name} range edits`, (db) => {
+  const CONFIG_ID = 'eigenlayer01'
+  const OTHER_CONFIG_ID = 'eigenlayer02'
+  const INDEXER_ID = `eigenda_layer_indexer::${DA_LAYER}`
+  const START = UnixTime.fromDate(new Date('2025-09-01T00:00:00Z'))
+  // in the middle of the 10:00 bucket
+  const MAX_HEIGHT = START + 10 * UnixTime.HOUR + 30 * UnixTime.MINUTE
+  const CURRENT_HEIGHT = START + 20 * UnixTime.HOUR
+
+  beforeEach(() => {
+    _TEST_ONLY_resetUniqueIds()
+  })
+
+  afterEach(async () => {
+    _TEST_ONLY_resetUniqueIds()
+    await db.dataAvailability.deleteAll()
+    await db.indexerConfiguration.deleteAll()
+    await db.indexerState.deleteAll()
+  })
+
+  it('lowering untilTimestamp trims the rows instead of wiping them', async () => {
+    const indexerService = new IndexerService(db)
+    const configuration: Configuration<TimestampDaIndexedConfig> = {
+      id: CONFIG_ID,
+      minHeight: START,
+      maxHeight: MAX_HEIGHT,
+      properties: {
+        configurationId: CONFIG_ID,
+        projectId: ProjectId(DA_LAYER),
+        type: 'baseLayer' as const,
+        daLayer: DA_LAYER,
+        sinceTimestamp: START,
+      },
+    }
+
+    // the configuration as it was saved before untilTimestamp was set
+    await indexerService.upsertConfigurations(
+      INDEXER_ID,
+      [{ ...configuration, maxHeight: null, currentHeight: CURRENT_HEIGHT }],
+      (v) => JSON.stringify(v),
+    )
+
+    const indexedHours = []
+    for (let t = START; t < CURRENT_HEIGHT; t += UnixTime.HOUR) {
+      indexedHours.push(t)
+    }
+    await db.dataAvailability.upsertMany([
+      ...indexedHours.map((timestamp) => ({
+        timestamp,
+        totalSize: 100n,
+        projectId: DA_LAYER,
+        daLayer: DA_LAYER,
+        configurationId: CONFIG_ID,
+      })),
+      // another configuration must not be affected
+      ...indexedHours.map((timestamp) => ({
+        timestamp,
+        totalSize: 200n,
+        projectId: 'project-a',
+        daLayer: DA_LAYER,
+        configurationId: OTHER_CONFIG_ID,
+      })),
+    ])
+
+    const indexer = new EigenDaLayerIndexer(
+      {
+        daLayer: DA_LAYER,
+        eigenClient: mockObject<EigenApiClient>({}),
+        configurations: [configuration],
+        parents: [],
+        indexerService,
+        db,
+      },
+      Logger.SILENT,
+    )
+
+    const { safeHeight } = await indexer.initialize()
+
+    expect(safeHeight).toEqual(MAX_HEIGHT)
+
+    const records = await db.dataAvailability.getAll()
+
+    // the 10:00 bucket straddles the new untilTimestamp and is kept
+    expect(
+      records
+        .filter((r) => r.configurationId === CONFIG_ID)
+        .map((r) => r.timestamp)
+        .sort((a, b) => a - b),
+    ).toEqual(indexedHours.filter((t) => t <= START + 10 * UnixTime.HOUR))
+
+    expect(
+      records.filter((r) => r.configurationId === OTHER_CONFIG_ID).length,
+    ).toEqual(indexedHours.length)
+
+    expect(await indexerService.getSavedConfigurations(INDEXER_ID)).toEqual([
+      {
+        id: CONFIG_ID,
+        properties: JSON.stringify(configuration.properties),
+        minHeight: START,
+        maxHeight: MAX_HEIGHT,
+        currentHeight: MAX_HEIGHT,
+      },
+    ])
+  })
+})

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.ts
@@ -131,18 +131,7 @@ export class EigenDaLayerIndexer extends ManagedMultiIndexer<TimestampDaIndexedC
   override async trimData(
     configurations: TrimRemovalConfiguration[],
   ): Promise<void> {
-    const deletedRecords = await trimEigenDaData(
-      this.$.db,
-      this.$.configurations,
-      configurations,
-    )
-
-    if (deletedRecords > 0) {
-      this.logger.info('Trimmed DA records for configurations', {
-        configurations: configurations.length,
-        deletedRecords,
-      })
-    }
+    await trimEigenDaData(this.$, this.logger, configurations)
   }
 
   get daLayer() {

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaLayerIndexer.ts
@@ -9,8 +9,10 @@ import { ManagedMultiIndexer } from '../../../../tools/uif/multi/ManagedMultiInd
 import type {
   Configuration,
   ManagedMultiIndexerOptions,
+  TrimRemovalConfiguration,
   WipeRemovalConfiguration,
 } from '../../../../tools/uif/multi/types'
+import { trimEigenDaData } from './trimEigenDaData'
 
 export interface Dependencies
   extends Omit<
@@ -120,6 +122,23 @@ export class EigenDaLayerIndexer extends ManagedMultiIndexer<TimestampDaIndexedC
 
     if (deletedRecords > 0) {
       this.logger.info('Wiped DA records for configurations', {
+        configurations: configurations.length,
+        deletedRecords,
+      })
+    }
+  }
+
+  override async trimData(
+    configurations: TrimRemovalConfiguration[],
+  ): Promise<void> {
+    const deletedRecords = await trimEigenDaData(
+      this.$.db,
+      this.$.configurations,
+      configurations,
+    )
+
+    if (deletedRecords > 0) {
+      this.logger.info('Trimmed DA records for configurations', {
         configurations: configurations.length,
         deletedRecords,
       })

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.test.ts
@@ -386,12 +386,60 @@ describe(EigenDaProjectsIndexer.name, () => {
         { id: configurations[0].id, range: [START, newMinHeight - 1] },
       ])
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenOnlyCalledWith(
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
         configurations[0].id,
         START,
         START + 5 * UnixTime.HOUR - 1,
+      )
+    })
+
+    it('does not delete anything when the trim stays within one bucket', async () => {
+      const newMinHeight = START + 30 * UnixTime.MINUTE
+      const configurations = [
+        createConfiguration('project1', DA_LAYER, 'customer1', {
+          minHeight: newMinHeight,
+        }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [START, newMinHeight - 1] },
+      ])
+
+      expect(repository.deleteByConfigInTimeRange).not.toHaveBeenCalled()
+    })
+
+    it('spares the previous day records written below minHeight', async () => {
+      // this indexer writes the records of the previous day at every 02:00
+      // height, so records below minHeight are legitimate and nothing would
+      // ever recreate them - only what the framework asks for is deleted
+      const oldMinHeight = UnixTime.fromDate(new Date('2025-09-01T00:00:00Z'))
+      const newMinHeight = UnixTime.fromDate(new Date('2025-09-10T00:00:00Z'))
+      const configurations = [
+        createConfiguration('project1', DA_LAYER, 'customer1', {
+          minHeight: newMinHeight,
+        }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [oldMinHeight, newMinHeight - 1] },
+      ])
+
+      // the records of 2025-08-31, written by the first 02:00 update of the
+      // configuration, are below the trimmed range and stay
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        oldMinHeight,
+        newMinHeight - 1,
       )
     })
 
@@ -414,9 +462,7 @@ describe(EigenDaProjectsIndexer.name, () => {
         { id: configurations[0].id, range: [newMaxHeight + 1, currentHeight] },
       ])
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenOnlyCalledWith(
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
         configurations[0].id,
         newMaxHeight + 1,
         currentHeight,
@@ -450,9 +496,7 @@ describe(EigenDaProjectsIndexer.name, () => {
 
       const { safeHeight } = await indexer.initialize()
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).toHaveBeenOnlyCalledWith(
+      expect(repository.deleteByConfigInTimeRange).toHaveBeenOnlyCalledWith(
         configurations[0].id,
         MAX_HEIGHT + 1,
         CURRENT_HEIGHT,
@@ -460,6 +504,35 @@ describe(EigenDaProjectsIndexer.name, () => {
       expect(repository.deleteByConfigIds).not.toHaveBeenCalled()
       expect(indexerService.upsertConfigurations).toHaveBeenCalledTimes(1)
       expect(safeHeight).toEqual(MAX_HEIGHT)
+    })
+
+    it('wipes when sinceTimestamp is lowered - gaps are not allowed', async () => {
+      const configurations = [
+        createConfiguration('project1', DA_LAYER, 'customer1', {
+          minHeight: START,
+        }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+        savedConfigurations: [
+          {
+            ...savedConfiguration(configurations[0], {
+              currentHeight: CURRENT_HEIGHT,
+            }),
+            minHeight: START + UnixTime.DAY,
+          },
+        ],
+      })
+
+      const { safeHeight } = await indexer.initialize()
+
+      expect(repository.deleteByConfigIds).toHaveBeenOnlyCalledWith([
+        configurations[0].id,
+      ])
+      expect(repository.deleteByConfigInTimeRange).not.toHaveBeenCalled()
+      expect(safeHeight).toEqual(START - 1)
     })
 
     it('does not double count when untilTimestamp is extended again', async () => {
@@ -497,9 +570,7 @@ describe(EigenDaProjectsIndexer.name, () => {
 
       await indexer.initialize()
 
-      expect(
-        repository.deleteByConfigurationIdInTimeRange,
-      ).not.toHaveBeenCalled()
+      expect(repository.deleteByConfigInTimeRange).not.toHaveBeenCalled()
       expect(repository.deleteByConfigIds).not.toHaveBeenCalled()
 
       // the whole day of the kept bucket is fetched again at 02:00 of the next
@@ -546,7 +617,7 @@ function mockIndexer($: {
   const repository = mockObject<Database['dataAvailability']>({
     deleteByConfigIds: mockFn().resolvesTo(10),
     deleteByConfigurationId: mockFn().resolvesTo(10),
-    deleteByConfigurationIdInTimeRange: mockFn().resolvesTo(10),
+    deleteByConfigInTimeRange: mockFn().resolvesTo(10),
     upsertMany: mockFn().resolvesTo(undefined),
   })
 

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.test.ts
@@ -7,7 +7,10 @@ import type { TimestampDaIndexedConfig } from '../../../../config/Config'
 import { mockDatabase } from '../../../../test/database'
 import type { IndexerService } from '../../../../tools/uif/IndexerService'
 import { _TEST_ONLY_resetUniqueIds } from '../../../../tools/uif/ids'
-import type { Configuration } from '../../../../tools/uif/multi/types'
+import type {
+  Configuration,
+  SavedConfiguration,
+} from '../../../../tools/uif/multi/types'
 import { EigenDaProjectsIndexer } from './EigenDaProjectsIndexer'
 
 const DA_LAYER = 'eigen-da'
@@ -361,6 +364,173 @@ describe(EigenDaProjectsIndexer.name, () => {
       ])
     })
   })
+
+  describe(EigenDaProjectsIndexer.prototype.trimData.name, () => {
+    const START = UnixTime.fromDate(new Date('2025-09-01T00:00:00Z'))
+
+    it('deletes records before the new minHeight, keeping its bucket', async () => {
+      // minHeight is raised into the middle of the 05:00 bucket
+      const newMinHeight = START + 5 * UnixTime.HOUR + 30 * UnixTime.MINUTE
+      const configurations = [
+        createConfiguration('project1', DA_LAYER, 'customer1', {
+          minHeight: newMinHeight,
+        }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [START, newMinHeight - 1] },
+      ])
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        START,
+        START + 5 * UnixTime.HOUR - 1,
+      )
+    })
+
+    it('deletes records after the new maxHeight, keeping its bucket', async () => {
+      const newMaxHeight = START + 10 * UnixTime.HOUR + 30 * UnixTime.MINUTE
+      const currentHeight = START + 5 * UnixTime.DAY
+      const configurations = [
+        createConfiguration('project1', DA_LAYER, 'customer1', {
+          minHeight: START,
+          maxHeight: newMaxHeight,
+        }),
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+      })
+
+      await indexer.trimData([
+        { id: configurations[0].id, range: [newMaxHeight + 1, currentHeight] },
+      ])
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        newMaxHeight + 1,
+        currentHeight,
+      )
+    })
+  })
+
+  describe('range edits', () => {
+    const START = UnixTime.fromDate(new Date('2025-09-01T00:00:00Z'))
+    const MAX_HEIGHT = UnixTime.fromDate(new Date('2025-09-05T12:30:00Z'))
+    const CURRENT_HEIGHT = UnixTime.fromDate(new Date('2025-09-10T02:00:00Z'))
+
+    it('trims instead of wiping when untilTimestamp is lowered', async () => {
+      const configurations = [
+        createConfiguration('project1', DA_LAYER, 'customer1', {
+          minHeight: START,
+          maxHeight: MAX_HEIGHT,
+        }),
+      ]
+
+      const { indexer, repository, indexerService } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+        savedConfigurations: [
+          savedConfiguration(configurations[0], {
+            maxHeight: null,
+            currentHeight: CURRENT_HEIGHT,
+          }),
+        ],
+      })
+
+      const { safeHeight } = await indexer.initialize()
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).toHaveBeenOnlyCalledWith(
+        configurations[0].id,
+        MAX_HEIGHT + 1,
+        CURRENT_HEIGHT,
+      )
+      expect(repository.deleteByConfigIds).not.toHaveBeenCalled()
+      expect(indexerService.upsertConfigurations).toHaveBeenCalledTimes(1)
+      expect(safeHeight).toEqual(MAX_HEIGHT)
+    })
+
+    it('does not double count when untilTimestamp is extended again', async () => {
+      const configurations = [
+        createConfiguration('project1', DA_LAYER, 'customer1', {
+          minHeight: START,
+        }),
+      ]
+      // the kept bucket of the trim above and the hour right after it
+      const keptBucket = UnixTime.fromDate(new Date('2025-09-05T12:00:00Z'))
+      const projectData = [
+        {
+          customer_id: 'customer1',
+          datetime: keptBucket,
+          total_size_mb: 100,
+        },
+        {
+          customer_id: 'customer1',
+          datetime: keptBucket + UnixTime.HOUR,
+          total_size_mb: 200,
+        },
+      ]
+
+      const { indexer, repository } = mockIndexer({
+        configurations,
+        daLayer: DA_LAYER,
+        projectData,
+        savedConfigurations: [
+          savedConfiguration(configurations[0], {
+            maxHeight: MAX_HEIGHT,
+            currentHeight: MAX_HEIGHT,
+          }),
+        ],
+      })
+
+      await indexer.initialize()
+
+      expect(
+        repository.deleteByConfigurationIdInTimeRange,
+      ).not.toHaveBeenCalled()
+      expect(repository.deleteByConfigIds).not.toHaveBeenCalled()
+
+      // the whole day of the kept bucket is fetched again at 02:00 of the next
+      // day and upserted with an overwrite of totalSize, so its value does not
+      // accumulate
+      const from = UnixTime.fromDate(new Date('2025-09-06T01:00:00Z'))
+      const updateCallback = await indexer.multiUpdate(
+        from,
+        from + 30 * UnixTime.HOUR,
+        configurations,
+      )
+      await updateCallback()
+
+      expect(repository.upsertMany).toHaveBeenOnlyCalledWith([
+        {
+          timestamp: keptBucket,
+          totalSize: BigInt(Math.round(100 * 1024 * 1024)),
+          projectId: configurations[0].properties.projectId,
+          daLayer: DA_LAYER,
+          configurationId: configurations[0].id,
+        },
+        {
+          timestamp: keptBucket + UnixTime.HOUR,
+          totalSize: BigInt(Math.round(200 * 1024 * 1024)),
+          projectId: configurations[0].properties.projectId,
+          daLayer: DA_LAYER,
+          configurationId: configurations[0].id,
+        },
+      ])
+    })
+  })
 })
 
 function mockIndexer($: {
@@ -371,10 +541,12 @@ function mockIndexer($: {
     datetime: number
     total_size_mb: number
   }[]
+  savedConfigurations?: SavedConfiguration<string>[]
 }) {
   const repository = mockObject<Database['dataAvailability']>({
     deleteByConfigIds: mockFn().resolvesTo(10),
     deleteByConfigurationId: mockFn().resolvesTo(10),
+    deleteByConfigurationIdInTimeRange: mockFn().resolvesTo(10),
     upsertMany: mockFn().resolvesTo(undefined),
   })
 
@@ -387,7 +559,7 @@ function mockIndexer($: {
   })
 
   const indexerService = mockObject<IndexerService>({
-    getSavedConfigurations: mockFn().resolvesTo([]),
+    getSavedConfigurations: mockFn().resolvesTo($.savedConfigurations ?? []),
     insertConfigurations: mockFn().resolvesTo(undefined),
     upsertConfigurations: mockFn().resolvesTo(undefined),
     deleteConfigurations: mockFn().resolvesTo(undefined),
@@ -429,11 +601,12 @@ function createConfiguration(
   projectId: string,
   daLayer: string,
   customerId?: string,
+  range?: { minHeight?: number; maxHeight?: number | null },
 ): Configuration<TimestampDaIndexedConfig> {
   return {
     id: `config-${projectId}`,
-    minHeight: 1640995200, // 2022-01-01 00:00:00 UTC
-    maxHeight: null,
+    minHeight: range?.minHeight ?? 1640995200, // 2022-01-01 00:00:00 UTC
+    maxHeight: range?.maxHeight ?? null,
     properties: {
       configurationId: `config-${projectId}`,
       projectId: ProjectId(projectId),
@@ -442,5 +615,21 @@ function createConfiguration(
       sinceTimestamp: UnixTime.fromDate(new Date('2022-01-01T00:00:00Z')),
       customerId: customerId ?? 'default-customer',
     },
+  }
+}
+
+function savedConfiguration(
+  configuration: Configuration<TimestampDaIndexedConfig>,
+  overrides: { maxHeight?: number | null; currentHeight: number },
+): SavedConfiguration<string> {
+  return {
+    id: configuration.id,
+    properties: JSON.stringify(configuration.properties),
+    minHeight: configuration.minHeight,
+    maxHeight:
+      overrides.maxHeight === undefined
+        ? configuration.maxHeight
+        : overrides.maxHeight,
+    currentHeight: overrides.currentHeight,
   }
 }

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.ts
@@ -8,9 +8,11 @@ import { ManagedMultiIndexer } from '../../../../tools/uif/multi/ManagedMultiInd
 import type {
   Configuration,
   ManagedMultiIndexerOptions,
+  TrimRemovalConfiguration,
   WipeRemovalConfiguration,
 } from '../../../../tools/uif/multi/types'
 import { mapEigenProjectData } from './mapEigenProjectData'
+import { trimEigenDaData } from './trimEigenDaData'
 
 export interface Dependencies
   extends Omit<
@@ -133,6 +135,23 @@ export class EigenDaProjectsIndexer extends ManagedMultiIndexer<TimestampDaIndex
 
     if (deletedRecords > 0) {
       this.logger.info('Wiped DA records for configurations', {
+        configurations: configurations.length,
+        deletedRecords,
+      })
+    }
+  }
+
+  override async trimData(
+    configurations: TrimRemovalConfiguration[],
+  ): Promise<void> {
+    const deletedRecords = await trimEigenDaData(
+      this.$.db,
+      this.$.configurations,
+      configurations,
+    )
+
+    if (deletedRecords > 0) {
+      this.logger.info('Trimmed DA records for configurations', {
         configurations: configurations.length,
         deletedRecords,
       })

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/EigenDaProjectsIndexer.ts
@@ -144,18 +144,7 @@ export class EigenDaProjectsIndexer extends ManagedMultiIndexer<TimestampDaIndex
   override async trimData(
     configurations: TrimRemovalConfiguration[],
   ): Promise<void> {
-    const deletedRecords = await trimEigenDaData(
-      this.$.db,
-      this.$.configurations,
-      configurations,
-    )
-
-    if (deletedRecords > 0) {
-      this.logger.info('Trimmed DA records for configurations', {
-        configurations: configurations.length,
-        deletedRecords,
-      })
-    }
+    await trimEigenDaData(this.$, this.logger, configurations)
   }
 
   get daLayer() {

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/trimEigenDaData.test.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/trimEigenDaData.test.ts
@@ -1,0 +1,69 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { getEigenDaTrimRange } from './trimEigenDaData'
+
+const HOUR = UnixTime.HOUR
+const START = UnixTime.fromDate(new Date('2025-09-01T00:00:00Z'))
+
+describe(getEigenDaTrimRange.name, () => {
+  describe('head trim', () => {
+    it('keeps the bucket containing a mid-hour minHeight', () => {
+      const minHeight = START + 5 * HOUR + 30 * UnixTime.MINUTE
+
+      expect(getEigenDaTrimRange([START, minHeight - 1], minHeight)).toEqual([
+        START,
+        START + 5 * HOUR - 1,
+      ])
+    })
+
+    it('deletes every bucket before an hour aligned minHeight', () => {
+      const minHeight = START + 5 * HOUR
+
+      expect(getEigenDaTrimRange([START, minHeight - 1], minHeight)).toEqual([
+        START,
+        minHeight - 1,
+      ])
+    })
+
+    it('returns an empty range when the trim stays within one bucket', () => {
+      const minHeight = START + 30 * UnixTime.MINUTE
+
+      const [from, to] = getEigenDaTrimRange([START, minHeight - 1], minHeight)
+      expect(to < from).toEqual(true)
+    })
+  })
+
+  describe('tail trim', () => {
+    it('keeps the bucket containing a mid-hour maxHeight', () => {
+      const minHeight = START
+      const maxHeight = START + 5 * HOUR + 30 * UnixTime.MINUTE
+      const currentHeight = START + 20 * HOUR
+
+      // records are hour aligned, so the bucket containing maxHeight
+      // (START + 5 * HOUR) is already below the range
+      expect(
+        getEigenDaTrimRange([maxHeight + 1, currentHeight], minHeight),
+      ).toEqual([maxHeight + 1, currentHeight])
+    })
+
+    it('keeps the bucket starting exactly at maxHeight', () => {
+      const minHeight = START
+      const maxHeight = START + 5 * HOUR
+      const currentHeight = START + 20 * HOUR
+
+      expect(
+        getEigenDaTrimRange([maxHeight + 1, currentHeight], minHeight),
+      ).toEqual([maxHeight + 1, currentHeight])
+    })
+
+    it('is not clamped to the bucket of a mid-hour minHeight', () => {
+      const minHeight = START + 30 * UnixTime.MINUTE
+      const maxHeight = START + 5 * HOUR
+      const currentHeight = START + 20 * HOUR
+
+      expect(
+        getEigenDaTrimRange([maxHeight + 1, currentHeight], minHeight),
+      ).toEqual([maxHeight + 1, currentHeight])
+    })
+  })
+})

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/trimEigenDaData.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/trimEigenDaData.ts
@@ -1,0 +1,77 @@
+import type { Database } from '@l2beat/database'
+import { assert, UnixTime } from '@l2beat/shared-pure'
+import type {
+  Configuration,
+  TrimRemovalConfiguration,
+} from '../../../../tools/uif/multi/types'
+
+/**
+ * Returns the range of record timestamps to delete for a trim of `range`.
+ *
+ * The EigenDA indexers are timestamp based - their UIF heights ARE unix
+ * timestamps - and every record is an hourly bucket that holds the data of the
+ * whole hour it starts. A bucket can therefore straddle the edge of the trimmed
+ * range, so we only delete buckets that lie ENTIRELY outside the retained range:
+ *
+ * - head trim (minHeight raised): the bucket containing the new minHeight is
+ *   kept. After a trim `currentHeight` stays where it was, so no update would
+ *   ever fill that hour again and deleting it would leave a permanent hole in
+ *   the middle of the retained data. The bucket also holds the value of the
+ *   whole hour (the API is always queried for a full hour), so it is not a
+ *   partial value.
+ * - tail trim (maxHeight lowered): needs no adjustment. Records are hour
+ *   aligned and the trim starts at `maxHeight + 1`, which already keeps the
+ *   bucket containing maxHeight.
+ *
+ * Keeping the boundary buckets cannot lead to double counting when the range is
+ * extended again later: the indexer resumes at `currentHeight + 1`, re-fetches
+ * the full hour and the records are upserted by overwriting `totalSize`
+ * (`DataAvailabilityRepository.upsertMany`), never by accumulating it.
+ */
+export function getEigenDaTrimRange(
+  range: [number, number],
+  minHeight: number,
+): [number, number] {
+  const [from, to] = range
+  const boundaryBucket = UnixTime.toStartOf(minHeight, 'hour')
+  // Only a trim of the head of the range can contain the boundary bucket,
+  // for a tail trim `boundaryBucket <= minHeight <= maxHeight < from`.
+  return boundaryBucket >= from
+    ? [from, Math.min(to, boundaryBucket - 1)]
+    : [from, to]
+}
+
+export async function trimEigenDaData<T>(
+  db: Database,
+  indexerConfigurations: Configuration<T>[],
+  toTrim: TrimRemovalConfiguration[],
+): Promise<number> {
+  let deletedRecords = 0
+
+  for (const configuration of toTrim) {
+    const indexerConfiguration = indexerConfigurations.find(
+      (c) => c.id === configuration.id,
+    )
+    assert(
+      indexerConfiguration,
+      `Configuration ${configuration.id} not found among indexer configurations`,
+    )
+
+    const [from, to] = getEigenDaTrimRange(
+      configuration.range,
+      indexerConfiguration.minHeight,
+    )
+    if (to < from) {
+      continue
+    }
+
+    deletedRecords +=
+      await db.dataAvailability.deleteByConfigurationIdInTimeRange(
+        configuration.id,
+        from,
+        to,
+      )
+  }
+
+  return deletedRecords
+}

--- a/packages/backend/src/modules/data-availability/indexers/eigen-da/trimEigenDaData.ts
+++ b/packages/backend/src/modules/data-availability/indexers/eigen-da/trimEigenDaData.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@l2beat/backend-tools'
 import type { Database } from '@l2beat/database'
 import { assert, UnixTime } from '@l2beat/shared-pure'
 import type {
@@ -13,65 +14,71 @@ import type {
  * whole hour it starts. A bucket can therefore straddle the edge of the trimmed
  * range, so we only delete buckets that lie ENTIRELY outside the retained range:
  *
- * - head trim (minHeight raised): the bucket containing the new minHeight is
- *   kept. After a trim `currentHeight` stays where it was, so no update would
- *   ever fill that hour again and deleting it would leave a permanent hole in
- *   the middle of the retained data. The bucket also holds the value of the
- *   whole hour (the API is always queried for a full hour), so it is not a
- *   partial value.
- * - tail trim (maxHeight lowered): needs no adjustment. Records are hour
- *   aligned and the trim starts at `maxHeight + 1`, which already keeps the
- *   bucket containing maxHeight.
+ * - head trim (minHeight raised, `[oldMinHeight, newMinHeight - 1]`): the bucket
+ *   containing the new minHeight is kept. After a trim `currentHeight` stays
+ *   where it was, so no update would ever fill that hour again and deleting it
+ *   would leave a permanent hole in the middle of the retained data. The bucket
+ *   also holds the value of the whole hour (the API is always queried for a
+ *   full hour), so it is not a partial value.
+ * - tail trim (maxHeight lowered, `[newMaxHeight + 1, currentHeight]`): needs no
+ *   adjustment. Records are hour aligned and the range starts at maxHeight + 1,
+ *   which already keeps the bucket containing maxHeight.
  *
  * Keeping the boundary buckets cannot lead to double counting when the range is
  * extended again later: the indexer resumes at `currentHeight + 1`, re-fetches
  * the full hour and the records are upserted by overwriting `totalSize`
  * (`DataAvailabilityRepository.upsertMany`), never by accumulating it.
+ *
+ * We delete only what the framework asks for instead of everything outside the
+ * configuration range on purpose: `EigenDaProjectsIndexer` writes the records of
+ * the PREVIOUS day at every 02:00 height, so records legitimately exist below
+ * minHeight and nothing would ever recreate them.
  */
 export function getEigenDaTrimRange(
   range: [number, number],
   minHeight: number,
 ): [number, number] {
   const [from, to] = range
-  const boundaryBucket = UnixTime.toStartOf(minHeight, 'hour')
-  // Only a trim of the head of the range can contain the boundary bucket,
-  // for a tail trim `boundaryBucket <= minHeight <= maxHeight < from`.
-  return boundaryBucket >= from
-    ? [from, Math.min(to, boundaryBucket - 1)]
-    : [from, to]
+  // mergeConfigurations only asks to trim the head of the range (entirely below
+  // the new minHeight) or its tail (entirely above the new maxHeight, which it
+  // asserts is not lower than minHeight)
+  const isHeadTrim = to < minHeight
+  if (!isHeadTrim) {
+    return [from, to]
+  }
+  return [from, UnixTime.toStartOf(minHeight, 'hour') - 1]
 }
 
 export async function trimEigenDaData<T>(
-  db: Database,
-  indexerConfigurations: Configuration<T>[],
+  $: { db: Database; configurations: Configuration<T>[] },
+  logger: Logger,
   toTrim: TrimRemovalConfiguration[],
-): Promise<number> {
+): Promise<void> {
+  const configurations = new Map($.configurations.map((c) => [c.id, c]))
+
   let deletedRecords = 0
+  for (const trim of toTrim) {
+    // mergeConfigurations only trims configurations the indexer was
+    // constructed with
+    const configuration = configurations.get(trim.id)
+    assert(configuration, `Configuration ${trim.id} not found`)
 
-  for (const configuration of toTrim) {
-    const indexerConfiguration = indexerConfigurations.find(
-      (c) => c.id === configuration.id,
-    )
-    assert(
-      indexerConfiguration,
-      `Configuration ${configuration.id} not found among indexer configurations`,
-    )
-
-    const [from, to] = getEigenDaTrimRange(
-      configuration.range,
-      indexerConfiguration.minHeight,
-    )
+    const [from, to] = getEigenDaTrimRange(trim.range, configuration.minHeight)
     if (to < from) {
       continue
     }
 
-    deletedRecords +=
-      await db.dataAvailability.deleteByConfigurationIdInTimeRange(
-        configuration.id,
-        from,
-        to,
-      )
+    deletedRecords += await $.db.dataAvailability.deleteByConfigInTimeRange(
+      trim.id,
+      from,
+      to,
+    )
   }
 
-  return deletedRecords
+  if (deletedRecords > 0) {
+    logger.info('Trimmed DA records for configurations', {
+      configurations: toTrim.length,
+      deletedRecords,
+    })
+  }
 }

--- a/packages/database/src/repositories/DataAvailabilityRepository.test.ts
+++ b/packages/database/src/repositories/DataAvailabilityRepository.test.ts
@@ -714,6 +714,81 @@ describeDatabase(DataAvailabilityRepository.name, (db) => {
   )
 
   describe(
+    DataAvailabilityRepository.prototype.deleteByConfigurationIdInTimeRange
+      .name,
+    () => {
+      const HOUR_0 = UnixTime.toStartOf(UnixTime.now(), 'day')
+      const HOUR_1 = HOUR_0 + UnixTime.HOUR
+      const HOUR_2 = HOUR_0 + 2 * UnixTime.HOUR
+      const HOUR_3 = HOUR_0 + 3 * UnixTime.HOUR
+
+      it('deletes only rows of the configuration inside the range', async () => {
+        await repository.upsertMany([
+          record('project-a', 'layer-a', 'config-id-1', HOUR_0, 100n),
+          record('project-a', 'layer-a', 'config-id-1', HOUR_1, 200n),
+          record('project-a', 'layer-a', 'config-id-1', HOUR_2, 300n),
+          record('project-a', 'layer-a', 'config-id-1', HOUR_3, 400n),
+          record('project-b', 'layer-a', 'config-id-2', HOUR_1, 500n),
+          record('project-b', 'layer-a', 'config-id-2', HOUR_2, 600n),
+        ])
+
+        const deletedCount =
+          await repository.deleteByConfigurationIdInTimeRange(
+            'config-id-1',
+            HOUR_1,
+            HOUR_2,
+          )
+
+        expect(deletedCount).toEqual(2)
+
+        const remainingRecords = await repository.getAll()
+        expect(remainingRecords).toEqualUnsorted([
+          record('project-a', 'layer-a', 'config-id-1', HOUR_0, 100n),
+          record('project-a', 'layer-a', 'config-id-1', HOUR_3, 400n),
+          record('project-b', 'layer-a', 'config-id-2', HOUR_1, 500n),
+          record('project-b', 'layer-a', 'config-id-2', HOUR_2, 600n),
+        ])
+      })
+
+      it('the range is inclusive on both ends', async () => {
+        await repository.upsertMany([
+          record('project-a', 'layer-a', 'config-id-1', HOUR_0, 100n),
+          record('project-a', 'layer-a', 'config-id-1', HOUR_1, 200n),
+          record('project-a', 'layer-a', 'config-id-1', HOUR_2, 300n),
+        ])
+
+        const deletedCount =
+          await repository.deleteByConfigurationIdInTimeRange(
+            'config-id-1',
+            HOUR_0,
+            HOUR_2,
+          )
+
+        expect(deletedCount).toEqual(3)
+        expect(await repository.getAll()).toEqual([])
+      })
+
+      it('returns 0 for an empty range', async () => {
+        await repository.upsertMany([
+          record('project-a', 'layer-a', 'config-id-1', HOUR_1, 200n),
+        ])
+
+        const deletedCount =
+          await repository.deleteByConfigurationIdInTimeRange(
+            'config-id-1',
+            HOUR_2,
+            HOUR_1,
+          )
+
+        expect(deletedCount).toEqual(0)
+        expect(await repository.getAll()).toEqualUnsorted([
+          record('project-a', 'layer-a', 'config-id-1', HOUR_1, 200n),
+        ])
+      })
+    },
+  )
+
+  describe(
     DataAvailabilityRepository.prototype.getLatestTimestampsByConfigId.name,
     () => {
       it('returns latest timestamp for each configuration ID', async () => {

--- a/packages/database/src/repositories/DataAvailabilityRepository.test.ts
+++ b/packages/database/src/repositories/DataAvailabilityRepository.test.ts
@@ -714,8 +714,7 @@ describeDatabase(DataAvailabilityRepository.name, (db) => {
   )
 
   describe(
-    DataAvailabilityRepository.prototype.deleteByConfigurationIdInTimeRange
-      .name,
+    DataAvailabilityRepository.prototype.deleteByConfigInTimeRange.name,
     () => {
       const HOUR_0 = UnixTime.toStartOf(UnixTime.now(), 'day')
       const HOUR_1 = HOUR_0 + UnixTime.HOUR
@@ -732,12 +731,11 @@ describeDatabase(DataAvailabilityRepository.name, (db) => {
           record('project-b', 'layer-a', 'config-id-2', HOUR_2, 600n),
         ])
 
-        const deletedCount =
-          await repository.deleteByConfigurationIdInTimeRange(
-            'config-id-1',
-            HOUR_1,
-            HOUR_2,
-          )
+        const deletedCount = await repository.deleteByConfigInTimeRange(
+          'config-id-1',
+          HOUR_1,
+          HOUR_2,
+        )
 
         expect(deletedCount).toEqual(2)
 
@@ -757,12 +755,11 @@ describeDatabase(DataAvailabilityRepository.name, (db) => {
           record('project-a', 'layer-a', 'config-id-1', HOUR_2, 300n),
         ])
 
-        const deletedCount =
-          await repository.deleteByConfigurationIdInTimeRange(
-            'config-id-1',
-            HOUR_0,
-            HOUR_2,
-          )
+        const deletedCount = await repository.deleteByConfigInTimeRange(
+          'config-id-1',
+          HOUR_0,
+          HOUR_2,
+        )
 
         expect(deletedCount).toEqual(3)
         expect(await repository.getAll()).toEqual([])
@@ -773,12 +770,11 @@ describeDatabase(DataAvailabilityRepository.name, (db) => {
           record('project-a', 'layer-a', 'config-id-1', HOUR_1, 200n),
         ])
 
-        const deletedCount =
-          await repository.deleteByConfigurationIdInTimeRange(
-            'config-id-1',
-            HOUR_2,
-            HOUR_1,
-          )
+        const deletedCount = await repository.deleteByConfigInTimeRange(
+          'config-id-1',
+          HOUR_2,
+          HOUR_1,
+        )
 
         expect(deletedCount).toEqual(0)
         expect(await repository.getAll()).toEqualUnsorted([

--- a/packages/database/src/repositories/DataAvailabilityRepository.ts
+++ b/packages/database/src/repositories/DataAvailabilityRepository.ts
@@ -262,12 +262,11 @@ export class DataAvailabilityRepository extends BaseRepository {
     return Number(result.numDeletedRows)
   }
 
-  async deleteByConfigurationIdInTimeRange(
+  async deleteByConfigInTimeRange(
     configurationId: string,
     fromInclusive: UnixTime,
     toInclusive: UnixTime,
   ): Promise<number> {
-    if (toInclusive < fromInclusive) return 0
     const result = await this.db
       .deleteFrom('DataAvailability')
       .where('configurationId', '=', configurationId)

--- a/packages/database/src/repositories/DataAvailabilityRepository.ts
+++ b/packages/database/src/repositories/DataAvailabilityRepository.ts
@@ -262,6 +262,21 @@ export class DataAvailabilityRepository extends BaseRepository {
     return Number(result.numDeletedRows)
   }
 
+  async deleteByConfigurationIdInTimeRange(
+    configurationId: string,
+    fromInclusive: UnixTime,
+    toInclusive: UnixTime,
+  ): Promise<number> {
+    if (toInclusive < fromInclusive) return 0
+    const result = await this.db
+      .deleteFrom('DataAvailability')
+      .where('configurationId', '=', configurationId)
+      .where('timestamp', '>=', UnixTime.toDate(fromInclusive))
+      .where('timestamp', '<=', UnixTime.toDate(toInclusive))
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
   async getMaxHistoricalRecordByDaLayer(
     daLayers: string[],
   ): Promise<DataAvailabilityRecord[]> {


### PR DESCRIPTION
## Motivation

Same failure mode as #12615, for the timestamp-based EigenDA indexers: without a `trimData` implementation, any `sinceTimestamp`/`untilTimestamp` edit on an `eigen-da` daTracking configuration made the multi-indexer merge wipe that configuration's entire history.

Part of the [daTracking config store](https://linear.app/l2beat/project/datracking-config-store-59c4257b58d0) project. Fixes L2B-14742.

## Changes

- `trimData` on both `EigenDaLayerIndexer` and `EigenDaProjectsIndexer` via a shared `trimEigenDaData` helper; covers exactly the table `wipeData` covers (`DataAvailability`).
- New generic `DataAvailabilityRepository.deleteByConfigurationIdInTimeRange(configurationId, from, to)`.
- Lowering `sinceTimestamp` still wipes + re-indexes (no gaps) — pinned by a test.
- **Boundary rule (documented in the helper)**: buckets entirely outside the retained range are deleted; the straddling hour bucket is **kept**. This intentionally differs from the block indexer (#12615, which deletes it): EigenDA upserts *overwrite* (`totalSize = excluded.totalSize`, no accumulator), so re-writing the kept bucket on trim-then-extend produces the identical value — proven by a `does not double count when untilTimestamp is extended again` test on each indexer — while deleting it would leave a permanent hole (the indexer resumes at `currentHeight + 1` and never revisits that hour). Same principle both sides: never double-count, never leave an unrecoverable hole.
- Trim uses the framework-supplied range (head-clamped), not the config's `[min,max]`: the projects indexer writes rows for the *previous day* relative to the producing height, so rows legitimately exist below `sinceTimestamp` and must survive trims.
- Fully additive — no changes to `mergeConfigurations`, `ManagedMultiIndexer`, or block-indexer code.

## Testing

- EigenDa-scoped: 32 passing; red-first verified (removing the override makes the range-edit tests fail with a wipe)
- Full backend suite: 1353 passing (with real Postgres); database suite: 802 passing
- typecheck/lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)