### PR TITLE
Fix AccessControl handler wiping DEFAULT_ADMIN_ROLE members

### DIFF
--- a/packages/config/src/projects/lido/diffHistory.md
+++ b/packages/config/src/projects/lido/diffHistory.md
@@ -1,3 +1,723 @@
+Generated with discovered.json: 0x79209b4bd7b3d1cb414987d7ff58ee103c750a08
+
+# Diff at Thu, 20 Aug 2026 12:02:26 GMT:
+
+- author: vincfurc (<vincfurc@users.noreply.github.com>)
+- comparing to: main@87a85ccf740bd2f0afce19c2723802be5984edc7 block: 1786960746
+- current timestamp: 1787227248
+
+## Description
+
+Regenerated after fixing the `accessControl` discovery handler.
+
+## Watched changes
+
+```diff
+    contract Liquid staked Ether 2.0 Token (eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84) [lido/stETH] {
+    +++ description: The rebasing stETH token and Lido protocol accounting entrypoint. It accepts stake, accounts for consensus- and execution-layer balances, mints and burns shares, and applies oracle reports. Version 3 adds external stake-backed shares and balance-based validator accounting.
+      values.getFeeDistribution.treasuryFeeBasisPoints:
+-        3793
++        3783
+      values.getFeeDistribution.operatorsFeeBasisPoints:
+-        6206
++        6216
+    }
+```
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1786960746 (main branch discovery), not current.
+
+```diff
+    contract ValidatorsExitBusOracle (eth:0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e) [lido/ValidatorsExitBusOracle] {
+    +++ description: Receives committee-consensus lists of validators that staking modules must exit and emits the exit requests. SRv3 accounts for the validators' effective-balance weights and key indices when applying per-report and replenishing exit limits.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract OracleReportSanityChecker (eth:0x147f8d3cf3004FAf9Bf94E88B54b6C06De507be9) [lido/OracleReportSanityChecker] {
+    +++ description: Validates AccountingOracle report values against configurable safety limits. The version 3 checker covers validator balance flows, consolidations, external pending balances, triggerable exits, and EIP-7251 balance weights.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract ConsolidationGateway (eth:0x17be979344f2c2cC806229a532D92f8742C10462) [lido/ConsolidationGateway] {
+    +++ description: Validates validator ownership proofs and submits EIP-7251 consolidation requests through the protocol consolidation-request predeploy. It rate-limits the amount consolidated and preserves its ETH balance across requests.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract VaultHub (eth:0x1d201BE093d847f6446530Efb0E8Fb426d176709) [lido/VaultHub] {
+    +++ description: The central registry and lifecycle manager for stVaults connected to Lido. It enforces collateral and risk parameters, tracks vault reports and liabilities, mints and burns stETH shares, settles fees, rebalances unhealthy vaults, and manages bad debt.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedGate (eth:0x207798e6fD1aa7Ee8a63782A64c959cD6727b78C) [lido/CuratedGate] {
+    +++ description: Merkle-gated onboarding contract for a curated Community Staking Module cohort. An eligible address consumes its proof to create a node operator with this gate's configured bond curve and metadata group.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Voting (eth:0x2e59A20f205bB85a89C53f1936454680651E618e) [lido/Voting] {
+    +++ description: Lido DAO's Aragon token voting application. LDO holders vote on executable DAO scripts, with configurable support, quorum, vote duration, and an objection phase.
+      receivedPermissions.22:
++        {"permission":"interact","from":"eth:0xF0211b7660680B49De1A7E9f25C65660F0a13Fea","description":"grant or revoke EasyTrack roles, change motion settings and executor, and add or remove allowed script factories.","role":".defaultAdmins"}
+    }
+```
+
+```diff
+    contract Accounting (eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6) [lido/Accounting] {
+    +++ description: Manages node-operator bonds for a permissionless staking module. It accepts ETH, stETH and wstETH bonds, applies bond curves, locks or penalizes bond, and lets eligible node-operator addresses claim rewards after the module's fee distribution.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract FeeDistributor (eth:0x367d23c756599c20DCc8D6943F4976E8F88D60d7) [lido/FeeDistributor] {
+    +++ description: Receives a staking module's stETH fee shares and distributes them to node operators according to a Merkle tree submitted by its FeeOracle. Claims are accounted in stETH shares.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedGate (eth:0x3BbBb175f7F07954DE00052b20E1c5572223F24D) [lido/CuratedGate] {
+    +++ description: Merkle-gated onboarding contract for a curated Community Staking Module cohort. An eligible address consumes its proof to create a node operator with this gate's configured bond curve and metadata group.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Lido Dao Agent (eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c) [lido/LidoDaoAgent] {
+    +++ description: The Lido DAO's Aragon execution and treasury agent. It can transfer assets, execute arbitrary calls or scripts, and validate signatures according to granular ACL permissions.
+      directlyReceivedPermissions.0:
++        {"permission":"interact","from":"eth:0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e","description":"grant or revoke every ValidatorsExitBusOracle role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.1:
++        {"permission":"interact","from":"eth:0x147f8d3cf3004FAf9Bf94E88B54b6C06De507be9","description":"grant or revoke OracleReportSanityChecker roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.2:
++        {"permission":"interact","from":"eth:0x17be979344f2c2cC806229a532D92f8742C10462","description":"grant or revoke ConsolidationGateway roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.3:
++        {"permission":"interact","from":"eth:0x1d201BE093d847f6446530Efb0E8Fb426d176709","description":"grant or revoke every VaultHub role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.4:
++        {"permission":"interact","from":"eth:0x207798e6fD1aa7Ee8a63782A64c959cD6727b78C","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.5:
++        {"permission":"interact","from":"eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6","description":"grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.","role":".defaultAdmins"}
+      directlyReceivedPermissions.6:
++        {"permission":"interact","from":"eth:0x367d23c756599c20DCc8D6943F4976E8F88D60d7","description":"grant or revoke FeeDistributor roles and change the rebate recipient.","role":".defaultAdmins"}
+      directlyReceivedPermissions.7:
++        {"permission":"interact","from":"eth:0x3BbBb175f7F07954DE00052b20E1c5572223F24D","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.10:
++        {"permission":"interact","from":"eth:0x3FC2C71579D80790Aaa3fc7Be8B66ac39dC57374","description":"grant or revoke TopUpGateway roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.11:
++        {"permission":"interact","from":"eth:0x4D4074628678Bd302921c20573EEa1ed38DdF7FB","description":"grant or revoke every FeeOracle role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.12:
++        {"permission":"interact","from":"eth:0x4d72BFF1BeaC69925F8Bd12526a39BAAb069e5Da","description":"grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.","role":".defaultAdmins"}
+      directlyReceivedPermissions.18:
++        {"permission":"interact","from":"eth:0x5DB427080200c235F2Ae8Cd17A7be87921f7AD6c","description":"grant or revoke LazyOracle roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.21:
++        {"permission":"interact","from":"eth:0x6093EFA6B5E2FF3be54d1c895c9deA932805c49F","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.22:
++        {"permission":"interact","from":"eth:0x610B517D380f287c239C93F8eF6FfBd567AA4bA5","description":"grant or revoke Ejector roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.24:
++        {"permission":"interact","from":"eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.25:
++        {"permission":"interact","from":"eth:0x773933F9db8964A17d62fb808f2EC7A2de4247CC","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.27:
++        {"permission":"interact","from":"eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.28:
++        {"permission":"interact","from":"eth:0x852deD011285fe67063a08005c71a85690503Cee","description":"grant or revoke every AccountingOracle role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.31:
++        {"permission":"interact","from":"eth:0x86A8d4E0db5938D21d98047544668FCCB1A9ADc8","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.32:
++        {"permission":"interact","from":"eth:0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1","description":"grant or revoke every WithdrawalQueue role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.33:
++        {"permission":"interact","from":"eth:0x8c002c6eE10cf8adb78D1F9EB2e134FdaF8A7C1a","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.34:
++        {"permission":"interact","from":"eth:0x8EeFCdbD984c30E472BcbF545783D051CB5114e5","description":"grant or revoke every FeeOracle role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.36:
++        {"permission":"interact","from":"eth:0x902D64c93F6595339aA46105627a085591051aFb","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.39:
++        {"permission":"interact","from":"eth:0x9D28ad303C90DF524BA960d7a2DAC56DcC31e428","description":"grant or revoke ParametersRegistry roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.40:
++        {"permission":"interact","from":"eth:0x9Dc70b5A4f4F5E4AF9058C983D560564F031f1D7","description":"grant or revoke ConsolidationMigrator roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.41:
++        {"permission":"interact","from":"eth:0xa12760721A72A7199aB38059DA6690b9Cd4ed7B8","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.42:
++        {"permission":"interact","from":"eth:0xA64b339eebD3dC3De848298B6a140955932901d8","description":"grant or revoke MetaRegistry roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.43:
++        {"permission":"interact","from":"eth:0xaa328816027F2D32B9F56d190BC9Fa4A5C07637f","description":"grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.","role":".defaultAdmins"}
+      directlyReceivedPermissions.53:
++        {"permission":"interact","from":"eth:0xB314D4A76C457c93150d308787939063F4Cc67E0","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.54:
++        {"permission":"interact","from":"eth:0xb8cd8F059Ad7a5dB8CAfDe34aAb007317F7156C8","description":"grant or revoke asset-recovery and administrative roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.57:
++        {"permission":"interact","from":"eth:0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09","description":"grant or revoke OracleDaemonConfig roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.58:
++        {"permission":"interact","from":"eth:0xC392F457960f1B13Ebaf1aa6C065479dD507E1E3","description":"grant or revoke verifier pause and resume roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.59:
++        {"permission":"interact","from":"eth:0xC69685E89Cefc327b43B7234AC646451B27c544d","description":"grant or revoke OperatorGrid roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.61:
++        {"permission":"interact","from":"eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.62:
++        {"permission":"interact","from":"eth:0xd907CE33B4Be423823d1CFFe80BD147E8b8554C8","description":"grant or revoke ConsolidationBus roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.63:
++        {"permission":"interact","from":"eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0","description":"grant or revoke FeeDistributor roles and change the rebate recipient.","role":".defaultAdmins"}
+      directlyReceivedPermissions.64:
++        {"permission":"interact","from":"eth:0xDa5F930cE326EB5205085D66c72A4E79d60cB8C1","description":"grant or revoke Curated Staking Module roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.65:
++        {"permission":"interact","from":"eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F","description":"grant or revoke Community Staking Module roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.67:
++        {"permission":"interact","from":"eth:0xDC00116a0D3E064427dA2600449cfD2566B3037B","description":"grant or revoke every TriggerableWithdrawalsGateway role.","role":".defaultAdmins"}
+      directlyReceivedPermissions.68:
++        {"permission":"interact","from":"eth:0xe181A377A2d2BDE9A83f1474BC3DB7A412de091E","description":"grant or revoke Ejector roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.69:
++        {"permission":"interact","from":"eth:0xE76c52750019b80B43E36DF30bf4060EB73F573a","description":"grant or revoke Burner roles and enable migration of excess stETH.","role":".defaultAdmins"}
+      directlyReceivedPermissions.70:
++        {"permission":"interact","from":"eth:0xeF273Ca4A21Ba7B414Ae3C9f9b443038cb133F72","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins"}
+      directlyReceivedPermissions.71:
++        {"permission":"interact","from":"eth:0xf4618370a1fBf46905B16C10817c8CFaD924D6db","description":"grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.","role":".defaultAdmins"}
+      directlyReceivedPermissions.72:
++        {"permission":"interact","from":"eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3","description":"grant or revoke PredepositGuarantee roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.75:
++        {"permission":"interact","from":"eth:0xfce7aB839e55de77730716D05b3553e45ab3A5Ba","description":"grant or revoke verifier pause and resume roles.","role":".defaultAdmins"}
+      directlyReceivedPermissions.77:
++        {"permission":"interact","from":"eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999","description":"grant or revoke StakingRouter roles and administer the router's privileged operations.","role":".defaultAdmins"}
+      directlyReceivedPermissions.78:
++        {"permission":"interact","from":"eth:0xffC1C5d59CeAC6F6c27E701F04a70cb50474607C","description":"grant or revoke ParametersRegistry roles.","role":".defaultAdmins"}
+    }
+```
+
+```diff
+    contract TopUpGateway (eth:0x3FC2C71579D80790Aaa3fc7Be8B66ac39dC57374) [lido/TopUpGateway] {
+    +++ description: Validates consensus-layer proofs and submits EIP-7251 validator top-ups for staking modules. It limits top-up batch size, proof age, and call frequency.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract FeeOracle (eth:0x4D4074628678Bd302921c20573EEa1ed38DdF7FB) [lido/FeeOracle] {
+    +++ description: Receives committee-consensus reports containing a staking module's reward-distribution Merkle root and forwards them to FeeDistributor and ValidatorStrikes.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Accounting (eth:0x4d72BFF1BeaC69925F8Bd12526a39BAAb069e5Da) [lido/Accounting] {
+    +++ description: Manages node-operator bonds for a permissionless staking module. It accepts ETH, stETH and wstETH bonds, applies bond curves, locks or penalizes bond, and lets eligible node-operator addresses claim rewards after the module's fee distribution.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract LazyOracle (eth:0x5DB427080200c235F2Ae8Cd17A7be87921f7AD6c) [lido/LazyOracle] {
+    +++ description: Verifies cryptographic oracle reports for individual stVaults and forwards accepted total-value, fee, and liability updates to VaultHub. Reports outside configured rate, reward, or quarantine bounds are rejected or quarantined.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedGate (eth:0x6093EFA6B5E2FF3be54d1c895c9deA932805c49F) [lido/CuratedGate] {
+    +++ description: Merkle-gated onboarding contract for a curated Community Staking Module cohort. An eligible address consumes its proof to create a node operator with this gate's configured bond curve and metadata group.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Ejector (eth:0x610B517D380f287c239C93F8eF6FfBd567AA4bA5) [lido/Ejector] {
+    +++ description: Submits triggerable full-withdrawal requests for validators. Node operators may voluntarily eject their own validators, while ValidatorStrikes can eject validators for poor performance.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract HashConsensus (eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4) [lido/HashConsensus] {
+    +++ description: Collects report hashes from an enumerable oracle committee and forwards a report to its processor once quorum agrees. It defines report frames, quorum, fast-lane members, and the report processor.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedGate (eth:0x773933F9db8964A17d62fb808f2EC7A2de4247CC) [lido/CuratedGate] {
+    +++ description: Merkle-gated onboarding contract for a curated Community Staking Module cohort. An eligible address consumes its proof to create a node operator with this gate's configured bond curve and metadata group.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract HashConsensus (eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a) [lido/HashConsensus] {
+    +++ description: Collects report hashes from an enumerable oracle committee and forwards a report to its processor once quorum agrees. It defines report frames, quorum, fast-lane members, and the report processor.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract AccountingOracle (eth:0x852deD011285fe67063a08005c71a85690503Cee) [lido/AccountingOracle] {
+    +++ description: Receives committee-consensus reports of Lido's Beacon Chain balances, validator state, withdrawals, and staking-module accounting data, then drives the stETH accounting rebase and related protocol updates.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedGate (eth:0x86A8d4E0db5938D21d98047544668FCCB1A9ADc8) [lido/CuratedGate] {
+    +++ description: Merkle-gated onboarding contract for a curated Community Staking Module cohort. An eligible address consumes its proof to create a node operator with this gate's configured bond curve and metadata group.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract WithdrawalQueueERC721 (eth:0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1) [lido/WithdrawalQueueERC721] {
+    +++ description: Queues stETH and wstETH withdrawal requests as transferable NFTs. Oracle reports can enter bunker mode and finalize batches by supplying ETH and a maximum share rate, after which NFT owners claim ETH.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedGate (eth:0x8c002c6eE10cf8adb78D1F9EB2e134FdaF8A7C1a) [lido/CuratedGate] {
+    +++ description: Merkle-gated onboarding contract for a curated Community Staking Module cohort. An eligible address consumes its proof to create a node operator with this gate's configured bond curve and metadata group.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract FeeOracle (eth:0x8EeFCdbD984c30E472BcbF545783D051CB5114e5) [lido/FeeOracle] {
+    +++ description: Receives committee-consensus reports containing a staking module's reward-distribution Merkle root and forwards them to FeeDistributor and ValidatorStrikes.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract HashConsensus (eth:0x902D64c93F6595339aA46105627a085591051aFb) [lido/HashConsensus] {
+    +++ description: Collects report hashes from an enumerable oracle committee and forwards a report to its processor once quorum agrees. It defines report frames, quorum, fast-lane members, and the report processor.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract ParametersRegistry (eth:0x9D28ad303C90DF524BA960d7a2DAC56DcC31e428) [lido/ParametersRegistry] {
+    +++ description: Stores configurable Community Staking Module parameters, including bond curves, operator rewards, penalties, key limits, queue policy, performance thresholds, and validator-exit rules.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract ConsolidationMigrator (eth:0x9Dc70b5A4f4F5E4AF9058C983D560564F031f1D7) [lido/ConsolidationMigrator] {
+    +++ description: Coordinates the one-time migration of eligible Curated Module v1 validators into Curated Module v2 through the delayed ConsolidationBus pipeline.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract VettedGate (eth:0xa12760721A72A7199aB38059DA6690b9Cd4ed7B8) [lido/VettedGate] {
+    +++ description: Merkle-gated node-operator onboarding contract. Eligible addresses can create an operator using the configured bond curve, or an existing operator owner can consume a proof to claim that curve.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract MetaRegistry (eth:0xA64b339eebD3dC3De848298B6a140955932901d8) [lido/MetaRegistry] {
+    +++ description: Stores metadata that groups permissionless staking-module node operators, describes their operators, and assigns bond-curve weights.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract ValidatorStrikes (eth:0xaa328816027F2D32B9F56d190BC9Fa4A5C07637f) [lido/ValidatorStrikes] {
+    +++ description: Stores the oracle-provided Merkle root of validator performance strikes. Proven strike data can cause a poor-performing validator to be ejected and penalized.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract VettedGate (eth:0xB314D4A76C457c93150d308787939063F4Cc67E0) [lido/VettedGate] {
+    +++ description: Merkle-gated node-operator onboarding contract. Eligible addresses can create an operator using the configured bond curve, or an existing operator owner can consume a proof to claim that curve.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract PermissionlessGate (eth:0xb8cd8F059Ad7a5dB8CAfDe34aAb007317F7156C8) [lido/PermissionlessGate] {
+    +++ description: Permissionless Community Staking Module onboarding contract. Any address can create a node operator using its fixed bond curve by depositing ETH, stETH or wstETH.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract OracleDaemonConfig (eth:0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09) [lido/OracleDaemonConfig] {
+    +++ description: Stores key-value configuration consumed by Lido's off-chain oracle daemon.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Community Staking Module Verifier (eth:0xC392F457960f1B13Ebaf1aa6C065479dD507E1E3) [lido/CSVerifier] {
+    +++ description: Permissionless beacon-state proof verifier for a Community Staking Module. Valid proofs report validator balances, withdrawals and slashing to the connected module.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract OperatorGrid (eth:0xC69685E89Cefc327b43B7234AC646451B27c544d) [lido/OperatorGrid] {
+    +++ description: Registry of stVault node-operator groups and risk tiers. It defines per-tier share limits, reserve ratios, forced-rebalance thresholds and fees, coordinates two-party tier changes, and can jail vaults.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract EmergencyProtectedTimelock (eth:0xCE0425301C85c5Ea2A0873A2dEe44d78E02D2316) [lido/EmergencyProtectedTimelock] {
+    +++ description: Timelock used by Dual Governance. Governance submits and schedules batches, anyone may execute a ready batch, and time-bounded emergency committees can activate emergency mode and execute already submitted proposals without the ordinary schedule delay.
+      receivedPermissions.0:
++        {"permission":"interact","from":"eth:0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e","description":"grant or revoke every ValidatorsExitBusOracle role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.1:
++        {"permission":"interact","from":"eth:0x147f8d3cf3004FAf9Bf94E88B54b6C06De507be9","description":"grant or revoke OracleReportSanityChecker roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.2:
++        {"permission":"interact","from":"eth:0x17be979344f2c2cC806229a532D92f8742C10462","description":"grant or revoke ConsolidationGateway roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.3:
++        {"permission":"interact","from":"eth:0x1d201BE093d847f6446530Efb0E8Fb426d176709","description":"grant or revoke every VaultHub role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.4:
++        {"permission":"interact","from":"eth:0x207798e6fD1aa7Ee8a63782A64c959cD6727b78C","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.6:
++        {"permission":"interact","from":"eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6","description":"grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.7:
++        {"permission":"interact","from":"eth:0x367d23c756599c20DCc8D6943F4976E8F88D60d7","description":"grant or revoke FeeDistributor roles and change the rebate recipient.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.8:
++        {"permission":"interact","from":"eth:0x3BbBb175f7F07954DE00052b20E1c5572223F24D","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.12:
++        {"permission":"interact","from":"eth:0x3FC2C71579D80790Aaa3fc7Be8B66ac39dC57374","description":"grant or revoke TopUpGateway roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.13:
++        {"permission":"interact","from":"eth:0x4D4074628678Bd302921c20573EEa1ed38DdF7FB","description":"grant or revoke every FeeOracle role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.14:
++        {"permission":"interact","from":"eth:0x4d72BFF1BeaC69925F8Bd12526a39BAAb069e5Da","description":"grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.20:
++        {"permission":"interact","from":"eth:0x5DB427080200c235F2Ae8Cd17A7be87921f7AD6c","description":"grant or revoke LazyOracle roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.23:
++        {"permission":"interact","from":"eth:0x6093EFA6B5E2FF3be54d1c895c9deA932805c49F","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.24:
++        {"permission":"interact","from":"eth:0x610B517D380f287c239C93F8eF6FfBd567AA4bA5","description":"grant or revoke Ejector roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.26:
++        {"permission":"interact","from":"eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.27:
++        {"permission":"interact","from":"eth:0x773933F9db8964A17d62fb808f2EC7A2de4247CC","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.29:
++        {"permission":"interact","from":"eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.30:
++        {"permission":"interact","from":"eth:0x852deD011285fe67063a08005c71a85690503Cee","description":"grant or revoke every AccountingOracle role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.33:
++        {"permission":"interact","from":"eth:0x86A8d4E0db5938D21d98047544668FCCB1A9ADc8","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.34:
++        {"permission":"interact","from":"eth:0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1","description":"grant or revoke every WithdrawalQueue role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.35:
++        {"permission":"interact","from":"eth:0x8c002c6eE10cf8adb78D1F9EB2e134FdaF8A7C1a","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.36:
++        {"permission":"interact","from":"eth:0x8EeFCdbD984c30E472BcbF545783D051CB5114e5","description":"grant or revoke every FeeOracle role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.38:
++        {"permission":"interact","from":"eth:0x902D64c93F6595339aA46105627a085591051aFb","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.41:
++        {"permission":"interact","from":"eth:0x9D28ad303C90DF524BA960d7a2DAC56DcC31e428","description":"grant or revoke ParametersRegistry roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.42:
++        {"permission":"interact","from":"eth:0x9Dc70b5A4f4F5E4AF9058C983D560564F031f1D7","description":"grant or revoke ConsolidationMigrator roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.43:
++        {"permission":"interact","from":"eth:0xa12760721A72A7199aB38059DA6690b9Cd4ed7B8","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.44:
++        {"permission":"interact","from":"eth:0xA64b339eebD3dC3De848298B6a140955932901d8","description":"grant or revoke MetaRegistry roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.45:
++        {"permission":"interact","from":"eth:0xaa328816027F2D32B9F56d190BC9Fa4A5C07637f","description":"grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.55:
++        {"permission":"interact","from":"eth:0xB314D4A76C457c93150d308787939063F4Cc67E0","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.56:
++        {"permission":"interact","from":"eth:0xb8cd8F059Ad7a5dB8CAfDe34aAb007317F7156C8","description":"grant or revoke asset-recovery and administrative roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.60:
++        {"permission":"interact","from":"eth:0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09","description":"grant or revoke OracleDaemonConfig roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.62:
++        {"permission":"interact","from":"eth:0xC392F457960f1B13Ebaf1aa6C065479dD507E1E3","description":"grant or revoke verifier pause and resume roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.63:
++        {"permission":"interact","from":"eth:0xC69685E89Cefc327b43B7234AC646451B27c544d","description":"grant or revoke OperatorGrid roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.66:
++        {"permission":"interact","from":"eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288","description":"grant or revoke every HashConsensus role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.67:
++        {"permission":"interact","from":"eth:0xd907CE33B4Be423823d1CFFe80BD147E8b8554C8","description":"grant or revoke ConsolidationBus roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.68:
++        {"permission":"interact","from":"eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0","description":"grant or revoke FeeDistributor roles and change the rebate recipient.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.69:
++        {"permission":"interact","from":"eth:0xDa5F930cE326EB5205085D66c72A4E79d60cB8C1","description":"grant or revoke Curated Staking Module roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.70:
++        {"permission":"interact","from":"eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F","description":"grant or revoke Community Staking Module roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.73:
++        {"permission":"interact","from":"eth:0xDC00116a0D3E064427dA2600449cfD2566B3037B","description":"grant or revoke every TriggerableWithdrawalsGateway role.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.74:
++        {"permission":"interact","from":"eth:0xe181A377A2d2BDE9A83f1474BC3DB7A412de091E","description":"grant or revoke Ejector roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.75:
++        {"permission":"interact","from":"eth:0xE76c52750019b80B43E36DF30bf4060EB73F573a","description":"grant or revoke Burner roles and enable migration of excess stETH.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.76:
++        {"permission":"interact","from":"eth:0xeF273Ca4A21Ba7B414Ae3C9f9b443038cb133F72","description":"grant or revoke gate roles and change the gate's display name.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.77:
++        {"permission":"interact","from":"eth:0xf4618370a1fBf46905B16C10817c8CFaD924D6db","description":"grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.78:
++        {"permission":"interact","from":"eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3","description":"grant or revoke PredepositGuarantee roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.82:
++        {"permission":"interact","from":"eth:0xfce7aB839e55de77730716D05b3553e45ab3A5Ba","description":"grant or revoke verifier pause and resume roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.84:
++        {"permission":"interact","from":"eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999","description":"grant or revoke StakingRouter roles and administer the router's privileged operations.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+      receivedPermissions.85:
++        {"permission":"interact","from":"eth:0xffC1C5d59CeAC6F6c27E701F04a70cb50474607C","description":"grant or revoke ParametersRegistry roles.","role":".defaultAdmins","via":[{"address":"eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"},{"address":"eth:0x23E0B465633FF5178808F4A75186E2F2F9537021"}]}
+    }
+```
+
+```diff
+    contract HashConsensus (eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288) [lido/HashConsensus] {
+    +++ description: Collects report hashes from an enumerable oracle committee and forwards a report to its processor once quorum agrees. It defines report frames, quorum, fast-lane members, and the report processor.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract ConsolidationBus (eth:0xd907CE33B4Be423823d1CFFe80BD147E8b8554C8) [lido/ConsolidationBus] {
+    +++ description: Queues validator consolidation batches and, after an execution delay, forwards proven EIP-7251 requests to ConsolidationGateway.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract FeeDistributor (eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0) [lido/FeeDistributor] {
+    +++ description: Receives a staking module's stETH fee shares and distributes them to node operators according to a Merkle tree submitted by its FeeOracle. Claims are accounted in stETH shares.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedModule (eth:0xDa5F930cE326EB5205085D66c72A4E79d60cB8C1) [lido/CuratedModule] {
+    +++ description: The permissioned Curated Staking Module. It manages approved node operators and validator keys, accepts deposits and top-ups from the StakingRouter, and processes validator lifecycle reports and penalties.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CSModule (eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F) [lido/CSModule] {
+    +++ description: Lido's permissionless Community Staking Module. It manages node operators and validator keys, accepts router deposits and top-ups, processes validator exits, and applies bond-backed penalties.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract TriggerableWithdrawalsGateway (eth:0xDC00116a0D3E064427dA2600449cfD2566B3037B) [lido/TriggerableWithdrawalsGateway] {
+    +++ description: The permissioned entrypoint for full EIP-7002 validator withdrawals. It charges the current request fee, applies a replenishing global exit limit, forwards requests to WithdrawalVault, and notifies StakingRouter.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Ejector (eth:0xe181A377A2d2BDE9A83f1474BC3DB7A412de091E) [lido/Ejector] {
+    +++ description: Submits triggerable full-withdrawal requests for validators. Node operators may voluntarily eject their own validators, while ValidatorStrikes can eject validators for poor performance.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Burner (eth:0xE76c52750019b80B43E36DF30bf4060EB73F573a) [lido/Burner] {
+    +++ description: Escrows stETH shares requested for cover or non-cover burning and burns them during an oracle report. Excess stETH can be recovered into the Lido protocol during migration.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract CuratedGate (eth:0xeF273Ca4A21Ba7B414Ae3C9f9b443038cb133F72) [lido/CuratedGate] {
+    +++ description: Merkle-gated onboarding contract for a curated Community Staking Module cohort. An eligible address consumes its proof to create a node operator with this gate's configured bond curve and metadata group.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract EasyTrack (eth:0xF0211b7660680B49De1A7E9f25C65660F0a13Fea) [lido/EasyTrack] {
+    +++ description: Optimistic Lido DAO motion system. Approved factories restrict the target and selector of each motion; LDO holders can object, and an unobstructed motion is executed through the EVMScriptExecutor after its delay.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x2e59A20f205bB85a89C53f1936454680651E618e"
+      values.defaultAdmins.0:
++        "eth:0x2e59A20f205bB85a89C53f1936454680651E618e"
+    }
+```
+
+```diff
+    contract ValidatorStrikes (eth:0xf4618370a1fBf46905B16C10817c8CFaD924D6db) [lido/ValidatorStrikes] {
+    +++ description: Stores the oracle-provided Merkle root of validator performance strikes. Proven strike data can cause a poor-performing validator to be ejected and penalized.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract PredepositGuarantee (eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3) [lido/PredepositGuarantee] {
+    +++ description: Protects StakingVault deposits by proving validator withdrawal credentials and requiring an initial predeposit before the remaining validator deposit is sent.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract Community Staking Module Verifier (eth:0xfce7aB839e55de77730716D05b3553e45ab3A5Ba) [lido/CSVerifier] {
+    +++ description: Permissionless beacon-state proof verifier for a Community Staking Module. Valid proofs report validator balances, withdrawals and slashing to the connected module.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract StakingRouter (eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999) [lido/StakingRouter] {
+    +++ description: Coordinates Lido staking modules, allocates deposits and top-ups, tracks validator balances and exit states, and distributes staking rewards. Version 3 uses validator balances instead of validator counts and supports EIP-7251 compounding validators.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
+```diff
+    contract ParametersRegistry (eth:0xffC1C5d59CeAC6F6c27E701F04a70cb50474607C) [lido/ParametersRegistry] {
+    +++ description: Stores configurable Community Staking Module parameters, including bond curves, operator rewards, penalties, key limits, queue policy, performance thresholds, and validator-exit rules.
+      values.accessControl.DEFAULT_ADMIN_ROLE.members.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+      values.defaultAdmins.0:
++        "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
+    }
+```
+
 Generated with discovered.json: 0x488e27099773f22e992af12f86cec7a114781c8b
 
 # Diff at Mon, 17 Aug 2026 10:06:36 GMT:

--- a/packages/config/src/projects/lido/discovered.json
+++ b/packages/config/src/projects/lido/discovered.json
@@ -1,6 +1,6 @@
 {
   "name": "lido",
-  "timestamp": 1786960746,
+  "timestamp": 1787227248,
   "configHash": "0xd81215717c1ebb70bed962324cfdbf257203ad4552b6e7e33d4f0e40d2853200",
   "entries": [
     {
@@ -24,8 +24,8 @@
       "sinceBlock": 11052984,
       "values": {
         "$immutable": true,
-        "get_deposit_count": "0x6abf260000000000",
-        "get_deposit_root": "0xb4e308849cfb20854055ccd0701041615e1bfa932ba912f9e5eb26e2b5555514"
+        "get_deposit_count": "0x6ac6260000000000",
+        "get_deposit_root": "0xf960f4b391d2394d9ccd738cad0e73987f2ff52cc0f76afffc830a302efcff8d"
       },
       "implementationNames": {
         "eth:0x00000000219ab540356cBB839Cbe05303d7705Fa": "DepositContract"
@@ -311,7 +311,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -351,7 +351,7 @@
         "DATA_FORMAT_LIST_WITH_KEY_INDEX": 2,
         "dataSubmitters": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "EXIT_REQUEST_LIMIT_MANAGER_ROLE": "0x9c616dd118785b2e2fccf45a4ff151a335ff7b6a84cd1c4d7fd9f97f39ea9342",
         "EXIT_TYPE": 2,
         "exitLimitManagers": [],
@@ -363,9 +363,9 @@
         "GENESIS_TIME": 1606824023,
         "getConsensusContract": "eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a",
         "getConsensusReport": {
-          "hash": "0xdb77c0fcdcc73bb1f9b40b8bfd64c8ec587a6a08bc1faea13e2c86fa2c0efba7",
-          "refSlot": 15010559,
-          "processingDeadlineTime": 1786968011,
+          "hash": "0x6db18d8653e808ee1173476edcfb5e7ef35ea05fb60dc942acb344fbb39c95f0",
+          "refSlot": 15032159,
+          "processingDeadlineTime": 1787227211,
           "processingStarted": true
         },
         "getConsensusVersion": 5,
@@ -379,16 +379,16 @@
         },
         "getMaxValidatorsPerReport": 600,
         "getProcessingState": {
-          "currentFrameRefSlot": 15010559,
-          "processingDeadlineTime": 1786968011,
-          "dataHash": "0xdb77c0fcdcc73bb1f9b40b8bfd64c8ec587a6a08bc1faea13e2c86fa2c0efba7",
-          "dataSubmitted": true,
-          "dataFormat": 2,
+          "currentFrameRefSlot": 15033599,
+          "processingDeadlineTime": 0,
+          "dataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "dataSubmitted": false,
+          "dataFormat": 0,
           "requestsCount": 0,
           "requestsSubmitted": 0
         },
         "getResumeSinceTimestamp": 1684163759,
-        "getTotalRequestsProcessed": 150496,
+        "getTotalRequestsProcessed": 150578,
         "isPaused": false,
         "MANAGE_CONSENSUS_CONTRACT_ROLE": "0x04a0afbbd09d5ad397fc858789da4f8edd59f5ca5098d70faa490babee945c3b",
         "MANAGE_CONSENSUS_VERSION_ROLE": "0xc31b1e4b732c5173dc51d519dfa432bad95550ecc4b0f9a61c2a558a2a8e4341",
@@ -447,7 +447,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "ALL_LIMITS_MANAGER_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -525,7 +525,7 @@
         "CONSOLIDATION_ETH_AMOUNT_PER_DAY_LIMIT_MANAGER_ROLE": "0x66104568a23709e40729cd6c0b4b24e296898510ab1a757d8d76d8b7bb8ddcab",
         "consolidationEthDailyLimitManagers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "effectiveBalanceWeightManagers": [],
         "EXITED_ETH_AMOUNT_PER_DAY_LIMIT_MANAGER_ROLE": "0xfcbf51216e6462f6c733b5cc8e06873750fa849bd5f736187d1f87fa39466abd",
         "EXITED_VALIDATOR_ETH_AMOUNT_LIMIT_MANAGER_ROLE": "0xc8c135a577dae74b34fe5d1e5fc878bfd6afd7e69688368e0a15ccebebcdc485",
@@ -558,9 +558,9 @@
           "exitedValidatorEthAmountLimit": 32,
           "externalPendingBalanceCapEth": 300
         },
-        "getReportDataCount": 25,
+        "getReportDataCount": 28,
         "isPostMigrationFirstReportDone": true,
-        "lastReportTimestamp": 1786881611,
+        "lastReportTimestamp": 1787140811,
         "lastVaultBalanceAfterTransfer": 0,
         "MAX_BALANCE_EXIT_REQUESTED_PER_REPORT_IN_ETH_ROLE": "0x4943a281310045e6adfe0c785297f2d8dda39aa308297aa8d59b1cd427298e51",
         "MAX_CL_BALANCE_DECREASE_MANAGER_ROLE": "0x8f6844ca724706bfaf6fda925e1311e63ff0d58e56ea4522f293c021b4ce68db",
@@ -613,7 +613,7 @@
         "getEscrowState": 1,
         "getMinAssetsLockDuration": 18000,
         "getNextWithdrawalBatch": [],
-        "getRageQuitSupport": 1200411,
+        "getRageQuitSupport": 1194436,
         "getSignallingEscrowDetails": {
           "totalStETHLockedShares": 9198714211247,
           "totalStETHClaimedETH": 0,
@@ -660,7 +660,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -694,7 +694,7 @@
           "frameDurationInSec": 30
         },
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "EXIT_LIMIT_MANAGER_ROLE": "0xd452c9ff45a69fd8e9f95392cb8951f7a5b2599cd40b9704b6a786ab77072d33",
         "exitLimitManagers": [],
         "getConsolidationRequestLimitFullInfo": {
@@ -847,7 +847,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -884,7 +884,7 @@
         "CONNECT_DEPOSIT": "1000000000000000000",
         "CONSENSUS_CONTRACT": "eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
         "LIDO": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
@@ -971,7 +971,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -992,7 +992,7 @@
         "curveId": 2,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -1654,6 +1654,12 @@
         {
           "permission": "interact",
           "from": "eth:0xF0211b7660680B49De1A7E9f25C65660F0a13Fea",
+          "description": "grant or revoke EasyTrack roles, change motion settings and executor, and add or remove allowed script factories.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xF0211b7660680B49De1A7E9f25C65660F0a13Fea",
           "description": "pause creation and enactment of EasyTrack motions.",
           "role": ".pausers"
         },
@@ -1830,7 +1836,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_BOND_CURVES_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -1874,7 +1880,7 @@
         "chargePenaltyRecipient": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "FEE_DISTRIBUTOR": "eth:0x367d23c756599c20DCc8D6943F4976E8F88D60d7",
         "getBondLockPeriod": 5184000,
         "getCurvesCount": 7,
@@ -1901,7 +1907,7 @@
         "RESUME_ROLE": "0x2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c7",
         "resumers": ["eth:0x7914b5a1539b97Bd0bbd155757F25FD79A522d24"],
         "SET_BOND_CURVE_ROLE": "0x645c9e6d2a86805cb5a28b1e4751c0dab493df7cf935070ce405489ba1a7bf72",
-        "totalBondShares": "2498934868112553405183",
+        "totalBondShares": "2568082751163960845310",
         "WITHDRAWAL_QUEUE": "eth:0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
         "WSTETH": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
       },
@@ -1945,14 +1951,14 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "RECOVERER_ROLE": { "adminRole": "DEFAULT_ADMIN_ROLE", "members": [] }
         },
         "ACCOUNTING": "eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6",
         "assetRecoverers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "distributionDataHistoryCount": 1,
         "getInitializedVersion": 3,
         "ORACLE": "eth:0x8EeFCdbD984c30E472BcbF545783D051CB5114e5",
@@ -2044,7 +2050,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -2065,7 +2071,7 @@
         "curveId": 4,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -2149,6 +2155,54 @@
       "directlyReceivedPermissions": [
         {
           "permission": "interact",
+          "from": "eth:0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e",
+          "description": "grant or revoke every ValidatorsExitBusOracle role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x147f8d3cf3004FAf9Bf94E88B54b6C06De507be9",
+          "description": "grant or revoke OracleReportSanityChecker roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x17be979344f2c2cC806229a532D92f8742C10462",
+          "description": "grant or revoke ConsolidationGateway roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1d201BE093d847f6446530Efb0E8Fb426d176709",
+          "description": "grant or revoke every VaultHub role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x207798e6fD1aa7Ee8a63782A64c959cD6727b78C",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6",
+          "description": "grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x367d23c756599c20DCc8D6943F4976E8F88D60d7",
+          "description": "grant or revoke FeeDistributor roles and change the rebate recipient.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x3BbBb175f7F07954DE00052b20E1c5572223F24D",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
           "description": "grant, revoke, parameterize, or transfer management of the Agent execution permission.",
           "role": ".executePermissionManagers"
@@ -2158,6 +2212,24 @@
           "from": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
           "description": "grant, revoke, parameterize, or transfer management of the Agent script-runner permission.",
           "role": ".scriptPermissionManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x3FC2C71579D80790Aaa3fc7Be8B66ac39dC57374",
+          "description": "grant or revoke TopUpGateway roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x4D4074628678Bd302921c20573EEa1ed38DdF7FB",
+          "description": "grant or revoke every FeeOracle role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x4d72BFF1BeaC69925F8Bd12526a39BAAb069e5Da",
+          "description": "grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.",
+          "role": ".defaultAdmins"
         },
         {
           "permission": "interact",
@@ -2191,6 +2263,12 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0x5DB427080200c235F2Ae8Cd17A7be87921f7AD6c",
+          "description": "grant or revoke LazyOracle roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x5FbE8cEf9CCc56ad245736D3C5bAf82ad54Ca789",
           "description": "change the beacon implementation.",
           "role": ".owner"
@@ -2203,15 +2281,51 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0x6093EFA6B5E2FF3be54d1c895c9deA932805c49F",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x610B517D380f287c239C93F8eF6FfBd567AA4bA5",
+          "description": "grant or revoke Ejector roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4",
           "description": "add or remove oracle committee members and change the report quorum.",
           "role": ".memberAndQuorumManagers"
         },
         {
           "permission": "interact",
+          "from": "eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x773933F9db8964A17d62fb808f2EC7A2de4247CC",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a",
           "description": "add or remove oracle committee members and change the report quorum.",
           "role": ".memberAndQuorumManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x852deD011285fe67063a08005c71a85690503Cee",
+          "description": "grant or revoke every AccountingOracle role.",
+          "role": ".defaultAdmins"
         },
         {
           "permission": "interact",
@@ -2227,9 +2341,39 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0x86A8d4E0db5938D21d98047544668FCCB1A9ADc8",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+          "description": "grant or revoke every WithdrawalQueue role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x8c002c6eE10cf8adb78D1F9EB2e134FdaF8A7C1a",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x8EeFCdbD984c30E472BcbF545783D051CB5114e5",
+          "description": "grant or revoke every FeeOracle role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x902D64c93F6595339aA46105627a085591051aFb",
           "description": "add or remove oracle committee members and change the report quorum.",
           "role": ".memberAndQuorumManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x902D64c93F6595339aA46105627a085591051aFb",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins"
         },
         {
           "permission": "interact",
@@ -2242,6 +2386,36 @@
           "from": "eth:0x9895F0F17cc1d1891b6f18ee0b483B6f221b37Bb",
           "description": "grant, revoke, parameterize, or transfer management of the permission-creator permission.",
           "role": ".permissionCreatorManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9D28ad303C90DF524BA960d7a2DAC56DcC31e428",
+          "description": "grant or revoke ParametersRegistry roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9Dc70b5A4f4F5E4AF9058C983D560564F031f1D7",
+          "description": "grant or revoke ConsolidationMigrator roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xa12760721A72A7199aB38059DA6690b9Cd4ed7B8",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xA64b339eebD3dC3De848298B6a140955932901d8",
+          "description": "grant or revoke MetaRegistry roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xaa328816027F2D32B9F56d190BC9Fa4A5C07637f",
+          "description": "grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.",
+          "role": ".defaultAdmins"
         },
         {
           "permission": "interact",
@@ -2299,6 +2473,18 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0xB314D4A76C457c93150d308787939063F4Cc67E0",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xb8cd8F059Ad7a5dB8CAfDe34aAb007317F7156C8",
+          "description": "grant or revoke asset-recovery and administrative roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xb8FFC3Cd6e7Cf5a098A1c92F48009765B24088Dc",
           "description": "grant, revoke, parameterize, or transfer management of the Aragon application-manager permission.",
           "role": ".appManagerPermissionManagers"
@@ -2311,15 +2497,99 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09",
+          "description": "grant or revoke OracleDaemonConfig roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC392F457960f1B13Ebaf1aa6C065479dD507E1E3",
+          "description": "grant or revoke verifier pause and resume roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC69685E89Cefc327b43B7234AC646451B27c544d",
+          "description": "grant or revoke OperatorGrid roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
           "description": "add or remove oracle committee members and change the report quorum.",
           "role": ".memberAndQuorumManagers"
         },
         {
           "permission": "interact",
+          "from": "eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xd907CE33B4Be423823d1CFFe80BD147E8b8554C8",
+          "description": "grant or revoke ConsolidationBus roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0",
+          "description": "grant or revoke FeeDistributor roles and change the rebate recipient.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xDa5F930cE326EB5205085D66c72A4E79d60cB8C1",
+          "description": "grant or revoke Curated Staking Module roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F",
+          "description": "grant or revoke Community Staking Module roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xDC00116a0D3E064427dA2600449cfD2566B3037B",
           "description": "change the maximum, replenishment rate, and frame duration of the triggerable-withdrawal limit.",
           "role": ".exitLimitManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xDC00116a0D3E064427dA2600449cfD2566B3037B",
+          "description": "grant or revoke every TriggerableWithdrawalsGateway role.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xe181A377A2d2BDE9A83f1474BC3DB7A412de091E",
+          "description": "grant or revoke Ejector roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xE76c52750019b80B43E36DF30bf4060EB73F573a",
+          "description": "grant or revoke Burner roles and enable migration of excess stETH.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xeF273Ca4A21Ba7B414Ae3C9f9b443038cb133F72",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xf4618370a1fBf46905B16C10817c8CFaD924D6db",
+          "description": "grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3",
+          "description": "grant or revoke PredepositGuarantee roles.",
+          "role": ".defaultAdmins"
         },
         {
           "permission": "interact",
@@ -2335,9 +2605,27 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0xfce7aB839e55de77730716D05b3553e45ab3A5Ba",
+          "description": "grant or revoke verifier pause and resume roles.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
           "description": "add staking modules, change their fees and status, set deposit and top-up limits, and configure router-wide module parameters.",
           "role": ".stakingModuleManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
+          "description": "grant or revoke StakingRouter roles and administer the router's privileged operations.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xffC1C5d59CeAC6F6c27E701F04a70cb50474607C",
+          "description": "grant or revoke ParametersRegistry roles.",
+          "role": ".defaultAdmins"
         },
         {
           "permission": "upgrade",
@@ -2662,7 +2950,7 @@
           ]
         ],
         "$upgradeCount": 1,
-        "availableBalance": "2679211491597402205",
+        "availableBalance": "35108955955597402205",
         "beaconChainDepositsPaused": false,
         "DEPOSIT_CONTRACT": "eth:0x00000000219ab540356cBB839Cbe05303d7705Fa",
         "depositor": "eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3",
@@ -2716,7 +3004,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -2740,7 +3028,7 @@
         },
         "BEACON_ROOTS": "eth:0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getLastTopUpTimestamp": 0,
         "getMaxRootAge": 600,
         "getMaxValidatorsPerTopUp": 32,
@@ -2918,7 +3206,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -2953,7 +3241,7 @@
         "consensusVersionManagers": [],
         "dataSubmitters": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "FEE_DISTRIBUTOR": "eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0",
         "GENESIS_TIME": 1606824023,
         "getConsensusContract": "eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4",
@@ -3037,7 +3325,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "SET_BOND_CURVE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -3079,7 +3367,7 @@
         "chargePenaltyRecipient": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "FEE_DISTRIBUTOR": "eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0",
         "getBondLockPeriod": 4838400,
         "getCurvesCount": 4,
@@ -3106,7 +3394,7 @@
         "RESUME_ROLE": "0x2fc10cc8ae19568712f7a176fb4978616a610650813c9d05326c34abb62749c7",
         "resumers": ["eth:0x7914b5a1539b97Bd0bbd155757F25FD79A522d24"],
         "SET_BOND_CURVE_ROLE": "0x645c9e6d2a86805cb5a28b1e4751c0dab493df7cf935070ce405489ba1a7bf72",
-        "totalBondShares": "26300982502776333560549",
+        "totalBondShares": "26324447041236962573124",
         "WITHDRAWAL_QUEUE": "eth:0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
         "WSTETH": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
       },
@@ -3192,9 +3480,9 @@
         "getRecoveryVault": "eth:0x0000000000000000000000000000000000000000",
         "getRewardDistributionState": 2,
         "getStakingModuleSummary": {
-          "totalExitedValidators": 184997,
-          "totalDepositedValidators": 448177,
-          "depositableValidatorsCount": 21662
+          "totalExitedValidators": 185049,
+          "totalDepositedValidators": 448774,
+          "depositableValidatorsCount": 21065
         },
         "getStuckPenaltyDelay": 0,
         "getType": "0x637572617465642d6f6e636861696e2d76310000000000000000000000000000",
@@ -3384,7 +3672,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "UPDATE_SANITY_PARAMS_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -3392,14 +3680,14 @@
           }
         },
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "latestReportData": {
-          "timestamp": 1786881611,
-          "refSlot": 15004799,
-          "treeRoot": "0x59d3630c76be1cb559d9f41e734eccc0251354148bb2304f5eda8be15889e163",
-          "reportCid": "QmRwGu3aH4aBiAEns4XZuGiPZxckjm3q6sSafShyNc8hvB"
+          "timestamp": 1787140811,
+          "refSlot": 15026399,
+          "treeRoot": "0x608d0d3c25c362794642022ddb384066d51843f9caf2910751b7f8cdfbb3731a",
+          "reportCid": "QmZWAMxoUXireHFhuRNUcyBJRMzWtZh6XA2NqkiGhfzNF2"
         },
-        "latestReportTimestamp": 1786881611,
+        "latestReportTimestamp": 1787140811,
         "LIDO_LOCATOR": "eth:0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "MAX_LIDO_FEE_RATE_PER_SECOND": "10000000000000000000",
         "MAX_QUARANTINE_PERIOD": 2592000,
@@ -3712,7 +4000,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -3733,7 +4021,7 @@
         "curveId": 0,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -3799,7 +4087,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -3816,7 +4104,7 @@
         },
         "assetRecoverers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
         "MODULE": "eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F",
@@ -3896,8 +4184,8 @@
       "sinceBlock": 25544988,
       "values": {
         "$immutable": true,
-        "getCumulativeRevenueUSD": "145443549058714262330342",
-        "lastReportTimestamp": 1786881611,
+        "getCumulativeRevenueUSD": "370101793094939546344506",
+        "lastReportTimestamp": 1787140811,
         "LIDO_LOCATOR": "eth:0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "ORACLE_ROUTER": "eth:0x79ef3a538200Fe4981D67E7e886bfb36D4Cb5a31",
         "pendingRevenueStEth": 0,
@@ -3940,7 +4228,7 @@
           ]
         ],
         "$upgradeCount": 1,
-        "availableBalance": "76734667703819892788",
+        "availableBalance": "584937498254248493238",
         "beaconChainDepositsPaused": false,
         "DEPOSIT_CONTRACT": "eth:0x00000000219ab540356cBB839Cbe05303d7705Fa",
         "depositor": "eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3",
@@ -4019,7 +4307,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_MEMBERS_AND_QUORUM_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -4044,7 +4332,7 @@
         },
         "consensusDisablers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "DISABLE_CONSENSUS_ROLE": "0x10b016346186602d93fc7a27ace09ba944baf9453611b186d36acd3d3d667dc0",
         "fastLaneConfigManagers": [],
         "frameConfigManagers": [],
@@ -4238,7 +4526,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -4259,7 +4547,7 @@
         "curveId": 6,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -4625,10 +4913,10 @@
         "DOMAIN_SEPARATOR": "0xd4a8ff90a402dc7d4fcbf60f5488291263c743ccff180e139f47d139cedfd5fe",
         "name": "Wrapped liquid staked Ether 2.0",
         "stETH": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
-        "stEthPerToken": "1241810533145946736",
+        "stEthPerToken": "1242032879881643218",
         "symbol": "wstETH",
-        "tokensPerStEth": "805275823733468543",
-        "totalSupply": "3692447386137294956436681"
+        "tokensPerStEth": "805131664546024572",
+        "totalSupply": "3688808972687392066879249"
       },
       "implementationNames": {
         "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": "WstETH"
@@ -4660,7 +4948,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_MEMBERS_AND_QUORUM_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -4685,7 +4973,7 @@
         },
         "consensusDisablers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "DISABLE_CONSENSUS_ROLE": "0x10b016346186602d93fc7a27ace09ba944baf9453611b186d36acd3d3d667dc0",
         "fastLaneConfigManagers": [],
         "frameConfigManagers": [],
@@ -4713,8 +5001,8 @@
             "eth:0x042a9e5acCfa17e28300F1b5967f20891E973922"
           ],
           "lastReportedRefSlots": [
-            15010559, 15010559, 15010559, 15010559, 15010559, 15010559,
-            14963039, 15009119, 15009119
+            15032159, 15032159, 15032159, 15032159, 15032159, 15032159,
+            15032159, 15032159, 15032159
           ]
         },
         "getQuorum": 5,
@@ -4894,7 +5182,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_CONSENSUS_VERSION_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -4913,7 +5201,7 @@
         "consensusVersionManagers": [],
         "dataSubmitters": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "EXTRA_DATA_FORMAT_EMPTY": 0,
         "EXTRA_DATA_FORMAT_LIST": 1,
         "EXTRA_DATA_TYPE_EXITED_VALIDATORS": 2,
@@ -4921,27 +5209,27 @@
         "GENESIS_TIME": 1606824023,
         "getConsensusContract": "eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
         "getConsensusReport": {
-          "hash": "0x1c625963d0e659f15261b1bd19648a006474dc062f7749946c2cd13b0b9c2964",
-          "refSlot": 15004799,
-          "processingDeadlineTime": 1786968011,
+          "hash": "0x1f1d1239e8276602f8fe8bade189bf1693601bdb9ae5f5a907b75450e49cd705",
+          "refSlot": 15026399,
+          "processingDeadlineTime": 1787227211,
           "processingStarted": true
         },
         "getConsensusVersion": 6,
         "getContractVersion": 5,
         "getCurrentFrame": {
-          "refSlot": 15004799,
-          "refSlotTimestamp": 1786881611
+          "refSlot": 15033599,
+          "refSlotTimestamp": 1787227211
         },
         "getProcessingState": {
-          "currentFrameRefSlot": 15004799,
-          "processingDeadlineTime": 1786968011,
-          "mainDataHash": "0x1c625963d0e659f15261b1bd19648a006474dc062f7749946c2cd13b0b9c2964",
-          "mainDataSubmitted": true,
-          "extraDataHash": "0x489cefa902519e5a63a1e77da29007c306504cf27bc9fa46655f747d02ff95fe",
-          "extraDataFormat": 1,
-          "extraDataSubmitted": true,
-          "extraDataItemsCount": 1,
-          "extraDataItemsSubmitted": 1
+          "currentFrameRefSlot": 15033599,
+          "processingDeadlineTime": 0,
+          "mainDataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "mainDataSubmitted": false,
+          "extraDataHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "extraDataFormat": 0,
+          "extraDataSubmitted": false,
+          "extraDataItemsCount": 0,
+          "extraDataItemsSubmitted": 0
         },
         "LOCATOR": "eth:0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "MANAGE_CONSENSUS_CONTRACT_ROLE": "0x04a0afbbd09d5ad397fc858789da4f8edd59f5ca5098d70faa490babee945c3b",
@@ -5061,7 +5349,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -5082,7 +5370,7 @@
         "curveId": 5,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -5195,7 +5483,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -5224,14 +5512,14 @@
         "BUNKER_MODE_DISABLED_TIMESTAMP": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
         "bunkerModeSinceTimestamp": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "FINALIZE_ROLE": "0x485191a2ef18512555bd4426d18a716ce8e98c80ec2de16394dcf86d7d91bc80",
         "finalizers": ["eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"],
         "getBaseURI": "https://wq-api.lido.fi/v1/nft",
         "getContractVersion": 1,
-        "getLastFinalizedRequestId": 132499,
-        "getLastRequestId": 132581,
-        "getLockedEtherAmount": "26916307488996499962358",
+        "getLastFinalizedRequestId": 132698,
+        "getLastRequestId": 132914,
+        "getLockedEtherAmount": "26269322185065511596032",
         "getNFTDescriptorAddress": "eth:0x0000000000000000000000000000000000000000",
         "getResumeSinceTimestamp": 1684163759,
         "isBunkerModeActive": false,
@@ -5257,8 +5545,8 @@
         "resumers": ["eth:0x7914b5a1539b97Bd0bbd155757F25FD79A522d24"],
         "STETH": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
         "symbol": "unstETH",
-        "unfinalizedRequestNumber": 82,
-        "unfinalizedStETH": "3627990064605571068398",
+        "unfinalizedRequestNumber": 216,
+        "unfinalizedStETH": "22795442420549588432471",
         "WSTETH": "eth:0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0"
       },
       "implementationNames": {
@@ -5368,7 +5656,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -5389,7 +5677,7 @@
         "curveId": 1,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -5536,7 +5824,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -5571,7 +5859,7 @@
         "consensusVersionManagers": [],
         "dataSubmitters": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "FEE_DISTRIBUTOR": "eth:0x367d23c756599c20DCc8D6943F4976E8F88D60d7",
         "GENESIS_TIME": 1606824023,
         "getConsensusContract": "eth:0x902D64c93F6595339aA46105627a085591051aFb",
@@ -5653,7 +5941,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_MEMBERS_AND_QUORUM_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -5678,7 +5966,7 @@
         },
         "consensusDisablers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "DISABLE_CONSENSUS_ROLE": "0x10b016346186602d93fc7a27ace09ba944baf9453611b186d36acd3d3d667dc0",
         "fastLaneConfigManagers": [],
         "frameConfigManagers": [],
@@ -5885,7 +6173,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_CURVE_PARAMETERS_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -5918,7 +6206,7 @@
         },
         "curveParameterManagers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "defaultAllowedExitDelay": 345600,
         "defaultBadPerformancePenalty": "258000000000000000",
         "defaultExitDelayFee": "100000000000000000",
@@ -5998,7 +6286,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "ALLOW_PAIR_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -6012,7 +6300,7 @@
         "ALLOW_PAIR_ROLE": "0x11b7ee1b50f8c4aefc7ba573dc738d6c20f03c1869ff81aa1d8be99ab7cfd7c1",
         "allowedPairs": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "DISALLOW_PAIR_ROLE": "0x4638c3377b40c5fdb49ab3032cbb02972024761b03e6a0d7dcf113f5673c03a8",
         "getConsolidationBus": "eth:0xd907CE33B4Be423823d1CFFe80BD147E8b8554C8",
         "getStakingRouter": "eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
@@ -6076,7 +6364,7 @@
         "getChainId": 1,
         "GnosisSafe_modules": [],
         "multisigThreshold": "4 of 7 (57%)",
-        "nonce": 73,
+        "nonce": 74,
         "VERSION": "1.3.0"
       },
       "implementationNames": {
@@ -6131,7 +6419,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -6154,7 +6442,7 @@
         "assetRecoverers": [],
         "curveId": 3,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -6286,7 +6574,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "SET_BOND_CURVE_WEIGHT_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -6313,7 +6601,7 @@
         "ACCOUNTING": "eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6",
         "bondCurveWeightSetters": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "MANAGE_OPERATOR_GROUPS_ROLE": "0xbd52a11eecbed162251d4104ff65b5bf0f6c161e7f24994550fc61db8659b4e9",
         "MODULE": "eth:0xDa5F930cE326EB5205085D66c72A4E79d60cB8C1",
@@ -6415,12 +6703,12 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           }
         },
         "ACCOUNTING": "eth:0x4d72BFF1BeaC69925F8Bd12526a39BAAb069e5Da",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "ejector": "eth:0x610B517D380f287c239C93F8eF6FfBd567AA4bA5",
         "EXIT_PENALTIES": "eth:0x06cd61045f958A209a0f8D746e103eCc625f4193",
         "getInitializedVersion": 1,
@@ -6602,51 +6890,51 @@
           "verifyingContract": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"
         },
         "getBalanceStats": {
-          "clValidatorsBalanceAtLastReport": "8828929489864170000000000",
-          "clPendingBalanceAtLastReport": "675264000000000000000000",
-          "depositedSinceLastReport": "1472000000000000000000",
-          "depositedForCurrentReport": 0
+          "clValidatorsBalanceAtLastReport": "8918883760768063000000000",
+          "clPendingBalanceAtLastReport": "612672000000000000000000",
+          "depositedSinceLastReport": "8960000000000000000000",
+          "depositedForCurrentReport": "8960000000000000000000"
         },
         "getBeaconStat": {
-          "depositedValidators": 490639,
-          "beaconValidators": 490639,
-          "beaconBalance": "9504193489864170000000000"
+          "depositedValidators": 491721,
+          "beaconValidators": 491721,
+          "beaconBalance": "9531555760768063000000000"
         },
-        "getBufferedEther": "5622340392185106550543",
+        "getBufferedEther": "20594389375301661715411",
         "getContractVersion": 4,
-        "getCurrentStakeLimit": "147930312500000000000000",
-        "getDepositableEther": "1994350327579535482145",
-        "getDepositsReserve": "28000000000000000000",
+        "getCurrentStakeLimit": "150000000000000000000000",
+        "getDepositableEther": 0,
+        "getDepositsReserve": 0,
         "getDepositsReserveTarget": "1500000000000000000000",
         "getEIP712StETH": "eth:0x8F73e4C2A6D852bb4ab2A45E6a9CF5715b3228B7",
         "getEVMScriptRegistry": "eth:0x853cc0D5917f49B57B8e9F89e491F5E18919093A",
-        "getExternalEther": "4663942788493190703148",
-        "getExternalShares": "3755760370849624395907",
+        "getExternalEther": "4156747471736502460885",
+        "getExternalShares": "3346729011016689456413",
         "getFee": 999,
         "getFeeDistribution": {
-          "treasuryFeeBasisPoints": 3793,
+          "treasuryFeeBasisPoints": 3783,
           "insuranceFeeBasisPoints": 0,
-          "operatorsFeeBasisPoints": 6206
+          "operatorsFeeBasisPoints": 6216
         },
         "getInitializationBlock": 11473216,
         "getLidoLocator": "eth:0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "getMaxExternalRatioBP": 3000,
-        "getMaxMintableExternalShares": "3278762872033065127601988",
+        "getMaxMintableExternalShares": "3295775783885905357421115",
         "getRecoveryVault": "eth:0x0000000000000000000000000000000000000000",
         "getStakeLimitFullInfo": {
           "isStakingPaused_": false,
           "isStakingLimitSet": true,
-          "currentStakeLimit": "147930312500000000000000",
+          "currentStakeLimit": "150000000000000000000000",
           "maxStakeLimit": "150000000000000000000000",
           "maxStakeLimitGrowthBlocks": 6400,
-          "prevStakeLimit": "147860000000000000000000",
-          "prevStakeBlockNumber": 25774055
+          "prevStakeLimit": "149999988800000000000000",
+          "prevStakeBlockNumber": 25796186
         },
-        "getTotalPooledEther": "9515951773044848297253691",
-        "getTotalShares": "7662965902646650712390996",
+        "getTotalPooledEther": "9565266897615101164176296",
+        "getTotalShares": "7701299259103834798837313",
         "getTreasury": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
         "getWithdrawalCredentials": "0x010000000000000000000000b9d7934878b5fb9610b3fe8a5e441e8fad7e293f",
-        "getWithdrawalsReserve": "3627990064605571068398",
+        "getWithdrawalsReserve": "20594389375301661715411",
         "hasInitialized": true,
         "implementation": "eth:0x028271E30a695c0527A0C50cA30603feD004cDb0",
         "isDepositable": false,
@@ -6682,7 +6970,7 @@
         ],
         "stakingPausers": [],
         "symbol": "stETH",
-        "totalSupply": "9515951773044848297253691"
+        "totalSupply": "9565266897615101164176296"
       },
       "fieldMeta": {
         "stakeLimitConfiguration": {
@@ -7026,7 +7314,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -7057,7 +7345,7 @@
         "assetRecoverers": [],
         "curveId": 2,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -7112,14 +7400,14 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "RECOVERER_ROLE": { "adminRole": "DEFAULT_ADMIN_ROLE", "members": [] }
         },
         "assetRecoverers": [],
         "CURVE_ID": 0,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "MODULE": "eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F",
         "RECOVERER_ROLE": "0xb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc"
       },
@@ -7333,7 +7621,7 @@
         ],
         "periodsLength": 69,
         "proxyType": 2,
-        "transactionsNextIndex": 825,
+        "transactionsNextIndex": 826,
         "vault": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"
       },
       "implementationNames": {
@@ -7480,7 +7768,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "CONFIG_MANAGER_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -7490,7 +7778,7 @@
         "CONFIG_MANAGER_ROLE": "0xbbfb55d933c2bfa638763473275b1d84c4418e58d26cf9d2cd5758237756d9f0",
         "configManagers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": []
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
       },
       "implementationNames": {
         "eth:0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09": "OracleDaemonConfig"
@@ -7753,7 +8041,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -7770,7 +8058,7 @@
         "BEACON_ROOTS": "eth:0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02",
         "CAPELLA_SLOT": 6209536,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "FIRST_SUPPORTED_SLOT": 11649024,
         "getResumeSinceTimestamp": 0,
         "GI_FIRST_BALANCES_NODE_CURR": "0x0000000000000000000000000000000000000000000000000026000000000028",
@@ -7859,7 +8147,7 @@
         "getChainId": 1,
         "GnosisSafe_modules": [],
         "multisigThreshold": "4 of 6 (67%)",
-        "nonce": 22,
+        "nonce": 23,
         "VERSION": "1.3.0"
       },
       "implementationNames": {
@@ -7896,7 +8184,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "REGISTRY_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -7909,7 +8197,7 @@
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_TIER_ID": 0,
         "DEFAULT_TIER_OPERATOR": "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getConfirmExpiry": 86400,
         "LIDO_LOCATOR": "eth:0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
         "MAX_CONFIRM_EXPIRY": 2592000,
@@ -8037,9 +8325,89 @@
       "receivedPermissions": [
         {
           "permission": "interact",
+          "from": "eth:0x0De4Ea0184c2ad0BacA7183356Aea5B8d5Bf5c6e",
+          "description": "grant or revoke every ValidatorsExitBusOracle role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x147f8d3cf3004FAf9Bf94E88B54b6C06De507be9",
+          "description": "grant or revoke OracleReportSanityChecker roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x17be979344f2c2cC806229a532D92f8742C10462",
+          "description": "grant or revoke ConsolidationGateway roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1d201BE093d847f6446530Efb0E8Fb426d176709",
+          "description": "grant or revoke every VaultHub role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x207798e6fD1aa7Ee8a63782A64c959cD6727b78C",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021",
           "description": "make arbitrary calls through this executor and transfer its ownership.",
           "role": ".owner"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6",
+          "description": "grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x367d23c756599c20DCc8D6943F4976E8F88D60d7",
+          "description": "grant or revoke FeeDistributor roles and change the rebate recipient.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x3BbBb175f7F07954DE00052b20E1c5572223F24D",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
         },
         {
           "permission": "interact",
@@ -8065,6 +8433,36 @@
           "from": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
           "description": "grant, revoke, parameterize, or transfer management of the Agent script-runner permission.",
           "role": ".scriptPermissionManagers",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x3FC2C71579D80790Aaa3fc7Be8B66ac39dC57374",
+          "description": "grant or revoke TopUpGateway roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x4D4074628678Bd302921c20573EEa1ed38DdF7FB",
+          "description": "grant or revoke every FeeOracle role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x4d72BFF1BeaC69925F8Bd12526a39BAAb069e5Da",
+          "description": "grant or revoke Accounting roles, change the bond lock period and penalty recipient, and configure fee splits and custom rewards claimers.",
+          "role": ".defaultAdmins",
           "via": [
             { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
             { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
@@ -8122,6 +8520,16 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0x5DB427080200c235F2Ae8Cd17A7be87921f7AD6c",
+          "description": "grant or revoke LazyOracle roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x5FbE8cEf9CCc56ad245736D3C5bAf82ad54Ca789",
           "description": "change the beacon implementation.",
           "role": ".owner",
@@ -8142,6 +8550,26 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0x6093EFA6B5E2FF3be54d1c895c9deA932805c49F",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x610B517D380f287c239C93F8eF6FfBd567AA4bA5",
+          "description": "grant or revoke Ejector roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4",
           "description": "add or remove oracle committee members and change the report quorum.",
           "role": ".memberAndQuorumManagers",
@@ -8152,9 +8580,49 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0x71093efF8D8599b5fA340D665Ad60fA7C80688e4",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x773933F9db8964A17d62fb808f2EC7A2de4247CC",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a",
           "description": "add or remove oracle committee members and change the report quorum.",
           "role": ".memberAndQuorumManagers",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x7FaDB6358950c5fAA66Cb5EB8eE5147De3df355a",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x852deD011285fe67063a08005c71a85690503Cee",
+          "description": "grant or revoke every AccountingOracle role.",
+          "role": ".defaultAdmins",
           "via": [
             { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
             { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
@@ -8182,9 +8650,59 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0x86A8d4E0db5938D21d98047544668FCCB1A9ADc8",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x889edC2eDab5f40e902b864aD4d7AdE8E412F9B1",
+          "description": "grant or revoke every WithdrawalQueue role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x8c002c6eE10cf8adb78D1F9EB2e134FdaF8A7C1a",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x8EeFCdbD984c30E472BcbF545783D051CB5114e5",
+          "description": "grant or revoke every FeeOracle role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0x902D64c93F6595339aA46105627a085591051aFb",
           "description": "add or remove oracle committee members and change the report quorum.",
           "role": ".memberAndQuorumManagers",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x902D64c93F6595339aA46105627a085591051aFb",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins",
           "via": [
             { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
             { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
@@ -8205,6 +8723,56 @@
           "from": "eth:0x9895F0F17cc1d1891b6f18ee0b483B6f221b37Bb",
           "description": "grant, revoke, parameterize, or transfer management of the permission-creator permission.",
           "role": ".permissionCreatorManagers",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9D28ad303C90DF524BA960d7a2DAC56DcC31e428",
+          "description": "grant or revoke ParametersRegistry roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9Dc70b5A4f4F5E4AF9058C983D560564F031f1D7",
+          "description": "grant or revoke ConsolidationMigrator roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xa12760721A72A7199aB38059DA6690b9Cd4ed7B8",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xA64b339eebD3dC3De848298B6a140955932901d8",
+          "description": "grant or revoke MetaRegistry roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xaa328816027F2D32B9F56d190BC9Fa4A5C07637f",
+          "description": "grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.",
+          "role": ".defaultAdmins",
           "via": [
             { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
             { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
@@ -8302,6 +8870,26 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0xB314D4A76C457c93150d308787939063F4Cc67E0",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xb8cd8F059Ad7a5dB8CAfDe34aAb007317F7156C8",
+          "description": "grant or revoke asset-recovery and administrative roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xb8FFC3Cd6e7Cf5a098A1c92F48009765B24088Dc",
           "description": "grant, revoke, parameterize, or transfer management of the Aragon application-manager permission.",
           "role": ".appManagerPermissionManagers",
@@ -8331,10 +8919,40 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0xbf05A929c3D7885a6aeAd833a992dA6E5ac23b09",
+          "description": "grant or revoke OracleDaemonConfig roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xC1db28B3301331277e307FDCfF8DE28242A4486E",
           "description": "change Dual Governance configuration, proposer executors, tiebreaker and reseal settings.",
           "role": ".adminExecutor",
           "via": [
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC392F457960f1B13Ebaf1aa6C065479dD507E1E3",
+          "description": "grant or revoke verifier pause and resume roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC69685E89Cefc327b43B7234AC646451B27c544d",
+          "description": "grant or revoke OperatorGrid roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
             { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
           ]
         },
@@ -8359,6 +8977,56 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0xD624B08C83bAECF0807Dd2c6880C3154a5F0B288",
+          "description": "grant or revoke every HashConsensus role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xd907CE33B4Be423823d1CFFe80BD147E8b8554C8",
+          "description": "grant or revoke ConsolidationBus roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0",
+          "description": "grant or revoke FeeDistributor roles and change the rebate recipient.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xDa5F930cE326EB5205085D66c72A4E79d60cB8C1",
+          "description": "grant or revoke Curated Staking Module roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F",
+          "description": "grant or revoke Community Staking Module roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xDBfa0B8A15a503f25224fcA5F84a3853230A715C",
           "description": "add or remove subcommittee members, change quorum and voting timelock, or transfer subcommittee ownership.",
           "role": ".owner",
@@ -8371,6 +9039,66 @@
           "from": "eth:0xDC00116a0D3E064427dA2600449cfD2566B3037B",
           "description": "change the maximum, replenishment rate, and frame duration of the triggerable-withdrawal limit.",
           "role": ".exitLimitManagers",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xDC00116a0D3E064427dA2600449cfD2566B3037B",
+          "description": "grant or revoke every TriggerableWithdrawalsGateway role.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xe181A377A2d2BDE9A83f1474BC3DB7A412de091E",
+          "description": "grant or revoke Ejector roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xE76c52750019b80B43E36DF30bf4060EB73F573a",
+          "description": "grant or revoke Burner roles and enable migration of excess stETH.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xeF273Ca4A21Ba7B414Ae3C9f9b443038cb133F72",
+          "description": "grant or revoke gate roles and change the gate's display name.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xf4618370a1fBf46905B16C10817c8CFaD924D6db",
+          "description": "grant or revoke ValidatorStrikes roles and change the Ejector used for poor-performing validators.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3",
+          "description": "grant or revoke PredepositGuarantee roles.",
+          "role": ".defaultAdmins",
           "via": [
             { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
             { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
@@ -8407,9 +9135,39 @@
         },
         {
           "permission": "interact",
+          "from": "eth:0xfce7aB839e55de77730716D05b3553e45ab3A5Ba",
+          "description": "grant or revoke verifier pause and resume roles.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
           "from": "eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
           "description": "add staking modules, change their fees and status, set deposit and top-up limits, and configure router-wide module parameters.",
           "role": ".stakingModuleManagers",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xFdDf38947aFB03C621C71b06C9C70bce73f12999",
+          "description": "grant or revoke StakingRouter roles and administer the router's privileged operations.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
+            { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xffC1C5d59CeAC6F6c27E701F04a70cb50474607C",
+          "description": "grant or revoke ParametersRegistry roles.",
+          "role": ".defaultAdmins",
           "via": [
             { "address": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c" },
             { "address": "eth:0x23E0B465633FF5178808F4A75186E2F2F9537021" }
@@ -8879,7 +9637,7 @@
           ]
         ],
         "$upgradeCount": 1,
-        "availableBalance": "3524370200070323434",
+        "availableBalance": "3538840614840633511",
         "beaconChainDepositsPaused": false,
         "DEPOSIT_CONTRACT": "eth:0x00000000219ab540356cBB839Cbe05303d7705Fa",
         "depositor": "eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3",
@@ -8954,7 +9712,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_MEMBERS_AND_QUORUM_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -8979,7 +9737,7 @@
         },
         "consensusDisablers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "DISABLE_CONSENSUS_ROLE": "0x10b016346186602d93fc7a27ace09ba944baf9453611b186d36acd3d3d667dc0",
         "fastLaneConfigManagers": [],
         "frameConfigManagers": [],
@@ -9007,8 +9765,8 @@
             "eth:0x042a9e5acCfa17e28300F1b5967f20891E973922"
           ],
           "lastReportedRefSlots": [
-            15004799, 15004799, 15004799, 15004799, 15004799, 14997599,
-            14983199, 14990399, 14997599
+            15004799, 15011999, 15019199, 15026399, 15026399, 15026399,
+            15026399, 15026399, 14997599
           ]
         },
         "getQuorum": 5,
@@ -9105,7 +9863,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PUBLISH_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -9121,7 +9879,7 @@
         "batchSize": 200,
         "configManagers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "executionDelay": 86400,
         "getConsolidationGateway": "eth:0x17be979344f2c2cC806229a532D92f8742C10462",
         "MANAGE_ROLE": "0xa076a07f65bcd51bcb15a0f01a65bc18f2d922acb81bcfd8af4caf5adb557091",
@@ -9183,25 +9941,25 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "RECOVERER_ROLE": { "adminRole": "DEFAULT_ADMIN_ROLE", "members": [] }
         },
         "ACCOUNTING": "eth:0x4d72BFF1BeaC69925F8Bd12526a39BAAb069e5Da",
         "assetRecoverers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "distributionDataHistoryCount": 11,
         "getInitializedVersion": 3,
         "ORACLE": "eth:0x4D4074628678Bd302921c20573EEa1ed38DdF7FB",
-        "pendingSharesToDistribute": "33031344164933550038",
+        "pendingSharesToDistribute": "40715426383481312347",
         "proxy__getAdmin": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
         "proxy__getImplementation": "eth:0x936da7cDB7eed1084d294E23eA1d7Ad72DCcfE0E",
         "proxy__getIsOssified": false,
         "rebateRecipient": "eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c",
         "RECOVERER_ROLE": "0xb3e25b5404b87e5a838579cb5d7481d61ad96ee284d38ec1e97c07ba64e7f6fc",
         "STETH": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
-        "totalClaimableShares": "168873125955845161198",
+        "totalClaimableShares": "168063348187052493443",
         "treeRoot": "0x6053e3ea79c923cbe457d778e6df232d65c1ee766fe095aecb209a20ff8540b7"
       },
       "implementationNames": {
@@ -9262,7 +10020,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "STAKING_ROUTER_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -9321,7 +10079,7 @@
         "assetRecoverers": [],
         "CREATE_NODE_OPERATOR_ROLE": "0xc72a21b38830f4d6418a239e17db78b945cc7cfee674bac97fd596eaf0438478",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "delayedPenaltyReporters": [
           "eth:0x2570e0b22AD904501dfB0d49575991ACB801dD91"
         ],
@@ -9333,127 +10091,127 @@
         "getActiveNodeOperatorsCount": 46,
         "getDepositAllocationTargets": {
           "currentValidators": [
-            250, 0, 245, 250, 245, 210, 245, 40, 245, 250, 198, 50, 250, 245,
-            245, 0, 245, 250, 250, 245, 0, 0, 246, 245, 245, 245, 245, 150, 100,
-            245, 0, 198, 49, 245, 245, 245, 245, 0, 250, 245, 206, 20, 245, 0,
-            245, 239
+            271, 0, 246, 256, 246, 215, 246, 41, 254, 254, 198, 57, 301, 246,
+            246, 0, 246, 254, 254, 246, 0, 0, 247, 246, 246, 246, 246, 151, 104,
+            296, 0, 221, 64, 246, 271, 246, 246, 0, 265, 246, 206, 20, 246, 0,
+            246, 239
           ],
           "targetValidators": [
-            245, 0, 245, 245, 245, 206, 245, 39, 245, 245, 196, 49, 245, 245,
-            245, 0, 245, 245, 245, 245, 0, 0, 245, 245, 245, 245, 245, 147, 98,
-            245, 0, 196, 49, 245, 245, 245, 245, 0, 245, 245, 203, 41, 245, 0,
-            245, 245
+            253, 0, 253, 253, 253, 212, 253, 40, 253, 253, 202, 50, 253, 253,
+            253, 0, 253, 253, 253, 253, 0, 0, 253, 253, 253, 253, 253, 152, 101,
+            253, 0, 202, 50, 253, 253, 253, 253, 0, 253, 253, 210, 43, 253, 0,
+            253, 253
           ]
         },
         "getInitializedVersion": 1,
         "getNodeOperatorDepositInfoToUpdateCount": 0,
         "getNodeOperatorsCount": 46,
-        "getNonce": 452,
+        "getNonce": 483,
         "getResumeSinceTimestamp": 1784904479,
         "getStakingModuleSummary": {
           "totalExitedValidators": 0,
-          "totalDepositedValidators": 4275,
-          "depositableValidatorsCount": 109
+          "totalDepositedValidators": 4512,
+          "depositableValidatorsCount": 0
         },
         "getTopUpAllocationTargets": {
           "currentAllocations": [
-            "251808000000000000000000",
+            "252992000000000000000000",
             0,
-            "251648000000000000000000",
-            "251840000000000000000000",
-            "251712000000000000000000",
-            "211485440000000000000000",
-            "251648000000000000000000",
-            "40290560000000000000000",
-            "251680000000000000000000",
-            "251808000000000000000000",
-            "201356800000000000000000",
-            "50355200000000000000000",
-            "251840000000000000000000",
-            "251680000000000000000000",
-            "251680000000000000000000",
+            "252224000000000000000000",
+            "252544000000000000000000",
+            "252192000000000000000000",
+            "212156160000000000000000",
+            "252224000000000000000000",
+            "40419840000000000000000",
+            "252448000000000000000000",
+            "252448000000000000000000",
+            "201817600000000000000000",
+            "50694400000000000000000",
+            "253984000000000000000000",
+            "252192000000000000000000",
+            "252192000000000000000000",
             0,
-            "251680000000000000000000",
-            "251840000000000000000000",
-            "251840000000000000000000",
-            "251680000000000000000000",
+            "252224000000000000000000",
+            "252480000000000000000000",
+            "252480000000000000000000",
+            "252224000000000000000000",
             0,
             0,
-            "251712000000000000000000",
-            "251680000000000000000000",
-            "251648000000000000000000",
-            "251680000000000000000000",
-            "251712000000000000000000",
-            "151065600000000000000000",
-            "100710400000000000000000",
-            "251680000000000000000000",
+            "252256000000000000000000",
+            "252224000000000000000000",
+            "252192000000000000000000",
+            "252192000000000000000000",
+            "252192000000000000000000",
+            "151443200000000000000000",
+            "101068800000000000000000",
+            "253824000000000000000000",
             0,
-            "201382400000000000000000",
-            "50329600000000000000000",
-            "251648000000000000000000",
-            "251680000000000000000000",
-            "251680000000000000000000",
-            "251680000000000000000000",
+            "202579200000000000000000",
+            "50924800000000000000000",
+            "252224000000000000000000",
+            "252992000000000000000000",
+            "252224000000000000000000",
+            "252192000000000000000000",
             0,
-            "251808000000000000000000",
-            "251680000000000000000000",
-            "209258560000000000000000",
-            "42165440000000000000000",
-            "251680000000000000000000",
+            "252832000000000000000000",
+            "252224000000000000000000",
+            "209417920000000000000000",
+            "42198080000000000000000",
+            "252224000000000000000000",
             0,
-            "251680000000000000000000",
-            "252128000000000000000000"
+            "252224000000000000000000",
+            "252000000000000000000000"
           ],
           "targetAllocations": [
-            "251722352941176470588235",
+            "252458352941176470588235",
             0,
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "211446776470588235294117",
-            "251722352941176470588235",
-            "40275576470588235294117",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "201377882352941176470588",
-            "50344470588235294117647",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "212065016470588235294117",
+            "252458352941176470588235",
+            "40393336470588235294117",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "201966682352941176470588",
+            "50491670588235294117647",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
             0,
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
             0,
             0,
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "151033411764705882352941",
-            "100688941176470588235294",
-            "251722352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "151475011764705882352941",
+            "100983341176470588235294",
+            "252458352941176470588235",
             0,
-            "201377882352941176470588",
-            "50344470588235294117647",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "251722352941176470588235",
+            "201966682352941176470588",
+            "50491670588235294117647",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
             0,
-            "251722352941176470588235",
-            "251722352941176470588235",
-            "208929552941176470588235",
-            "42792800000000000000000",
-            "251722352941176470588235",
+            "252458352941176470588235",
+            "252458352941176470588235",
+            "209540432941176470588235",
+            "42917920000000000000000",
+            "252458352941176470588235",
             0,
-            "251722352941176470588235",
-            "251722352941176470588235"
+            "252458352941176470588235",
+            "252458352941176470588235"
           ]
         },
-        "getTotalModuleStake": "136800000000000000000000",
+        "getTotalModuleStake": "144384000000000000000000",
         "getType": "0x637572617465642d6f6e636861696e2d76320000000000000000000000000000",
         "isPaused": false,
         "LIDO_LOCATOR": "eth:0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
@@ -9563,7 +10321,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "STAKING_ROUTER_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -9641,7 +10399,7 @@
         "assetRecoverers": [],
         "CREATE_NODE_OPERATOR_ROLE": "0xc72a21b38830f4d6418a239e17db78b945cc7cfee674bac97fd596eaf0438478",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "delayedPenaltyReporters": [
           "eth:0xC52fC3081123073078698F1EAc2f1Dc7Bd71880f"
         ],
@@ -9650,17 +10408,17 @@
         ],
         "EXIT_PENALTIES": "eth:0x06cd61045f958A209a0f8D746e103eCc625f4193",
         "FEE_DISTRIBUTOR": "eth:0xD99CC66fEC647E68294C6477B40fC7E0F6F618D0",
-        "getActiveNodeOperatorsCount": 614,
+        "getActiveNodeOperatorsCount": 616,
         "getInitializedVersion": 3,
         "getKeysForTopUp": [],
         "getNodeOperatorDepositInfoToUpdateCount": 0,
-        "getNodeOperatorsCount": 614,
-        "getNonce": 5297,
+        "getNodeOperatorsCount": 616,
+        "getNonce": 5361,
         "getResumeSinceTimestamp": 1729872203,
         "getStakingModuleSummary": {
-          "totalExitedValidators": 1626,
-          "totalDepositedValidators": 26108,
-          "depositableValidatorsCount": 219
+          "totalExitedValidators": 1627,
+          "totalDepositedValidators": 26356,
+          "depositableValidatorsCount": 1
         },
         "getTopUpQueue": {
           "enabled": false,
@@ -9669,7 +10427,7 @@
           "head": 0
         },
         "getTopUpQueueItem": [],
-        "getTotalModuleStake": "784640000000000000000000",
+        "getTotalModuleStake": "791360000000000000000000",
         "getType": "0x636f6d6d756e6974792d6f6e636861696e2d7631000000000000000000000000",
         "isPaused": false,
         "LIDO_LOCATOR": "eth:0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb",
@@ -9820,7 +10578,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "ADD_FULL_WITHDRAWAL_REQUEST_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -9848,7 +10606,7 @@
         },
         "ADD_FULL_WITHDRAWAL_REQUEST_ROLE": "0x15fac8ba7fe8dd5344b88c1915452ce66976f270d1cd793c3b0ab579cecd33c0",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "exitLimitManagers": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "exitRequestLimitConfiguration": {
           "maxExitRequestsLimit": 250,
@@ -9938,7 +10696,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -9955,7 +10713,7 @@
         },
         "assetRecoverers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
         "MODULE": "eth:0xDa5F930cE326EB5205085D66c72A4E79d60cB8C1",
@@ -10011,7 +10769,7 @@
           ]
         ],
         "$upgradeCount": 1,
-        "availableBalance": "1779036079989762789",
+        "availableBalance": "2479036079989762789",
         "beaconChainDepositsPaused": false,
         "DEPOSIT_CONTRACT": "eth:0x00000000219ab540356cBB839Cbe05303d7705Fa",
         "depositor": "eth:0xF4bF42c6D6A0E38825785048124DBAD6c9eaaac3",
@@ -10096,7 +10854,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "REQUEST_BURN_SHARES_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -10111,11 +10869,11 @@
           }
         },
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getContractVersion": 1,
         "getCoverSharesBurnt": "14684898881648297203",
         "getExcessStETH": 0,
-        "getNonCoverSharesBurnt": "14141935436386624968818300",
+        "getNonCoverSharesBurnt": "14153140444711846483834645",
         "getSharesRequestedToBurn": { "coverShares": 0, "nonCoverShares": 0 },
         "isMigrationAllowed": false,
         "LIDO": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
@@ -10206,7 +10964,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -10227,7 +10985,7 @@
         "curveId": 3,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
         "DEFAULT_BOND_CURVE_ID": 0,
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "getInitializedVersion": 1,
         "getResumeSinceTimestamp": 0,
         "isPaused": false,
@@ -10531,7 +11289,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x2e59A20f205bB85a89C53f1936454680651E618e"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -10551,7 +11309,7 @@
         },
         "CANCEL_ROLE": "0x9f959e00d95122f5cbd677010436cf273ef535b86b056afc172852144b9491d7",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x2e59A20f205bB85a89C53f1936454680651E618e"],
         "evmScriptExecutor": "eth:0xFE5986E06210aC1eCC1aDCafc0cc7f8D63B3F977",
         "getEVMScriptFactories": [
           "eth:0xFeBd8FAC16De88206d4b18764e826AF38546AfE0",
@@ -10609,15 +11367,48 @@
         "getMotion": [],
         "getMotions": [
           {
-            "id": 1118,
-            "evmScriptFactory": "eth:0xf2476f967C826722F5505eDfc4b2561A34033477",
-            "creator": "eth:0x55897893c19e4B0c52731a3b7C689eC417005Ad6",
+            "id": 1119,
+            "evmScriptFactory": "eth:0x1F809D2cb72a5Ab13778811742050eDa876129b6",
+            "creator": "eth:0xe2A682A9722354D825d1BbDF372cC86B2ea82c8C",
             "duration": 259200,
-            "startDate": 1786712327,
-            "snapshotBlock": 25753426,
+            "startDate": 1787062871,
+            "snapshotBlock": 25782537,
             "objectionsThreshold": 50,
             "objectionsAmount": 0,
-            "evmScriptHash": "0x647308947cd9d231ec80050f65b0aa8d84817adb75034bd8658f59ce2e418d06"
+            "evmScriptHash": "0x11c134c165f1e7ef615bd541b50745361d47e6f4d9f454310cd1e17d858adc48"
+          },
+          {
+            "id": 1120,
+            "evmScriptFactory": "eth:0x1F809D2cb72a5Ab13778811742050eDa876129b6",
+            "creator": "eth:0xe2A682A9722354D825d1BbDF372cC86B2ea82c8C",
+            "duration": 259200,
+            "startDate": 1787062871,
+            "snapshotBlock": 25782537,
+            "objectionsThreshold": 50,
+            "objectionsAmount": 0,
+            "evmScriptHash": "0x2fb903986edf44b3689dd771c533d68378ecfdd77215bf9638aa67df9f63c25c"
+          },
+          {
+            "id": 1121,
+            "evmScriptFactory": "eth:0x1F809D2cb72a5Ab13778811742050eDa876129b6",
+            "creator": "eth:0xe2A682A9722354D825d1BbDF372cC86B2ea82c8C",
+            "duration": 259200,
+            "startDate": 1787062871,
+            "snapshotBlock": 25782537,
+            "objectionsThreshold": 50,
+            "objectionsAmount": 0,
+            "evmScriptHash": "0x286a89ab5c2030d283e7daf0eeb873b8a8f1bf3c17dd10c58a36ca3e1cf90512"
+          },
+          {
+            "id": 1122,
+            "evmScriptFactory": "eth:0x1F809D2cb72a5Ab13778811742050eDa876129b6",
+            "creator": "eth:0xe2A682A9722354D825d1BbDF372cC86B2ea82c8C",
+            "duration": 259200,
+            "startDate": 1787062871,
+            "snapshotBlock": 25782537,
+            "objectionsThreshold": 50,
+            "objectionsAmount": 0,
+            "evmScriptHash": "0x00dd2445d0eedcbbbfb4ae8f395b770011f912f01d397bbca9d3de56a8d1e7b9"
           }
         ],
         "governanceToken": "eth:0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32",
@@ -10700,12 +11491,12 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           }
         },
         "ACCOUNTING": "eth:0x2F91e3A8C5d6593bf4F8403fCfeCcd62dF59f6F6",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "ejector": "eth:0xe181A377A2d2BDE9A83f1474BC3DB7A412de091E",
         "EXIT_PENALTIES": "eth:0x004aFb7DAA7dEA20EbAaB75c9F4892C879FaCCe0",
         "getInitializedVersion": 1,
@@ -10783,7 +11574,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -10800,7 +11591,7 @@
         "ACTIVATION_DEPOSIT_AMOUNT": "31000000000000000000",
         "BEACON_ROOTS": "eth:0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02",
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "DEPOSIT_DOMAIN": "0x03000000f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a9",
         "getResumeSinceTimestamp": 1769692907,
         "GI_FIRST_VALIDATOR_CURR": "0x0000000000000000000000000000000000000000000000000096000000000028",
@@ -11209,7 +12000,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "PAUSE_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -11226,7 +12017,7 @@
         "BEACON_ROOTS": "eth:0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02",
         "CAPELLA_SLOT": 6209536,
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "FIRST_SUPPORTED_SLOT": 11649024,
         "getResumeSinceTimestamp": 0,
         "GI_FIRST_BALANCES_NODE_CURR": "0x0000000000000000000000000000000000000000000000000026000000000028",
@@ -11357,7 +12148,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "0x00b1e70095ba5bacc3202c3db9faf1f7873186f0ed7b6c84e80c0018dcc6e38e": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -11405,7 +12196,7 @@
           }
         },
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "DEPOSIT_CONTRACT": "eth:0x00000000219ab540356cBB839Cbe05303d7705Fa",
         "exitedValidatorReporters": [
           "eth:0x852deD011285fe67063a08005c71a85690503Cee"
@@ -11423,19 +12214,19 @@
               "stakeShareLimit": 10000,
               "status": 0,
               "name": "curated-onchain-v1",
-              "lastDepositAt": 1785488687,
-              "lastDepositBlock": 25651826,
-              "exitedValidatorsCount": 184997,
+              "lastDepositAt": 1787180759,
+              "lastDepositBlock": 25792331,
+              "exitedValidatorsCount": 185049,
               "priorityExitShareThreshold": 10000,
               "maxDepositsPerBlock": 150,
               "minDepositBlockDistance": 25,
               "withdrawalCredentialsType": 1,
-              "validatorsBalanceGwei": 7923903444305342
+              "validatorsBalanceGwei": 8012592380566187
             },
             "summary": {
-              "totalExitedValidators": 184997,
-              "totalDepositedValidators": 448177,
-              "depositableValidatorsCount": 21662
+              "totalExitedValidators": 185049,
+              "totalDepositedValidators": 448774,
+              "depositableValidatorsCount": 21065
             }
           },
           {
@@ -11456,7 +12247,7 @@
               "maxDepositsPerBlock": 150,
               "minDepositBlockDistance": 25,
               "withdrawalCredentialsType": 1,
-              "validatorsBalanceGwei": 160074257425777
+              "validatorsBalanceGwei": 160022200851338
             },
             "summary": {
               "totalExitedValidators": 7079,
@@ -11465,8 +12256,8 @@
             }
           },
           {
-            "nodeOperatorsCount": 614,
-            "activeNodeOperatorsCount": 614,
+            "nodeOperatorsCount": 616,
+            "activeNodeOperatorsCount": 616,
             "state": {
               "id": 3,
               "stakingModuleAddress": "eth:0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F",
@@ -11475,19 +12266,19 @@
               "stakeShareLimit": 900,
               "status": 0,
               "name": "Community Staking",
-              "lastDepositAt": 1785430811,
-              "lastDepositBlock": 25647027,
-              "exitedValidatorsCount": 1626,
+              "lastDepositAt": 1787164595,
+              "lastDepositBlock": 25790989,
+              "exitedValidatorsCount": 1627,
               "priorityExitShareThreshold": 1080,
               "maxDepositsPerBlock": 30,
               "minDepositBlockDistance": 25,
               "withdrawalCredentialsType": 1,
-              "validatorsBalanceGwei": 744951788133051
+              "validatorsBalanceGwei": 746269179350538
             },
             "summary": {
-              "totalExitedValidators": 1626,
-              "totalDepositedValidators": 26108,
-              "depositableValidatorsCount": 219
+              "totalExitedValidators": 1627,
+              "totalDepositedValidators": 26356,
+              "depositableValidatorsCount": 1
             }
           },
           {
@@ -11501,8 +12292,8 @@
               "stakeShareLimit": 10000,
               "status": 0,
               "name": "curated-onchain-v2",
-              "lastDepositAt": 1786891775,
-              "lastDepositBlock": 25768326,
+              "lastDepositAt": 1787163911,
+              "lastDepositBlock": 25790932,
               "exitedValidatorsCount": 0,
               "priorityExitShareThreshold": 10000,
               "maxDepositsPerBlock": 100,
@@ -11512,35 +12303,35 @@
             },
             "summary": {
               "totalExitedValidators": 0,
-              "totalDepositedValidators": 4275,
-              "depositableValidatorsCount": 109
+              "totalDepositedValidators": 4512,
+              "depositableValidatorsCount": 0
             }
           }
         ],
         "getContractVersion": 4,
         "getMaxTopUpPerBlockGwei": 3200000000000,
         "getModuleValidatorsBalance": [
-          "7923903444305342000000000",
-          "160074257425777000000000",
-          "744951788133051000000000",
+          "8012592380566187000000000",
+          "160022200851338000000000",
+          "746269179350538000000000",
           0
         ],
         "getStakingFeeAggregateDistribution": {
-          "modulesFee": "3792528514551355664",
-          "treasuryFee": "6207471485448644334",
+          "modulesFee": "3789921129321309631",
+          "treasuryFee": "6210078870678690365",
           "basePrecision": "100000000000000000000"
         },
-        "getStakingModuleActiveValidatorsCount": [263180, 5000, 24482, 4275],
+        "getStakingModuleActiveValidatorsCount": [263725, 5000, 24729, 4512],
         "getStakingModuleIds": [1, 2, 3, 4],
         "getStakingModuleIsActive": [true, true, true, true],
         "getStakingModuleIsDepositsPaused": [false, false, false, false],
         "getStakingModuleIsStopped": [false, false, false, false],
         "getStakingModuleLastDepositBlock": [
-          25651826, 24687607, 25647027, 25768326
+          25792331, 24687607, 25790989, 25790932
         ],
         "getStakingModuleMaxDepositsPerBlock": [150, 150, 30, 100],
         "getStakingModuleMinDepositBlockDistance": [25, 25, 25, 75],
-        "getStakingModuleNonce": [18737, 1130, 5297, 452],
+        "getStakingModuleNonce": [18755, 1130, 5361, 483],
         "getStakingModules": [
           {
             "id": 1,
@@ -11550,14 +12341,14 @@
             "stakeShareLimit": 10000,
             "status": 0,
             "name": "curated-onchain-v1",
-            "lastDepositAt": 1785488687,
-            "lastDepositBlock": 25651826,
-            "exitedValidatorsCount": 184997,
+            "lastDepositAt": 1787180759,
+            "lastDepositBlock": 25792331,
+            "exitedValidatorsCount": 185049,
             "priorityExitShareThreshold": 10000,
             "maxDepositsPerBlock": 150,
             "minDepositBlockDistance": 25,
             "withdrawalCredentialsType": 1,
-            "validatorsBalanceGwei": 7923903444305342
+            "validatorsBalanceGwei": 8012592380566187
           },
           {
             "id": 2,
@@ -11574,7 +12365,7 @@
             "maxDepositsPerBlock": 150,
             "minDepositBlockDistance": 25,
             "withdrawalCredentialsType": 1,
-            "validatorsBalanceGwei": 160074257425777
+            "validatorsBalanceGwei": 160022200851338
           },
           {
             "id": 3,
@@ -11584,14 +12375,14 @@
             "stakeShareLimit": 900,
             "status": 0,
             "name": "Community Staking",
-            "lastDepositAt": 1785430811,
-            "lastDepositBlock": 25647027,
-            "exitedValidatorsCount": 1626,
+            "lastDepositAt": 1787164595,
+            "lastDepositBlock": 25790989,
+            "exitedValidatorsCount": 1627,
             "priorityExitShareThreshold": 1080,
             "maxDepositsPerBlock": 30,
             "minDepositBlockDistance": 25,
             "withdrawalCredentialsType": 1,
-            "validatorsBalanceGwei": 744951788133051
+            "validatorsBalanceGwei": 746269179350538
           },
           {
             "id": 4,
@@ -11601,8 +12392,8 @@
             "stakeShareLimit": 10000,
             "status": 0,
             "name": "curated-onchain-v2",
-            "lastDepositAt": 1786891775,
-            "lastDepositBlock": 25768326,
+            "lastDepositAt": 1787163911,
+            "lastDepositBlock": 25790932,
             "exitedValidatorsCount": 0,
             "priorityExitShareThreshold": 10000,
             "maxDepositsPerBlock": 100,
@@ -11613,9 +12404,9 @@
         ],
         "getStakingModulesCount": 4,
         "getStakingModuleStateAccounting": [
-          [7923903444305342, 184997],
-          [160074257425777, 7079],
-          [744951788133051, 1626],
+          [8012592380566187, 185049],
+          [160022200851338, 7079],
+          [746269179350538, 1627],
           [0, 0]
         ],
         "getStakingModuleStateConfig": [
@@ -11657,10 +12448,10 @@
           ]
         ],
         "getStakingModuleStateDeposits": [
-          [1785488687, 25651826, 150, 25],
+          [1787180759, 25792331, 150, 25],
           [1773875987, 24687607, 150, 25],
-          [1785430811, 25647027, 30, 25],
-          [1786891775, 25768326, 100, 75]
+          [1787164595, 25790989, 30, 25],
+          [1787163911, 25790932, 100, 75]
         ],
         "getStakingModuleStatus": [0, 0, 0, 0],
         "getStakingModuleWithdrawalCredentials": [
@@ -11677,15 +12468,15 @@
           ],
           "stakingModuleIds": [1, 2, 3],
           "stakingModuleFees": [
-            "3141225908181465125",
-            "145045224438180159",
-            "506257381931710380"
+            "3144347889737111813",
+            "143535630819843714",
+            "502037608764354104"
           ],
-          "totalFee": "9999999999999999998",
+          "totalFee": "9999999999999999996",
           "precisionPoints": "100000000000000000000"
         },
         "getTotalFeeE4Precision": 999,
-        "getTotalModulesValidatorsBalance": "8828929489864170000000000",
+        "getTotalModulesValidatorsBalance": "8918883760768063000000000",
         "getWithdrawalCredentials": "0x010000000000000000000000b9d7934878b5fb9610b3fe8a5e441e8fad7e293f",
         "INITIAL_DEPOSIT_SIZE": "32000000000000000000",
         "LIDO": "eth:0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84",
@@ -11955,7 +12746,7 @@
         "accessControl": {
           "DEFAULT_ADMIN_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
-            "members": []
+            "members": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"]
           },
           "MANAGE_GENERAL_PENALTIES_AND_CHARGES_ROLE": {
             "adminRole": "DEFAULT_ADMIN_ROLE",
@@ -11988,7 +12779,7 @@
         },
         "curveParameterManagers": [],
         "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "defaultAdmins": [],
+        "defaultAdmins": ["eth:0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c"],
         "defaultAllowedExitDelay": 345600,
         "defaultBadPerformancePenalty": 0,
         "defaultExitDelayFee": "10000000000000000",
@@ -18845,6 +19636,6 @@
     "lido/wstETH": "0x9b708a05879c062566a96f737bd9998af0ceda3a51a54456a93cd24fd4c4dfdf",
     "lido/WstETHReferralStaker": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c"
   },
-  "usedBlockNumbers": { "ethereum": 25774058 },
-  "permissionsConfigHash": "0xcaccfdefbcd3aeb3d838a5efe4c63ca26066c064a3efb9e53aadb0a47dbbadcd"
+  "usedBlockNumbers": { "ethereum": 25796192 },
+  "permissionsConfigHash": "0xd963c74938c7307dcfc46ca4545402b1c1256c36f39d8e40fc3beb0ea144519e"
 }

--- a/packages/discovery/src/discovery/handlers/user/AccessControlHandler.test.ts
+++ b/packages/discovery/src/discovery/handlers/user/AccessControlHandler.test.ts
@@ -281,11 +281,52 @@ describe(AccessControlHandler.name, () => {
     })
   })
 
+  it('does not re-derive an ABI role name that roleNames already maps, even without includeEmptyRoles', async () => {
+    const address = ChainSpecificAddress.random()
+    const customRole = utils.solidityKeccak256(['string'], ['custom wizard'])
+    const derivedRole = utils.solidityKeccak256(['string'], ['WIZARD_ROLE'])
+    const member = EthereumAddress.random()
+    const other = EthereumAddress.random()
+    const provider = mockObject<IProvider>({
+      chain: 'ethereum',
+      async getLogs() {
+        return [RoleGranted(customRole, member), RoleGranted(derivedRole, other)]
+      },
+    })
+
+    const handler = new AccessControlHandler(
+      'someName',
+      { type: 'accessControl', roleNames: { [customRole]: 'WIZARD_ROLE' } },
+      ['function WIZARD_ROLE() view returns (bytes32)'],
+    )
+    const value = await handler.execute(provider, address)
+
+    expect(value).toEqual({
+      field: 'someName',
+      value: {
+        DEFAULT_ADMIN_ROLE: {
+          adminRole: 'DEFAULT_ADMIN_ROLE',
+          members: [],
+        },
+        WIZARD_ROLE: {
+          adminRole: 'DEFAULT_ADMIN_ROLE',
+          members: [
+            ChainSpecificAddress.fromLong('ethereum', member).toString(),
+          ],
+        },
+        [derivedRole]: {
+          adminRole: 'DEFAULT_ADMIN_ROLE',
+          members: [
+            ChainSpecificAddress.fromLong('ethereum', other).toString(),
+          ],
+        },
+      },
+      ignoreRelative: undefined,
+    })
+  })
+
   it('keeps DEFAULT_ADMIN_ROLE members when the ABI exposes DEFAULT_ADMIN_ROLE()', async () => {
-    // Regression: OpenZeppelin's AccessControl exposes a `DEFAULT_ADMIN_ROLE()` view
-    // returning bytes32(0). Hashing it to keccak256("DEFAULT_ADMIN_ROLE") registered a
-    // phantom role under the same display name which, together with includeEmptyRoles,
-    // used to overwrite the real (bytes32(0)) role's members with an empty set.
+    // Regression: keccak256("DEFAULT_ADMIN_ROLE") must not shadow bytes32(0)
     const address = ChainSpecificAddress.random()
     const admin = EthereumAddress.random()
     const provider = mockObject<IProvider>({

--- a/packages/discovery/src/discovery/handlers/user/AccessControlHandler.test.ts
+++ b/packages/discovery/src/discovery/handlers/user/AccessControlHandler.test.ts
@@ -290,7 +290,10 @@ describe(AccessControlHandler.name, () => {
     const provider = mockObject<IProvider>({
       chain: 'ethereum',
       async getLogs() {
-        return [RoleGranted(customRole, member), RoleGranted(derivedRole, other)]
+        return [
+          RoleGranted(customRole, member),
+          RoleGranted(derivedRole, other),
+        ]
       },
     })
 

--- a/packages/discovery/src/discovery/handlers/user/AccessControlHandler.test.ts
+++ b/packages/discovery/src/discovery/handlers/user/AccessControlHandler.test.ts
@@ -280,4 +280,46 @@ describe(AccessControlHandler.name, () => {
       ignoreRelative: undefined,
     })
   })
+
+  it('keeps DEFAULT_ADMIN_ROLE members when the ABI exposes DEFAULT_ADMIN_ROLE()', async () => {
+    // Regression: OpenZeppelin's AccessControl exposes a `DEFAULT_ADMIN_ROLE()` view
+    // returning bytes32(0). Hashing it to keccak256("DEFAULT_ADMIN_ROLE") registered a
+    // phantom role under the same display name which, together with includeEmptyRoles,
+    // used to overwrite the real (bytes32(0)) role's members with an empty set.
+    const address = ChainSpecificAddress.random()
+    const admin = EthereumAddress.random()
+    const provider = mockObject<IProvider>({
+      chain: 'ethereum',
+      async getLogs() {
+        return [RoleGranted('0x' + '0'.repeat(64), admin)]
+      },
+    })
+
+    const handler = new AccessControlHandler(
+      'someName',
+      { type: 'accessControl', includeEmptyRoles: true },
+      [
+        'function DEFAULT_ADMIN_ROLE() view returns (bytes32)',
+        'function WIZARD_ROLE() view returns (bytes32)',
+      ],
+    )
+    const value = await handler.execute(provider, address)
+
+    expect(value).toEqual({
+      field: 'someName',
+      value: {
+        DEFAULT_ADMIN_ROLE: {
+          adminRole: 'DEFAULT_ADMIN_ROLE',
+          members: [
+            ChainSpecificAddress.fromLong('ethereum', admin).toString(),
+          ],
+        },
+        WIZARD_ROLE: {
+          adminRole: 'DEFAULT_ADMIN_ROLE',
+          members: [],
+        },
+      },
+      ignoreRelative: undefined,
+    })
+  })
 })

--- a/packages/discovery/src/discovery/handlers/user/AccessControlHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/AccessControlHandler.ts
@@ -50,6 +50,15 @@ export class AccessControlHandler implements Handler {
       const name = entry.match(/^function (\w+)_ROLE\(\)/)?.[1]
       if (name) {
         const fullName = name + '_ROLE'
+        // OpenZeppelin's AccessControl exposes a `DEFAULT_ADMIN_ROLE()` accessor whose
+        // value is bytes32(0), already registered above. Deriving
+        // keccak256("DEFAULT_ADMIN_ROLE") here would register a phantom hash under the
+        // same "DEFAULT_ADMIN_ROLE" display name; in `execute` the by-name mapping then
+        // collapses the two entries and the phantom (empty) one can overwrite the real
+        // zero-hash role's members.
+        if (fullName === 'DEFAULT_ADMIN_ROLE') {
+          continue
+        }
         if (explicitlyNamedRoles?.has(fullName)) {
           continue
         }

--- a/packages/discovery/src/discovery/handlers/user/AccessControlHandler.ts
+++ b/packages/discovery/src/discovery/handlers/user/AccessControlHandler.ts
@@ -40,26 +40,16 @@ export class AccessControlHandler implements Handler {
     abi: string[],
   ) {
     this.knownNames.set(DEFAULT_ADMIN_ROLE_BYTES, 'DEFAULT_ADMIN_ROLE')
-    const explicitlyNamedRoles = definition.includeEmptyRoles
-      ? new Set(Object.values(definition.roleNames ?? {}))
-      : undefined
     for (const [hash, name] of Object.entries(definition.roleNames ?? {})) {
       this.knownNames.set(hash, name)
     }
+    // Registered names (DEFAULT_ADMIN_ROLE, roleNames) win over ABI-derived hashes
+    const registeredNames = new Set(this.knownNames.values())
     for (const entry of abi) {
       const name = entry.match(/^function (\w+)_ROLE\(\)/)?.[1]
       if (name) {
         const fullName = name + '_ROLE'
-        // OpenZeppelin's AccessControl exposes a `DEFAULT_ADMIN_ROLE()` accessor whose
-        // value is bytes32(0), already registered above. Deriving
-        // keccak256("DEFAULT_ADMIN_ROLE") here would register a phantom hash under the
-        // same "DEFAULT_ADMIN_ROLE" display name; in `execute` the by-name mapping then
-        // collapses the two entries and the phantom (empty) one can overwrite the real
-        // zero-hash role's members.
-        if (fullName === 'DEFAULT_ADMIN_ROLE') {
-          continue
-        }
-        if (explicitlyNamedRoles?.has(fullName)) {
+        if (registeredNames.has(fullName)) {
           continue
         }
         const hash = utils.solidityKeccak256(['string'], [fullName])


### PR DESCRIPTION
The accessControl handler scans a contract's ABI for `<X>_ROLE()` accessors and registers `keccak256("<X>_ROLE") -> "<X>_ROLE"` so role hashes render with their names. OpenZeppelin's AccessControl exposes a `DEFAULT_ADMIN_ROLE()` accessor, so this registers a phantom `keccak256("DEFAULT_ADMIN_ROLE")` hash under the display name "DEFAULT_ADMIN_ROLE" — but the real DEFAULT_ADMIN_ROLE value is bytes32(0), which is already registered explicitly.

Trigger conditions (grant block is irrelevant): the field is configured with `includeEmptyRoles` AND the contract's ABI exposes a `DEFAULT_ADMIN_ROLE()` accessor. `includeEmptyRoles` inserts an empty entry under the phantom hash; in `execute` both the real zero-hash role (holding the actual admin members) and the phantom hash map to the same "DEFAULT_ADMIN_ROLE" display name, and the final `Object.fromEntries` keeps the last one — the empty phantom — silently wiping the real DEFAULT_ADMIN_ROLE members.

Effect: affected contracts show `DEFAULT_ADMIN_ROLE.members: []` in discovery regardless of when the admin was granted (it commonly looks constructor- specific only because admins are usually granted in the constructor). Verified across the Lido project: SanityChecker, TriggerableWithdrawalsGateway, VaultHub, PredepositGuarantee, CSModule -> Agent; EasyTrack -> Voting — hiding the grant/revoke-all-roles edge from the modelled permission graph.

Skip deriving the phantom hash for DEFAULT_ADMIN_ROLE; the real bytes32(0) role is already registered. Adds a regression test. (Does not close the more general class where two role hashes map to the same display name and collide in Object.fromEntries — a possible follow-up.)

<img width="1031" height="220" alt="Screenshot 2026-08-19 at 16 00 14" src="https://github.com/user-attachments/assets/ff7042fc-a463-42e0-955c-f34cd4aad8c1" />
