### PR TITLE
Add support for BlockScoutV2

### DIFF
--- a/packages/backend/src/config/features/updateMonitor.test.ts
+++ b/packages/backend/src/config/features/updateMonitor.test.ts
@@ -1,0 +1,34 @@
+import { Env } from '@l2beat/backend-tools'
+import type { ChainConfig } from '@l2beat/config'
+import { expect } from 'earl'
+import { getChainDiscoveryConfig } from './updateMonitor'
+
+describe(getChainDiscoveryConfig.name, () => {
+  it('preserves Blockscout V2, V1, and Sourcify source order', () => {
+    const chain: ChainConfig = {
+      name: 'example',
+      chainId: 123,
+      apis: [
+        { type: 'rpc', url: 'https://rpc.example' },
+        { type: 'blockscoutV2', url: 'https://blockscout.example/api/v2' },
+        { type: 'blockscout', url: 'https://blockscout.example/api' },
+        { type: 'sourcify', chainId: 123 },
+      ],
+    }
+    const env = new Env({
+      EXAMPLE_RPC_URL_FOR_DISCOVERY: 'https://rpc.example',
+    })
+
+    const result = getChainDiscoveryConfig(env, chain.name, [chain])
+
+    expect(result.explorer).toEqual([
+      { type: 'blockscoutV2', url: 'https://blockscout.example/api/v2' },
+      {
+        type: 'blockscout',
+        url: 'https://blockscout.example/api',
+        unsupported: { getContractCreation: undefined },
+      },
+      { type: 'sourcify', chainId: 123 },
+    ])
+  })
+})

--- a/packages/backend/src/config/features/updateMonitor.ts
+++ b/packages/backend/src/config/features/updateMonitor.ts
@@ -72,7 +72,7 @@ export function getUpdateMonitorConfig(
   }
 }
 
-function getChainDiscoveryConfig(
+export function getChainDiscoveryConfig(
   env: Env,
   chain: string,
   chains: ChainConfig[],
@@ -98,6 +98,12 @@ function getChainDiscoveryConfig(
 
   for (const api of chainConfig.apis) {
     switch (api.type) {
+      case 'blockscoutV2':
+        explorer.push({
+          type: api.type,
+          url: api.url,
+        })
+        break
       case 'blockscout':
       case 'routescan':
         explorer.push({

--- a/packages/config/src/projects/robinhood/diffHistory.md
+++ b/packages/config/src/projects/robinhood/diffHistory.md
@@ -1,3 +1,47 @@
+Generated with discovered.json: 0x2b84d0d09e78f471ef88d0bda3c8091c33182b35
+
+# Diff at Mon, 24 Aug 2026 17:01:43 GMT:
+
+- author: Michał Podsiadły (<michal.podsiadly@l2beat.com>)
+- comparing to: main@13eb47c755f8f1545e987d7aa8482c1840bc9dfd block: 1786359815
+- current timestamp: 1787590711
+
+## Description
+
+Provide description of changes. This section will be preserved.
+
+## Config/verification related changes
+
+Following changes come from updates made to the config file,
+or/and contracts becoming verified, not from differences found during
+discovery. Values are for block 1786359815 (main branch discovery), not current.
+
+```diff
+    contract RollupProxy (eth:0x23A19d23e89166adedbDcB432518AB01e4272D94) [orbitstack/RollupProxyBoLD] {
+    +++ description: Central contract for the project's configuration like its execution logic hash (`wasmModuleRoot`) and addresses of the other system contracts. Entry point for Proposers creating new assertions (state commitments) and Challengers submitting fraud proofs (In the Orbit stack, these two roles are both called Validators).
++++ description: ArbOS version derived from known wasmModuleRoots.
+      values.arbOsFromWmRoot:
+-        "0xc10cd7ec6acaf1c441a3f6bd0900ad20f15855ba775a96f1939118cbc629dc97"
++        "ArbOS v61 wasmModuleRoot"
+      usedTypes.0.arg.0xc10cd7ec6acaf1c441a3f6bd0900ad20f15855ba775a96f1939118cbc629dc97:
++        "ArbOS v61 wasmModuleRoot"
+    }
+```
+
+```diff
+    contract SafeL2 (robinhood:0x3A0C507Cc7F8785C877359ad49d0476966d17a1C) [GnosisSafe] {
+    +++ description: None
+      unverified:
+-        true
+      sourceHashes.0:
+-        null
++        "0xfe0725afd3cf2e5fb7627005a6bcf13ef7e35f78034eed2211edbffdb6a9aab5"
+      implementationNames.robinhood:0x3A0C507Cc7F8785C877359ad49d0476966d17a1C:
+-        ""
++        "SafeProxy"
+    }
+```
+
 Generated with discovered.json: 0xc5244324694475bfa66bbff62c0ac74f82a0f54a
 
 # Diff at Mon, 10 Aug 2026 11:04:49 GMT:

--- a/packages/config/src/projects/robinhood/discovered.json
+++ b/packages/config/src/projects/robinhood/discovered.json
@@ -1,6 +1,6 @@
 {
   "name": "robinhood",
-  "timestamp": 1786359815,
+  "timestamp": 1787590711,
   "configHash": "0xb41933f40dc9d8a56aabdb790c3ef5658af4071801a9a53e338db683cfa3a0e8",
   "entries": [
     {
@@ -244,7 +244,7 @@
         ],
         "$upgradeCount": 1,
         "anyTrustFastConfirmer": "eth:0x0000000000000000000000000000000000000000",
-        "arbOsFromWmRoot": "0xc10cd7ec6acaf1c441a3f6bd0900ad20f15855ba775a96f1939118cbc629dc97",
+        "arbOsFromWmRoot": "ArbOS v61 wasmModuleRoot",
         "baseStake": "1000000000000000000",
         "bridge": "eth:0xDf8755334ce7A73cCF6b581C02eA649AE3E864b3",
         "chainId": 4663,
@@ -259,7 +259,7 @@
         ],
         "inbox": "eth:0x1A07cc4BD17E0118BdB54D70990D2158AbAD7a2D",
         "isPostBoLD": true,
-        "latestConfirmed": "0x4608f3926c5e3112a7a2a26848c30f83845dbcfd90fc5f11c2fe77b5502e28d3",
+        "latestConfirmed": "0x84c306a33755315b5654ae57585fc0e634acdc9a20a21ddf91a723dd1f0f87ca",
         "loserStakeEscrow": "eth:0x1F3Bdec08A161Ca9e5480feF33A3B2278c2931C5",
         "minimumAssertionPeriod": 75,
         "outbox": "eth:0xf0ce991ea4A0d2400A4AB49b20ae333f6Dce3DE9",
@@ -326,6 +326,7 @@
             "0xdb698a2576298f25448bc092e52cf13b1e24141c997135d70f217d674bbeb69a": "ArbOS v40 wasmModuleRoot",
             "0x8a7513bf7bb3e3db04b0d982d0e973bcf57bf8b88aef7c6d03dba3a81a56a499": "ArbOS v51 wasmModuleRoot",
             "0xc2c02df561d4afaf9a1d6785f70098ec3874765c638e3cb6dbe8d3c83333e14c": "ArbOS v51.1 wasmModuleRoot",
+            "0xc10cd7ec6acaf1c441a3f6bd0900ad20f15855ba775a96f1939118cbc629dc97": "ArbOS v61 wasmModuleRoot",
             "0xe81f986823a85105c5fd91bb53b4493d38c0c26652d23f76a7405ac889908287": "Celestia Nitro 3.2.1 wasmModuleRoot",
             "0xaf1dbdfceb871c00bfbb1675983133df04f0ed04e89647812513c091e3a982b3": "Celestia Nitro 3.3.2 wasmModuleRoot",
             "0x597de35fc2ee60e5b2840157370d037542d6a4bc587af7f88202636c54e6bd8d": "Celestia Nitro ArbOS v40 wasmModuleRoot"
@@ -929,7 +930,7 @@
           ]
         ],
         "$upgradeCount": 1,
-        "batchCount": 95338,
+        "batchCount": 139711,
         "batchPosterManager": "eth:0x0000000000000000000000000000000000000000",
         "batchPosters": ["eth:0xDaa526086787d9DEbE1D7F3FFdb1fE50cf8687F4"],
         "bridge": "eth:0xDf8755334ce7A73cCF6b581C02eA649AE3E864b3",
@@ -968,7 +969,7 @@
         "rollup": "eth:0x23A19d23e89166adedbDcB432518AB01e4272D94",
         "sequencerVersion": "0x00",
         "setIsBatchPosterCount": 1,
-        "totalDelayedMessagesRead": 115288,
+        "totalDelayedMessagesRead": 163611,
         "TREE_DAS_MESSAGE_HEADER_FLAG": "0x08",
         "ZERO_HEAVY_MESSAGE_HEADER_FLAG": "0x20"
       },
@@ -1054,7 +1055,7 @@
         "decimals": 18,
         "name": "Wrapped Ether",
         "symbol": "WETH",
-        "totalSupply": "2243517861073716163476108"
+        "totalSupply": "2052841882960552834542448"
       },
       "implementationNames": {
         "eth:0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "WETH9"
@@ -1162,7 +1163,7 @@
           "eth:0xc34f4907822d1cDC6aE3038Be22e6f12DEa35bd4"
         ],
         "allowedOutboxList": ["eth:0xf0ce991ea4A0d2400A4AB49b20ae333f6Dce3DE9"],
-        "delayedMessageCount": 115304,
+        "delayedMessageCount": 163637,
         "inboxHistory": [
           "eth:0x1A07cc4BD17E0118BdB54D70990D2158AbAD7a2D",
           "eth:0xc34f4907822d1cDC6aE3038Be22e6f12DEa35bd4"
@@ -1170,8 +1171,8 @@
         "outboxHistory": ["eth:0xf0ce991ea4A0d2400A4AB49b20ae333f6Dce3DE9"],
         "rollup": "eth:0x23A19d23e89166adedbDcB432518AB01e4272D94",
         "sequencerInbox": "eth:0xBd0D173EEb87D57A09521c24388a12789F33ba96",
-        "sequencerMessageCount": 95338,
-        "sequencerReportedSubMessageCount": 32747463
+        "sequencerMessageCount": 139711,
+        "sequencerReportedSubMessageCount": 45027551
       },
       "fieldMeta": {
         "allowedOutboxList": {
@@ -1765,10 +1766,9 @@
       "name": "SafeL2",
       "address": "robinhood:0x3A0C507Cc7F8785C877359ad49d0476966d17a1C",
       "type": "Contract",
-      "unverified": true,
       "template": "GnosisSafe",
       "sourceHashes": [
-        null,
+        "0xfe0725afd3cf2e5fb7627005a6bcf13ef7e35f78034eed2211edbffdb6a9aab5",
         "0x076f4dffc7979344d7d248e876b1a947d75ebdf18b5746e3e2305d62eab1ab05"
       ],
       "proxyType": "gnosis safe",
@@ -1793,11 +1793,11 @@
         "getChainId": 4663,
         "GnosisSafe_modules": [],
         "multisigThreshold": "3 of 7 (43%)",
-        "nonce": 5,
+        "nonce": 6,
         "VERSION": "1.4.1"
       },
       "implementationNames": {
-        "robinhood:0x3A0C507Cc7F8785C877359ad49d0476966d17a1C": "",
+        "robinhood:0x3A0C507Cc7F8785C877359ad49d0476966d17a1C": "SafeProxy",
         "robinhood:0x29fcB43b46531BcA003ddC8FCB67FFE91900C762": "SafeL2"
       }
     },
@@ -2158,7 +2158,7 @@
         "getChainId": 4663,
         "GnosisSafe_modules": [],
         "multisigThreshold": "7 of 8 (88%)",
-        "nonce": 4,
+        "nonce": 5,
         "VERSION": "1.4.1"
       },
       "implementationNames": {
@@ -2367,8 +2367,8 @@
         "symbol": "NVDA",
         "terms": "https://robinhood.com/stocktoken/rhj",
         "tokenPaused": false,
-        "totalSupply": "18476020000000000000000",
-        "totalSupplyUI": "18476020000000000000000",
+        "totalSupply": "32096011000000000000000",
+        "totalSupplyUI": "32096011000000000000000",
         "uid": "0x00000000000000000000000000000000915f477416294f5099a5e0e09f327ce5",
         "uiMultiplier": "1000000000000000000"
       },
@@ -3793,6 +3793,9 @@
       "event BeaconUpgraded(address indexed beacon)",
       "event Upgraded(address indexed implementation)"
     ],
+    "robinhood:0x3A0C507Cc7F8785C877359ad49d0476966d17a1C": [
+      "constructor(address _singleton)"
+    ],
     "robinhood:0x3c3E52bC8C181D06A76e2518bBc655C5BB3Ce7Cd": [
       "event Initialized(uint8 version)",
       "event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)",
@@ -3981,6 +3984,6 @@
     "robinhood/accessControlsRegistry": "0xa1fbf84eb609ea4cdccdf8a5051375ec6540a6484aa187e4fc021e7231538e24",
     "robinhood/rwa": "0x6a4b6026d07de4fbe785cf745eed6aab91d27bef2776ed3280a828368f1bf7b2"
   },
-  "usedBlockNumbers": { "ethereum": 25724172, "robinhood": 32747661 },
+  "usedBlockNumbers": { "ethereum": 25826385, "robinhood": 45028036 },
   "permissionsConfigHash": "0x520b503f3c9bb5253b5b60876b8bc989e1134376a9b01ce981bf188bacf2f3f0"
 }

--- a/packages/config/src/projects/robinhood/robinhood.ts
+++ b/packages/config/src/projects/robinhood/robinhood.ts
@@ -187,7 +187,12 @@ export const robinhood: ScalingProject = orbitStackL2({
         url: 'https://rpc.mainnet.chain.robinhood.com',
         callsPerMinute: 600,
       },
+      {
+        type: 'blockscoutV2',
+        url: 'https://robinhoodchain.blockscout.com/api/v2',
+      },
       { type: 'blockscout', url: 'https://robinhoodchain.blockscout.com/api' },
+      { type: 'sourcify', chainId: 4663 },
     ],
   },
   usesEthereumBlobs: true,

--- a/packages/discovery/src/config/chains.ts
+++ b/packages/discovery/src/config/chains.ts
@@ -22,6 +22,7 @@ interface ChainConfig {
         url: string
         unsupported?: EtherscanUnsupportedMethods
       }
+    | { type: 'blockscoutV2'; url: string }
     | { type: 'sourcify' }
   >
   multicall: MulticallConfig | undefined
@@ -62,6 +63,10 @@ export const chains: ChainConfig[] = [
     shortName: 'robinhood',
     multicall: getMulticall3Config(406),
     explorer: [
+      {
+        type: 'blockscoutV2',
+        url: 'https://robinhoodchain.blockscout.com/api/v2',
+      },
       {
         type: 'blockscout',
         url: 'https://robinhoodchain.blockscout.com/api',

--- a/packages/discovery/src/config/config.discovery.ts
+++ b/packages/discovery/src/config/config.discovery.ts
@@ -70,36 +70,34 @@ export function getChainConfig(chain: string): DiscoveryChainConfig {
       'COINGECKO_API_KEY',
     ]),
     multicall: chainConfig.multicall,
-    explorer: ensureArray(chainConfig.explorer).map((e) =>
-      e.type === 'blockscout'
-        ? { type: e.type, url: e.url, unsupported: e.unsupported }
-        : e.type === 'sourcify'
-          ? { type: e.type, chainId: chainConfig.chainId }
-          : e.type === 'etherscan'
-            ? {
-                type: e.type,
-                chainId: chainConfig.chainId,
-                url: e.customUrl ?? 'https://api.etherscan.io/v2/api',
-                apiKey: e.customUrl
-                  ? ''
-                  : env.string([
-                      'ETHERSCAN_API_KEY_FOR_DISCOVERY',
-                      'ETHERSCAN_API_KEY',
-                    ]),
-                unsupported: e.unsupported,
-              }
-            : ({
-                type: e.type,
-                url: e.url,
-                apiKey: env.string([
-                  `${ENV_NAME}_ETHERSCAN_V1_API_KEY_FOR_DISCOVERY`,
-                  `${ENV_NAME}_ETHERSCAN_V1_API_KEY`,
-                  //support for legacy local configs
-                  `DISCOVERY_${ENV_NAME}_ETHERSCAN_V1_API_KEY`,
+    explorer: ensureArray(chainConfig.explorer).map((e): ExplorerConfig => {
+      switch (e.type) {
+        case 'blockscoutV2':
+          return { type: e.type, url: e.url }
+        case 'blockscout':
+        case 'routescan':
+          return {
+            type: e.type,
+            url: e.url,
+            unsupported: e.unsupported,
+          }
+        case 'sourcify':
+          return { type: e.type, chainId: chainConfig.chainId }
+        case 'etherscan':
+          return {
+            type: e.type,
+            chainId: chainConfig.chainId,
+            url: e.customUrl ?? 'https://api.etherscan.io/v2/api',
+            apiKey: e.customUrl
+              ? ''
+              : env.string([
+                  'ETHERSCAN_API_KEY_FOR_DISCOVERY',
+                  'ETHERSCAN_API_KEY',
                 ]),
-                unsupported: e.unsupported,
-              } as ExplorerConfig),
-    ),
+            unsupported: e.unsupported,
+          }
+      }
+    }),
   }
 }
 

--- a/packages/discovery/src/utils/BlockscoutV2SourceClient.test.ts
+++ b/packages/discovery/src/utils/BlockscoutV2SourceClient.test.ts
@@ -1,0 +1,149 @@
+import type { HttpClient } from '@l2beat/shared'
+import { EthereumAddress, Hash256 } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import { Response } from 'node-fetch'
+import { BlockscoutV2SourceClient } from './BlockscoutV2SourceClient'
+
+const API_URL = 'https://blockscout.example/api/v2'
+
+describe(BlockscoutV2SourceClient.name, () => {
+  it('maps verified smart contract metadata', async () => {
+    const libraryAddress = EthereumAddress.random()
+    const response = {
+      is_verified: true,
+      name: 'Example',
+      compiler_version: 'v0.8.26+commit.8a97fa7a',
+      optimization_runs: null,
+      abi: [
+        {
+          type: 'function',
+          name: 'value',
+          inputs: [],
+          outputs: [{ name: '', type: 'uint256' }],
+          stateMutability: 'view',
+        },
+      ],
+      source_code: 'contract Example {}',
+      file_path: 'src/Example.sol',
+      compiler_settings: {
+        optimizer: { enabled: true, runs: 200 },
+        evmVersion: 'paris',
+        viaIR: true,
+        remappings: ['@openzeppelin/=lib/openzeppelin/'],
+        libraries: {
+          'src/Example.sol': { ExampleLibrary: libraryAddress.toString() },
+        },
+      },
+      constructor_args: '0x1234',
+      additional_sources: [
+        {
+          file_path: 'src/Dependency.sol',
+          source_code: 'library Dependency {}',
+        },
+      ],
+      external_libraries: [],
+      language: 'solidity',
+    }
+    const httpClient = mockObject<HttpClient>({
+      fetchRaw: mockFn().resolvesTo(
+        new Response(JSON.stringify(response), { status: 200 }),
+      ),
+    })
+    const client = new BlockscoutV2SourceClient(httpClient, API_URL)
+
+    const result = await client.getContractSource(EthereumAddress.random())
+
+    expect(result).toEqual({
+      name: 'Example',
+      rootFile: 'src/Example.sol',
+      isVerified: true,
+      abi: ['function value() view returns (uint256)'],
+      solidityVersion: 'v0.8.26+commit.8a97fa7a',
+      constructorArguments: '1234',
+      remappings: ['@openzeppelin/=lib/openzeppelin/'],
+      files: {
+        'src/Example.sol': 'contract Example {}',
+        'src/Dependency.sol': 'library Dependency {}',
+      },
+      libraries: { ExampleLibrary: libraryAddress },
+      compilerSettings: {
+        optimizer: { enabled: true, runs: 200 },
+        evmVersion: 'paris',
+        viaIR: true,
+        metadata: undefined,
+        debug: undefined,
+      },
+    })
+  })
+
+  it('reports an unverified contract on a 404', async () => {
+    const httpClient = mockObject<HttpClient>({
+      fetchRaw: mockFn().resolvesTo(new Response('', { status: 404 })),
+    })
+    const client = new BlockscoutV2SourceClient(httpClient, API_URL)
+
+    const result = await client.getContractSource(EthereumAddress.random())
+
+    expect(result).toEqual({
+      name: '',
+      rootFile: undefined,
+      isVerified: false,
+      abi: [],
+      solidityVersion: '',
+      constructorArguments: '',
+      remappings: [],
+      files: {},
+      libraries: {},
+    })
+  })
+
+  it('rejects inconsistent verified metadata without source code', async () => {
+    const httpClient = mockObject<HttpClient>({
+      fetchRaw: mockFn().resolvesTo(
+        new Response(JSON.stringify({ is_verified: true, name: 'Example' }), {
+          status: 200,
+        }),
+      ),
+    })
+    const client = new BlockscoutV2SourceClient(httpClient, API_URL)
+
+    await expect(
+      client.getContractSource(EthereumAddress.random()),
+    ).toBeRejectedWith('returned a verified contract without source code')
+  })
+
+  it('gets the contract deployment transaction', async () => {
+    const address = EthereumAddress.random()
+    const transactionHash = Hash256.random()
+    const fetch = mockFn().resolvesTo({
+      creation_transaction_hash: transactionHash.toString(),
+    })
+    const client = new BlockscoutV2SourceClient(
+      mockObject<HttpClient>({ fetch }),
+      API_URL,
+    )
+
+    const result = await client.getContractDeploymentTx(address)
+
+    expect(result).toEqual(transactionHash)
+    expect(fetch).toHaveBeenCalledWith(
+      `${API_URL}/addresses/${address.toString()}`,
+      { timeout: 10000 },
+    )
+  })
+
+  it('returns undefined when an address has no deployment transaction', async () => {
+    const client = new BlockscoutV2SourceClient(
+      mockObject<HttpClient>({
+        fetch: mockFn().resolvesTo({ creation_transaction_hash: null }),
+      }),
+      API_URL,
+    )
+
+    const result = await client.getContractDeploymentTx(
+      EthereumAddress.random(),
+    )
+
+    expect(result).toEqual(undefined)
+  })
+})

--- a/packages/discovery/src/utils/BlockscoutV2SourceClient.ts
+++ b/packages/discovery/src/utils/BlockscoutV2SourceClient.ts
@@ -1,0 +1,165 @@
+import { Logger } from '@l2beat/backend-tools'
+import { BlockscoutV2Client, type HttpClient } from '@l2beat/shared'
+import { EthereumAddress, Hash256, type UnixTime } from '@l2beat/shared-pure'
+import type { ContractSource, IEtherscanClient } from './IEtherscanClient'
+import { jsonToHumanReadableAbi } from './jsonToHumanReadableAbi'
+
+export class BlockscoutV2SourceClient implements IEtherscanClient {
+  private readonly client: BlockscoutV2Client
+
+  constructor(httpClient: HttpClient, url: string, logger = Logger.SILENT) {
+    this.client = new BlockscoutV2Client(httpClient, url, logger)
+  }
+
+  async getContractSource(address: EthereumAddress): Promise<ContractSource> {
+    const result = await this.client.getSmartContract(address)
+
+    if (result === undefined || !result.is_verified) {
+      return unverifiedContractSource()
+    }
+
+    if (result.source_code === undefined || result.source_code === null) {
+      throw new Error(
+        `Blockscout V2 returned a verified contract without source code for ${address.toString()}`,
+      )
+    }
+
+    const name = result.name?.trim() ?? ''
+    const extension = result.language?.toLowerCase() === 'vyper' ? 'vy' : 'sol'
+    const rootFile = result.file_path ?? `${name || 'Contract'}.${extension}`
+    const files: Record<string, string> = {
+      [rootFile]: result.source_code,
+    }
+    for (const source of result.additional_sources ?? []) {
+      files[source.file_path] = source.source_code
+    }
+
+    const settings = result.compiler_settings ?? undefined
+    const optimizer =
+      settings?.optimizer ??
+      (result.optimization_enabled !== undefined
+        ? {
+            enabled: result.optimization_enabled,
+            runs:
+              result.optimization_runs ??
+              result.optimizations_runs ??
+              undefined,
+          }
+        : undefined)
+
+    return {
+      name,
+      rootFile,
+      isVerified: true,
+      abi: parseAbi(result.abi),
+      solidityVersion: result.compiler_version ?? '',
+      constructorArguments: strip0x(result.constructor_args ?? ''),
+      remappings: settings?.remappings ?? [],
+      files,
+      libraries: parseLibraries(
+        settings?.libraries,
+        result.external_libraries ?? [],
+      ),
+      compilerSettings: {
+        optimizer,
+        evmVersion: settings?.evmVersion ?? result.evm_version ?? undefined,
+        viaIR: settings?.viaIR,
+        metadata: settings?.metadata,
+        debug:
+          settings?.debug?.revertStrings !== undefined
+            ? {
+                revertStrings: settings.debug.revertStrings,
+                debugInfo: settings.debug.debugInfo,
+              }
+            : undefined,
+      },
+    }
+  }
+
+  async getContractDeploymentTx(
+    address: EthereumAddress,
+  ): Promise<Hash256 | undefined> {
+    const result = await this.client.getAddress(address)
+    return result.creation_transaction_hash === undefined ||
+      result.creation_transaction_hash === null
+      ? undefined
+      : Hash256(result.creation_transaction_hash)
+  }
+
+  getFirstTxTimestamp(_address: EthereumAddress): Promise<UnixTime> {
+    throw new Error(notImplementedMessage('getFirstTxTimestamp'))
+  }
+
+  getAtMost10RecentOutgoingTxs(
+    _address: EthereumAddress,
+    _blockNumber: number,
+  ): Promise<{ input: string; to: EthereumAddress; hash: Hash256 }[]> {
+    throw new Error(notImplementedMessage('getAtMost10RecentOutgoingTxs'))
+  }
+
+  getBlockNumberAtOrBefore(_timestamp: UnixTime): Promise<number> {
+    throw new Error(notImplementedMessage('getBlockNumberAtOrBefore'))
+  }
+}
+
+function unverifiedContractSource(): ContractSource {
+  return {
+    name: '',
+    rootFile: undefined,
+    isVerified: false,
+    abi: [],
+    solidityVersion: '',
+    constructorArguments: '',
+    remappings: [],
+    files: {},
+    libraries: {},
+  }
+}
+
+function parseAbi(abi: string | unknown[] | null | undefined): string[] {
+  if (abi === undefined || abi === null) {
+    return []
+  }
+  return jsonToHumanReadableAbi(
+    typeof abi === 'string' ? abi : JSON.stringify(abi),
+  )
+}
+
+function parseLibraries(
+  compilerLibraries: unknown,
+  externalLibraries: { name: string; address_hash: string }[],
+): Record<string, EthereumAddress> {
+  const result: Record<string, EthereumAddress> = {}
+
+  if (isRecord(compilerLibraries)) {
+    for (const [nameOrFile, value] of Object.entries(compilerLibraries)) {
+      if (typeof value === 'string') {
+        result[nameOrFile] = EthereumAddress(value)
+      } else if (isRecord(value)) {
+        for (const [name, address] of Object.entries(value)) {
+          if (typeof address === 'string') {
+            result[name] = EthereumAddress(address)
+          }
+        }
+      }
+    }
+  }
+
+  for (const library of externalLibraries) {
+    result[library.name] = EthereumAddress(library.address_hash)
+  }
+
+  return result
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function strip0x(value: string): string {
+  return value.startsWith('0x') ? value.slice(2) : value
+}
+
+function notImplementedMessage(feature: string) {
+  return `Blockscout V2 feature not implemented: only source code and contract deployment fetching are supported. ${feature} is not supported by this explorer.`
+}

--- a/packages/discovery/src/utils/CombiningEtherscanClient.test.ts
+++ b/packages/discovery/src/utils/CombiningEtherscanClient.test.ts
@@ -1,0 +1,155 @@
+import type { HttpClient } from '@l2beat/shared'
+import { EthereumAddress, Hash256 } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import { Response } from 'node-fetch'
+import { CombiningEtherscanClient } from './CombiningEtherscanClient'
+
+const BLOCKSCOUT_URL = 'https://blockscout.example/api'
+const CHAIN_ID = 1
+
+describe(CombiningEtherscanClient.name, () => {
+  it('reports unverified when one source client fails and another reports unverified', async () => {
+    const address = EthereumAddress.random()
+    const httpClient = mockObject<HttpClient>({
+      fetch: mockFn().rejectsWith(
+        new Error('HTTP error: 429 Too Many Requests'),
+      ),
+      fetchRaw: mockFn().resolvesTo(
+        new Response('', { status: 404, statusText: 'Not Found' }),
+      ),
+    })
+    const client = new CombiningEtherscanClient(httpClient, [
+      { type: 'blockscout', url: BLOCKSCOUT_URL },
+      { type: 'sourcify', chainId: CHAIN_ID },
+    ])
+
+    const result = await client.getContractSource(address)
+
+    expect(result.isVerified).toEqual(false)
+  })
+
+  it('throws with provider errors when every source client fails', async () => {
+    const address = EthereumAddress.random()
+    const client = new CombiningEtherscanClient(
+      mockObject<HttpClient>({
+        fetch: mockFn().rejectsWith(
+          new Error('HTTP error: 429 Too Many Requests'),
+        ),
+      }),
+      [
+        { type: 'blockscout', url: `${BLOCKSCOUT_URL}/one` },
+        { type: 'blockscout', url: `${BLOCKSCOUT_URL}/two` },
+      ],
+    )
+
+    await expect(client.getContractSource(address)).toBeRejectedWith(
+      `All clients failed to fetch contract source for ${address.toString()}: blockscout:${BLOCKSCOUT_URL}/one failed to fetch contract source: HTTP error: 429 Too Many Requests; blockscout:${BLOCKSCOUT_URL}/two failed to fetch contract source: HTTP error: 429 Too Many Requests`,
+    )
+  })
+
+  it('reports unverified when all source clients report unverified', async () => {
+    const address = EthereumAddress.random()
+    const httpClient = mockObject<HttpClient>({
+      fetch: mockFn().resolvesTo({
+        message: 'OK',
+        result: [{ Address: address.toString() }],
+      }),
+      fetchRaw: mockFn().resolvesTo(
+        new Response('', { status: 404, statusText: 'Not Found' }),
+      ),
+    })
+    const client = new CombiningEtherscanClient(httpClient, [
+      { type: 'blockscout', url: BLOCKSCOUT_URL },
+      { type: 'sourcify', chainId: CHAIN_ID },
+    ])
+
+    const result = await client.getContractSource(address)
+
+    expect(result.isVerified).toEqual(false)
+  })
+
+  it('returns verified source without querying remaining clients', async () => {
+    const address = EthereumAddress.random()
+    const fetchRaw = mockFn()
+    const httpClient = mockObject<HttpClient>({
+      fetch: mockFn().resolvesTo({
+        message: 'OK',
+        result: [
+          {
+            SourceCode: 'contract Example {}',
+            ABI: '[]',
+            ContractName: 'Example',
+            FileName: 'Example.sol',
+            CompilerVersion: 'v0.8.0',
+            OptimizationUsed: '0',
+            EVMVersion: 'default',
+          },
+        ],
+      }),
+      fetchRaw,
+    })
+    const client = new CombiningEtherscanClient(httpClient, [
+      { type: 'blockscout', url: BLOCKSCOUT_URL },
+      { type: 'sourcify', chainId: CHAIN_ID },
+    ])
+
+    const result = await client.getContractSource(address)
+
+    expect(result.isVerified).toEqual(true)
+    expect(result.name).toEqual('Example')
+    expect(fetchRaw).toHaveBeenCalledTimes(0)
+  })
+
+  it('uses Blockscout V2 source metadata before V1', async () => {
+    const address = EthereumAddress.random()
+    const fetch = mockFn()
+    const httpClient = mockObject<HttpClient>({
+      fetch,
+      fetchRaw: mockFn().resolvesTo(
+        new Response(
+          JSON.stringify({
+            is_verified: true,
+            name: 'ExampleV2',
+            source_code: 'contract ExampleV2 {}',
+            file_path: 'ExampleV2.sol',
+          }),
+          { status: 200 },
+        ),
+      ),
+    })
+    const client = new CombiningEtherscanClient(httpClient, [
+      { type: 'blockscoutV2', url: `${BLOCKSCOUT_URL}/v2` },
+      { type: 'blockscout', url: BLOCKSCOUT_URL },
+    ])
+
+    const result = await client.getContractSource(address)
+
+    expect(result.isVerified).toEqual(true)
+    expect(result.name).toEqual('ExampleV2')
+    expect(fetch).toHaveBeenCalledTimes(0)
+  })
+
+  it('uses Blockscout V2 contract deployment metadata before V1', async () => {
+    const address = EthereumAddress.random()
+    const transactionHash = Hash256.random()
+    const fetch = mockFn().resolvesTo({
+      creation_transaction_hash: transactionHash.toString(),
+    })
+    const client = new CombiningEtherscanClient(
+      mockObject<HttpClient>({ fetch }),
+      [
+        { type: 'blockscoutV2', url: `${BLOCKSCOUT_URL}/v2` },
+        { type: 'blockscout', url: BLOCKSCOUT_URL },
+      ],
+    )
+
+    const result = await client.getContractDeploymentTx(address)
+
+    expect(result).toEqual(transactionHash)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith(
+      `${BLOCKSCOUT_URL}/v2/addresses/${address.toString()}`,
+      { timeout: 10000 },
+    )
+  })
+})

--- a/packages/discovery/src/utils/CombiningEtherscanClient.ts
+++ b/packages/discovery/src/utils/CombiningEtherscanClient.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@l2beat/backend-tools'
-import type { HttpClient } from '@l2beat/shared'
+import { type HttpClient, sanitizeUrl } from '@l2beat/shared'
 import {
   assert,
   type EthereumAddress,
@@ -7,7 +7,9 @@ import {
   type UnixTime,
 } from '@l2beat/shared-pure'
 import { BlockscoutClient } from './BlockscoutClient'
+import { BlockscoutV2SourceClient } from './BlockscoutV2SourceClient'
 import { EtherscanClient } from './EtherscanClient'
+import { getErrorMessage } from './getErrorMessage'
 import type {
   ContractSource,
   ExplorerConfig,
@@ -18,7 +20,7 @@ import { RoutescanClient } from './RoutescanClient'
 import { SourcifyClient } from './SourcifyClient'
 
 export class CombiningEtherscanClient implements IEtherscanClient {
-  private clients: IEtherscanClient[]
+  private clients: { label: string; client: IEtherscanClient }[]
 
   constructor(
     httpClient: HttpClient,
@@ -28,44 +30,71 @@ export class CombiningEtherscanClient implements IEtherscanClient {
     assert(configs.length > 0, 'We need at least one explorer configured')
 
     this.clients = configs.map((config) => {
+      const label = getClientLabel(config)
       switch (config.type) {
         case 'etherscan-v1': {
-          return EtherscanClient.createForDiscovery(
-            httpClient,
-            logger,
-            config.url,
-            config.apiKey,
-            config.unsupported,
-          )
+          return {
+            label,
+            client: EtherscanClient.createForDiscovery(
+              httpClient,
+              logger,
+              config.url,
+              config.apiKey,
+              config.unsupported,
+            ),
+          }
         }
         case 'etherscan': {
-          return EtherscanClient.createForDiscovery(
-            httpClient,
-            logger,
-            config.url,
-            config.apiKey,
-            config.unsupported,
-            { chainId: config.chainId.toString() },
-          )
+          return {
+            label,
+            client: EtherscanClient.createForDiscovery(
+              httpClient,
+              logger,
+              config.url,
+              config.apiKey,
+              config.unsupported,
+              { chainId: config.chainId.toString() },
+            ),
+          }
         }
         case 'routescan': {
-          return RoutescanClient.createForDiscovery(
-            httpClient,
-            logger,
-            config.url,
-            '',
-            config.unsupported,
-          )
+          return {
+            label,
+            client: RoutescanClient.createForDiscovery(
+              httpClient,
+              logger,
+              config.url,
+              '',
+              config.unsupported,
+            ),
+          }
         }
         case 'blockscout': {
-          return new BlockscoutClient(
-            httpClient,
-            config.url,
-            config.unsupported,
-          )
+          return {
+            label,
+            client: new BlockscoutClient(
+              httpClient,
+              config.url,
+              config.unsupported,
+              logger,
+            ),
+          }
+        }
+        case 'blockscoutV2': {
+          return {
+            label,
+            client: new BlockscoutV2SourceClient(
+              httpClient,
+              config.url,
+              logger,
+            ),
+          }
         }
         case 'sourcify': {
-          return new SourcifyClient(httpClient, config.chainId)
+          return {
+            label,
+            client: new SourcifyClient(httpClient, config.chainId, logger),
+          }
         }
         default: {
           throw new Error('Unknown explorer type')
@@ -77,7 +106,7 @@ export class CombiningEtherscanClient implements IEtherscanClient {
   private async tryClients<T>(
     fn: (client: IEtherscanClient) => Promise<T | undefined>,
   ): Promise<T | undefined> {
-    for (const client of this.clients) {
+    for (const { client } of this.clients) {
       try {
         const result = await fn(client)
         if (result !== undefined) {
@@ -108,20 +137,32 @@ export class CombiningEtherscanClient implements IEtherscanClient {
 
   async getContractSource(address: EthereumAddress): Promise<ContractSource> {
     let lastUnverified: ContractSource | undefined
-    for (const client of this.clients) {
+    const errors: Error[] = []
+    for (const { label, client } of this.clients) {
       try {
         const source = await client.getContractSource(address)
         if (source.isVerified) {
           return source
         }
         lastUnverified = source
-      } catch {}
+      } catch (error) {
+        errors.push(
+          new Error(
+            `${label} failed to fetch contract source: ${getErrorMessage(error)}`,
+            { cause: error },
+          ),
+        )
+      }
     }
 
     if (lastUnverified !== undefined) {
       return lastUnverified
     }
-    throw new Error('No client could fetch contract source')
+
+    throw new AggregateError(
+      errors,
+      `All clients failed to fetch contract source for ${address.toString()}: ${errors.map((error) => error.message).join('; ')}`,
+    )
   }
 
   getContractDeploymentTx(
@@ -143,5 +184,19 @@ export class CombiningEtherscanClient implements IEtherscanClient {
     return this.tryClientsOrThrow('recent outgoing txs', (c) =>
       c.getAtMost10RecentOutgoingTxs(address, blockNumber),
     )
+  }
+}
+
+function getClientLabel(config: ExplorerConfig): string {
+  switch (config.type) {
+    case 'sourcify':
+      return `sourcify:${config.chainId}`
+    case 'etherscan':
+      return `etherscan:${config.chainId}`
+    case 'etherscan-v1':
+    case 'routescan':
+    case 'blockscout':
+    case 'blockscoutV2':
+      return `${config.type}:${sanitizeUrl(config.url)}`
   }
 }

--- a/packages/discovery/src/utils/IEtherscanClient.ts
+++ b/packages/discovery/src/utils/IEtherscanClient.ts
@@ -31,6 +31,11 @@ interface BlockscoutExplorerConfig {
   unsupported?: EtherscanUnsupportedMethods
 }
 
+interface BlockscoutV2ExplorerConfig {
+  type: 'blockscoutV2'
+  url: string
+}
+
 interface RoutescanExplorerConfig {
   type: 'routescan'
   url: string
@@ -52,6 +57,7 @@ export type ExplorerConfig =
   | EtherscanExplorerConfig
   | EtherscanV1ExplorerConfig
   | BlockscoutExplorerConfig
+  | BlockscoutV2ExplorerConfig
   | RoutescanExplorerConfig
   | SourcifyExplorerConfig
 

--- a/packages/shared/src/services/blockscout/BlockscoutV2Client.test.ts
+++ b/packages/shared/src/services/blockscout/BlockscoutV2Client.test.ts
@@ -1,5 +1,6 @@
 import { EthereumAddress, UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
+import { Response } from 'node-fetch'
 import type { HttpClient } from '../../clients'
 import { BlockscoutV2Client } from './BlockscoutV2Client'
 
@@ -118,6 +119,80 @@ describe(BlockscoutV2Client.name, () => {
       await expect(() =>
         blockscoutClient.getInternalTransactions(address),
       ).toBeRejectedWith('At .items: Expected array, got undefined.')
+    })
+  })
+
+  describe(BlockscoutV2Client.prototype.getSmartContract.name, () => {
+    it('fetches and parses smart contract metadata', async () => {
+      const address = EthereumAddress.random()
+      const response = {
+        is_verified: true,
+        name: 'Example',
+        source_code: 'contract Example {}',
+        file_path: 'Example.sol',
+        optimization_runs: null,
+      }
+      const httpClient = mockObject<HttpClient>({
+        fetchRaw: mockFn().resolvesTo(
+          new Response(JSON.stringify(response), { status: 200 }),
+        ),
+      })
+      const blockscoutClient = new BlockscoutV2Client(httpClient, API_URL)
+
+      const result = await blockscoutClient.getSmartContract(address)
+
+      expect(httpClient.fetchRaw).toHaveBeenCalledWith(
+        `${API_URL}/smart-contracts/${address.toString()}`,
+        { timeout: 10000 },
+      )
+      expect(result).toEqual(response)
+    })
+
+    it('returns undefined for a contract without source metadata', async () => {
+      const httpClient = mockObject<HttpClient>({
+        fetchRaw: mockFn().resolvesTo(new Response('', { status: 404 })),
+      })
+      const blockscoutClient = new BlockscoutV2Client(httpClient, API_URL)
+
+      const result = await blockscoutClient.getSmartContract(
+        EthereumAddress.random(),
+      )
+
+      expect(result).toEqual(undefined)
+    })
+
+    it('throws on an upstream error', async () => {
+      const httpClient = mockObject<HttpClient>({
+        fetchRaw: mockFn().resolvesTo(
+          new Response('', { status: 500, statusText: 'Internal Error' }),
+        ),
+      })
+      const blockscoutClient = new BlockscoutV2Client(httpClient, API_URL)
+
+      await expect(
+        blockscoutClient.getSmartContract(EthereumAddress.random()),
+      ).toBeRejectedWith('HTTP error: 500 Internal Error')
+    })
+  })
+
+  describe(BlockscoutV2Client.prototype.getAddress.name, () => {
+    it('fetches and parses address information', async () => {
+      const address = EthereumAddress.random()
+      const creationTransactionHash =
+        '0x8ee5e5adb4dafb1a30a367c780f7db156f933c8d453efb7736c6a0be22ce5ac1'
+      const callMock = mockFn().resolvesTo({
+        hash: address.toString(),
+        creation_transaction_hash: creationTransactionHash,
+      })
+      const client = new BlockscoutV2Client(mockObject<HttpClient>(), API_URL)
+      client.call = callMock
+
+      const result = await client.getAddress(address)
+
+      expect(callMock).toHaveBeenCalledWith('addresses', address.toString())
+      expect(result).toEqual({
+        creation_transaction_hash: creationTransactionHash,
+      })
     })
   })
 })

--- a/packages/shared/src/services/blockscout/BlockscoutV2Client.ts
+++ b/packages/shared/src/services/blockscout/BlockscoutV2Client.ts
@@ -2,8 +2,12 @@ import { Logger, RateLimiter } from '@l2beat/backend-tools'
 import type { EthereumAddress } from '@l2beat/shared-pure'
 import type { HttpClient } from '../../clients'
 import {
+  BlockscoutAddressInfo,
+  type BlockscoutAddressInfo as BlockscoutAddressInfoResponse,
   BlockscoutGetInternalTransactionsResponse,
   type BlockscoutInternalTransaction,
+  BlockscoutSmartContract,
+  type BlockscoutSmartContract as BlockscoutSmartContractResponse,
 } from './model'
 
 export class BlockscoutV2Client {
@@ -18,6 +22,9 @@ export class BlockscoutV2Client {
     private readonly logger = Logger.SILENT,
   ) {
     this.call = this.rateLimiter.wrap(this.call.bind(this))
+    this.getSmartContract = this.rateLimiter.wrap(
+      this.getSmartContract.bind(this),
+    )
     this.logger = logger.for(this)
   }
 
@@ -33,13 +40,42 @@ export class BlockscoutV2Client {
     return BlockscoutGetInternalTransactionsResponse.parse(result).items
   }
 
+  async getSmartContract(
+    address: EthereumAddress,
+  ): Promise<BlockscoutSmartContractResponse | undefined> {
+    const url = `${this.url}/smart-contracts/${address.toString()}`
+    const response = await this.httpClient.fetchRaw(url, {
+      timeout: this.timeoutMs,
+    })
+
+    if (response.status === 404) {
+      return undefined
+    }
+
+    if (!response.ok) {
+      throw new Error(`HTTP error: ${response.status} ${response.statusText}`)
+    }
+
+    return BlockscoutSmartContract.parse(await response.json())
+  }
+
+  async getAddress(
+    address: EthereumAddress,
+  ): Promise<BlockscoutAddressInfoResponse> {
+    const result = await this.call('addresses', address.toString())
+    return BlockscoutAddressInfo.parse(result)
+  }
+
   async call(
     module: string,
-    id: string,
-    action: string,
+    id?: string,
+    action?: string,
     params?: Record<string, string>,
   ) {
-    let url = `${this.url}/${module}/${id}/${action}`
+    const path = [module, id, action]
+      .filter((part): part is string => part !== undefined)
+      .join('/')
+    let url = `${this.url}/${path}`
 
     if (params) {
       const query = new URLSearchParams({

--- a/packages/shared/src/services/blockscout/model.ts
+++ b/packages/shared/src/services/blockscout/model.ts
@@ -82,3 +82,77 @@ export const BlockscoutGetInternalTransactionsResponse = v.object({
   items: v.array(BlockscoutInternalTransaction),
   next_page_params: v.union([BlockscoutNextPageParams, v.null()]),
 })
+
+const NullableString = v.union([v.string(), v.null()])
+
+const BlockscoutCompilerSettings = v.object({
+  optimizer: v
+    .object({
+      enabled: v.boolean().optional(),
+      runs: v.number().optional(),
+    })
+    .optional(),
+  evmVersion: v.string().optional(),
+  viaIR: v.boolean().optional(),
+  metadata: v
+    .object({
+      bytecodeHash: v.string().optional(),
+      useLiteralContent: v.boolean().optional(),
+      appendCBOR: v.boolean().optional(),
+    })
+    .optional(),
+  debug: v
+    .object({
+      revertStrings: v.string().optional(),
+      debugInfo: v.array(v.string()).optional(),
+    })
+    .optional(),
+  remappings: v.array(v.string()).optional(),
+  libraries: v.unknown().optional(),
+})
+
+export type BlockscoutSmartContract = v.infer<typeof BlockscoutSmartContract>
+
+export const BlockscoutSmartContract = v.object({
+  is_verified: v.boolean(),
+  name: NullableString.optional(),
+  compiler_version: NullableString.optional(),
+  optimization_enabled: v.boolean().optional(),
+  optimization_runs: v.union([v.number(), v.null()]).optional(),
+  optimizations_runs: v.union([v.number(), v.null()]).optional(),
+  evm_version: NullableString.optional(),
+  abi: v.union([v.string(), v.array(v.unknown()), v.null()]).optional(),
+  source_code: NullableString.optional(),
+  file_path: NullableString.optional(),
+  compiler_settings: v.union([BlockscoutCompilerSettings, v.null()]).optional(),
+  constructor_args: NullableString.optional(),
+  additional_sources: v
+    .union([
+      v.array(
+        v.object({
+          file_path: v.string(),
+          source_code: v.string(),
+        }),
+      ),
+      v.null(),
+    ])
+    .optional(),
+  external_libraries: v
+    .union([
+      v.array(
+        v.object({
+          name: v.string(),
+          address_hash: v.string(),
+        }),
+      ),
+      v.null(),
+    ])
+    .optional(),
+  language: NullableString.optional(),
+})
+
+export type BlockscoutAddressInfo = v.infer<typeof BlockscoutAddressInfo>
+
+export const BlockscoutAddressInfo = v.object({
+  creation_transaction_hash: NullableString.optional(),
+})


### PR DESCRIPTION
Fixes issue with Robinhood - Blockscout V1 on RH is heavily rate-limited, disco falls back to Sourcify (see combined client) - Sourcify returns 404, thus the whole combined-client call returns unverified (yet contract is verified on BS, but API is barely working - also UM cached verified response) - that's where Blockscout V2 kicks is - it works just fine for some reason, so why not just add it


@codex review 