### PR TITLE
Debounce compare chart queries, add selection reset and tooltip row cap

### DIFF
--- a/packages/frontend/src/pages/layer2s/compare/components/CompareMetricLineChart.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/CompareMetricLineChart.tsx
@@ -181,9 +181,6 @@ function CustomTooltip({
   )
   if (visible.length === 0) return null
 
-  // With many projects selected a full list would grow taller than the
-  // chart itself; the rows are value-sorted, so the cutoff drops the least
-  // significant series.
   const sorted = [...visible].sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
   const shown = sorted.slice(0, MAX_TOOLTIP_ROWS)
   const hiddenCount = sorted.length - shown.length

--- a/packages/frontend/src/pages/layer2s/compare/components/CompareMetricLineChart.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/CompareMetricLineChart.tsx
@@ -153,6 +153,8 @@ export function CompareMetricLineChart({
   )
 }
 
+const MAX_TOOLTIP_ROWS = 10
+
 function CustomTooltip({
   payload,
   label,
@@ -179,6 +181,13 @@ function CustomTooltip({
   )
   if (visible.length === 0) return null
 
+  // With many projects selected a full list would grow taller than the
+  // chart itself; the rows are value-sorted, so the cutoff drops the least
+  // significant series.
+  const sorted = [...visible].sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
+  const shown = sorted.slice(0, MAX_TOOLTIP_ROWS)
+  const hiddenCount = sorted.length - shown.length
+
   return (
     <ChartTooltipWrapper>
       <div className="flex w-[200px] flex-col [@media(min-width:600px)]:w-60">
@@ -186,33 +195,36 @@ function CustomTooltip({
           {renderTimestamp(label)}
         </div>
         <div className="mt-2 flex flex-col gap-2">
-          {[...visible]
-            .sort((a, b) => (b.value ?? 0) - (a.value ?? 0))
-            .map((entry) => {
-              const config = entry.name ? meta[entry.name] : undefined
-              if (!config) return null
-              return (
-                <div
-                  key={entry.name}
-                  className="flex items-center justify-between gap-x-3"
-                >
-                  <div className="flex items-center gap-1">
-                    <ChartDataIndicator
-                      backgroundColor={config.color}
-                      type={config.indicatorType}
-                    />
-                    <span className="font-medium text-label-value-14">
-                      {config.label}
-                    </span>
-                  </div>
-                  <span className="whitespace-nowrap font-medium text-label-value-15 text-primary tabular-nums">
-                    {entry.value !== null && entry.value !== undefined
-                      ? formatValue(entry.value)
-                      : 'No data'}
+          {shown.map((entry) => {
+            const config = entry.name ? meta[entry.name] : undefined
+            if (!config) return null
+            return (
+              <div
+                key={entry.name}
+                className="flex items-center justify-between gap-x-3"
+              >
+                <div className="flex items-center gap-1">
+                  <ChartDataIndicator
+                    backgroundColor={config.color}
+                    type={config.indicatorType}
+                  />
+                  <span className="font-medium text-label-value-14">
+                    {config.label}
                   </span>
                 </div>
-              )
-            })}
+                <span className="whitespace-nowrap font-medium text-label-value-15 text-primary tabular-nums">
+                  {entry.value !== null && entry.value !== undefined
+                    ? formatValue(entry.value)
+                    : 'No data'}
+                </span>
+              </div>
+            )
+          })}
+          {hiddenCount > 0 && (
+            <div className="font-medium text-label-value-14 text-secondary">
+              +{hiddenCount} more
+            </div>
+          )}
         </div>
       </div>
     </ChartTooltipWrapper>

--- a/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
@@ -178,6 +178,16 @@ export function CompareProjectPicker({
         <PlusIcon className="size-4" />
         Add project
       </DashedButton>
+      {!isDefaultSelection && (
+        // Clearing the explicit selection falls back to the top-N defaults,
+        // the same state as a fresh visit.
+        <DashedButton
+          onClick={() => onChange([])}
+          className="h-7 rounded-lg px-2.5"
+        >
+          Reset
+        </DashedButton>
+      )}
       {isDefaultSelection && (
         <p className="w-full font-medium text-2xs text-secondary">
           Showing top projects by default. Add or remove projects to build your

--- a/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
@@ -182,7 +182,7 @@ export function CompareProjectPicker({
         <button
           type="button"
           onClick={() => onChange([])}
-          className="h-7 cursor-pointer rounded-lg bg-surface-primary px-2.5 font-medium text-secondary text-sm leading-none hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+          className="h-7 cursor-pointer px-1 font-medium text-secondary text-sm leading-none"
         >
           Reset
         </button>

--- a/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
@@ -179,8 +179,6 @@ export function CompareProjectPicker({
         Add project
       </DashedButton>
       {!isDefaultSelection && (
-        // Clearing the explicit selection falls back to the top-N defaults,
-        // the same state as a fresh visit.
         <DashedButton
           onClick={() => onChange([])}
           className="h-7 rounded-lg px-2.5"

--- a/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/CompareProjectPicker.tsx
@@ -179,12 +179,13 @@ export function CompareProjectPicker({
         Add project
       </DashedButton>
       {!isDefaultSelection && (
-        <DashedButton
+        <button
+          type="button"
           onClick={() => onChange([])}
-          className="h-7 rounded-lg px-2.5"
+          className="h-7 cursor-pointer rounded-lg bg-surface-primary px-2.5 font-medium text-secondary text-sm leading-none hover:bg-surface-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
         >
           Reset
-        </DashedButton>
+        </button>
       )}
       {isDefaultSelection && (
         <p className="w-full font-medium text-2xs text-secondary">

--- a/packages/frontend/src/pages/layer2s/compare/components/L2CompareCharts.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/L2CompareCharts.tsx
@@ -88,9 +88,6 @@ export function L2CompareCharts({
       .map((slug) => bySlug.get(slug))
       .filter((project) => project !== undefined)
   }, [state.projects, allProjects, defaultProjectSlugs])
-  // Selecting projects one by one would fire a backend query per click;
-  // charts query for this debounced selection instead. The initial value
-  // matches the SSR-prefetched query input, so first paint reuses it.
   const queryProjects = useDebouncedValue(selectedProjects, 400)
 
   const displayedMetrics = useMemo(() => {

--- a/packages/frontend/src/pages/layer2s/compare/components/L2CompareCharts.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/components/L2CompareCharts.tsx
@@ -17,6 +17,7 @@ import {
 } from '~/components/core/tooltip/Tooltip'
 import { PrimaryCard } from '~/components/primary-card/PrimaryCard'
 import { useCopyToClipboard } from '~/hooks/useCopyToClipboard'
+import { useDebouncedValue } from '~/hooks/useDebouncedValue'
 import { useIsClient } from '~/hooks/useIsClient'
 import { useTimeout } from '~/hooks/useTimeout'
 import { useUrlStateSync } from '~/hooks/useUrlStateSync'
@@ -87,6 +88,10 @@ export function L2CompareCharts({
       .map((slug) => bySlug.get(slug))
       .filter((project) => project !== undefined)
   }, [state.projects, allProjects, defaultProjectSlugs])
+  // Selecting projects one by one would fire a backend query per click;
+  // charts query for this debounced selection instead. The initial value
+  // matches the SSR-prefetched query input, so first paint reuses it.
+  const queryProjects = useDebouncedValue(selectedProjects, 400)
 
   const displayedMetrics = useMemo(() => {
     const unique = new Map<CompareMetricId, CompareMetric>()
@@ -179,6 +184,7 @@ export function L2CompareCharts({
               config={config}
               chartRange={state.chartRange}
               projects={selectedProjects}
+              queryProjects={queryProjects}
               setConfig={setChartConfig(index)}
               isHovered={
                 hoveredChartId === undefined || hoveredChartId === index
@@ -208,6 +214,7 @@ function CompareChartCard({
   config,
   chartRange,
   projects,
+  queryProjects,
   setConfig,
   isHovered,
   onHoverChange,
@@ -217,6 +224,7 @@ function CompareChartCard({
   config: CompareChartConfig
   chartRange: ChartRange
   projects: CompareProjectEntry[]
+  queryProjects: CompareProjectEntry[]
   setConfig: Dispatch<SetStateAction<CompareChartConfig>>
   /** False while another card is hovered, so this card's tooltip hides. */
   isHovered: boolean
@@ -255,6 +263,7 @@ function CompareChartCard({
         >
           <metric.Chart
             projects={projects}
+            queryProjects={queryProjects}
             config={config}
             chartRange={chartRange}
           />

--- a/packages/frontend/src/pages/layer2s/compare/metrics/activity/ActivityCompareChart.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/metrics/activity/ActivityCompareChart.tsx
@@ -13,13 +13,14 @@ import { getActivityCompareChartParams } from './activityCompareMetric'
 
 export function ActivityCompareChart({
   projects,
+  queryProjects,
   config,
   chartRange,
 }: CompareMetricChartProps) {
   const trpc = useTRPC()
   const { data, isLoading } = useQuery(
     trpc.activity.detailedChartWithProjectsRanges.queryOptions(
-      getActivityCompareChartParams(projects, chartRange),
+      getActivityCompareChartParams(queryProjects, chartRange),
     ),
   )
   const unit = config.activityUnit

--- a/packages/frontend/src/pages/layer2s/compare/metrics/costs/CostsCompareChart.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/metrics/costs/CostsCompareChart.tsx
@@ -16,13 +16,14 @@ const UNIT_INDEX = { gas: 0, eth: 1, usd: 2 } as const
 
 export function CostsCompareChart({
   projects,
+  queryProjects,
   config,
   chartRange,
 }: CompareMetricChartProps) {
   const trpc = useTRPC()
   const { data, isLoading } = useQuery(
     trpc.costs.detailedChartWithProjectsRanges.queryOptions(
-      getCostsCompareChartParams(projects, chartRange),
+      getCostsCompareChartParams(queryProjects, chartRange),
     ),
   )
   const unit = config.costsUnit

--- a/packages/frontend/src/pages/layer2s/compare/metrics/data-posted/DataPostedCompareChart.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/metrics/data-posted/DataPostedCompareChart.tsx
@@ -12,12 +12,13 @@ import { getDataPostedCompareChartParams } from './dataPostedCompareMetric'
 
 export function DataPostedCompareChart({
   projects,
+  queryProjects,
   chartRange,
 }: CompareMetricChartProps) {
   const trpc = useTRPC()
   const { data, isLoading } = useQuery(
     trpc.da.detailedChartWithProjectsRanges.queryOptions(
-      getDataPostedCompareChartParams(projects, chartRange),
+      getDataPostedCompareChartParams(queryProjects, chartRange),
     ),
   )
 

--- a/packages/frontend/src/pages/layer2s/compare/metrics/tvs/TvsCompareChart.tsx
+++ b/packages/frontend/src/pages/layer2s/compare/metrics/tvs/TvsCompareChart.tsx
@@ -27,13 +27,14 @@ const TVS_FILTER_VALUE_INDEX: Record<CompareTvsFilter, number> = {
 
 export function TvsCompareChart({
   projects,
+  queryProjects,
   config,
   chartRange,
 }: CompareMetricChartProps) {
   const trpc = useTRPC()
   const { data, isLoading } = useQuery(
     trpc.tvs.detailedChartWithProjectsRanges.queryOptions(
-      getTvsCompareChartParams(projects, config, chartRange),
+      getTvsCompareChartParams(queryProjects, config, chartRange),
     ),
   )
   const unit = config.tvsUnit

--- a/packages/frontend/src/pages/layer2s/compare/metrics/types.ts
+++ b/packages/frontend/src/pages/layer2s/compare/metrics/types.ts
@@ -10,13 +10,6 @@ import type {
 
 export interface CompareMetricChartProps {
   projects: CompareProjectEntry[]
-  /**
-   * The selection to query data for: `projects` debounced, so toggling
-   * several projects in a row fires one backend query instead of one per
-   * click. Charts render from the live `projects` and read data for it from
-   * here - projects not yet in the response simply have no line until the
-   * debounced query catches up.
-   */
   queryProjects: CompareProjectEntry[]
   config: CompareChartConfig
   chartRange: ChartRange

--- a/packages/frontend/src/pages/layer2s/compare/metrics/types.ts
+++ b/packages/frontend/src/pages/layer2s/compare/metrics/types.ts
@@ -10,6 +10,14 @@ import type {
 
 export interface CompareMetricChartProps {
   projects: CompareProjectEntry[]
+  /**
+   * The selection to query data for: `projects` debounced, so toggling
+   * several projects in a row fires one backend query instead of one per
+   * click. Charts render from the live `projects` and read data for it from
+   * here - projects not yet in the response simply have no line until the
+   * debounced query catches up.
+   */
+  queryProjects: CompareProjectEntry[]
   config: CompareChartConfig
   chartRange: ChartRange
 }


### PR DESCRIPTION
## Summary

- Debounce the project selection used for chart queries by 400ms so rapid add/remove edits don't fire a request per keystroke; charts still render the immediate selection while data catches up
- Thread a separate `queryProjects` prop through `CompareMetricChartProps` and use it in the TVS, costs, activity and data posted compare charts
- Add a Reset button to the project picker, shown only when the selection differs from the default
- Cap the compare chart tooltip at 10 rows sorted by value, with a `+N more` line for the remainder

## Testing

- Not run — verified visually on the compare page: adding/removing several projects quickly issues one request per metric after settling, Reset returns to the default top-projects view, and the tooltip truncates past 10 series