### PR TITLE
Model nav group links as separated sections

### DIFF
--- a/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
+++ b/packages/frontend/src/components/nav/mobile/MobileNavTabs.tsx
@@ -14,18 +14,16 @@ export function MobileNavTabs({ groups }: { groups: NavGroup[] }) {
   const currentGroup = groups
     .filter((g) => g.type === 'multiple')
     .find((g) => {
+      const firstLink = g.links[0]?.[0]
       return (
-        g.links[0] &&
-        isLinkActive({ href: `/${g.links[0].href.split('/')[1]}`, pathname }) &&
+        firstLink &&
+        isLinkActive({ href: `/${firstLink.href.split('/')[1]}`, pathname }) &&
         !g.disableMobileTabs
       )
     })
   if (!currentGroup) return null
 
-  const links = [
-    ...currentGroup.links,
-    ...(currentGroup.secondaryLinks ?? []).flat(),
-  ]
+  const links = currentGroup.links.flat()
 
   // Do not display the tabs if the current group is not found,
   // or the current group does not have a link that matches the current path.

--- a/packages/frontend/src/components/nav/mobile/MobileSelectedLink.tsx
+++ b/packages/frontend/src/components/nav/mobile/MobileSelectedLink.tsx
@@ -16,9 +16,9 @@ export function MobileSelectedLink({
     if (group.type === 'single') {
       return isLinkActive({ href: group.href, pathname })
     }
-    return [...group.links, ...(group.secondaryLinks ?? []).flat()].some(
-      (link) => isLinkActive({ href: link.href, pathname }),
-    )
+    return group.links
+      .flat()
+      .some((link) => isLinkActive({ href: link.href, pathname }))
   })
 
   const selectedSideLink = sideLinks.find((link) =>

--- a/packages/frontend/src/components/nav/sidebar/NavSidebar.tsx
+++ b/packages/frontend/src/components/nav/sidebar/NavSidebar.tsx
@@ -113,10 +113,7 @@ function NavCollapsibleItem({
   closeMobileSidebar: () => void
 }) {
   const pathname = usePathname()
-  const allGroupLinks = useMemo(
-    () => [...group.links, ...(group.secondaryLinks ?? []).flat()],
-    [group.links, group.secondaryLinks],
-  )
+  const allGroupLinks = useMemo(() => group.links.flat(), [group.links])
   const isGroupActive = pathname.startsWith('/' + group.match)
   const isAnyLinkActive = allGroupLinks.some((link) =>
     isLinkActive({ href: link.href, pathname, exact: link.exactMatch }),
@@ -124,7 +121,7 @@ function NavCollapsibleItem({
 
   const [open, setOpen] = useState(isAnyLinkActive)
 
-  if (!group.links[0]) return null
+  if (allGroupLinks.length === 0) return null
 
   return (
     <Collapsible className="flex flex-col" open={open} onOpenChange={setOpen}>
@@ -146,61 +143,45 @@ function NavCollapsibleItem({
       </CollapsibleTrigger>
       <CollapsibleContent>
         <SidebarGroupSub>
-          {group.links.map((item) => (
-            <Fragment key={item.title}>
-              <SidebarGroupSubButton
-                href={item.href}
-                isActive={isLinkActive({
-                  href: item.href,
-                  pathname,
-                  exact: item.exactMatch,
-                })}
-                onClick={closeMobileSidebar}
-              >
-                <span className="leading-tight">{item.title}</span>
-              </SidebarGroupSubButton>
-              {item.subLinks && item.subLinks.length > 0 && (
-                <SidebarGroupSub className="mt-1 mb-1.5 gap-2">
-                  {item.subLinks.map((subItem) => (
-                    <SidebarGroupSubLink
-                      key={subItem.title}
-                      href={subItem.href}
-                      isActive={isLinkActive({
-                        href: subItem.href,
-                        pathname,
-                        exact: subItem.exactMatch,
-                      })}
-                      onClick={closeMobileSidebar}
-                    >
-                      {subItem.title}
-                    </SidebarGroupSubLink>
-                  ))}
-                </SidebarGroupSub>
-              )}
+          {group.links.map((section, index) => (
+            // Sections carry no identity of their own, so the index is the key.
+            <Fragment key={index}>
+              {index > 0 && <SidebarSeparator />}
+              {section.map((item) => (
+                <Fragment key={item.title}>
+                  <SidebarGroupSubButton
+                    href={item.href}
+                    isActive={isLinkActive({
+                      href: item.href,
+                      pathname,
+                      exact: item.exactMatch,
+                    })}
+                    onClick={closeMobileSidebar}
+                  >
+                    <span className="leading-tight">{item.title}</span>
+                  </SidebarGroupSubButton>
+                  {item.subLinks && item.subLinks.length > 0 && (
+                    <SidebarGroupSub className="mt-1 mb-1.5 gap-2">
+                      {item.subLinks.map((subItem) => (
+                        <SidebarGroupSubLink
+                          key={subItem.title}
+                          href={subItem.href}
+                          isActive={isLinkActive({
+                            href: subItem.href,
+                            pathname,
+                            exact: subItem.exactMatch,
+                          })}
+                          onClick={closeMobileSidebar}
+                        >
+                          {subItem.title}
+                        </SidebarGroupSubLink>
+                      ))}
+                    </SidebarGroupSub>
+                  )}
+                </Fragment>
+              ))}
             </Fragment>
           ))}
-          {group.secondaryLinks?.map(
-            (section, index) =>
-              section.length > 0 && (
-                <Fragment key={index}>
-                  <SidebarSeparator />
-                  {section.map((item) => (
-                    <SidebarGroupSubButton
-                      href={item.href}
-                      key={item.title}
-                      isActive={isLinkActive({
-                        href: item.href,
-                        pathname,
-                        exact: item.exactMatch,
-                      })}
-                      onClick={closeMobileSidebar}
-                    >
-                      <span>{item.title}</span>
-                    </SidebarGroupSubButton>
-                  ))}
-                </Fragment>
-              ),
-          )}
         </SidebarGroupSub>
       </CollapsibleContent>
     </Collapsible>

--- a/packages/frontend/src/components/nav/types.ts
+++ b/packages/frontend/src/components/nav/types.ts
@@ -5,9 +5,8 @@ export type NavGroup =
       match: string
       icon: React.ReactNode
       disableMobileTabs?: boolean
-      links: NavLink[]
-      /** Link sections rendered after `links`, each preceded by a separator. */
-      secondaryLinks?: NavLink[][]
+      /** Link sections, rendered with a separator between consecutive sections. */
+      links: NavLink[][]
     }
   | ({
       type: 'single'

--- a/packages/frontend/src/consts/navGroups.tsx
+++ b/packages/frontend/src/consts/navGroups.tsx
@@ -29,55 +29,55 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
     icon: (
       <L2Icon className="transition-colors duration-300 group-data-[active=true]:stroke-brand" />
     ),
-    links: compact<NavLink>([
-      {
-        title: 'Summary',
-        href: '/layer2s/summary',
-      },
-      {
-        title: 'Risk Analysis',
-        shortTitle: 'Risks',
-        href: '/layer2s/risk',
-        subLinks: [
-          {
-            title: 'Overview',
-            href: '/layer2s/risk',
-            exactMatch: true,
-          },
-          {
-            title: 'State Validation',
-            href: '/layer2s/risk/state-validation',
-          },
-          {
-            title: 'Data Availability',
-            shortTitle: 'DA',
-            href: '/layer2s/risk/data-availability',
-          },
-          {
-            title: 'Sequencing',
-            href: '/layer2s/risk/sequencing',
-          },
-        ],
-      },
-      {
-        title: 'Value Secured',
-        shortTitle: 'Value',
-        href: '/layer2s/tvs',
-      },
-      {
-        title: 'Activity',
-        href: '/layer2s/activity',
-      },
-      {
-        title: 'Liveness',
-        href: '/layer2s/liveness',
-      },
-      {
-        title: 'Costs',
-        href: '/layer2s/costs',
-      },
-    ]),
-    secondaryLinks: compact<NavLink[]>([
+    links: compact<NavLink[]>([
+      [
+        {
+          title: 'Summary',
+          href: '/layer2s/summary',
+        },
+        {
+          title: 'Risk Analysis',
+          shortTitle: 'Risks',
+          href: '/layer2s/risk',
+          subLinks: [
+            {
+              title: 'Overview',
+              href: '/layer2s/risk',
+              exactMatch: true,
+            },
+            {
+              title: 'State Validation',
+              href: '/layer2s/risk/state-validation',
+            },
+            {
+              title: 'Data Availability',
+              shortTitle: 'DA',
+              href: '/layer2s/risk/data-availability',
+            },
+            {
+              title: 'Sequencing',
+              href: '/layer2s/risk/sequencing',
+            },
+          ],
+        },
+        {
+          title: 'Value Secured',
+          shortTitle: 'Value',
+          href: '/layer2s/tvs',
+        },
+        {
+          title: 'Activity',
+          href: '/layer2s/activity',
+        },
+        {
+          title: 'Liveness',
+          href: '/layer2s/liveness',
+        },
+        {
+          title: 'Costs',
+          href: '/layer2s/costs',
+        },
+      ],
       [
         {
           title: 'Archived',
@@ -100,18 +100,20 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
       <BridgesIcon className="transition-colors duration-300 group-data-[active=true]:stroke-brand" />
     ),
     links: [
-      {
-        title: 'Summary',
-        href: '/interop/summary',
-      },
-      {
-        title: 'Token frameworks',
-        href: '/interop/token-frameworks',
-      },
-      {
-        title: 'Intent bridges',
-        href: '/interop/intent-bridges',
-      },
+      [
+        {
+          title: 'Summary',
+          href: '/interop/summary',
+        },
+        {
+          title: 'Token frameworks',
+          href: '/interop/token-frameworks',
+        },
+        {
+          title: 'Intent bridges',
+          href: '/interop/intent-bridges',
+        },
+      ],
     ],
   },
   {
@@ -140,27 +142,27 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
       <DataAvailabilityIcon className="transition-colors duration-300 group-data-[active=true]:fill-brand" />
     ),
     links: [
-      {
-        title: 'Summary',
-        href: '/data-availability/summary',
-      },
-      {
-        title: 'Risk Analysis',
-        shortTitle: 'Risks',
-        href: '/data-availability/risk',
-      },
-      {
-        title: 'Throughput',
-        shortTitle: 'Throughput',
-        href: '/data-availability/throughput',
-      },
-      {
-        title: 'Liveness',
-        shortTitle: 'Liveness',
-        href: '/data-availability/liveness',
-      },
-    ],
-    secondaryLinks: [
+      [
+        {
+          title: 'Summary',
+          href: '/data-availability/summary',
+        },
+        {
+          title: 'Risk Analysis',
+          shortTitle: 'Risks',
+          href: '/data-availability/risk',
+        },
+        {
+          title: 'Throughput',
+          shortTitle: 'Throughput',
+          href: '/data-availability/throughput',
+        },
+        {
+          title: 'Liveness',
+          shortTitle: 'Liveness',
+          href: '/data-availability/liveness',
+        },
+      ],
       [
         {
           title: 'Archived',
@@ -187,27 +189,29 @@ export const navGroups: NavGroup[] = compact<NavGroup>([
       <EcosystemsIcon className="transition-colors duration-300 group-data-[active=true]:stroke-brand" />
     ),
     links: [
-      {
-        name: 'Agglayer',
-        slug: 'agglayer',
-      },
-      {
-        name: 'Arbitrum Orbit',
-        slug: 'arbitrum-orbit',
-      },
-      {
-        name: 'Superchain',
-        slug: 'superchain',
-      },
-      {
-        name: 'The Elastic Network',
-        slug: 'the-elastic-network',
-      },
-    ]
-      .sort(createOrderedSort(PARTNERS_ORDER, (item) => item.slug))
-      .map((ecosystem) => ({
-        title: ecosystem.name,
-        href: `/ecosystems/${ecosystem.slug}`,
-      })),
+      [
+        {
+          name: 'Agglayer',
+          slug: 'agglayer',
+        },
+        {
+          name: 'Arbitrum Orbit',
+          slug: 'arbitrum-orbit',
+        },
+        {
+          name: 'Superchain',
+          slug: 'superchain',
+        },
+        {
+          name: 'The Elastic Network',
+          slug: 'the-elastic-network',
+        },
+      ]
+        .sort(createOrderedSort(PARTNERS_ORDER, (item) => item.slug))
+        .map((ecosystem) => ({
+          title: ecosystem.name,
+          href: `/ecosystems/${ecosystem.slug}`,
+        })),
+    ],
   },
 ])


### PR DESCRIPTION
## Summary

- Replace `NavGroup.links` + `NavGroup.secondaryLinks` with `links: NavLink[][]` — link *sections*, rendered with a separator between consecutive sections
- `NavSidebar` renders every link through one code path (the secondary list previously had its own copy without `subLinks` support); mobile tabs / selected link just `flat()` the sections
- Layer 2s group: `Summary … Costs | ─── | Archived | ─── | Compare`; Data Availability keeps `… | ─── | Archived`

Stacked on #12504 (`project-compare-feature`).

## Testing

- `pnpm typecheck`, `pnpm lint`, `pnpm test`
- Checked the rendered sidebar order in the running app

🤖 Generated with [Claude Code](https://claude.com/claude-code)