### PR TITLE
Return partial Relay requests instead of failing the update

### DIFF
--- a/packages/backend/src/modules/interop/engine/InteropModule.ts
+++ b/packages/backend/src/modules/interop/engine/InteropModule.ts
@@ -216,7 +216,7 @@ export function createInteropModule({
     },
   )
 
-  const relayApiClient = new RelayApiClient(new HttpClient())
+  const relayApiClient = new RelayApiClient(new HttpClient(), logger)
   const relayRootIndexer = new RelayRootIndexer(logger)
   const relayIndexer = new RelayIndexer(
     config.interop.config.chains,

--- a/packages/backend/src/modules/interop/plugins/relay/RelayApiClient.test.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/RelayApiClient.test.ts
@@ -1,5 +1,7 @@
-import { expect } from 'earl'
-import { GetRequestsResponse } from './RelayApiClient'
+import { Logger } from '@l2beat/backend-tools'
+import type { HttpClient } from '@l2beat/shared'
+import { expect, mockFn, mockObject } from 'earl'
+import { GetRequestsResponse, RelayApiClient } from './RelayApiClient'
 
 describe('GetRequestsResponse', () => {
   it('normalizes null app fee fields', () => {
@@ -46,4 +48,85 @@ const RESPONSE_WITH_NULL_APP_FEES = {
       updatedAt: '2026-08-18T17:52:03.279Z',
     },
   ],
+}
+
+describe(RelayApiClient.name, () => {
+  describe(RelayApiClient.prototype.getAllRequests.name, () => {
+    it('returns pages fetched before a failure', async () => {
+      const httpClient = mockObject<HttpClient>({
+        fetch: mockFn()
+          .resolvesToOnce(page(['a', 'b'], 'cursor-1'))
+          .rejectsWithOnce(new Error('network timeout')),
+      })
+      const client = new RelayApiClient(httpClient, Logger.SILENT)
+
+      const result = await client.getAllRequests({ limit: 500 })
+
+      expect(result.requests.map((r) => r.id)).toEqual(['a', 'b'])
+      expect(result.continuation).toEqual('cursor-1')
+      expect(httpClient.fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws when the first page fails', async () => {
+      const httpClient = mockObject<HttpClient>({
+        fetch: mockFn().rejectsWith(new Error('network timeout')),
+      })
+      const client = new RelayApiClient(httpClient, Logger.SILENT)
+
+      await expect(client.getAllRequests({ limit: 500 })).toBeRejectedWith(
+        'network timeout',
+      )
+    })
+
+    it('paginates until the limit is reached', async () => {
+      const httpClient = mockObject<HttpClient>({
+        fetch: mockFn()
+          .resolvesToOnce(page(['a'], 'cursor-1'))
+          .resolvesToOnce(page(['b'], undefined)),
+      })
+      const client = new RelayApiClient(httpClient, Logger.SILENT)
+
+      const result = await client.getAllRequests({ limit: 500 })
+
+      expect(result.requests.map((r) => r.id)).toEqual(['a', 'b'])
+      expect(result.continuation).toEqual(undefined)
+    })
+
+    it('reports the cursor when the limit stops the walk', async () => {
+      const httpClient = mockObject<HttpClient>({
+        fetch: mockFn().resolvesToOnce(page(['a'], 'cursor-1')),
+      })
+      const client = new RelayApiClient(httpClient, Logger.SILENT)
+
+      const result = await client.getAllRequests({ limit: 1 })
+
+      expect(result.requests.map((r) => r.id)).toEqual(['a'])
+      expect(result.continuation).toEqual('cursor-1')
+    })
+
+    it('always sorts by updatedAt ascending', async () => {
+      const httpClient = mockObject<HttpClient>({
+        fetch: mockFn().resolvesTo(page(['a'], undefined)),
+      })
+      const client = new RelayApiClient(httpClient, Logger.SILENT)
+
+      await client.getAllRequests({ limit: 500 })
+
+      const url = httpClient.fetch.calls[0]?.args[0] as string
+      expect(url).toInclude('sortBy=updatedAt')
+      expect(url).toInclude('sortDirection=asc')
+    })
+  })
+})
+
+function page(ids: string[], continuation: string | undefined) {
+  return {
+    requests: ids.map((id) => ({
+      id,
+      data: {},
+      createdAt: '2026-08-24T15:03:00.000Z',
+      updatedAt: '2026-08-24T15:03:00.000Z',
+    })),
+    continuation,
+  }
 }

--- a/packages/backend/src/modules/interop/plugins/relay/RelayApiClient.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/RelayApiClient.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@l2beat/backend-tools'
 import type { HttpClient } from '@l2beat/shared'
 import { v } from '@l2beat/validate'
 
@@ -22,6 +23,11 @@ interface GetRequestsOptions {
   sortBy?: 'createdAt' | 'updatedAt'
   sortDirection?: 'asc' | 'desc'
 }
+
+type GetAllRequestsOptions = Omit<
+  GetRequestsOptions,
+  'sortBy' | 'sortDirection'
+>
 
 const CurrencyObject = v.object({
   chainId: v.number().optional(),
@@ -172,7 +178,12 @@ export const GetRequestsResponse = v.object({
 })
 
 export class RelayApiClient {
-  constructor(private httpClient: HttpClient) {}
+  constructor(
+    private httpClient: HttpClient,
+    private logger: Logger,
+  ) {
+    this.logger = logger.for(this)
+  }
 
   async getRequests(options: GetRequestsOptions = {}) {
     const queryParams: Record<string, string> = {}
@@ -189,18 +200,34 @@ export class RelayApiClient {
     return GetRequestsResponse.parse(data)
   }
 
-  async getAllRequests(options: GetRequestsOptions = {}) {
+  async getAllRequests(options: GetAllRequestsOptions = {}) {
     let limit = options.limit ?? 50
     const result: GetRequestsResponse = {
       requests: [],
     }
     let continuation = options.continuation
     do {
-      const res = await this.getRequests({
-        ...options,
-        limit: Math.min(limit, 50),
-        continuation,
-      })
+      let res: GetRequestsResponse
+      try {
+        res = await this.getRequests({
+          ...options,
+          sortBy: 'updatedAt',
+          sortDirection: 'asc',
+          limit: Math.min(limit, 50),
+          continuation,
+        })
+      } catch (error) {
+        if (result.requests.length === 0) {
+          throw error
+        }
+        this.logger.warn('Returning partial requests', {
+          fetched: result.requests.length,
+          requested: options.limit ?? 50,
+          continuation,
+          error,
+        })
+        break
+      }
       for (const req of res.requests) {
         if (limit > 0) {
           limit -= 1
@@ -209,6 +236,7 @@ export class RelayApiClient {
       }
       continuation = res.continuation
     } while (continuation && limit > 0)
+    result.continuation = continuation
     return result
   }
 }

--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
@@ -114,8 +114,6 @@ export class RelayIndexer extends ManagedChildIndexer {
     const res = await this.relayApiClient.getAllRequests({
       limit: 500,
       startTimestamp: from,
-      sortBy: 'updatedAt',
-      sortDirection: 'asc',
     })
 
     const successes = res.requests.filter((x) => x.status === 'success')

--- a/packages/backend/src/modules/interop/plugins/relay/script.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/script.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@l2beat/backend-tools'
 import { ProjectService } from '@l2beat/config'
 import { HttpClient } from '@l2beat/shared'
 import { RelayApiClient } from './RelayApiClient'
@@ -8,7 +9,7 @@ main().catch((error) => {
 })
 
 async function main() {
-  const client = new RelayApiClient(new HttpClient())
+  const client = new RelayApiClient(new HttpClient(), Logger.SILENT)
   const ps = new ProjectService()
   const chains = (await ps.getProjects({ select: ['chainConfig'] })).map(
     (p) => p.chainConfig,
@@ -27,8 +28,6 @@ async function main() {
     const res = await client.getAllRequests({
       limit: 50,
       startTimestamp: lastTime,
-      sortBy: 'updatedAt',
-      sortDirection: 'asc',
     })
 
     const successes = res.requests.filter((x) => x.status === 'success')


### PR DESCRIPTION
From daily checks

A limit of 500 is fetched as 10 sequential pages, so one slow page threw and syncedTo was never written, leaving the indexer reissuing the same request. Pages are sorted by updatedAt ascending, so a prefix is contiguous and syncedTo just lands earlier in the window. A first page failure still throws.