### PR TITLE
add interfold disco

### DIFF
--- a/packages/config/src/projects/_templates/interfold/AdminPlugin/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/AdminPlugin/shapes.json
@@ -1,0 +1,8 @@
+{
+  "Admin.sol": {
+    "hash": "0x7204d3a9ce1568e5894d5e7b486018ae887e15c72dfa66f72b9192ce39e2b528",
+    "address": "eth:0xdB3c40bb17e9AD1f51178AF5A66eF32d19176A1c",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/AdminPlugin/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/AdminPlugin/template.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "AdminPlugin",
+  "category": "gov",
+  "description": "Non-upgradeable Aragon Admin plugin. Holders of its DAO-granted EXECUTE_PROPOSAL permission can submit actions that the plugin forwards immediately, without a vote or onchain delay.",
+  "ignoreMethods": ["canExecute", "hasSucceeded", "proposalCount"],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose permission manager authorizes the plugin and its callers."
+    },
+    "getCurrentTargetConfig": {
+      "description": "Stored execution target and operation. A zero target resolves to the DAO; delegatecall changes the security context.",
+      "type": "CODE_CHANGE"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/AragonExecutor/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/AragonExecutor/shapes.json
@@ -1,0 +1,8 @@
+{
+  "AragonExecutor.sol": {
+    "hash": "0x32bc01a3f64b9896ce2c0ef766f4b0edf9403118a014126063663ee89fd82ffb",
+    "address": "eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/AragonExecutor/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/AragonExecutor/template.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "AragonExecutor",
+  "category": "gov",
+  "description": "Immutable Aragon action executor used as a delegatecall target by PublicTokenVoting. It executes proposal action batches in the calling plugin's context."
+}

--- a/packages/config/src/projects/_templates/interfold/BfvDecryptionVerifier/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/BfvDecryptionVerifier/shapes.json
@@ -1,0 +1,8 @@
+{
+  "BfvDecryptionVerifier.sol": {
+    "hash": "0xf0eb04078f1d26488697d2fc81ac7d419765e655d6b38d23b5f8cab946146bee",
+    "address": "eth:0xf143b969ea481Ccf251194D15F82007C67AABc53",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BfvDecryptionVerifier/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/BfvDecryptionVerifier/template.jsonc
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "BfvDecryptionVerifier",
+  "category": "core",
+  "description": "Threshold-decryption proof wrapper. It checks the generated circuit proof and binds its parties and public-key context to the committee recorded by CiphernodeRegistry.",
+  "fields": {
+    "circuitVerifier": {
+      "description": "Generated onchain verifier for the BFV threshold-decryption proof.",
+      "type": "CODE_CHANGE"
+    },
+    "ciphernodeRegistry": {
+      "description": "Immutable committee and public-key source against which decryption proofs are checked."
+    },
+    "threshold": {
+      "description": "Immutable number of decryption shares required by this proof circuit.",
+      "type": "RISK_PARAMETER"
+    },
+    "expectedC6FoldKeyHash": {
+      "description": "Immutable hash binding the accepted C6-fold verification key.",
+      "type": "CODE_CHANGE"
+    },
+    "expectedC7KeyHash": {
+      "description": "Immutable hash binding the accepted C7 verification key.",
+      "type": "CODE_CHANGE"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BfvPkVerifier/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/BfvPkVerifier/shapes.json
@@ -1,0 +1,8 @@
+{
+  "BfvPkVerifier.sol": {
+    "hash": "0x13506be90fff7c3922e3b110f61dcfe0114bdaeda4e9e883448e30f4969cd771",
+    "address": "eth:0xBA1854fDA7A5c127606572e43Dc7B37b7A15bdFf",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BfvPkVerifier/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/BfvPkVerifier/template.jsonc
@@ -1,0 +1,24 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "BfvPkVerifier",
+  "category": "core",
+  "description": "BFV public-key proof wrapper. It binds the generated circuit verifier to the expected DKG-fold and C5 verification-key hashes.",
+  "fields": {
+    "circuitVerifier": {
+      "description": "Generated onchain verifier for the BFV distributed-key-generation proof.",
+      "type": "CODE_CHANGE"
+    },
+    "expectedNodesFoldKeyHash": {
+      "description": "Immutable hash binding the accepted nodes-fold verification key.",
+      "type": "CODE_CHANGE"
+    },
+    "expectedC5KeyHash": {
+      "description": "Immutable hash binding the accepted C5 verification key.",
+      "type": "CODE_CHANGE"
+    },
+    "h": {
+      "description": "Immutable circuit parameter used by the BFV public-key proof.",
+      "type": "CODE_CHANGE"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BondedCheckpoints/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/BondedCheckpoints/shapes.json
@@ -1,0 +1,8 @@
+{
+  "BondedCheckpoints.sol": {
+    "hash": "0x8ad2ea77f39af5b32c176b962b813d16e18902db7133fb50165d1632c71997f3",
+    "address": "eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BondedCheckpoints/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/BondedCheckpoints/template.jsonc
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "BondedCheckpoints",
+  "category": "core",
+  "description": "Voting-power checkpoint store updated exclusively by the BondingRegistry so FOLD bonded to ciphernode operators remains visible to governance snapshots.",
+  "ignoreInWatchMode": ["clock"],
+  "fields": {
+    "registry": {
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "write bonded-FOLD voting-power checkpoints."
+        }
+      ]
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BondedVotes/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/BondedVotes/shapes.json
@@ -1,0 +1,8 @@
+{
+  "BondedVotes.sol": {
+    "hash": "0x652c9badf1bc0079bb5168226877cf7c70b74479fa19068d2fe42066fa4eb075",
+    "address": "eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BondedVotes/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/BondedVotes/template.jsonc
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "BondedVotes",
+  "category": "gov",
+  "description": "Voting-power adapter used by PublicTokenVoting. It counts voting-escrow power, FOLD bonded to ciphernode operators, and eligible vesting-locked wallet FOLD while using FOLD total supply as the quorum denominator.",
+  "ignoreMethods": ["getPastTotalSupply"],
+  "ignoreInWatchMode": ["clock"],
+  "fields": {
+    "token": {
+      "description": "Immutable FOLD token supplying metadata and the total-supply denominator."
+    },
+    "votesSource": {
+      "description": "Immutable primary IVotes source; currently an adapter for the FOLD voting escrow."
+    },
+    "escrow": {
+      "description": "Immutable FOLD voting escrow used to attribute locked balances."
+    },
+    "checkpoints": {
+      "description": "Immutable history of FOLD bonded through the BondingRegistry."
+    },
+    "registry": {
+      "description": "Immutable BondingRegistry that custodies bonded FOLD and writes checkpoints."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BondingRegistry/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/BondingRegistry/shapes.json
@@ -1,0 +1,8 @@
+{
+  "BondingRegistry.sol": {
+    "hash": "0x2f4ffa441ee6931aaf10dc75ea17d88ac1e02780b5802234253f4732f19706ae",
+    "address": "eth:0x4FF6e77A10E8f06C11a4DD2A71b6AB55394640e4",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/BondingRegistry/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/BondingRegistry/template.jsonc
@@ -1,0 +1,133 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "BondingRegistry",
+  "category": "core",
+  "description": "Collateral registry for ciphernode operators. Operators become eligible by depositing ticket collateral backed by sUSDS and a FOLD bond; the contract also enforces exits, committee obligations, bans and slashing debits.",
+  "ignoreInWatchMode": [
+    "bondingAssetConfigurationVersion",
+    "ciphernodeBonds",
+    "eligibilityConfigurationVersion",
+    "reservedSlashedTicketBalance",
+    "slashedCiphernodeBond",
+    "slashedTicketBalance",
+    "ticketBalances",
+    "totalCiphernodeBondLiability",
+    "unresolvedCommitteeCount"
+  ],
+  "fields": {
+    "owner": {
+      "description": "Account controlling bonding and authorization parameters.",
+      "type": "PERMISSION",
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "replace collateral assets and protocol dependencies; change bond, ticket, eligibility and exit parameters; authorize slashing managers and reward distributors; clear bans from old managers; withdraw slashed funds; and replace the slashed-funds treasury."
+        }
+      ]
+    },
+    "activeOperators": {
+      "description": "Operator keys currently active under the collateral and ban rules, reconstructed from activation events.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "event",
+        "select": "operator",
+        "add": {
+          "event": "OperatorActivationChanged",
+          "where": ["=", "#active", true]
+        },
+        "remove": {
+          "event": "OperatorActivationChanged",
+          "where": ["=", "#active", false]
+        }
+      },
+      "permissions": [
+        {
+          "type": "member",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties."
+        }
+      ]
+    },
+    "bondOwners": {
+      "description": "Latest collateral owner for each operator key, reconstructed from ownership events. One address can own several operator positions.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "event",
+        "groupBy": "operator",
+        "select": "bondOwner",
+        "set": { "event": "BondOwnerSet" }
+      }
+    },
+    "ticketBalances": {
+      "description": "Latest ticket-token balance for each operator reconstructed from balance-update events.",
+      "handler": {
+        "type": "event",
+        "groupBy": "operator",
+        "select": "newBalance",
+        "set": { "event": "TicketBalanceUpdated" },
+        "ignoreRelative": true
+      }
+    },
+    "ciphernodeBonds": {
+      "description": "Latest FOLD bond for each operator reconstructed from bond-update events.",
+      "handler": {
+        "type": "event",
+        "groupBy": "operator",
+        "select": "newBond",
+        "set": { "event": "CiphernodeBondUpdated" },
+        "ignoreRelative": true
+      }
+    },
+    "authorizedSlashingManagerAt": {
+      "description": "Contracts currently authorized to debit ticket collateral and FOLD bonds, ban operators and manage slash-routing state.",
+      "type": "PERMISSION",
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "slash operator ticket collateral and FOLD bonds, ban operators and manage slash-routing state."
+        }
+      ]
+    },
+    "authorizedDistributors": {
+      "description": "Contracts currently allowed to credit ticket collateral on behalf of operators.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "event",
+        "select": "distributor",
+        "add": {
+          "event": "RewardDistributorUpdated",
+          "where": ["=", "#authorized", true]
+        },
+        "remove": {
+          "event": "RewardDistributorUpdated",
+          "where": ["=", "#authorized", false]
+        }
+      },
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "deposit and credit ticket collateral for an operator."
+        }
+      ]
+    },
+    "requiredCiphernodeBond": {
+      "description": "Minimum FOLD bond required for an operator to remain eligible.",
+      "type": "RISK_PARAMETER"
+    },
+    "ticketPrice": {
+      "description": "Amount of sUSDS-backed ticket token represented by one sortition ticket.",
+      "type": "RISK_PARAMETER"
+    },
+    "minTicketBalance": {
+      "description": "Minimum number of tickets required for operator eligibility.",
+      "type": "RISK_PARAMETER"
+    },
+    "ciphernodeBondActiveBps": {
+      "description": "Minimum fraction of the configured FOLD bond that must remain after slashing for an operator to stay active.",
+      "type": "RISK_PARAMETER"
+    },
+    "exitDelay": {
+      "description": "Delay before queued ticket collateral and FOLD bond exits can be claimed.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/CiphernodeRegistry/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/CiphernodeRegistry/shapes.json
@@ -1,0 +1,8 @@
+{
+  "CiphernodeRegistry.sol": {
+    "hash": "0x181143fe8736537b7086ceca31a6731ebb34e2e2612a63c3ff66ef5c7f3816af",
+    "address": "eth:0xB06Aaf9EF87984192490E947078D2f3563399b7B",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/CiphernodeRegistry/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/CiphernodeRegistry/template.jsonc
@@ -1,0 +1,113 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "CiphernodeRegistry",
+  "category": "core",
+  "description": "Registry of ciphernodes and E3 committees. It performs ticket-weighted committee selection, records DKG (distributed key generation) proof anchors and the committee public key (to which cyphertexts can be encrypted), and tracks committee viability.",
+  "ignoreMethods": [
+    "committeePublicKey",
+    "committeeThresholdMet",
+    "dkgFoldAttestationVerifierFor",
+    "getActiveCommitteeNodes",
+    "getCommitteeDeadline",
+    "getCommitteeHash",
+    "getCommitteeNodes",
+    "getCommitteeViability",
+    "getDkgAnchors",
+    "isOpen",
+    "publicKeyHashes",
+    "rootAt",
+    "roots",
+    "sortitionEntropyBlocks",
+    "sortitionSeed",
+    "sortitionSeedResolved",
+    "sortitionTicketPrices"
+  ],
+  "ignoreRelatives": ["BLOCKHASH_HISTORY"],
+  "ignoreInWatchMode": ["ciphernodes", "root", "treeSize"],
+  "fields": {
+    "owner": {
+      "description": "Account controlling registry configuration.",
+      "type": "PERMISSION",
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "replace the coordinator, bonding and slashing dependencies; add or remove ciphernodes; change the sortition window; and update the DKG verifier and accusation-vote validity parameters. DKG-verifier replacement and risk-reducing accusation-window changes use a two-day propose/commit delay, while other changes are immediate."
+        }
+      ]
+    },
+    "$members": {
+      "description": "Current registered ciphernode operator keys reconstructed from add and remove events. For each E3, the active configuration selects three of these keys; $threshold applies to that selected committee, not to the full registry.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "event",
+        "select": "node",
+        "add": { "event": "CiphernodeAdded" },
+        "remove": { "event": "CiphernodeRemoved" }
+      },
+      "permissions": [
+        {
+          "type": "member",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption."
+        }
+      ]
+    },
+    "$threshold": {
+      "description": "Decryption shares required within each newly selected minimum-size committee. This represents two of the selected three ciphernodes, not two of all registered $members.",
+      "handler": {
+        "type": "call",
+        "address": "{{ interfold }}",
+        "method": "function committeeThresholds(uint8 size, uint256 index) view returns (uint32)",
+        "args": [0, 0]
+      }
+    },
+    "selectedCommitteeSize": {
+      "description": "Number of ciphernodes selected from $members for each minimum-size committee.",
+      "type": "RISK_PARAMETER",
+      "handler": {
+        "type": "call",
+        "address": "{{ interfold }}",
+        "method": "function committeeThresholds(uint8 size, uint256 index) view returns (uint32)",
+        "args": [0, 1]
+      }
+    },
+    "interfold": {
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "request and release E3 committees."
+        }
+      ]
+    },
+    "bondingRegistry": {
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "add and remove ciphernode operator keys as collateral positions are registered and exited."
+        }
+      ]
+    },
+    "slashingManager": {
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "expel selected members from active committees."
+        }
+      ]
+    },
+    "dkgFoldAttestationVerifier": {
+      "description": "Verifier that authenticates each selected node's DKG-fold commitment before the aggregate DKG proof is accepted.",
+      "type": "CODE_CHANGE"
+    },
+    "sortitionSubmissionWindow": {
+      "description": "Time after entropy becomes available during which eligible operators submit a ticket for committee sortition.",
+      "type": "RISK_PARAMETER"
+    },
+    "accusationVoteValidity": {
+      "description": "Validity window for committee accusation attestations used by permissionless proof-based slashing.",
+      "type": "RISK_PARAMETER"
+    },
+    "numCiphernodes": {
+      "description": "Number of currently registered ciphernode keys."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/DecryptionAggregatorVerifier/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/DecryptionAggregatorVerifier/shapes.json
@@ -1,0 +1,8 @@
+{
+  "DecryptionAggregatorVerifier.sol": {
+    "hash": "0xbdc13b8d6f0794b577d5b148fb0caba273bd1e8894b17225a0039259466a35b0",
+    "address": "eth:0x53Fc34b412E16A1aE05A86934b821F82ca2a10da",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/DecryptionAggregatorVerifier/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/DecryptionAggregatorVerifier/template.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "DecryptionAggregatorVerifier",
+  "category": "core",
+  "description": "Immutable generated Honk verifier for the BFV threshold-decryption aggregation circuit."
+}

--- a/packages/config/src/projects/_templates/interfold/DkgAggregatorVerifier/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/DkgAggregatorVerifier/shapes.json
@@ -1,0 +1,8 @@
+{
+  "DkgAggregatorVerifier.sol": {
+    "hash": "0xbfdaa6f199a3036bf6b0b70808e87690fa7894d4669c609e43c510c02b499e9f",
+    "address": "eth:0x9e58443eB40A1B08D07f89D36bf69909d401a542",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/DkgAggregatorVerifier/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/DkgAggregatorVerifier/template.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "DkgAggregatorVerifier",
+  "category": "core",
+  "description": "Immutable generated Honk verifier for the BFV distributed-key-generation aggregation circuit."
+}

--- a/packages/config/src/projects/_templates/interfold/DkgFoldAttestationVerifier/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/DkgFoldAttestationVerifier/shapes.json
@@ -1,0 +1,8 @@
+{
+  "DkgFoldAttestationVerifier.sol": {
+    "hash": "0x67747087afb0bc510c37bab97808da631f8ed0c3dc65f3f8356e098865077952",
+    "address": "eth:0xE5657c0756B772B600D6c73eDbF046f32129c770",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/DkgFoldAttestationVerifier/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/DkgFoldAttestationVerifier/template.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "DkgFoldAttestationVerifier",
+  "category": "core",
+  "description": "Immutable verifier for EIP-712 attestations that bind selected ciphernode operator keys to the party commitments folded into an E3 distributed-key-generation proof."
+}

--- a/packages/config/src/projects/_templates/interfold/E3RefundManager/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/E3RefundManager/shapes.json
@@ -1,0 +1,8 @@
+{
+  "E3RefundManager.sol": {
+    "hash": "0x9a5f2a5ae202a5a570f526127420fdcc919af6dc90b48df309bb1b7cfaa9ec7d",
+    "address": "eth:0xE506249Ba5ede04A68b702b92704a0b88054f86A",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/E3RefundManager/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/E3RefundManager/template.jsonc
@@ -1,0 +1,34 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "E3RefundManager",
+  "category": "core",
+  "description": "Upgradeable accounting contract that snapshots the refund policy for each E3 and distributes request fees and routed slashed funds between the requester, honest committee members, protocol treasury and reserve.",
+  "ignoreMethods": ["getE3PolicySnapshot", "getRefundDistribution"],
+  "fields": {
+    "owner": {
+      "description": "Account controlling future refund policy and dependencies.",
+      "type": "PERMISSION",
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "change the work-allocation split, coordinator and treasury without an onchain delay."
+        }
+      ]
+    },
+    "interfold": {
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "snapshot E3 refund policy and credit protocol payments."
+        }
+      ]
+    },
+    "getWorkAllocation": {
+      "description": "Current fee allocation between committee formation, DKG, decryption and the protocol, plus the share assigned to an honest replacement when another node is slashed.",
+      "type": "RISK_PARAMETER"
+    },
+    "treasury": {
+      "description": "Recipient of the protocol share and treasury-directed slashed funds."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/EscrowVotesAdapter/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/EscrowVotesAdapter/shapes.json
@@ -1,0 +1,8 @@
+{
+  "EscrowVotesAdapter.sol": {
+    "hash": "0x3e89d3203385dde7d25cf452e705dd2aa1ea29318d45bb4f9ea783d843cefbc9",
+    "address": "eth:0xB67C1ABaC78686c67b91bBd1032813D86047104B",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/EscrowVotesAdapter/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/EscrowVotesAdapter/template.jsonc
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "EscrowVotesAdapter",
+  "category": "gov",
+  "description": "Upgradeable IVotes adapter that exposes voting power from veFOLD locks. BondedVotes uses it as its primary voting-power source.",
+  "ignoreMethods": ["getPastTotalSupply", "proxiableUUID", "tokenIsDelegated"],
+  "ignoreInWatchMode": ["clock"],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose permission manager grants delegation administration and upgrade roles."
+    },
+    "escrow": {
+      "description": "VotingEscrow from which lock balances and ownership are read."
+    },
+    "escrowClock": {
+      "description": "Clock used for timestamp-indexed voting checkpoints."
+    },
+    "paused": {
+      "description": "Whether delegation updates through the adapter are paused.",
+      "type": "RISK_PARAMETER"
+    },
+    "MAX_EPOCHS": {
+      "description": "Maximum number of epochs traversed by voting-power calculations.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/Interfold/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/Interfold/shapes.json
@@ -1,0 +1,8 @@
+{
+  "Interfold.sol": {
+    "hash": "0x25830faa7c9d8c4aecf3d78f04ce54c52aae87769713d3e9ad951ca08abd4277",
+    "address": "eth:0x8AcBf712513C802eFFc255FEa588ED21DC7A61bA",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/Interfold/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/Interfold/template.jsonc
@@ -1,0 +1,129 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "Interfold",
+  "category": "core",
+  "description": "Coordinator for Encrypted Execution Environments (E3s). It accepts requests for allowlisted programs, selects a ciphernode committee, snapshots the configured proof system, and verifies the encrypted result and threshold decryption before publishing plaintext output.",
+  "ignoreMethods": [
+    "checkFailureCondition",
+    "e3CryptoConfigIds",
+    "e3Payments",
+    "e3s",
+    "getDeadlines",
+    "getE3",
+    "getE3LifecycleDeadline",
+    "getE3Stage",
+    "getE3TimeoutConfig",
+    "getFailureReason",
+    "getRequester"
+  ],
+  "ignoreRelatives": ["feeToken"],
+  "ignoreInWatchMode": ["activeE3Count", "nexte3Id"],
+  "fields": {
+    "owner": {
+      "description": "Account controlling protocol configuration.",
+      "type": "PERMISSION",
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "pause or unpause new requests; replace the registry, bonding, slashing and refund dependencies; allow fee assets and E3 programs; replace proof verifiers; and change pricing, timeouts, parameter sets and committee thresholds without an onchain delay."
+        }
+      ]
+    },
+    "requestsPaused": {
+      "description": "Whether new E3 requests are disabled.",
+      "type": "RISK_PARAMETER"
+    },
+    "registeredE3Programs": {
+      "description": "E3 application contracts permanently allowlisted by governance. Registration cannot be revoked in the current implementation.",
+      "type": "CODE_CHANGE",
+      "handler": {
+        "type": "event",
+        "select": "e3Program",
+        "add": { "event": "event E3ProgramRegistered(address e3Program)" }
+      }
+    },
+    "bfvDecryptionThreshold": {
+      "description": "Number of decryption shares required for the active minimum-size BFV committee.",
+      "type": "RISK_PARAMETER",
+      "handler": {
+        "type": "call",
+        "method": "function committeeThresholds(uint8 size, uint256 index) view returns (uint32)",
+        "args": [0, 0]
+      }
+    },
+    "bfvCommitteeSize": {
+      "description": "Number of ciphernode seats in the active minimum-size BFV committee.",
+      "type": "RISK_PARAMETER",
+      "handler": {
+        "type": "call",
+        "method": "function committeeThresholds(uint8 size, uint256 index) view returns (uint32)",
+        "args": [0, 1]
+      }
+    },
+    "bfvParamSet": {
+      "description": "ABI-encoded BFV parameter set accepted by the active circuits. Param-set index 0 is the only set accepted by the current crypto configuration.",
+      "type": "RISK_PARAMETER",
+      "handler": {
+        "type": "call",
+        "method": "function paramSetRegistry(uint8 paramSet) view returns (bytes)",
+        "args": [0]
+      }
+    },
+    "bfvPkVerifier": {
+      "description": "Verifier used for BFV distributed-key-generation proofs for future E3s.",
+      "type": "CODE_CHANGE",
+      "handler": {
+        "type": "call",
+        "method": "function getPkVerifier(bytes32 encryptionSchemeId) view returns (address)",
+        "args": [
+          "0x2c2a814a0495f913a3a312fc4771e37552bc14f8a2d4075a08122d356f0849c6"
+        ]
+      }
+    },
+    "bfvDecryptionVerifier": {
+      "description": "Verifier used for BFV threshold-decryption proofs for future E3s.",
+      "type": "CODE_CHANGE",
+      "handler": {
+        "type": "call",
+        "method": "function getDecryptionVerifier(bytes32 encryptionSchemeId) view returns (address)",
+        "args": [
+          "0x2c2a814a0495f913a3a312fc4771e37552bc14f8a2d4075a08122d356f0849c6"
+        ]
+      }
+    },
+    "bfvCiphertextVerifier": {
+      "description": "Verifier used for the encrypted computation output of future BFV E3s.",
+      "type": "CODE_CHANGE",
+      "handler": {
+        "type": "call",
+        "method": "function getCiphertextVerifier(bytes32 encryptionSchemeId) view returns (address)",
+        "args": [
+          "0x2c2a814a0495f913a3a312fc4771e37552bc14f8a2d4075a08122d356f0849c6"
+        ]
+      }
+    },
+    "activeCryptoConfigId": {
+      "description": "Hash of the exact circuit configuration accepted for new requests.",
+      "type": "CODE_CHANGE"
+    },
+    "getTimeoutConfig": {
+      "description": "Protocol-wide DKG, encrypted-computation and decryption timeout windows applied to new E3s.",
+      "type": "RISK_PARAMETER"
+    },
+    "getPricingConfig": {
+      "description": "Fee model and fee split applied to new E3s, including minimum committee and threshold constraints.",
+      "type": "RISK_PARAMETER"
+    },
+    "maxDuration": {
+      "description": "Maximum request duration accepted by the coordinator.",
+      "type": "RISK_PARAMETER"
+    },
+    "markFailedGracePeriod": {
+      "description": "Grace period after a lifecycle deadline during which failure processing remains restricted.",
+      "type": "RISK_PARAMETER"
+    },
+    "feeToken": {
+      "description": "External ERC-20 collected from E3 requesters. Its own protocol is outside the Interfold discovery perimeter."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/InterfoldTicketToken/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/InterfoldTicketToken/shapes.json
@@ -1,0 +1,8 @@
+{
+  "InterfoldTicketToken.sol": {
+    "hash": "0xef3cd5cf8d395de14d8015a8da3ca3bbc44246f18e69d4a8c53de0d84174f9c4",
+    "address": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/InterfoldTicketToken/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/InterfoldTicketToken/template.jsonc
@@ -1,0 +1,45 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "InterfoldTicketToken",
+  "category": "core",
+  "description": "Non-transferable ERC-20 Votes wrapper for sUSDS used as ciphernode ticket collateral. Only the configured BondingRegistry can deposit, mint, burn, withdraw or pay out the underlying asset.",
+  "ignoreMethods": ["getPastTotalSupply"],
+  "ignoreRelatives": ["underlying"],
+  "ignoreInWatchMode": ["clock", "payableBalance", "totalSupply"],
+  "fields": {
+    "registry": {
+      "description": "Contract exclusively allowed to move the underlying collateral and mint or burn ticket tokens.",
+      "type": "PERMISSION",
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "deposit and withdraw underlying sUSDS, mint and burn ticket tokens, and pay out underlying reserved by ticket slashing."
+        }
+      ]
+    },
+    "owner": {
+      "description": "Account that can transfer ownership, rescue unrelated ERC-20s and manage the registry address. Because the registry is locked, replacement requires a one-day delay and zero outstanding ticket supply and payable balance.",
+      "type": "PERMISSION",
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "schedule and activate a registry replacement after one day when all ticket liabilities are zero, and rescue ERC-20s other than the underlying sUSDS."
+        }
+      ]
+    },
+    "underlying": {
+      "description": "External sUSDS token backing ticket collateral one-for-one; its Maker/Sky dependencies are outside the Interfold discovery perimeter."
+    },
+    "registryLocked": {
+      "description": "One-way flag requiring future registry replacements to use the delayed, zero-liability flow.",
+      "type": "RISK_PARAMETER"
+    },
+    "REGISTRY_CHANGE_DELAY": {
+      "description": "Delay between requesting and activating a locked registry replacement.",
+      "type": "RISK_PARAMETER"
+    },
+    "payableBalance": {
+      "description": "Underlying sUSDS reserved after ticket burns and available for protocol-directed payout."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/InterfoldToken/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/InterfoldToken/shapes.json
@@ -1,0 +1,8 @@
+{
+  "InterfoldToken.sol": {
+    "hash": "0x88be41d416945518f0140f4523687bcd81d2328e011b415781ae47ae97051d82",
+    "address": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/InterfoldToken/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/InterfoldToken/template.jsonc
@@ -1,0 +1,62 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "FOLD",
+  "category": "core",
+  "description": "Fixed-cap FOLD governance and ciphernode-bond token. Minting and pre-TGE transfer controls are disabled after the one-way TGE transition, while lock-policy administration can continue until the immutable lock cutoff.",
+  "ignoreMethods": ["getPastTotalSupply"],
+  "ignoreRelatives": ["CLAIM_SOURCE"],
+  "ignoreInWatchMode": ["clock"],
+  "fields": {
+    "accessControl": {
+      "description": "Current role administrators and members. Some launch roles retain membership even where their pre-TGE functions now revert.",
+      "handler": { "type": "accessControl" }
+    },
+    "defaultAdmins": {
+      "description": "Members of DEFAULT_ADMIN_ROLE. Admin minting is disabled after TGE, but this role can grant and revoke the remaining roles.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "accessControl",
+        "pickRoleMembers": "DEFAULT_ADMIN_ROLE"
+      },
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "grant and revoke FOLD roles. The role's direct mint function permanently reverts after TGE."
+        }
+      ]
+    },
+    "lockManagers": {
+      "description": "Members of LOCK_MANAGER_ROLE.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "accessControl",
+        "pickRoleMembers": "LOCK_MANAGER_ROLE"
+      },
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "create immutable vesting policies, link claimed balances to policies and exempt accounts from automatic claim locks until the immutable lock cutoff."
+        }
+      ]
+    },
+    "owner": {
+      "description": "Ownable controller. The one-time claim-source setter has already been consumed; the remaining live owner action is ownership transfer."
+    },
+    "phase": {
+      "description": "Token lifecycle phase. Phase 3 is the irreversible live phase in which unrestricted transfers are enabled and minting is closed.",
+      "type": "RISK_PARAMETER"
+    },
+    "CLAIM_SOURCE": {
+      "description": "One-time auction claim source. The completed auction and its dependencies are outside the live Interfold protocol perimeter."
+    },
+    "BONDING_REGISTRY": {
+      "description": "Immutable registry in which bonded FOLD remains included in governance voting power."
+    },
+    "MAX_SUPPLY": {
+      "description": "Immutable maximum FOLD supply."
+    },
+    "NO_MORE_LOCKS": {
+      "description": "Immutable timestamp after which no new token locks can be created or linked."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/ListedCheckCondition/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/ListedCheckCondition/shapes.json
@@ -1,0 +1,8 @@
+{
+  "ListedCheckCondition.sol": {
+    "hash": "0x3ce47497decc268ba14803a8a7bb936775fb9100ee19ab8efcc0aec0bcb0ac73",
+    "address": "eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/ListedCheckCondition/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/ListedCheckCondition/template.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "VotingEscrowMemberCondition",
+  "category": "gov",
+  "description": "Immutable Aragon condition on the voting-escrow multisig's public proposal grant. When the multisig is configured as only-listed, it restricts proposal creators to current listed members. The associated Multisig address is embedded immutably in bytecode."
+}

--- a/packages/config/src/projects/_templates/interfold/MockE3Program/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/MockE3Program/shapes.json
@@ -1,0 +1,8 @@
+{
+  "MockE3Program.sol": {
+    "hash": "0x38bddeea4408ea6799cd424256303ee01badb0182f323a92b889a290f8efe00d",
+    "address": "eth:0x4976E5E47852eFCe6851d35B95A1A2E19456F3D7",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/MockE3Program/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/MockE3Program/template.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "MockE3Program",
+  "category": "core",
+  "description": "Permanently allowlisted test E3 application. It accepts arbitrary input and returns successful validation and output verification, so requests using it exercise the protocol proof pipeline without application-level correctness checks."
+}

--- a/packages/config/src/projects/_templates/interfold/SPPRuleCondition/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/SPPRuleCondition/shapes.json
@@ -1,0 +1,8 @@
+{
+  "SPPRuleCondition.sol": {
+    "hash": "0x820364f6b02461f786e2dfaa81e0059689349246f89bf5b49bf33424d05d117e",
+    "address": "eth:0xE437E5c7EeB0D49F97CfD040fb8a02A60a61c0f0",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/SPPRuleCondition/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/SPPRuleCondition/template.jsonc
@@ -1,0 +1,16 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "PublicProposalCondition",
+  "category": "gov",
+  "description": "Aragon condition attached to the public CREATE_PROPOSAL permission. Its mutable rule program determines which callers and proposal calls qualify for the otherwise-public grant.",
+  "ignoreMethods": ["decodeRuleValue"],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose permission manager controls updates to the condition's rule program."
+    },
+    "getRules": {
+      "description": "Current ordered rule program evaluated for public proposal creation.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/SlashingManager/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/SlashingManager/shapes.json
@@ -1,0 +1,8 @@
+{
+  "SlashingManager.sol": {
+    "hash": "0x6c22fa41562f0c1711c54cad35a5dc279f856b8cd1e3f329e8ede042eda17f1c",
+    "address": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/SlashingManager/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/SlashingManager/template.jsonc
@@ -1,0 +1,89 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "SlashingManager",
+  "category": "core",
+  "description": "Policy and evidence router for ciphernode penalties, appeals and bans. Slashing is effective only for reasons with an enabled policy and through a manager authorized by the BondingRegistry.",
+  "ignoreMethods": [
+    "getE3AccusationWindow",
+    "getE3Dependencies",
+    "getPendingSlashRoute",
+    "getSlashProposal"
+  ],
+  "ignoreInWatchMode": [
+    "activeBanCount",
+    "activeE3Assignments",
+    "totalProposals"
+  ],
+  "fields": {
+    "accessControl": {
+      "description": "Current role administrators and members.",
+      "handler": { "type": "accessControl" }
+    },
+    "defaultAdmins": {
+      "description": "Members of DEFAULT_ADMIN_ROLE.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "accessControl",
+        "pickRoleMembers": "DEFAULT_ADMIN_ROLE"
+      },
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "replace the coordinator, bonding registry, ciphernode registry and refund manager, and grant or revoke governance membership. A transfer of the default-admin role itself has the configured delay."
+        }
+      ]
+    },
+    "governanceMembers": {
+      "description": "Members of GOVERNANCE_ROLE.",
+      "type": "PERMISSION",
+      "handler": {
+        "type": "accessControl",
+        "pickRoleMembers": "GOVERNANCE_ROLE"
+      },
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "create or disable slash policies, grant or revoke evidence slashers, resolve appeals, close E3 assignments and propose, confirm or remove operator bans."
+        }
+      ]
+    },
+    "slashers": {
+      "description": "Members of SLASHER_ROLE.",
+      "type": "PERMISSION",
+      "handler": { "type": "accessControl", "pickRoleMembers": "SLASHER_ROLE" },
+      "permissions": [
+        {
+          "type": "interact",
+          "description": "submit evidence-based slash proposals for enabled non-proof policies."
+        }
+      ]
+    },
+    "slashPolicies": {
+      "description": "Latest configured slashing policy for each reason. An empty map means no ticket or FOLD penalty can currently be proposed through this manager.",
+      "type": "RISK_PARAMETER",
+      "handler": {
+        "type": "event",
+        "groupBy": "reason",
+        "select": "policy",
+        "set": { "event": "SlashPolicyUpdated" },
+        "ignoreRelative": true
+      }
+    },
+    "bannedNodes": {
+      "description": "Currently banned operator keys reconstructed from ban-status events.",
+      "handler": {
+        "type": "event",
+        "select": "node",
+        "add": { "event": "NodeBanUpdated", "where": ["=", "#status", true] },
+        "remove": {
+          "event": "NodeBanUpdated",
+          "where": ["=", "#status", false]
+        }
+      }
+    },
+    "defaultAdminDelay": {
+      "description": "Delay for transferring DEFAULT_ADMIN_ROLE. It does not delay calls made by the current admin or governance-role members.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/StagedProposalProcessor/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/StagedProposalProcessor/shapes.json
@@ -1,0 +1,8 @@
+{
+  "StagedProposalProcessor.sol": {
+    "hash": "0x001b18ae4604ab644ca37dc856974c6b97fb66cfbff5f17ade7109694d1ee295",
+    "address": "eth:0xCB895791C84484530d9fC9f68652b9bCC9D5288d",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/StagedProposalProcessor/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/StagedProposalProcessor/template.jsonc
@@ -1,0 +1,44 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "PublicStagedProposalProcessor",
+  "category": "gov",
+  "description": "Upgradeable Aragon staged-proposal plugin that executes DAO actions after proposals pass its configured sequence of voting or manual bodies, thresholds and timing windows.",
+  "ignoreMethods": [
+    "canExecute",
+    "canProposalAdvance",
+    "getBodyProposalId",
+    "getBodyResult",
+    "getCreateProposalParams",
+    "getProposal",
+    "getProposalTally",
+    "getStages",
+    "hasSucceeded",
+    "proposalCount",
+    "proxiableUUID",
+    "state"
+  ],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose permission manager controls proposal creation, configuration, advancement and upgrades."
+    },
+    "currentStages": {
+      "description": "Latest proposal-stage configuration reconstructed from events, including voting bodies, approval and veto thresholds, timing windows, and edit/cancel flags.",
+      "type": "RISK_PARAMETER",
+      "handler": {
+        "type": "event",
+        "select": "stages",
+        "set": { "event": "StagesUpdated" }
+      }
+    },
+    "getCurrentConfigIndex": {
+      "description": "Index of the stage configuration used by newly created proposals. Existing proposals retain their earlier snapshot."
+    },
+    "getCurrentTargetConfig": {
+      "description": "Stored target and call operation for passed proposal actions. A zero target resolves to the DAO; delegatecall changes the security context.",
+      "type": "CODE_CHANGE"
+    },
+    "getTrustedForwarder": {
+      "description": "Address trusted to append the effective caller to proposal transactions."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/TokenVoting/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/TokenVoting/shapes.json
@@ -1,0 +1,8 @@
+{
+  "TokenVoting.sol": {
+    "hash": "0x9154a89d8adf05af1d4ecc3635433d4611c6c8381ab1cd5ed06e52913ed42f89",
+    "address": "eth:0xbbc277951D93e866700471f71616b2c9D304E6F6",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/TokenVoting/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/TokenVoting/template.jsonc
@@ -1,0 +1,59 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "PublicTokenVoting",
+  "category": "gov",
+  "description": "Upgradeable Aragon majority-voting plugin used as the voting body in Interfold's public staged proposal path. Voting power comes from the immutable BondedVotes adapter.",
+  "ignoreMethods": [
+    "canExecute",
+    "canVote",
+    "getProposal",
+    "hasSucceeded",
+    "isMinApprovalReached",
+    "isMinParticipationReached",
+    "isSupportThresholdReached",
+    "isSupportThresholdReachedEarly",
+    "proposalCount",
+    "proxiableUUID",
+    "totalVotingPower"
+  ],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose permission manager controls voting settings, targets and upgrades."
+    },
+    "getVotingToken": {
+      "description": "Immutable IVotes source used for proposal snapshots and vote weights."
+    },
+    "votingMode": {
+      "description": "Early-execution mode applied to newly created votes.",
+      "type": "RISK_PARAMETER"
+    },
+    "supportThreshold": {
+      "description": "Required yes-vote ratio over yes plus no votes, using Aragon's 10^6 ratio base.",
+      "type": "RISK_PARAMETER"
+    },
+    "minParticipation": {
+      "description": "Minimum participating voting power relative to the snapshotted total supply, using Aragon's 10^6 ratio base.",
+      "type": "RISK_PARAMETER"
+    },
+    "minDuration": {
+      "description": "Minimum voting duration in seconds.",
+      "type": "RISK_PARAMETER"
+    },
+    "minProposerVotingPower": {
+      "description": "Minimum voting power the creator must hold at the proposal snapshot.",
+      "type": "RISK_PARAMETER"
+    },
+    "minApproval": {
+      "description": "Absolute minimum yes-vote requirement for a proposal to succeed.",
+      "type": "RISK_PARAMETER"
+    },
+    "tokenIndexedByTimestamp": {
+      "description": "Whether proposal snapshots use timestamp-based rather than block-number-based voting checkpoints.",
+      "type": "RISK_PARAMETER"
+    },
+    "getCurrentTargetConfig": {
+      "description": "Stored execution target and call operation for successful voting proposals.",
+      "type": "CODE_CHANGE"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrow/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrow/shapes.json
@@ -1,0 +1,8 @@
+{
+  "VotingEscrow.sol": {
+    "hash": "0xbc6579b4c42accae5c7400219895c015a3d275afd13088b59e85b094038ba821",
+    "address": "eth:0x201d4c1cd48F2fC1297eEa56B14A29a039164a91",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrow/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrow/template.jsonc
@@ -1,0 +1,51 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "VotingEscrow",
+  "category": "gov",
+  "description": "veFOLD escrow that custodies locked FOLD, issues lock NFTs and calculates the voting power consumed by BondedVotes through EscrowVotesAdapter.",
+  "ignoreMethods": [
+    "isVoting",
+    "locked",
+    "proxiableUUID",
+    "totalVotingPowerAt",
+    "votingPower"
+  ],
+  "ignoreInWatchMode": [
+    "currentExitingAmount",
+    "lastLockId",
+    "totalLocked",
+    "totalVotingPower"
+  ],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose permission manager grants the escrow's admin, pause, sweep and upgrade roles."
+    },
+    "token": { "description": "FOLD token custodied by the escrow." },
+    "ivotesAdapter": {
+      "description": "Adapter exposing the escrow's voting power through IVotes."
+    },
+    "clock": {
+      "description": "Upgradeable epoch clock used for voting checkpoints and lock timing."
+    },
+    "curve": {
+      "description": "Upgradeable voting-power curve applied to locked FOLD."
+    },
+    "lockNFT": {
+      "description": "Upgradeable ERC-721 representing FOLD lock positions."
+    },
+    "queue": {
+      "description": "Upgradeable exit queue controlling withdrawal cooldowns and fees."
+    },
+    "voter": {
+      "description": "Gauge-voting plugin allowed to update a lock's voting state."
+    },
+    "paused": {
+      "description": "Whether lock and voting-power operations are paused.",
+      "type": "RISK_PARAMETER"
+    },
+    "minDeposit": {
+      "description": "Minimum FOLD amount accepted for a voting-escrow lock.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowClock/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowClock/shapes.json
@@ -1,0 +1,8 @@
+{
+  "VotingEscrowClock.sol": {
+    "hash": "0x4a40c38873e8dd6be25ae82bbd232864c841271ce308509366c56987196b1c46",
+    "address": "eth:0xEC0162045B44C5506954E3A04dbbcdfe39f64f21",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowClock/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowClock/template.jsonc
@@ -1,0 +1,58 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "VotingEscrowClock",
+  "category": "gov",
+  "description": "Timestamp clock defining veFOLD epochs, checkpoint cadence and gauge-voting windows.",
+  "ignoreMethods": [
+    "proxiableUUID",
+    "resolveElapsedInEpoch",
+    "resolveEpoch",
+    "resolveEpochNextCheckpointIn",
+    "resolveEpochNextCheckpointTs",
+    "resolveEpochPrevCheckpointElapsed",
+    "resolveEpochPrevCheckpointTs",
+    "resolveEpochStartsIn",
+    "resolveEpochStartTs",
+    "resolveEpochVoteEndsIn",
+    "resolveEpochVoteEndTs",
+    "resolveEpochVoteStartsIn",
+    "resolveEpochVoteStartTs",
+    "resolveVotingActive"
+  ],
+  "ignoreInWatchMode": [
+    "currentEpoch",
+    "elapsedInEpoch",
+    "epochNextCheckpointIn",
+    "epochNextCheckpointTs",
+    "epochPrevCheckpointElapsed",
+    "epochPrevCheckpointTs",
+    "epochStartsIn",
+    "epochStartTs",
+    "epochVoteEndsIn",
+    "epochVoteEndTs",
+    "epochVoteStartsIn",
+    "epochVoteStartTs",
+    "votingActive"
+  ],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose Clock admin role can change timing and upgrade the implementation."
+    },
+    "epochDuration": {
+      "description": "Duration of a veFOLD epoch.",
+      "type": "RISK_PARAMETER"
+    },
+    "checkpointInterval": {
+      "description": "Interval between voting-power checkpoints.",
+      "type": "RISK_PARAMETER"
+    },
+    "voteDuration": {
+      "description": "Duration of the gauge-voting window in each epoch.",
+      "type": "RISK_PARAMETER"
+    },
+    "voteWindowBuffer": {
+      "description": "Buffer between the epoch boundary and gauge voting.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowExitQueue/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowExitQueue/shapes.json
@@ -1,0 +1,8 @@
+{
+  "VotingEscrowExitQueue.sol": {
+    "hash": "0xdf4efbc40c77de7dfb353dd7185741bdbf420c9381f9f561b47120d1ed0ffd97",
+    "address": "eth:0x037c00ba58D4d2A4870017aeaD7f79A0D23A294f",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowExitQueue/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowExitQueue/template.jsonc
@@ -1,0 +1,45 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "VotingEscrowExitQueue",
+  "category": "gov",
+  "description": "Queue applying cooldowns and optional fees to withdrawals from VotingEscrow.",
+  "ignoreMethods": [
+    "calculateFee",
+    "canExit",
+    "getTimeBasedFee",
+    "isCool",
+    "proxiableUUID",
+    "queue",
+    "ticketHolder",
+    "timeToMinLock"
+  ],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose queue roles control fees, cooldowns, withdrawals and upgrades."
+    },
+    "escrow": {
+      "description": "VotingEscrow that creates and completes withdrawal requests."
+    },
+    "clock": { "description": "Epoch clock used for exit timing." },
+    "cooldown": {
+      "description": "Current base withdrawal cooldown.",
+      "type": "RISK_PARAMETER"
+    },
+    "minCooldown": {
+      "description": "Minimum configurable withdrawal cooldown.",
+      "type": "RISK_PARAMETER"
+    },
+    "minLock": {
+      "description": "Minimum lock duration required by the queue.",
+      "type": "RISK_PARAMETER"
+    },
+    "feePercent": {
+      "description": "Current withdrawal fee ratio.",
+      "type": "RISK_PARAMETER"
+    },
+    "minFeePercent": {
+      "description": "Minimum configurable withdrawal fee ratio.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowGaugeVoter/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowGaugeVoter/shapes.json
@@ -1,0 +1,8 @@
+{
+  "VotingEscrowGaugeVoter.sol": {
+    "hash": "0xef1d8d75954efe33dde419c37a4cda54027a054626f2ce95eeaba5785a79b6e1",
+    "address": "eth:0x41d565fcC636805E3addDa99714067cB020F09Aa",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowGaugeVoter/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowGaugeVoter/template.jsonc
@@ -1,0 +1,43 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "VotingEscrowGaugeVoter",
+  "category": "gov",
+  "description": "Upgradeable, currently paused gauge-voting plugin connected to VotingEscrow. It can update voting state used by escrow lock operations but is not the Interfold DAO proposal-voting plugin.",
+  "ignoreMethods": ["epochTotalVotingPowerCast", "proxiableUUID"],
+  "ignoreInWatchMode": [
+    "currentEpochStart",
+    "epochId",
+    "epochStart",
+    "epochVoteEnd",
+    "epochVoteStart",
+    "getWriteEpochId",
+    "totalVotingPowerCast",
+    "votingActive"
+  ],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose permissions control gauge administration and upgrades."
+    },
+    "escrow": {
+      "description": "VotingEscrow whose lock voting state this plugin updates."
+    },
+    "clock": {
+      "description": "Clock defining gauge-voting epochs."
+    },
+    "ivotesAdapter": {
+      "description": "Voting-power source used by the gauge plugin."
+    },
+    "paused": {
+      "description": "Whether gauge voting is paused.",
+      "type": "RISK_PARAMETER"
+    },
+    "enableUpdateVotingPowerHook": {
+      "description": "Whether escrow transfers invoke the gauge-voting power update hook.",
+      "type": "RISK_PARAMETER"
+    },
+    "getCurrentTargetConfig": {
+      "description": "Stored execution target and operation for gauge-voting proposals.",
+      "type": "CODE_CHANGE"
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowLockNFT/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowLockNFT/shapes.json
@@ -1,0 +1,8 @@
+{
+  "VotingEscrowLockNFT.sol": {
+    "hash": "0x424f4df711b03adc7fa8ac4d99ece4e185fec69f61ab6beac1b7047c52275678",
+    "address": "eth:0x5F8a4394415a7630e715B8eb6F84b73c6172881a",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingEscrowLockNFT/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/VotingEscrowLockNFT/template.jsonc
@@ -1,0 +1,25 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "VotingEscrowLockNFT",
+  "category": "gov",
+  "description": "ERC-721 whose tokens represent individual veFOLD lock positions.",
+  "ignoreMethods": [
+    "getApproved",
+    "ownerOf",
+    "proxiableUUID",
+    "tokenByIndex",
+    "tokenURI"
+  ],
+  "ignoreInWatchMode": ["totalSupply"],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose Lock admin role controls whitelist configuration and upgrades."
+    },
+    "escrow": {
+      "description": "VotingEscrow exclusively responsible for minting and burning lock positions."
+    },
+    "WHITELIST_ANY_ADDRESS": {
+      "description": "Sentinel used by the transfer whitelist."
+    }
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingPowerCurve/shapes.json
+++ b/packages/config/src/projects/_templates/interfold/VotingPowerCurve/shapes.json
@@ -1,0 +1,8 @@
+{
+  "VotingPowerCurve.sol": {
+    "hash": "0x126b3fdbc9562d64b152d03a44f6a560539bbb3c9c35e4f58d91692a00d378e6",
+    "address": "eth:0x59417A78C133a6Fddf8a3b5e751378aF8d42e249",
+    "chain": "ethereum",
+    "blockNumber": 25831469
+  }
+}

--- a/packages/config/src/projects/_templates/interfold/VotingPowerCurve/template.jsonc
+++ b/packages/config/src/projects/_templates/interfold/VotingPowerCurve/template.jsonc
@@ -1,0 +1,35 @@
+{
+  "$schema": "../../../../../../discovery/schemas/contract.v2.schema.json",
+  "displayName": "VotingPowerCurve",
+  "category": "gov",
+  "description": "Curve that converts veFOLD lock amount and duration into voting power.",
+  "ignoreMethods": [
+    "getCoefficients",
+    "globalPointHistory",
+    "isWarm",
+    "previewMaxBias",
+    "proxiableUUID",
+    "slopeChanges",
+    "supplyAt",
+    "tokenPointIntervals",
+    "tokenPointLatestIndex"
+  ],
+  "ignoreInWatchMode": ["globalPointLatestIndex"],
+  "fields": {
+    "dao": {
+      "description": "Aragon DAO whose Curve admin role controls configuration and upgrades."
+    },
+    "escrow": {
+      "description": "VotingEscrow whose lock history is transformed into voting power."
+    },
+    "clock": { "description": "Epoch clock used by curve calculations." },
+    "maxTime": {
+      "description": "Maximum lock duration considered by the voting-power curve.",
+      "type": "RISK_PARAMETER"
+    },
+    "warmupPeriod": {
+      "description": "Warm-up period before newly locked FOLD reaches voting power.",
+      "type": "RISK_PARAMETER"
+    }
+  }
+}

--- a/packages/config/src/projects/interfold/config.jsonc
+++ b/packages/config/src/projects/interfold/config.jsonc
@@ -1,0 +1,1054 @@
+{
+  "$schema": "../../../../discovery/schemas/config.v2.schema.json",
+  "name": "interfold",
+  "import": ["../globalConfig.jsonc"],
+  "initialAddresses": [
+    "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715", // E3 coordinator
+    "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7", // ciphernode registry
+    "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F", // bonding registry
+    "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9", // slashing manager
+    "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e", // refund manager
+    "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D", // ticket token
+    "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904", // FOLD token
+    "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f", // CRISP application
+    "eth:0x40a18Fc27ac4a4d86fA70385c6814e453b6BFF2c", // active RISC Zero ciphertext verifier
+    "eth:0xF21e25455988887EE797050080141eba67B33920", // armed Aragon Admin plugin
+    "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb", // public staged proposal processor
+    "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC", // public token voting plugin
+    "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2", // public proposal condition
+    "eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E", // voting-power adapter used by TokenVoting
+    "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C", // listed-member executor of the voting-escrow DAO
+    "eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76" // membership condition on its public proposal grant
+  ],
+  "names": {
+    "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715": "Interfold",
+    "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7": "CiphernodeRegistry",
+    "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e": "InterfoldDAO",
+    "eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018": "InterfoldSafeA",
+    "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593": "InterfoldSafeB",
+    "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f": "CRISPProgram",
+    "eth:0x40a18Fc27ac4a4d86fA70385c6814e453b6BFF2c": "Risc0BfvCiphertextVerifier",
+    "eth:0xF21e25455988887EE797050080141eba67B33920": "AdminPlugin",
+    "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb": "PublicStagedProposalProcessor",
+    "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC": "PublicTokenVoting",
+    "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2": "PublicProposalCondition",
+    "eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E": "BondedVotes",
+    "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B": "VotingEscrowDAO",
+    "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C": "VotingEscrowMultisig",
+    "eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76": "VotingEscrowMemberCondition",
+    "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12": "VotingEscrow",
+    "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc": "EscrowVotesAdapter",
+    "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166": "VotingEscrowClock",
+    "eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9": "VotingPowerCurve",
+    "eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E": "VotingEscrowLockNFT",
+    "eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f": "VotingEscrowExitQueue",
+    "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0": "VotingEscrowGaugeVoter",
+    "eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4": "AragonExecutor"
+  },
+  "overrides": {
+    "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e": {
+      "fields": {
+        "daoExecutors": {
+          "description": "Current grantees of Aragon's EXECUTE_PERMISSION on this DAO, reconstructed from grant and revoke events.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "act",
+              "description": "execute arbitrary calls from the DAO, including calls to protocol owners and ProxyAdmins."
+            }
+          ]
+        },
+        "daoRootHolders": {
+          "description": "Current grantees of Aragon's ROOT_PERMISSION on this DAO, reconstructed from grant and revoke events.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x815fe80e4b37c8582a3b773d1d7071f983eacfd56b5965db654f3087c25ada33",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "grant and revoke permissions in the DAO."
+            }
+          ]
+        },
+        "daoUpgraders": {
+          "description": "Current grantees of Aragon's UPGRADE_DAO_PERMISSION on this DAO, reconstructed from grant and revoke events.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x1f53edd44352e5d15bad2b29233baa93bcd595e09457780bc7c5445bbbe751cc",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [{ "type": "upgrade" }]
+        },
+        "adminPluginExecutors": {
+          "description": "Addresses that can drive the armed Admin plugin without a DAO vote, reconstructed from Aragon grant and revoke events.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xF21e25455988887EE797050080141eba67B33920",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "act",
+              "description": "execute arbitrary DAO actions through the armed Admin plugin without a vote or an onchain delay."
+            }
+          ]
+        },
+        "adminTargetManagers": {
+          "description": "Current grantees allowed to redirect the Admin plugin's execution target.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xF21e25455988887EE797050080141eba67B33920",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "redirect calls made by the Admin plugin to another executor or target."
+            }
+          ]
+        },
+        "sppStageManagers": {
+          "description": "Current grantees allowed to replace the staged proposal process.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x6f36f8bf0398781285f5a40c489dbf3268ce3e205aba87f21e49e6805391b5a1",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "replace the stages, bodies, thresholds and timing rules for future public proposals."
+            }
+          ]
+        },
+        "sppProposalCreators": {
+          "description": "Current grantees allowed to create proposals in the staged proposal processor. Conditional grants remain visible in $activePermissions.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x8c433a4cd6b51969eca37f974940894297b9fcf4b282a213fea5cd8f85289c90",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "create a staged proposal when the attached Aragon condition permits it."
+            }
+          ]
+        },
+        "sppAdvancers": {
+          "description": "Current grantees allowed to advance proposals whose configured stage conditions have passed.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0xb014ce248804cab6a144581acce1eeb70ce5d54f08433b989d73bb0ccee3d3f9",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "advance proposals only after the configured stage rules permit advancement."
+            }
+          ]
+        },
+        "sppExecutors": {
+          "description": "Current grantees allowed to execute a staged proposal after its configured stages have passed.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "execute a staged proposal only after every configured stage has passed."
+            }
+          ]
+        },
+        "sppTargetManagers": {
+          "description": "Current grantees allowed to redirect the staged processor's execution target.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "redirect passed proposal actions to another executor or target."
+            }
+          ]
+        },
+        "sppTrustedForwarderManagers": {
+          "description": "Current grantees allowed to replace the staged processor's trusted meta-transaction forwarder.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x06d294bc8cbad2e393408b20dd019a772661f60b8d633e56761157cb1ec85f8c",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "replace the address trusted to append the effective caller to proposal transactions."
+            }
+          ]
+        },
+        "sppUpgraders": {
+          "description": "Current grantees of the UPGRADE_PLUGIN permission on the staged proposal processor.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [{ "type": "upgrade" }]
+        },
+        "tokenVotingSettingsManagers": {
+          "description": "Current grantees allowed to change public token-voting thresholds and duration.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0xbba35d41610b7d25c8e486006535c76bd423091563e694d206ae3d71ce949fe5",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "change support, participation, duration, proposer-power and minimum-approval requirements for future votes."
+            }
+          ]
+        },
+        "tokenVotingProposalCreators": {
+          "description": "Current grantees allowed to open token-voting proposals.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x8c433a4cd6b51969eca37f974940894297b9fcf4b282a213fea5cd8f85289c90",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "open a token vote using the caller-supplied proposal payload."
+            }
+          ]
+        },
+        "tokenVotingExecutors": {
+          "description": "Current grantees allowed to execute a successful token-voting proposal.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "execute a token-voting proposal only after the vote has succeeded."
+            }
+          ]
+        },
+        "tokenVotingTargetManagers": {
+          "description": "Current grantees allowed to redirect the token-voting plugin's execution target.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "redirect passed vote actions to another executor or target."
+            }
+          ]
+        },
+        "tokenVotingUpgraders": {
+          "description": "Current grantees of the UPGRADE_PLUGIN permission on the token-voting plugin.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [{ "type": "upgrade" }]
+        },
+        "conditionRuleManagers": {
+          "description": "Current grantees allowed to replace the public proposal-creation condition.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0xd3d98e95f3486fc234d80c098cf0d2a0a3fb187833d7e9cc930f8c4f8335a0e7",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "replace the rules that gate public creation of staged proposals."
+            }
+          ]
+        }
+      }
+    },
+    "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B": {
+      "fields": {
+        "veDaoExecutors": {
+          "description": "Current grantees of EXECUTE_PERMISSION on the voting-escrow DAO.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "act",
+              "description": "execute arbitrary calls from the voting-escrow DAO, including administration and upgrades of the voting-power stack."
+            }
+          ]
+        },
+        "veDaoRootHolders": {
+          "description": "Current grantees of ROOT_PERMISSION on the voting-escrow DAO.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x815fe80e4b37c8582a3b773d1d7071f983eacfd56b5965db654f3087c25ada33",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "grant and revoke permissions in the voting-escrow DAO."
+            }
+          ]
+        },
+        "veDaoUpgraders": {
+          "description": "Current grantees of UPGRADE_DAO_PERMISSION on the voting-escrow DAO.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x1f53edd44352e5d15bad2b29233baa93bcd595e09457780bc7c5445bbbe751cc",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [{ "type": "upgrade" }]
+        },
+        "votingEscrowAdmins": {
+          "description": "Current holders of the VotingEscrow ESCROW_ADMIN role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x5153bc4ddea3acc82e49822cf2356cf42e16e0ba80c942840692ca4dd7db5995",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            { "type": "upgrade" },
+            {
+              "type": "interact",
+              "description": "replace voting-power dependencies, change minimum deposits and split rules, and upgrade VotingEscrow."
+            }
+          ]
+        },
+        "votingEscrowPausers": {
+          "description": "Current holders of the VotingEscrow PAUSER role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x539440820030c4994db4e31b6b800deafd503688728f932addfe7a410515c14c",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "pause and unpause voting-escrow operations."
+            }
+          ]
+        },
+        "votingEscrowSweepers": {
+          "description": "Current holders of the VotingEscrow SWEEPER role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0xfdecf383ad5026ade6d21db07b04781efb7ede2811d8b5fe299044cc4bb91fc9",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "sweep unaccounted tokens and NFTs from VotingEscrow."
+            }
+          ]
+        },
+        "votesAdapterAdmins": {
+          "description": "Current holders of the EscrowIVotesAdapter DELEGATION_ADMIN role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0xc4a19b785a540c2c44664ee81553e51ce4d2ff785f770bea0ef0e33e9fc2e896",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            { "type": "upgrade" },
+            {
+              "type": "interact",
+              "description": "pause the escrow voting-power adapter, manage delegation settings and upgrade its implementation."
+            }
+          ]
+        },
+        "delegationTokenManagers": {
+          "description": "Current holders of the EscrowIVotesAdapter DELEGATION_TOKEN role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x4e4bdb05aa372e853fafb37a727873f403f7f9b7c0c697830b63f63502b87535",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "update delegated voting power through the escrow voting adapter."
+            }
+          ]
+        },
+        "clockAdmins": {
+          "description": "Current holders of the voting-escrow Clock admin role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x440d025ee487c9fe654894f3750aeb18132e334d52d7a9c0a3f6a5c77450a9b5",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            { "type": "upgrade" },
+            {
+              "type": "interact",
+              "description": "change voting epochs and upgrade the voting-escrow Clock."
+            }
+          ]
+        },
+        "curveAdmins": {
+          "description": "Current holders of the voting-power Curve admin role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x065385aea91ea94bccc193b44dcdc1da3bcab7e7328692e0b12cda00df64eac4",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            { "type": "upgrade" },
+            {
+              "type": "interact",
+              "description": "change voting-power curve parameters and upgrade the Curve implementation."
+            }
+          ]
+        },
+        "lockAdmins": {
+          "description": "Current holders of the voting-escrow Lock NFT admin role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x54e26bc44f032b9c63f050973076cd279ea75ee2dceeaee6367075804fd03838",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            { "type": "upgrade" },
+            {
+              "type": "interact",
+              "description": "change transfer whitelist settings and upgrade the voting-lock NFT."
+            }
+          ]
+        },
+        "exitQueueAdmins": {
+          "description": "Current holders of the voting-escrow exit-queue admin role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0xc394c78f190ebf6a0034c84aafb4c6893f1e601de9d700227b16d74a628ac114",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            { "type": "upgrade" },
+            {
+              "type": "interact",
+              "description": "change cooldowns and exit fees and upgrade the voting-escrow exit queue."
+            }
+          ]
+        },
+        "exitQueueWithdrawers": {
+          "description": "Current holders of the voting-escrow exit-queue withdrawal role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0x5d8e12c39142ff96d79d04d15d1ba1269e4fe57bb9d26f43523628b34ba108ec",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "complete queued voting-escrow withdrawals."
+            }
+          ]
+        },
+        "gaugeAdmins": {
+          "description": "Current holders of the voting-escrow gauge-voter admin role.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "=",
+                "0xfda1ae526c1fb38407f23e8b7712f7cfacc146f3e340a04221488331e0d42014",
+                ["get", "permissionId"]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "manage gauge metadata and the voting-power update hook."
+            }
+          ]
+        },
+        "gaugeUpgraders": {
+          "description": "Current grantees of UPGRADE_PLUGIN permission on the voting-escrow gauge voter.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [{ "type": "upgrade" }]
+        },
+        "veMultisigUpgraders": {
+          "description": "Current grantees of UPGRADE_PLUGIN permission on the voting-escrow multisig plugin.",
+          "type": "PERMISSION",
+          "copy": "$activePermissions",
+          "edit": [
+            "pipe",
+            [
+              "filter",
+              [
+                "and",
+                [
+                  "=",
+                  "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5",
+                  ["get", "permissionId"]
+                ],
+                [
+                  "=",
+                  "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+                  ["get", "where"]
+                ]
+              ]
+            ],
+            ["map", ["get", "who"]]
+          ],
+          "permissions": [{ "type": "upgrade" }]
+        }
+      }
+    },
+    "eth:0x11E91FB4793047a68dFff29158387229eA313ffE": {
+      "ignoreMethods": ["getSeq", "nonceSequenceNumber"]
+    },
+    "eth:0x34aA3F359A9D614239015126635CE7732c18fDF3": {
+      "ignoreMethods": ["getSeq", "nonceSequenceNumber"]
+    },
+    "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f": {
+      "description": "CRISP encrypted-ballot application. It verifies ballot eligibility and encryption proofs, commits ciphertext inputs, checks that a RISC Zero tally is bound to its input root and parameters, and decodes the threshold-decrypted tally.",
+      "category": "core",
+      "fields": {
+        "owner": {
+          "description": "Account controlling application-level proof configuration and requester-supplied census roots.",
+          "type": "PERMISSION",
+          "handler": {
+            "type": "call",
+            "method": "function owner() view returns (address)",
+            "args": []
+          },
+          "permissions": [
+            {
+              "type": "interact",
+              "description": "set the eligible-voter Merkle root once per requester-census E3 and replace the application RISC Zero verifier or guest image ID immediately. Such replacement cannot change the verifier snapshotted by Interfold, but can make an in-flight round fail."
+            }
+          ]
+        },
+        "interfold": {
+          "description": "Permanently bound E3 coordinator.",
+          "handler": {
+            "type": "call",
+            "method": "function interfold() view returns (address)",
+            "args": []
+          }
+        },
+        "risc0Verifier": {
+          "description": "Application-level RISC Zero verifier. The external RISC Zero deployment is outside this discovery perimeter.",
+          "type": "CODE_CHANGE",
+          "handler": {
+            "type": "call",
+            "method": "function risc0Verifier() view returns (address)",
+            "args": [],
+            "ignoreRelative": true
+          }
+        },
+        "imageId": {
+          "description": "Application-level RISC Zero guest image ID. It must agree with the protocol ciphertext verifier for successful completion.",
+          "type": "CODE_CHANGE",
+          "handler": {
+            "type": "call",
+            "method": "function imageId() view returns (bytes32)",
+            "args": []
+          }
+        }
+      }
+    },
+    "eth:0x40a18Fc27ac4a4d86fA70385c6814e453b6BFF2c": {
+      "description": "Unverified wrapper that accepts a RISC Zero receipt for the immutable guest image ID and the E3-specific journal constructed by Interfold.",
+      "category": "core",
+      "fields": {
+        "imageId": {
+          "description": "Immutable RISC Zero guest image ID accepted as the encrypted-computation program.",
+          "type": "CODE_CHANGE",
+          "handler": {
+            "type": "call",
+            "method": "function imageId() view returns (bytes32)",
+            "args": []
+          }
+        },
+        "risc0Verifier": {
+          "description": "Immutable RISC Zero verifier used to validate computation receipts.",
+          "handler": {
+            "type": "call",
+            "method": "function risc0Verifier() view returns (address)",
+            "args": [],
+            "ignoreRelative": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/config/src/projects/interfold/diffHistory.md
+++ b/packages/config/src/projects/interfold/diffHistory.md
@@ -1,0 +1,288 @@
+Generated with discovered.json: 0x2a2539ed1ecdfd35765fdc2b7800a2bbc621df33
+
+# Diff at Tue, 25 Aug 2026 10:45:17 GMT:
+
+- author: sekuba (<29250140+sekuba@users.noreply.github.com>)
+- current timestamp: 1787653815
+
+## Description
+
+Discovery rerun on the same block number with only config-related changes.
+
+## Initial discovery
+
+```diff
++   Status: CREATED
+    contract BondedVotes (eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E) [interfold/BondedVotes]
+    +++ description: Immutable voting-power adapter used by PublicTokenVoting. It counts voting-escrow power, FOLD bonded to ciphernode operators, and eligible vesting-locked wallet FOLD while using FOLD total supply as the quorum denominator.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrowGaugeVoter (eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0) [interfold/VotingEscrowGaugeVoter]
+    +++ description: Upgradeable, currently paused gauge-voting plugin connected to VotingEscrow. It can update voting state used by escrow lock operations but is not the Interfold DAO proposal-voting plugin.
+```
+
+```diff
++   Status: CREATED
+    contract BondingRegistry (eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F) [interfold/BondingRegistry]
+    +++ description: Upgradeable collateral registry for ciphernode operators. Operators become eligible by depositing ticket collateral backed by sUSDS and a FOLD bond; the contract also enforces exits, committee obligations, bans and slashing debits.
+```
+
+```diff
++   Status: CREATED
+    EOA  (eth:0x11E91FB4793047a68dFff29158387229eA313ffE)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract E3RefundManager (eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e) [interfold/E3RefundManager]
+    +++ description: Upgradeable accounting contract that snapshots the refund policy for each E3 and distributes request fees and routed slashed funds between the requester, honest committee members, protocol treasury and reserve.
+```
+
+```diff
++   Status: CREATED
+    contract Interfold (eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715) [interfold/Interfold]
+    +++ description: Upgradeable coordinator for ephemeral encrypted computations (E3s). It accepts requests for allowlisted programs, selects a ciphernode committee, snapshots the configured proof system, and verifies the encrypted result and threshold decryption before publishing plaintext output.
+```
+
+```diff
++   Status: CREATED
+    contract ProxyAdmin (eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7) [global/ProxyAdmin]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    EOA  (eth:0x2F3A1d13525748D2e6CC8EEA715CEFCF5B8ff833)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    EOA  (eth:0x34aA3F359A9D614239015126635CE7732c18fDF3)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract Risc0BfvCiphertextVerifier (eth:0x40a18Fc27ac4a4d86fA70385c6814e453b6BFF2c) [N/A]
+    +++ description: Unverified wrapper that accepts a RISC Zero receipt for the immutable guest image ID and the E3-specific journal constructed by Interfold.
+```
+
+```diff
++   Status: CREATED
+    contract MockE3Program (eth:0x4976E5E47852eFCe6851d35B95A1A2E19456F3D7) [interfold/MockE3Program]
+    +++ description: Permanently allowlisted test E3 application. It accepts arbitrary input and returns successful validation and output verification, so requests using it exercise the protocol proof pipeline without application-level correctness checks.
+```
+
+```diff
++   Status: CREATED
+    contract DecryptionAggregatorVerifier (eth:0x53Fc34b412E16A1aE05A86934b821F82ca2a10da) [interfold/DecryptionAggregatorVerifier]
+    +++ description: Immutable generated Honk verifier for the BFV threshold-decryption aggregation circuit.
+```
+
+```diff
++   Status: CREATED
+    contract InterfoldSafeA (eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018) [GnosisSafe]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract AragonExecutor (eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4) [interfold/AragonExecutor]
+    +++ description: Immutable Aragon action executor used as a delegatecall target by PublicTokenVoting. It executes proposal action batches in the calling plugin's context.
+```
+
+```diff
++   Status: CREATED
+    EOA  (eth:0x60Ca282757BA67f3aDbF21F3ba2eBe4Ab3eb01fc)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract InterfoldDAO (eth:0x652a31c669f9AB37f6040f279139a75D04F2679e) [zama/ZamaDAO]
+    +++ description: Aragon DAO that stores governance state and executes proposal action batches.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrow (eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12) [interfold/VotingEscrow]
+    +++ description: Upgradeable veFOLD escrow that custodies locked FOLD, issues lock NFTs and calculates the voting power consumed by BondedVotes through EscrowVotesAdapter.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrowExitQueue (eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f) [interfold/VotingEscrowExitQueue]
+    +++ description: Upgradeable queue applying cooldowns and optional fees to withdrawals from VotingEscrow.
+```
+
+```diff
++   Status: CREATED
+    contract CRISPProgram (eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f) [N/A]
+    +++ description: CRISP encrypted-ballot application. It verifies ballot eligibility and encryption proofs, commits ciphertext inputs, checks that a RISC Zero tally is bound to its input root and parameters, and decodes the threshold-decrypted tally.
+```
+
+```diff
++   Status: CREATED
+    contract GnosisSafe (eth:0x8B405dBf2F30844B608b08DaD20447A6955A6C6E) [GnosisSafe]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract InterfoldSafeB (eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593) [GnosisSafe]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    EOA  (eth:0x8d138c01765483cB79d787ce5933F609CbFDabcF)
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract EscrowVotesAdapter (eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc) [interfold/EscrowVotesAdapter]
+    +++ description: Upgradeable IVotes adapter that exposes voting power from veFOLD locks. BondedVotes uses it as its primary voting-power source.
+```
+
+```diff
++   Status: CREATED
+    contract ProxyAdmin (eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E) [global/ProxyAdmin]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract SlashingManager (eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9) [interfold/SlashingManager]
+    +++ description: Non-upgradeable policy and evidence router for ciphernode penalties, appeals and bans. Slashing is effective only for reasons with an enabled policy and through a manager authorized by the BondingRegistry.
+```
+
+```diff
++   Status: CREATED
+    contract GnosisSafe (eth:0x97843608a00e2bbc75ab0C1911387E002565DEDE) [GnosisSafe]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract PublicStagedProposalProcessor (eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb) [interfold/StagedProposalProcessor]
+    +++ description: Upgradeable Aragon staged-proposal plugin that executes DAO actions after proposals pass its configured sequence of voting or manual bodies, thresholds and timing windows.
+```
+
+```diff
++   Status: CREATED
+    contract DkgAggregatorVerifier (eth:0x9e58443eB40A1B08D07f89D36bf69909d401a542) [interfold/DkgAggregatorVerifier]
+    +++ description: Immutable generated Honk verifier for the BFV distributed-key-generation aggregation circuit.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrowDAO (eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B) [zama/ZamaDAO]
+    +++ description: Aragon DAO that stores governance state and executes proposal action batches.
+```
+
+```diff
++   Status: CREATED
+    contract ProxyAdmin (eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580) [global/ProxyAdmin]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract BfvPkVerifier (eth:0xBA1854fDA7A5c127606572e43Dc7B37b7A15bdFf) [interfold/BfvPkVerifier]
+    +++ description: Immutable BFV public-key proof wrapper. It binds the generated circuit verifier to the expected DKG-fold and C5 verification-key hashes.
+```
+
+```diff
++   Status: CREATED
+    contract InterfoldTicketToken (eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D) [interfold/InterfoldTicketToken]
+    +++ description: Non-transferable ERC-20 Votes wrapper for sUSDS used as ciphernode ticket collateral. Only the configured BondingRegistry can deposit, mint, burn, withdraw or pay out the underlying asset.
+```
+
+```diff
++   Status: CREATED
+    contract CiphernodeRegistry (eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7) [interfold/CiphernodeRegistry]
+    +++ description: Upgradeable registry of ciphernodes and per-E3 committees. It performs ticket-weighted committee sortition, records DKG proof anchors and the committee public key, and tracks committee viability.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrowClock (eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166) [interfold/VotingEscrowClock]
+    +++ description: Upgradeable timestamp clock defining veFOLD epochs, checkpoint cadence and gauge-voting windows.
+```
+
+```diff
++   Status: CREATED
+    contract PublicProposalCondition (eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2) [interfold/SPPRuleCondition]
+    +++ description: Non-upgradeable Aragon condition attached to the public CREATE_PROPOSAL permission. Its mutable rule program determines which callers and proposal calls qualify for the otherwise-public grant.
+```
+
+```diff
++   Status: CREATED
+    contract BondedCheckpoints (eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963) [interfold/BondedCheckpoints]
+    +++ description: Immutable voting-power checkpoint store updated exclusively by the BondingRegistry so FOLD bonded to ciphernode operators remains visible to governance snapshots.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrowMultisig (eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C) [zama/Multisig]
+    +++ description: Aragon multisig plugin for creating proposals and collecting approvals against a configurable threshold.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrowMemberCondition (eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76) [interfold/ListedCheckCondition]
+    +++ description: Immutable Aragon condition on the voting-escrow multisig's public proposal grant. When the multisig is configured as only-listed, it restricts proposal creators to current listed members. The associated Multisig address is embedded immutably in bytecode.
+```
+
+```diff
++   Status: CREATED
+    contract FOLD (eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904) [interfold/InterfoldToken]
+    +++ description: Fixed-cap FOLD governance and ciphernode-bond token. Minting and pre-TGE transfer controls are disabled after the one-way TGE transition, while lock-policy administration can continue until the immutable lock cutoff.
+```
+
+```diff
++   Status: CREATED
+    contract DkgFoldAttestationVerifier (eth:0xE5657c0756B772B600D6c73eDbF046f32129c770) [interfold/DkgFoldAttestationVerifier]
+    +++ description: Immutable verifier for EIP-712 attestations that bind selected ciphernode operator keys to the party commitments folded into an E3 distributed-key-generation proof.
+```
+
+```diff
++   Status: CREATED
+    contract VotingPowerCurve (eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9) [interfold/VotingPowerCurve]
+    +++ description: Upgradeable curve that converts veFOLD lock amount and duration into voting power.
+```
+
+```diff
++   Status: CREATED
+    contract BfvDecryptionVerifier (eth:0xf143b969ea481Ccf251194D15F82007C67AABc53) [interfold/BfvDecryptionVerifier]
+    +++ description: Immutable threshold-decryption proof wrapper. It checks the generated circuit proof and binds its parties and public-key context to the committee recorded by CiphernodeRegistry.
+```
+
+```diff
++   Status: CREATED
+    contract ProxyAdmin (eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b) [global/ProxyAdmin]
+    +++ description: None
+```
+
+```diff
++   Status: CREATED
+    contract AdminPlugin (eth:0xF21e25455988887EE797050080141eba67B33920) [interfold/AdminPlugin]
+    +++ description: Non-upgradeable Aragon Admin plugin. Holders of its DAO-granted EXECUTE_PROPOSAL permission can submit actions that the plugin forwards immediately, without a vote or onchain delay.
+```
+
+```diff
++   Status: CREATED
+    contract VotingEscrowLockNFT (eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E) [interfold/VotingEscrowLockNFT]
+    +++ description: Upgradeable ERC-721 whose tokens represent individual veFOLD lock positions.
+```
+
+```diff
++   Status: CREATED
+    contract PublicTokenVoting (eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC) [interfold/TokenVoting]
+    +++ description: Upgradeable Aragon majority-voting plugin used as the voting body in Interfold's public staged proposal path. Voting power comes from the immutable BondedVotes adapter.
+```

--- a/packages/config/src/projects/interfold/diffHistory.md
+++ b/packages/config/src/projects/interfold/diffHistory.md
@@ -1,13 +1,13 @@
-Generated with discovered.json: 0x2a2539ed1ecdfd35765fdc2b7800a2bbc621df33
+Generated with discovered.json: 0x88a98c9817c30a48c9fd00902ba96dfd16ac26a0
 
-# Diff at Tue, 25 Aug 2026 10:45:17 GMT:
+# Diff at Tue, 25 Aug 2026 12:09:04 GMT:
 
 - author: sekuba (<29250140+sekuba@users.noreply.github.com>)
 - current timestamp: 1787653815
 
 ## Description
 
-Discovery rerun on the same block number with only config-related changes.
+Interfold coordinates ephemeral encrypted computations on Ethereum using allowlisted application contracts and a ticket-selected committee of bonded ciphernodes (who do offchain execution). Users publish encrypted inputs, an offchain compute provider produces a proof-backed encrypted result, and a 2-of-3 committee of cyphernodes threshold-decrypts it into a publicly posted plaintext output. RISC Zero verifies the application-specific encrypted computation, while Honk proofs bind distributed key generation and threshold decryption to the selected committee and E3. New programs, verifiers and core configuration are DAO-controlled, and confidentiality depends on fewer than two selected committee members colluding. Protocol is paused atm.
 
 ## Initial discovery
 
@@ -206,7 +206,7 @@ Discovery rerun on the same block number with only config-related changes.
 ```diff
 +   Status: CREATED
     contract CiphernodeRegistry (eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7) [interfold/CiphernodeRegistry]
-    +++ description: Upgradeable registry of ciphernodes and per-E3 committees. It performs ticket-weighted committee sortition, records DKG proof anchors and the committee public key, and tracks committee viability.
+    +++ description: Registry of ciphernodes and E3 committees. It performs ticket-weighted committee selection, records DKG (distributed key generation) proof anchors and the committee public key (to which cyphertexts can be encrypted), and tracks committee viability.
 ```
 
 ```diff

--- a/packages/config/src/projects/interfold/diffHistory.md
+++ b/packages/config/src/projects/interfold/diffHistory.md
@@ -1,6 +1,6 @@
-Generated with discovered.json: 0x88a98c9817c30a48c9fd00902ba96dfd16ac26a0
+Generated with discovered.json: 0xd3a4075ede581d3d9135e6069c8d7387c91fcb89
 
-# Diff at Tue, 25 Aug 2026 12:09:04 GMT:
+# Diff at Tue, 25 Aug 2026 12:24:41 GMT:
 
 - author: sekuba (<29250140+sekuba@users.noreply.github.com>)
 - current timestamp: 1787653815
@@ -14,7 +14,7 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract BondedVotes (eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E) [interfold/BondedVotes]
-    +++ description: Immutable voting-power adapter used by PublicTokenVoting. It counts voting-escrow power, FOLD bonded to ciphernode operators, and eligible vesting-locked wallet FOLD while using FOLD total supply as the quorum denominator.
+    +++ description: Voting-power adapter used by PublicTokenVoting. It counts voting-escrow power, FOLD bonded to ciphernode operators, and eligible vesting-locked wallet FOLD while using FOLD total supply as the quorum denominator.
 ```
 
 ```diff
@@ -26,7 +26,7 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract BondingRegistry (eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F) [interfold/BondingRegistry]
-    +++ description: Upgradeable collateral registry for ciphernode operators. Operators become eligible by depositing ticket collateral backed by sUSDS and a FOLD bond; the contract also enforces exits, committee obligations, bans and slashing debits.
+    +++ description: Collateral registry for ciphernode operators. Operators become eligible by depositing ticket collateral backed by sUSDS and a FOLD bond; the contract also enforces exits, committee obligations, bans and slashing debits.
 ```
 
 ```diff
@@ -44,7 +44,7 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract Interfold (eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715) [interfold/Interfold]
-    +++ description: Upgradeable coordinator for ephemeral encrypted computations (E3s). It accepts requests for allowlisted programs, selects a ciphernode committee, snapshots the configured proof system, and verifies the encrypted result and threshold decryption before publishing plaintext output.
+    +++ description: Coordinator for Encrypted Execution Environments (E3s). It accepts requests for allowlisted programs, selects a ciphernode committee, snapshots the configured proof system, and verifies the encrypted result and threshold decryption before publishing plaintext output.
 ```
 
 ```diff
@@ -110,13 +110,13 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract VotingEscrow (eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12) [interfold/VotingEscrow]
-    +++ description: Upgradeable veFOLD escrow that custodies locked FOLD, issues lock NFTs and calculates the voting power consumed by BondedVotes through EscrowVotesAdapter.
+    +++ description: veFOLD escrow that custodies locked FOLD, issues lock NFTs and calculates the voting power consumed by BondedVotes through EscrowVotesAdapter.
 ```
 
 ```diff
 +   Status: CREATED
     contract VotingEscrowExitQueue (eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f) [interfold/VotingEscrowExitQueue]
-    +++ description: Upgradeable queue applying cooldowns and optional fees to withdrawals from VotingEscrow.
+    +++ description: Queue applying cooldowns and optional fees to withdrawals from VotingEscrow.
 ```
 
 ```diff
@@ -158,7 +158,7 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract SlashingManager (eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9) [interfold/SlashingManager]
-    +++ description: Non-upgradeable policy and evidence router for ciphernode penalties, appeals and bans. Slashing is effective only for reasons with an enabled policy and through a manager authorized by the BondingRegistry.
+    +++ description: Policy and evidence router for ciphernode penalties, appeals and bans. Slashing is effective only for reasons with an enabled policy and through a manager authorized by the BondingRegistry.
 ```
 
 ```diff
@@ -194,7 +194,7 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract BfvPkVerifier (eth:0xBA1854fDA7A5c127606572e43Dc7B37b7A15bdFf) [interfold/BfvPkVerifier]
-    +++ description: Immutable BFV public-key proof wrapper. It binds the generated circuit verifier to the expected DKG-fold and C5 verification-key hashes.
+    +++ description: BFV public-key proof wrapper. It binds the generated circuit verifier to the expected DKG-fold and C5 verification-key hashes.
 ```
 
 ```diff
@@ -212,19 +212,19 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract VotingEscrowClock (eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166) [interfold/VotingEscrowClock]
-    +++ description: Upgradeable timestamp clock defining veFOLD epochs, checkpoint cadence and gauge-voting windows.
+    +++ description: Timestamp clock defining veFOLD epochs, checkpoint cadence and gauge-voting windows.
 ```
 
 ```diff
 +   Status: CREATED
     contract PublicProposalCondition (eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2) [interfold/SPPRuleCondition]
-    +++ description: Non-upgradeable Aragon condition attached to the public CREATE_PROPOSAL permission. Its mutable rule program determines which callers and proposal calls qualify for the otherwise-public grant.
+    +++ description: Aragon condition attached to the public CREATE_PROPOSAL permission. Its mutable rule program determines which callers and proposal calls qualify for the otherwise-public grant.
 ```
 
 ```diff
 +   Status: CREATED
     contract BondedCheckpoints (eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963) [interfold/BondedCheckpoints]
-    +++ description: Immutable voting-power checkpoint store updated exclusively by the BondingRegistry so FOLD bonded to ciphernode operators remains visible to governance snapshots.
+    +++ description: Voting-power checkpoint store updated exclusively by the BondingRegistry so FOLD bonded to ciphernode operators remains visible to governance snapshots.
 ```
 
 ```diff
@@ -254,13 +254,13 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract VotingPowerCurve (eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9) [interfold/VotingPowerCurve]
-    +++ description: Upgradeable curve that converts veFOLD lock amount and duration into voting power.
+    +++ description: Curve that converts veFOLD lock amount and duration into voting power.
 ```
 
 ```diff
 +   Status: CREATED
     contract BfvDecryptionVerifier (eth:0xf143b969ea481Ccf251194D15F82007C67AABc53) [interfold/BfvDecryptionVerifier]
-    +++ description: Immutable threshold-decryption proof wrapper. It checks the generated circuit proof and binds its parties and public-key context to the committee recorded by CiphernodeRegistry.
+    +++ description: Threshold-decryption proof wrapper. It checks the generated circuit proof and binds its parties and public-key context to the committee recorded by CiphernodeRegistry.
 ```
 
 ```diff
@@ -278,7 +278,7 @@ Interfold coordinates ephemeral encrypted computations on Ethereum using allowli
 ```diff
 +   Status: CREATED
     contract VotingEscrowLockNFT (eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E) [interfold/VotingEscrowLockNFT]
-    +++ description: Upgradeable ERC-721 whose tokens represent individual veFOLD lock positions.
+    +++ description: ERC-721 whose tokens represent individual veFOLD lock positions.
 ```
 
 ```diff

--- a/packages/config/src/projects/interfold/discovered.json
+++ b/packages/config/src/projects/interfold/discovered.json
@@ -12,7 +12,7 @@
         "0x652c9badf1bc0079bb5168226877cf7c70b74479fa19068d2fe42066fa4eb075"
       ],
       "proxyType": "immutable",
-      "description": "Immutable voting-power adapter used by PublicTokenVoting. It counts voting-escrow power, FOLD bonded to ciphernode operators, and eligible vesting-locked wallet FOLD while using FOLD total supply as the quorum denominator.",
+      "description": "Voting-power adapter used by PublicTokenVoting. It counts voting-escrow power, FOLD bonded to ciphernode operators, and eligible vesting-locked wallet FOLD while using FOLD total supply as the quorum denominator.",
       "ignoreInWatchMode": ["clock"],
       "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
       "sinceTimestamp": 1787141627,
@@ -178,7 +178,7 @@
         "0x2f4ffa441ee6931aaf10dc75ea17d88ac1e02780b5802234253f4732f19706ae"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable collateral registry for ciphernode operators. Operators become eligible by depositing ticket collateral backed by sUSDS and a FOLD bond; the contract also enforces exits, committee obligations, bans and slashing debits.",
+      "description": "Collateral registry for ciphernode operators. Operators become eligible by depositing ticket collateral backed by sUSDS and a FOLD bond; the contract also enforces exits, committee obligations, bans and slashing debits.",
       "receivedPermissions": [
         {
           "permission": "interact",
@@ -502,7 +502,7 @@
         "0x25830faa7c9d8c4aecf3d78f04ce54c52aae87769713d3e9ad951ca08abd4277"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable coordinator for ephemeral encrypted computations (E3s). It accepts requests for allowlisted programs, selects a ciphernode committee, snapshots the configured proof system, and verifies the encrypted result and threshold decryption before publishing plaintext output.",
+      "description": "Coordinator for Encrypted Execution Environments (E3s). It accepts requests for allowlisted programs, selects a ciphernode committee, snapshots the configured proof system, and verifies the encrypted result and threshold decryption before publishing plaintext output.",
       "receivedPermissions": [
         {
           "permission": "interact",
@@ -1852,7 +1852,7 @@
         "0xbc6579b4c42accae5c7400219895c015a3d275afd13088b59e85b094038ba821"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable veFOLD escrow that custodies locked FOLD, issues lock NFTs and calculates the voting power consumed by BondedVotes through EscrowVotesAdapter.",
+      "description": "veFOLD escrow that custodies locked FOLD, issues lock NFTs and calculates the voting power consumed by BondedVotes through EscrowVotesAdapter.",
       "ignoreInWatchMode": [
         "currentExitingAmount",
         "lastLockId",
@@ -1947,7 +1947,7 @@
         "0xdf4efbc40c77de7dfb353dd7185741bdbf420c9381f9f561b47120d1ed0ffd97"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable queue applying cooldowns and optional fees to withdrawals from VotingEscrow.",
+      "description": "Queue applying cooldowns and optional fees to withdrawals from VotingEscrow.",
       "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
       "sinceTimestamp": 1787028983,
       "sinceBlock": 25779726,
@@ -2679,7 +2679,7 @@
         "0x6c22fa41562f0c1711c54cad35a5dc279f856b8cd1e3f329e8ede042eda17f1c"
       ],
       "proxyType": "immutable",
-      "description": "Non-upgradeable policy and evidence router for ciphernode penalties, appeals and bans. Slashing is effective only for reasons with an enabled policy and through a manager authorized by the BondingRegistry.",
+      "description": "Policy and evidence router for ciphernode penalties, appeals and bans. Slashing is effective only for reasons with an enabled policy and through a manager authorized by the BondingRegistry.",
       "receivedPermissions": [
         {
           "permission": "interact",
@@ -3925,7 +3925,7 @@
         "0x13506be90fff7c3922e3b110f61dcfe0114bdaeda4e9e883448e30f4969cd771"
       ],
       "proxyType": "immutable",
-      "description": "Immutable BFV public-key proof wrapper. It binds the generated circuit verifier to the expected DKG-fold and C5 verification-key hashes.",
+      "description": "BFV public-key proof wrapper. It binds the generated circuit verifier to the expected DKG-fold and C5 verification-key hashes.",
       "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
       "sinceTimestamp": 1787109299,
       "sinceBlock": 25786398,
@@ -4117,7 +4117,7 @@
           "type": "PERMISSION"
         },
         "$members": {
-          "description": "Current registered ciphernode operator keys reconstructed from add and remove events. Distinct keys do not prove distinct owners or infrastructure. For each E3, the active configuration selects three of these keys; $threshold applies to that selected committee, not to the full registry.",
+          "description": "Current registered ciphernode operator keys reconstructed from add and remove events. For each E3, the active configuration selects three of these keys; $threshold applies to that selected committee, not to the full registry.",
           "type": "PERMISSION"
         },
         "$threshold": {
@@ -4159,7 +4159,7 @@
         "0x4a40c38873e8dd6be25ae82bbd232864c841271ce308509366c56987196b1c46"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable timestamp clock defining veFOLD epochs, checkpoint cadence and gauge-voting windows.",
+      "description": "Timestamp clock defining veFOLD epochs, checkpoint cadence and gauge-voting windows.",
       "ignoreInWatchMode": [
         "currentEpoch",
         "elapsedInEpoch",
@@ -4252,7 +4252,7 @@
         "0x820364f6b02461f786e2dfaa81e0059689349246f89bf5b49bf33424d05d117e"
       ],
       "proxyType": "EIP1167 proxy",
-      "description": "Non-upgradeable Aragon condition attached to the public CREATE_PROPOSAL permission. Its mutable rule program determines which callers and proposal calls qualify for the otherwise-public grant.",
+      "description": "Aragon condition attached to the public CREATE_PROPOSAL permission. Its mutable rule program determines which callers and proposal calls qualify for the otherwise-public grant.",
       "deployerAddress": "eth:0x732D5F9155A524C29fe7b17a45C794C4F48abb9e",
       "sinceTimestamp": 1787251955,
       "sinceBlock": 25798247,
@@ -4335,7 +4335,7 @@
         "0x8ad2ea77f39af5b32c176b962b813d16e18902db7133fb50165d1632c71997f3"
       ],
       "proxyType": "immutable",
-      "description": "Immutable voting-power checkpoint store updated exclusively by the BondingRegistry so FOLD bonded to ciphernode operators remains visible to governance snapshots.",
+      "description": "Voting-power checkpoint store updated exclusively by the BondingRegistry so FOLD bonded to ciphernode operators remains visible to governance snapshots.",
       "ignoreInWatchMode": ["clock"],
       "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
       "sinceTimestamp": 1787109215,
@@ -4803,7 +4803,7 @@
         "0x126b3fdbc9562d64b152d03a44f6a560539bbb3c9c35e4f58d91692a00d378e6"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable curve that converts veFOLD lock amount and duration into voting power.",
+      "description": "Curve that converts veFOLD lock amount and duration into voting power.",
       "ignoreInWatchMode": ["globalPointLatestIndex"],
       "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
       "sinceTimestamp": 1787028983,
@@ -4860,7 +4860,7 @@
         "0xf0eb04078f1d26488697d2fc81ac7d419765e655d6b38d23b5f8cab946146bee"
       ],
       "proxyType": "immutable",
-      "description": "Immutable threshold-decryption proof wrapper. It checks the generated circuit proof and binds its parties and public-key context to the committee recorded by CiphernodeRegistry.",
+      "description": "Threshold-decryption proof wrapper. It checks the generated circuit proof and binds its parties and public-key context to the committee recorded by CiphernodeRegistry.",
       "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
       "sinceTimestamp": 1787109323,
       "sinceBlock": 25786400,
@@ -5407,7 +5407,7 @@
         "0x424f4df711b03adc7fa8ac4d99ece4e185fec69f61ab6beac1b7047c52275678"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable ERC-721 whose tokens represent individual veFOLD lock positions.",
+      "description": "ERC-721 whose tokens represent individual veFOLD lock positions.",
       "ignoreInWatchMode": ["totalSupply"],
       "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
       "sinceTimestamp": 1787028983,

--- a/packages/config/src/projects/interfold/discovered.json
+++ b/packages/config/src/projects/interfold/discovered.json
@@ -1,0 +1,8057 @@
+{
+  "name": "interfold",
+  "timestamp": 1787653815,
+  "configHash": "0x0a84b3a825d240860856e25ca3a71affc4ebe537906b5efd51e18fced1d50d36",
+  "entries": [
+    {
+      "name": "BondedVotes",
+      "address": "eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E",
+      "type": "Contract",
+      "template": "interfold/BondedVotes",
+      "sourceHashes": [
+        "0x652c9badf1bc0079bb5168226877cf7c70b74479fa19068d2fe42066fa4eb075"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable voting-power adapter used by PublicTokenVoting. It counts voting-escrow power, FOLD bonded to ciphernode operators, and eligible vesting-locked wallet FOLD while using FOLD total supply as the quorum denominator.",
+      "ignoreInWatchMode": ["clock"],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787141627,
+      "sinceBlock": 25789082,
+      "values": {
+        "$immutable": true,
+        "checkpoints": "eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963",
+        "clock": 1787653811,
+        "CLOCK_MODE": "mode=timestamp",
+        "decimals": 18,
+        "escrow": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+        "name": "Interfold",
+        "registry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "symbol": "FOLD",
+        "token": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+        "totalSupply": "1200000000000000000000000000",
+        "votesSource": "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc"
+      },
+      "fieldMeta": {
+        "token": {
+          "description": "Immutable FOLD token supplying metadata and the total-supply denominator."
+        },
+        "votesSource": {
+          "description": "Immutable primary IVotes source; currently an adapter for the FOLD voting escrow."
+        },
+        "escrow": {
+          "description": "Immutable FOLD voting escrow used to attribute locked balances."
+        },
+        "checkpoints": {
+          "description": "Immutable history of FOLD bonded through the BondingRegistry."
+        },
+        "registry": {
+          "description": "Immutable BondingRegistry that custodies bonded FOLD and writes checkpoints."
+        }
+      },
+      "implementationNames": {
+        "eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E": "BondedVotes"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "VotingEscrowGaugeVoter",
+      "address": "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0",
+      "type": "Contract",
+      "template": "interfold/VotingEscrowGaugeVoter",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0xef1d8d75954efe33dde419c37a4cda54027a054626f2ce95eeaba5785a79b6e1"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable, currently paused gauge-voting plugin connected to VotingEscrow. It can update voting state used by escrow lock operations but is not the Interfold DAO proposal-voting plugin.",
+      "ignoreInWatchMode": [
+        "currentEpochStart",
+        "epochId",
+        "epochStart",
+        "epochVoteEnd",
+        "epochVoteStart",
+        "getWriteEpochId",
+        "totalVotingPowerCast",
+        "votingActive"
+      ],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x41d565fcC636805E3addDa99714067cB020F09Aa",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0x41d565fcC636805E3addDa99714067cB020F09Aa"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "clock": "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166",
+        "currentEpochStart": 1786579200,
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "enableUpdateVotingPowerHook": true,
+        "epochId": 1477,
+        "epochStart": 1787788800,
+        "epochVoteEnd": 1787653811,
+        "epochVoteStart": 1787792400,
+        "escrow": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+        "GAUGE_ADMIN_ROLE": "0xfda1ae526c1fb38407f23e8b7712f7cfacc146f3e340a04221488331e0d42014",
+        "gaugeList": [],
+        "getAllGauges": [],
+        "getCurrentTargetConfig": {
+          "target": "eth:0x0000000000000000000000000000000000000000",
+          "operation": 0
+        },
+        "getTargetConfig": {
+          "target": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "operation": 0
+        },
+        "getWriteEpochId": 0,
+        "implementation": "eth:0x41d565fcC636805E3addDa99714067cB020F09Aa",
+        "ivotesAdapter": "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc",
+        "paused": true,
+        "pluginType": 0,
+        "protocolVersion": [1, 4, 0],
+        "SET_TARGET_CONFIG_PERMISSION_ID": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+        "totalVotingPowerCast": 0,
+        "UPGRADE_PLUGIN_PERMISSION_ID": "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5",
+        "votingActive": false
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose permissions control gauge administration and upgrades."
+        },
+        "escrow": {
+          "description": "VotingEscrow whose lock voting state this plugin updates."
+        },
+        "clock": { "description": "Clock defining gauge-voting epochs." },
+        "ivotesAdapter": {
+          "description": "Voting-power source used by the gauge plugin."
+        },
+        "paused": {
+          "description": "Whether gauge voting is paused.",
+          "type": "RISK_PARAMETER"
+        },
+        "enableUpdateVotingPowerHook": {
+          "description": "Whether escrow transfers invoke the gauge-voting power update hook.",
+          "type": "RISK_PARAMETER"
+        },
+        "getCurrentTargetConfig": {
+          "description": "Stored execution target and operation for gauge-voting proposals.",
+          "type": "CODE_CHANGE"
+        }
+      },
+      "implementationNames": {
+        "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0": "ERC1967Proxy",
+        "eth:0x41d565fcC636805E3addDa99714067cB020F09Aa": "AddressGaugeVoter"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0x0a3E22cb9778A10b188eC2BF149D628ab91A76a9",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "member",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties.",
+          "role": ".activeOperators"
+        },
+        {
+          "permission": "member",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption.",
+          "role": ".$members"
+        }
+      ]
+    },
+    {
+      "name": "BondingRegistry",
+      "address": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+      "type": "Contract",
+      "template": "interfold/BondingRegistry",
+      "sourceHashes": [
+        "0x3335d1c5141feebb2c3729ab3dc2810d3d9196ee836d49c75be1c2b800a77d81",
+        "0x2f4ffa441ee6931aaf10dc75ea17d88ac1e02780b5802234253f4732f19706ae"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable collateral registry for ciphernode operators. Operators become eligible by depositing ticket collateral backed by sUSDS and a FOLD bond; the contract also enforces exits, committee obligations, bans and slashing debits.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+          "description": "deposit and withdraw underlying sUSDS, mint and burn ticket tokens, and pay out underlying reserved by ticket slashing.",
+          "role": ".registry"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "add and remove ciphernode operator keys as collateral positions are registered and exited.",
+          "role": ".bondingRegistry"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963",
+          "description": "write bonded-FOLD voting-power checkpoints.",
+          "role": ".registry"
+        }
+      ],
+      "ignoreInWatchMode": [
+        "bondingAssetConfigurationVersion",
+        "ciphernodeBonds",
+        "eligibilityConfigurationVersion",
+        "reservedSlashedTicketBalance",
+        "slashedCiphernodeBond",
+        "slashedTicketBalance",
+        "ticketBalances",
+        "totalCiphernodeBondLiability",
+        "unresolvedCommitteeCount"
+      ],
+      "deployerAddress": "eth:0x0B84D82d10915Da42812e86A9ba33e80ac08c8CB",
+      "sinceTimestamp": 1783339751,
+      "sinceBlock": 25473398,
+      "values": {
+        "$admin": "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b",
+        "$implementation": "eth:0x4FF6e77A10E8f06C11a4DD2A71b6AB55394640e4",
+        "$pastUpgrades": [
+          [
+            "2026-07-06T12:09:11.000Z",
+            "0x4cd136ccece909ae71dc28bd031319138e466b255656ad2af9560314deba448d",
+            ["eth:0xAbDc95Bb3730d5CC65DA13a4B119Ab38E131EcB0"]
+          ],
+          [
+            "2026-08-19T11:51:59.000Z",
+            "0xdb666271c66b9b2a225c8a96d8dd1c7ce93c721a7244090d979361e82ab78757",
+            ["eth:0x4FF6e77A10E8f06C11a4DD2A71b6AB55394640e4"]
+          ]
+        ],
+        "$upgradeCount": 2,
+        "activeOperators": [
+          "eth:0xA303d8Cb0CE470F772A459b4a87AcB11b2978DB8",
+          "eth:0x291bD021638B9aef86c6d47e29CdA1cF3804bafb",
+          "eth:0x980AaA907E51a4e3cc89b8FF8e37Aa0D55D46597",
+          "eth:0x0a3E22cb9778A10b188eC2BF149D628ab91A76a9",
+          "eth:0xD81f88b9Ae6261d684f8BfEb6a642692213dAe86",
+          "eth:0x3b62d921EFdbc295B017fAb9Ba8a521457F037d3",
+          "eth:0x252a6c33C87C0b439671b983C3f730D2C46a5F1d"
+        ],
+        "authorizedDistributorCount": 2,
+        "authorizedDistributors": [
+          "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e"
+        ],
+        "authorizedSlashingManagerAt": [
+          "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9"
+        ],
+        "authorizedSlashingManagerCount": 1,
+        "bondedCheckpoints": "eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963",
+        "bondingAssetConfigurationVersion": 1,
+        "bondOwners": {
+          "eth:0xA303d8Cb0CE470F772A459b4a87AcB11b2978DB8": "eth:0x8B405dBf2F30844B608b08DaD20447A6955A6C6E",
+          "eth:0x291bD021638B9aef86c6d47e29CdA1cF3804bafb": "eth:0x291bD021638B9aef86c6d47e29CdA1cF3804bafb",
+          "eth:0x980AaA907E51a4e3cc89b8FF8e37Aa0D55D46597": "eth:0x34aA3F359A9D614239015126635CE7732c18fDF3",
+          "eth:0xEaD7F072eEC0b166b65C27329E8FeDE89E5a45f9": "eth:0xEaD7F072eEC0b166b65C27329E8FeDE89E5a45f9",
+          "eth:0x1F74B8172E78451203eF45eC719bc85D040710D3": "eth:0x1F74B8172E78451203eF45eC719bc85D040710D3",
+          "eth:0x0a3E22cb9778A10b188eC2BF149D628ab91A76a9": "eth:0x8d138c01765483cB79d787ce5933F609CbFDabcF",
+          "eth:0xCdc8B4379dDF736f8e34B0A65585E07dE7060A84": "eth:0x97843608a00e2bbc75ab0C1911387E002565DEDE",
+          "eth:0x252a6c33C87C0b439671b983C3f730D2C46a5F1d": "eth:0x97843608a00e2bbc75ab0C1911387E002565DEDE",
+          "eth:0x18ddBf8Aa6F72FC4D9E1911527d0CE1E9f3597d8": "eth:0x97843608a00e2bbc75ab0C1911387E002565DEDE",
+          "eth:0xD81f88b9Ae6261d684f8BfEb6a642692213dAe86": "eth:0x34aA3F359A9D614239015126635CE7732c18fDF3",
+          "eth:0x3b62d921EFdbc295B017fAb9Ba8a521457F037d3": "eth:0xBb66Ff0728ec074f3E374947246e8Daa7e6AA587",
+          "eth:0xFeb99E2C46b9A5fDA836e6d4374A59fc61a5E221": "eth:0xFeb99E2C46b9A5fDA836e6d4374A59fc61a5E221",
+          "eth:0xABFBc9eE2Df6cDd236741BedfdF34fDB3D9AED3E": "eth:0xABFBc9eE2Df6cDd236741BedfdF34fDB3D9AED3E",
+          "eth:0xFfE6D9d29480D0673C4FC46da22D21E245C8E731": "eth:0xFfE6D9d29480D0673C4FC46da22D21E245C8E731",
+          "eth:0xBB7BBED93D75613E206D5aE4743a47214356d6Ef": "eth:0xBB7BBED93D75613E206D5aE4743a47214356d6Ef",
+          "eth:0x2F3A1d13525748D2e6CC8EEA715CEFCF5B8ff833": "eth:0x2F3A1d13525748D2e6CC8EEA715CEFCF5B8ff833",
+          "eth:0xd64271606A20362A3c11d1C7C92897d6e4a5d45C": "eth:0xd64271606A20362A3c11d1C7C92897d6e4a5d45C"
+        },
+        "ciphernodeBondActiveBps": 8000,
+        "ciphernodeBonds": {
+          "eth:0xA303d8Cb0CE470F772A459b4a87AcB11b2978DB8": "32000000000000000000000",
+          "eth:0x291bD021638B9aef86c6d47e29CdA1cF3804bafb": "32000000000000000000000",
+          "eth:0x980AaA907E51a4e3cc89b8FF8e37Aa0D55D46597": "32000000000000000000000",
+          "eth:0x0a3E22cb9778A10b188eC2BF149D628ab91A76a9": "32000000000000000000000",
+          "eth:0xD81f88b9Ae6261d684f8BfEb6a642692213dAe86": "32000000000000000000000",
+          "eth:0xFeb99E2C46b9A5fDA836e6d4374A59fc61a5E221": "105000000000000000000",
+          "eth:0x3b62d921EFdbc295B017fAb9Ba8a521457F037d3": "32000000000000000000000",
+          "eth:0x252a6c33C87C0b439671b983C3f730D2C46a5F1d": "32000000000000000000000"
+        },
+        "ciphernodeBondToken": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+        "eligibilityConfigurationVersion": 4,
+        "exitDelay": 2592000,
+        "getCiphernodeBondToken": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+        "getTicketToken": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+        "MAX_AUTHORIZED_DISTRIBUTORS": 32,
+        "MAX_AUTHORIZED_SLASHING_MANAGERS": 32,
+        "MAX_EXIT_DELAY": 7776000,
+        "MIN_EXIT_DELAY": 86400,
+        "minTicketBalance": 1,
+        "numActiveOperators": 7,
+        "numRegisteredOperators": 7,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "pendingOwner": "eth:0x0000000000000000000000000000000000000000",
+        "registry": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+        "requiredCiphernodeBond": "32000000000000000000000",
+        "reservedSlashedTicketBalance": 0,
+        "slashedCiphernodeBond": 0,
+        "slashedFundsTreasury": "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593",
+        "slashedTicketBalance": 0,
+        "slashingManager": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+        "ticketBalances": {
+          "eth:0xA303d8Cb0CE470F772A459b4a87AcB11b2978DB8": "1000000000000000000000",
+          "eth:0x291bD021638B9aef86c6d47e29CdA1cF3804bafb": "1000000000000000000000",
+          "eth:0x980AaA907E51a4e3cc89b8FF8e37Aa0D55D46597": "3000000000000000000000",
+          "eth:0x0a3E22cb9778A10b188eC2BF149D628ab91A76a9": "1000000000000000000000",
+          "eth:0xD81f88b9Ae6261d684f8BfEb6a642692213dAe86": "3000000000000000000000",
+          "eth:0x3b62d921EFdbc295B017fAb9Ba8a521457F037d3": "2000000000000000000000",
+          "eth:0x252a6c33C87C0b439671b983C3f730D2C46a5F1d": "1000000000000000000000"
+        },
+        "ticketPrice": "1000000000000000000000",
+        "ticketToken": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+        "totalCiphernodeBondLiability": "224105000000000000000000",
+        "unresolvedCommitteeCount": 0
+      },
+      "fieldMeta": {
+        "owner": {
+          "description": "Account controlling bonding and authorization parameters.",
+          "type": "PERMISSION"
+        },
+        "activeOperators": {
+          "description": "Operator keys currently active under the collateral and ban rules, reconstructed from activation events.",
+          "type": "PERMISSION"
+        },
+        "bondOwners": {
+          "description": "Latest collateral owner for each operator key, reconstructed from ownership events. One address can own several operator positions.",
+          "type": "PERMISSION"
+        },
+        "ticketBalances": {
+          "description": "Latest ticket-token balance for each operator reconstructed from balance-update events."
+        },
+        "ciphernodeBonds": {
+          "description": "Latest FOLD bond for each operator reconstructed from bond-update events."
+        },
+        "authorizedSlashingManagerAt": {
+          "description": "Contracts currently authorized to debit ticket collateral and FOLD bonds, ban operators and manage slash-routing state.",
+          "type": "PERMISSION"
+        },
+        "authorizedDistributors": {
+          "description": "Contracts currently allowed to credit ticket collateral on behalf of operators.",
+          "type": "PERMISSION"
+        },
+        "requiredCiphernodeBond": {
+          "description": "Minimum FOLD bond required for an operator to remain eligible.",
+          "type": "RISK_PARAMETER"
+        },
+        "ticketPrice": {
+          "description": "Amount of sUSDS-backed ticket token represented by one sortition ticket.",
+          "type": "RISK_PARAMETER"
+        },
+        "minTicketBalance": {
+          "description": "Minimum number of tickets required for operator eligibility.",
+          "type": "RISK_PARAMETER"
+        },
+        "ciphernodeBondActiveBps": {
+          "description": "Minimum fraction of the configured FOLD bond that must remain after slashing for an operator to stay active.",
+          "type": "RISK_PARAMETER"
+        },
+        "exitDelay": {
+          "description": "Delay before queued ticket collateral and FOLD bond exits can be claimed.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F": "TransparentUpgradeableProxy",
+        "eth:0x4FF6e77A10E8f06C11a4DD2A71b6AB55394640e4": "BondingRegistry"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0x11E91FB4793047a68dFff29158387229eA313ffE",
+      "type": "EOA",
+      "sourceHashes": [
+        "0xdddaab1d0ccad17e0578e5dad9eab7bf81a90144cf89b5f4d5714c407dd2c9c5"
+      ],
+      "proxyType": "EIP7702 EOA",
+      "values": {
+        "$implementation": "eth:0x612373D7003d694220f7800EeaF8E3924c0951D3",
+        "CUSTOM_STORAGE_ROOT": "0x3b86514c5c56b21f08d8e56ab090292e07c2483b3e667a2a45849dcb71368600",
+        "domainBytes": "0xc7e4f5b2d381bdfacf8506a24542052ab4e951573cab4ce34bb1c9509c84cbbf06c015bd22b4c69690933c1058878ebdfef31f9aaae40bbe86d8a09fe1b2972c000000000000000000000000000000000000000000000000000000000000000100000000000000000000000011e91fb4793047a68dfff29158387229ea313ffe000000000000000000000000612373d7003d694220f7800eeaf8e3924c0951d3",
+        "domainSeparator": "0x8f87ce305c9b77d835f93da395c0e667af637869aec200fb3cf1ffd3f08ecf76",
+        "eip712Domain": {
+          "fields": "0x1f",
+          "name": "Calibur",
+          "version": "1.0.0",
+          "chainId": 1,
+          "verifyingContract": "eth:0x11E91FB4793047a68dFff29158387229eA313ffE",
+          "salt": "0x000000000000000000000000612373d7003d694220f7800eeaf8e3924c0951d3",
+          "extensions": []
+        },
+        "ENTRY_POINT": "eth:0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+        "keyAt": [],
+        "keyCount": 0,
+        "keyHashes": 0,
+        "namespaceAndVersion": "Uniswap.Calibur.1.0.0"
+      }
+    },
+    {
+      "name": "E3RefundManager",
+      "address": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+      "type": "Contract",
+      "template": "interfold/E3RefundManager",
+      "sourceHashes": [
+        "0x3335d1c5141feebb2c3729ab3dc2810d3d9196ee836d49c75be1c2b800a77d81",
+        "0x9a5f2a5ae202a5a570f526127420fdcc919af6dc90b48df309bb1b7cfaa9ec7d"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable accounting contract that snapshots the refund policy for each E3 and distributes request fees and routed slashed funds between the requester, honest committee members, protocol treasury and reserve.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "deposit and credit ticket collateral for an operator.",
+          "role": ".authorizedDistributors"
+        }
+      ],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109131,
+      "sinceBlock": 25786384,
+      "values": {
+        "$admin": "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E",
+        "$implementation": "eth:0xE506249Ba5ede04A68b702b92704a0b88054f86A",
+        "$pastUpgrades": [
+          [
+            "2026-08-19T03:12:11.000Z",
+            "0x38cc6134c117dbaa13ab2d268259a3d55096d88ca4775c7d74f56d6693ebb5c3",
+            ["eth:0xE506249Ba5ede04A68b702b92704a0b88054f86A"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "bondingRegistry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "getWorkAllocation": {
+          "committeeFormationBps": 1000,
+          "dkgBps": 4000,
+          "decryptionBps": 4500,
+          "protocolBps": 500,
+          "successSlashedNodeBps": 5000
+        },
+        "interfold": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+        "MAX_PROTOCOL_BPS": 5000,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "pendingOwner": "eth:0x0000000000000000000000000000000000000000",
+        "policyVersion": 1,
+        "treasury": "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593"
+      },
+      "fieldMeta": {
+        "owner": {
+          "description": "Account controlling future refund policy and dependencies.",
+          "type": "PERMISSION"
+        },
+        "getWorkAllocation": {
+          "description": "Current fee allocation between committee formation, DKG, decryption and the protocol, plus the share assigned to an honest replacement when another node is slashed.",
+          "type": "RISK_PARAMETER"
+        },
+        "treasury": {
+          "description": "Recipient of the protocol share and treasury-directed slashed funds."
+        }
+      },
+      "implementationNames": {
+        "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e": "TransparentUpgradeableProxy",
+        "eth:0xE506249Ba5ede04A68b702b92704a0b88054f86A": "E3RefundManager"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0x1F74B8172E78451203eF45eC719bc85D040710D3",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0x252a6c33C87C0b439671b983C3f730D2C46a5F1d",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "member",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties.",
+          "role": ".activeOperators"
+        },
+        {
+          "permission": "member",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption.",
+          "role": ".$members"
+        }
+      ]
+    },
+    {
+      "address": "eth:0x26f8034baBfbcA2233350a0Dca1CCcE3d01Fa41F",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "Interfold",
+      "address": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+      "type": "Contract",
+      "template": "interfold/Interfold",
+      "sourceHashes": [
+        "0x3335d1c5141feebb2c3729ab3dc2810d3d9196ee836d49c75be1c2b800a77d81",
+        "0x25830faa7c9d8c4aecf3d78f04ce54c52aae87769713d3e9ad951ca08abd4277"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable coordinator for ephemeral encrypted computations (E3s). It accepts requests for allowlisted programs, selects a ciphernode committee, snapshots the configured proof system, and verifies the encrypted result and threshold decryption before publishing plaintext output.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "deposit and credit ticket collateral for an operator.",
+          "role": ".authorizedDistributors"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "description": "snapshot E3 refund policy and credit protocol payments.",
+          "role": ".interfold"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "request and release E3 committees.",
+          "role": ".interfold"
+        }
+      ],
+      "ignoreInWatchMode": ["activeE3Count", "nexte3Id"],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109107,
+      "sinceBlock": 25786382,
+      "values": {
+        "$admin": "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580",
+        "$implementation": "eth:0x8AcBf712513C802eFFc255FEa588ED21DC7A61bA",
+        "$pastUpgrades": [
+          [
+            "2026-08-19T03:11:47.000Z",
+            "0x2b61a262b34e0d51826a54fd389c0510e4361944e006a0ccdd470c5626337c3e",
+            ["eth:0x8AcBf712513C802eFFc255FEa588ED21DC7A61bA"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "activeCryptoConfigId": "0x04f3677e73b0f5066d6caf5cbd92e3fb2e38338edaf5cfc971ab28f7b684da78",
+        "activeE3Count": 0,
+        "bfvCiphertextVerifier": "eth:0x40a18Fc27ac4a4d86fA70385c6814e453b6BFF2c",
+        "bfvCommitteeSize": 3,
+        "bfvDecryptionThreshold": 2,
+        "bfvDecryptionVerifier": "eth:0xf143b969ea481Ccf251194D15F82007C67AABc53",
+        "bfvParamSet": "0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000064000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000ffffee0010000000000000000000000000000000000000000000000000000000ffffc400100000000000000000000000000000000000000000000000000000000000000013300000000000000000000000000000000000000000000000000000000000000",
+        "bfvPkVerifier": "eth:0xBA1854fDA7A5c127606572e43Dc7B37b7A15bdFf",
+        "bondingRegistry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "ciphernodeRegistry": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+        "e3RefundManager": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+        "feeToken": "eth:0xdC035D45d973E3EC169d2276DDab16f1e407384F",
+        "feeTokenDecimals": 18,
+        "getPricingConfig": {
+          "keyGenFixedPerNode": "100000000000000000",
+          "keyGenPerEncryptionProof": "100000000000000000",
+          "coordinationPerPair": "10000000000000000",
+          "availabilityPerNodePerSec": 10000000000000,
+          "decryptionPerNode": "300000000000000000",
+          "publicationBase": "1000000000000000000",
+          "verificationPerProof": 5000000000000000,
+          "protocolTreasury": "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593",
+          "marginBps": 1000,
+          "protocolShareBps": 182,
+          "dkgUtilizationBps": 3000,
+          "computeUtilizationBps": 4000,
+          "decryptUtilizationBps": 3000,
+          "minCommitteeSize": 3,
+          "minThreshold": 2
+        },
+        "getTimeoutConfig": {
+          "dkgWindow": 21600,
+          "computeWindow": 604800,
+          "decryptionWindow": 21600
+        },
+        "markFailedGracePeriod": 3600,
+        "MAX_COMMITTEE_SIZE": 3,
+        "MAX_DURATION_CAP": 31536000,
+        "MAX_MARGIN_BPS": 5000,
+        "MAX_PROTOCOL_SHARE_BPS": 5000,
+        "MAX_TIMEOUT_WINDOW": 2592000,
+        "maxDuration": 2592000,
+        "nexte3Id": "18458939420885977824981152629962741023865184457287647280899939019117062782976",
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "pendingOwner": "eth:0x0000000000000000000000000000000000000000",
+        "registeredE3Programs": [
+          "eth:0x4976E5E47852eFCe6851d35B95A1A2E19456F3D7",
+          "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f"
+        ],
+        "requestsPaused": true,
+        "slashingManager": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9"
+      },
+      "fieldMeta": {
+        "owner": {
+          "description": "Account controlling protocol configuration.",
+          "type": "PERMISSION"
+        },
+        "requestsPaused": {
+          "description": "Whether new E3 requests are disabled.",
+          "type": "RISK_PARAMETER"
+        },
+        "registeredE3Programs": {
+          "description": "E3 application contracts permanently allowlisted by governance. Registration cannot be revoked in the current implementation.",
+          "type": "CODE_CHANGE"
+        },
+        "bfvDecryptionThreshold": {
+          "description": "Number of decryption shares required for the active minimum-size BFV committee.",
+          "type": "RISK_PARAMETER"
+        },
+        "bfvCommitteeSize": {
+          "description": "Number of ciphernode seats in the active minimum-size BFV committee.",
+          "type": "RISK_PARAMETER"
+        },
+        "bfvParamSet": {
+          "description": "ABI-encoded BFV parameter set accepted by the active circuits. Param-set index 0 is the only set accepted by the current crypto configuration.",
+          "type": "RISK_PARAMETER"
+        },
+        "bfvPkVerifier": {
+          "description": "Verifier used for BFV distributed-key-generation proofs for future E3s.",
+          "type": "CODE_CHANGE"
+        },
+        "bfvDecryptionVerifier": {
+          "description": "Verifier used for BFV threshold-decryption proofs for future E3s.",
+          "type": "CODE_CHANGE"
+        },
+        "bfvCiphertextVerifier": {
+          "description": "Verifier used for the encrypted computation output of future BFV E3s.",
+          "type": "CODE_CHANGE"
+        },
+        "activeCryptoConfigId": {
+          "description": "Hash of the exact circuit configuration accepted for new requests.",
+          "type": "CODE_CHANGE"
+        },
+        "getTimeoutConfig": {
+          "description": "Protocol-wide DKG, encrypted-computation and decryption timeout windows applied to new E3s.",
+          "type": "RISK_PARAMETER"
+        },
+        "getPricingConfig": {
+          "description": "Fee model and fee split applied to new E3s, including minimum committee and threshold constraints.",
+          "type": "RISK_PARAMETER"
+        },
+        "maxDuration": {
+          "description": "Maximum request duration accepted by the coordinator.",
+          "type": "RISK_PARAMETER"
+        },
+        "markFailedGracePeriod": {
+          "description": "Grace period after a lifecycle deadline during which failure processing remains restricted.",
+          "type": "RISK_PARAMETER"
+        },
+        "feeToken": {
+          "description": "External ERC-20 collected from E3 requesters. Its own protocol is outside the Interfold discovery perimeter."
+        }
+      },
+      "implementationNames": {
+        "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715": "TransparentUpgradeableProxy",
+        "eth:0x8AcBf712513C802eFFc255FEa588ED21DC7A61bA": "Interfold"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0x291bD021638B9aef86c6d47e29CdA1cF3804bafb",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "member",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties.",
+          "role": ".activeOperators"
+        },
+        {
+          "permission": "member",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption.",
+          "role": ".$members"
+        }
+      ]
+    },
+    {
+      "name": "ProxyAdmin",
+      "address": "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7",
+      "type": "Contract",
+      "template": "global/ProxyAdmin",
+      "sourceHashes": [
+        "0x8fd8f837bb320bd2a7463c103bea2ff207b0969b5795f320a6c868858aa92074"
+      ],
+      "proxyType": "immutable",
+      "directlyReceivedPermissions": [
+        {
+          "permission": "upgrade",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "role": "admin"
+        }
+      ],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109059,
+      "sinceBlock": 25786378,
+      "values": {
+        "$immutable": true,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "UPGRADE_INTERFACE_VERSION": "5.0.0"
+      },
+      "implementationNames": {
+        "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7": "ProxyAdmin"
+      }
+    },
+    {
+      "address": "eth:0x2F3A1d13525748D2e6CC8EEA715CEFCF5B8ff833",
+      "type": "EOA",
+      "sourceHashes": [
+        "0x1f44812af62d28f019e30e8eb2af596fb36c7db9d34576972c0405e110a6ef45"
+      ],
+      "proxyType": "EIP7702 EOA",
+      "values": {
+        "$implementation": "eth:0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B",
+        "delegationManager": "eth:0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3",
+        "DOMAIN_VERSION": "1",
+        "eip712Domain": {
+          "fields": "0x0f",
+          "name": "EIP7702StatelessDeleGator",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "eth:0x2F3A1d13525748D2e6CC8EEA715CEFCF5B8ff833",
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "extensions": []
+        },
+        "entryPoint": "eth:0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+        "getDeposit": 0,
+        "getDomainHash": "0x08988fe97a1975d42daf3ea3dd48aca6e517ec234efe883a57fa9a0f388e4f18",
+        "getNonce": 0,
+        "NAME": "EIP7702StatelessDeleGator",
+        "PACKED_USER_OP_TYPEHASH": "0xbc37962d8bd1d319c95199bdfda6d3f92baa8903a61b32d5f4ec1f4b36a3bc18",
+        "VERSION": "1.3.0"
+      }
+    },
+    {
+      "address": "eth:0x34aA3F359A9D614239015126635CE7732c18fDF3",
+      "type": "EOA",
+      "sourceHashes": [
+        "0xdddaab1d0ccad17e0578e5dad9eab7bf81a90144cf89b5f4d5714c407dd2c9c5"
+      ],
+      "proxyType": "EIP7702 EOA",
+      "values": {
+        "$implementation": "eth:0x612373D7003d694220f7800EeaF8E3924c0951D3",
+        "CUSTOM_STORAGE_ROOT": "0x3b86514c5c56b21f08d8e56ab090292e07c2483b3e667a2a45849dcb71368600",
+        "domainBytes": "0xc7e4f5b2d381bdfacf8506a24542052ab4e951573cab4ce34bb1c9509c84cbbf06c015bd22b4c69690933c1058878ebdfef31f9aaae40bbe86d8a09fe1b2972c000000000000000000000000000000000000000000000000000000000000000100000000000000000000000034aa3f359a9d614239015126635ce7732c18fdf3000000000000000000000000612373d7003d694220f7800eeaf8e3924c0951d3",
+        "domainSeparator": "0x07c8ebd8b7d2b6df4348d50e170169fd8f60f7904c1728871777213379de1b67",
+        "eip712Domain": {
+          "fields": "0x1f",
+          "name": "Calibur",
+          "version": "1.0.0",
+          "chainId": 1,
+          "verifyingContract": "eth:0x34aA3F359A9D614239015126635CE7732c18fDF3",
+          "salt": "0x000000000000000000000000612373d7003d694220f7800eeaf8e3924c0951d3",
+          "extensions": []
+        },
+        "ENTRY_POINT": "eth:0x4337084D9E255Ff0702461CF8895CE9E3b5Ff108",
+        "keyAt": [],
+        "keyCount": 0,
+        "keyHashes": 0,
+        "namespaceAndVersion": "Uniswap.Calibur.1.0.0"
+      }
+    },
+    {
+      "address": "eth:0x3b62d921EFdbc295B017fAb9Ba8a521457F037d3",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "member",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties.",
+          "role": ".activeOperators"
+        },
+        {
+          "permission": "member",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption.",
+          "role": ".$members"
+        }
+      ]
+    },
+    {
+      "name": "Risc0BfvCiphertextVerifier",
+      "address": "eth:0x40a18Fc27ac4a4d86fA70385c6814e453b6BFF2c",
+      "type": "Contract",
+      "unverified": true,
+      "proxyType": "immutable",
+      "description": "Unverified wrapper that accepts a RISC Zero receipt for the immutable guest image ID and the E3-specific journal constructed by Interfold.",
+      "deployerAddress": "eth:0x762D0A181d7184d5e224d3320fa7fF82D56a7dc6",
+      "sinceTimestamp": 1787419895,
+      "sinceBlock": 25812196,
+      "values": {
+        "$immutable": true,
+        "imageId": "0x7ed0ddeb0cafa64228b51399dff5ea00696c2617f28636b05bd67e6c1506eac3",
+        "risc0Verifier": "eth:0x082263Bb53463Ca6c7082bDAFEd51EfA9509cde0"
+      },
+      "fieldMeta": {
+        "imageId": {
+          "description": "Immutable RISC Zero guest image ID accepted as the encrypted-computation program.",
+          "type": "CODE_CHANGE"
+        },
+        "risc0Verifier": {
+          "description": "Immutable RISC Zero verifier used to validate computation receipts."
+        }
+      },
+      "implementationNames": {
+        "eth:0x40a18Fc27ac4a4d86fA70385c6814e453b6BFF2c": ""
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0x455e3DEFBC6b48D9127CF6acC609F5cEa87cA759",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0x466bfA89bC742c840bc4660890D679d96D65613c",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "MockE3Program",
+      "address": "eth:0x4976E5E47852eFCe6851d35B95A1A2E19456F3D7",
+      "type": "Contract",
+      "template": "interfold/MockE3Program",
+      "sourceHashes": [
+        "0x38bddeea4408ea6799cd424256303ee01badb0182f323a92b889a290f8efe00d"
+      ],
+      "proxyType": "immutable",
+      "description": "Permanently allowlisted test E3 application. It accepts arbitrary input and returns successful validation and output verification, so requests using it exercise the protocol proof pipeline without application-level correctness checks.",
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787108975,
+      "sinceBlock": 25786371,
+      "values": {
+        "$immutable": true,
+        "ENCRYPTION_SCHEME_ID": "0x2c2a814a0495f913a3a312fc4771e37552bc14f8a2d4075a08122d356f0849c6"
+      },
+      "implementationNames": {
+        "eth:0x4976E5E47852eFCe6851d35B95A1A2E19456F3D7": "MockE3Program"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "DecryptionAggregatorVerifier",
+      "address": "eth:0x53Fc34b412E16A1aE05A86934b821F82ca2a10da",
+      "type": "Contract",
+      "template": "interfold/DecryptionAggregatorVerifier",
+      "sourceHashes": [
+        "0xbdc13b8d6f0794b577d5b148fb0caba273bd1e8894b17225a0039259466a35b0"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable generated Honk verifier for the BFV threshold-decryption aggregation circuit.",
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109287,
+      "sinceBlock": 25786397,
+      "values": { "$immutable": true },
+      "implementationNames": {
+        "eth:0x53Fc34b412E16A1aE05A86934b821F82ca2a10da": "DecryptionAggregatorVerifier"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "InterfoldSafeA",
+      "address": "eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018",
+      "type": "Contract",
+      "template": "GnosisSafe",
+      "sourceHashes": [
+        "0xfe0725afd3cf2e5fb7627005a6bcf13ef7e35f78034eed2211edbffdb6a9aab5",
+        "0xe23c519b7324d6dc9132c8567ac55ae72bdf168c914d22825c7614d822364b0f"
+      ],
+      "proxyType": "gnosis safe",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "replace collateral assets and protocol dependencies; change bond, ticket, eligibility and exit parameters; authorize slashing managers and reward distributors; clear bans from old managers; withdraw slashed funds; and replace the slashed-funds treasury.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "description": "change the work-allocation split, coordinator and treasury without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "description": "pause or unpause new requests; replace the registry, bonding, slashing and refund dependencies; allow fee assets and E3 programs; replace proof verifiers; and change pricing, timeouts, parameter sets and committee thresholds without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change support, participation, duration, proposer-power and minimum-approval requirements for future votes.",
+          "role": ".tokenVotingSettingsManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "grant and revoke permissions in the DAO.",
+          "role": ".daoRootHolders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect calls made by the Admin plugin to another executor or target.",
+          "role": ".adminTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed proposal actions to another executor or target.",
+          "role": ".sppTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed vote actions to another executor or target.",
+          "role": ".tokenVotingTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the address trusted to append the effective caller to proposal transactions.",
+          "role": ".sppTrustedForwarderManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the rules that gate public creation of staged proposals.",
+          "role": ".conditionRuleManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the stages, bodies, thresholds and timing rules for future public proposals.",
+          "role": ".sppStageManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f",
+          "description": "set the eligible-voter Merkle root once per requester-census E3 and replace the application RISC Zero verifier or guest image ID immediately. Such replacement cannot change the verifier snapshotted by Interfold, but can make an in-flight round fail.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "create or disable slash policies, grant or revoke evidence slashers, resolve appeals, close E3 assignments and propose, confirm or remove operator bans.",
+          "role": ".governanceMembers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "replace the coordinator, bonding registry, ciphernode registry and refund manager, and grant or revoke governance membership. A transfer of the default-admin role itself has the configured delay.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change cooldowns and exit fees and upgrade the voting-escrow exit queue.",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin settings.",
+          "role": ".multisigSettingsAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change transfer whitelist settings and upgrade the voting-lock NFT.",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting epochs and upgrade the voting-escrow Clock.",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting-power curve parameters and upgrade the Curve implementation.",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "complete queued voting-escrow withdrawals.",
+          "role": ".exitQueueWithdrawers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "grant and revoke permissions in the voting-escrow DAO.",
+          "role": ".veDaoRootHolders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "manage gauge metadata and the voting-power update hook.",
+          "role": ".gaugeAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause and unpause voting-escrow operations.",
+          "role": ".votingEscrowPausers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause the escrow voting-power adapter, manage delegation settings and upgrade its implementation.",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "replace voting-power dependencies, change minimum deposits and split rules, and upgrade VotingEscrow.",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "sweep unaccounted tokens and NFTs from VotingEscrow.",
+          "role": ".votingEscrowSweepers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "update delegated voting power through the escrow voting adapter.",
+          "role": ".delegationTokenManagers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+          "description": "schedule and activate a registry replacement after one day when all ticket liabilities are zero, and rescue ERC-20s other than the underlying sUSDS.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "replace the coordinator, bonding and slashing dependencies; add or remove ciphernodes; change the sortition window; and update the DKG verifier and accusation-vote validity parameters. DKG-verifier replacement and risk-reducing accusation-window changes use a two-day propose/commit delay, while other changes are immediate.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+          "description": "create immutable vesting policies, link claimed balances to policies and exempt accounts from automatic claim locks until the immutable lock cutoff.",
+          "role": ".lockManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+          "description": "grant and revoke FOLD roles. The role's direct mint function permanently reverts after TGE.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "role": ".daoUpgraders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".gaugeUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".veDaoUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        }
+      ],
+      "directlyReceivedPermissions": [
+        {
+          "permission": "act",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "execute arbitrary DAO actions through the armed Admin plugin without a vote or an onchain delay.",
+          "role": ".adminPluginExecutors"
+        }
+      ],
+      "ignoreInWatchMode": ["nonce"],
+      "deployerAddress": "eth:0x732D5F9155A524C29fe7b17a45C794C4F48abb9e",
+      "sinceTimestamp": 1782737003,
+      "sinceBlock": 25423398,
+      "values": {
+        "$immutable": false,
+        "$implementation": "eth:0x41675C099F32341bf84BFc5382aF534df5C7461a",
+        "$members": [
+          "eth:0xCb83ef506989534463a0E3F6E5526a8FE26897B3",
+          "eth:0xA8C3c4B6aE7f31193057A6d8833980853Ef71f85",
+          "eth:0xC3F8EBC47A4C47D91b643a4C64d34eA7B2584260",
+          "eth:0x26f8034baBfbcA2233350a0Dca1CCcE3d01Fa41F",
+          "eth:0x7b4273f9291aEAC9ea85f44093Aca5fC873A7Cf5"
+        ],
+        "$threshold": 3,
+        "domainSeparator": "0x3ad9930badfc06cf3a3a15538a370d3e376cc164f607bcf51b8c6a5ba4d8b429",
+        "getChainId": 1,
+        "GnosisSafe_modules": [],
+        "multisigThreshold": "3 of 5 (60%)",
+        "nonce": 41,
+        "VERSION": "1.4.1"
+      },
+      "implementationNames": {
+        "eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018": "SafeProxy",
+        "eth:0x41675C099F32341bf84BFc5382aF534df5C7461a": "Safe"
+      }
+    },
+    {
+      "name": "AragonExecutor",
+      "address": "eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4",
+      "type": "Contract",
+      "template": "interfold/AragonExecutor",
+      "sourceHashes": [
+        "0x32bc01a3f64b9896ce2c0ef766f4b0edf9403118a014126063663ee89fd82ffb"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable Aragon action executor used as a delegatecall target by PublicTokenVoting. It executes proposal action batches in the calling plugin's context.",
+      "deployerAddress": "eth:0x187a34c86aA6378333cE9033Aa34718D2CEdEd2C",
+      "sinceTimestamp": 1741354751,
+      "sinceBlock": 21995354,
+      "values": { "$immutable": true },
+      "implementationNames": {
+        "eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4": "Executor"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0x60583563D5879C2E59973E5718c7DE2147971807",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0x60Ca282757BA67f3aDbF21F3ba2eBe4Ab3eb01fc",
+      "type": "EOA",
+      "sourceHashes": [
+        "0xd9649be084919b1ae25d4d396555667632253f10ddb6a9bddc939db45f797b10"
+      ],
+      "proxyType": "EIP7702 EOA",
+      "values": {
+        "$implementation": "eth:0x5A7FC11397E9a8AD41BF10bf13F22B0a63f96f6d",
+        "nonce": 0
+      }
+    },
+    {
+      "name": "InterfoldDAO",
+      "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+      "type": "Contract",
+      "template": "zama/ZamaDAO",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0xd54ad871bfd08607d81e0a9bad74aa0f9fa3dc9e2331986a47281d6ca0ae07a7"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Aragon DAO that stores governance state and executes proposal action batches.",
+      "directlyReceivedPermissions": [
+        {
+          "permission": "act",
+          "from": "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7",
+          "role": ".owner"
+        },
+        {
+          "permission": "act",
+          "from": "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E",
+          "role": ".owner"
+        },
+        {
+          "permission": "act",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "execute arbitrary calls from the voting-escrow DAO, including administration and upgrades of the voting-power stack.",
+          "role": ".veDaoExecutors"
+        },
+        {
+          "permission": "act",
+          "from": "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580",
+          "role": ".owner"
+        },
+        {
+          "permission": "act",
+          "from": "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b",
+          "role": ".owner"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "replace collateral assets and protocol dependencies; change bond, ticket, eligibility and exit parameters; authorize slashing managers and reward distributors; clear bans from old managers; withdraw slashed funds; and replace the slashed-funds treasury.",
+          "role": ".owner"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "description": "change the work-allocation split, coordinator and treasury without an onchain delay.",
+          "role": ".owner"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "description": "pause or unpause new requests; replace the registry, bonding, slashing and refund dependencies; allow fee assets and E3 programs; replace proof verifiers; and change pricing, timeouts, parameter sets and committee thresholds without an onchain delay.",
+          "role": ".owner"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change support, participation, duration, proposer-power and minimum-approval requirements for future votes.",
+          "role": ".tokenVotingSettingsManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "grant and revoke permissions in the DAO.",
+          "role": ".daoRootHolders"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect calls made by the Admin plugin to another executor or target.",
+          "role": ".adminTargetManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed proposal actions to another executor or target.",
+          "role": ".sppTargetManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed vote actions to another executor or target.",
+          "role": ".tokenVotingTargetManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the address trusted to append the effective caller to proposal transactions.",
+          "role": ".sppTrustedForwarderManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the rules that gate public creation of staged proposals.",
+          "role": ".conditionRuleManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the stages, bodies, thresholds and timing rules for future public proposals.",
+          "role": ".sppStageManagers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f",
+          "description": "set the eligible-voter Merkle root once per requester-census E3 and replace the application RISC Zero verifier or guest image ID immediately. Such replacement cannot change the verifier snapshotted by Interfold, but can make an in-flight round fail.",
+          "role": ".owner"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "create or disable slash policies, grant or revoke evidence slashers, resolve appeals, close E3 assignments and propose, confirm or remove operator bans.",
+          "role": ".governanceMembers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "replace the coordinator, bonding registry, ciphernode registry and refund manager, and grant or revoke governance membership. A transfer of the default-admin role itself has the configured delay.",
+          "role": ".defaultAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+          "description": "schedule and activate a registry replacement after one day when all ticket liabilities are zero, and rescue ERC-20s other than the underlying sUSDS.",
+          "role": ".owner"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "replace the coordinator, bonding and slashing dependencies; add or remove ciphernodes; change the sortition window; and update the DKG verifier and accusation-vote validity parameters. DKG-verifier replacement and risk-reducing accusation-window changes use a two-day propose/commit delay, while other changes are immediate.",
+          "role": ".owner"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "role": ".daoUpgraders"
+        }
+      ],
+      "deployerAddress": "eth:0x0B84D82d10915Da42812e86A9ba33e80ac08c8CB",
+      "sinceTimestamp": 1786931579,
+      "sinceBlock": 25771635,
+      "values": {
+        "$activePermissions": [
+          {
+            "permissionId": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+            "where": "eth:0xF21e25455988887EE797050080141eba67B33920",
+            "who": "eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+            "where": "eth:0xF21e25455988887EE797050080141eba67B33920",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+            "where": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "who": "eth:0xF21e25455988887EE797050080141eba67B33920",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x815fe80e4b37c8582a3b773d1d7071f983eacfd56b5965db654f3087c25ada33",
+            "where": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x1f53edd44352e5d15bad2b29233baa93bcd595e09457780bc7c5445bbbe751cc",
+            "where": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x06d294bc8cbad2e393408b20dd019a772661f60b8d633e56761157cb1ec85f8c",
+            "where": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+            "where": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xfaf505be9907aa6951c2ebe5b0312f4980e14f21912ed355372103cc8bd683bc",
+            "where": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+            "where": "eth:0xF21e25455988887EE797050080141eba67B33920",
+            "who": "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x6f36f8bf0398781285f5a40c489dbf3268ce3e205aba87f21e49e6805391b5a1",
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x06d294bc8cbad2e393408b20dd019a772661f60b8d633e56761157cb1ec85f8c",
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x8c433a4cd6b51969eca37f974940894297b9fcf4b282a213fea5cd8f85289c90",
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+            "condition": "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2"
+          },
+          {
+            "permissionId": "0xb014ce248804cab6a144581acce1eeb70ce5d54f08433b989d73bb0ccee3d3f9",
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+            "where": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "who": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xd3d98e95f3486fc234d80c098cf0d2a0a3fb187833d7e9cc930f8c4f8335a0e7",
+            "where": "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xbba35d41610b7d25c8e486006535c76bd423091563e694d206ae3d71ce949fe5",
+            "where": "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+            "where": "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+            "where": "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+            "where": "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+            "who": "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x8c433a4cd6b51969eca37f974940894297b9fcf4b282a213fea5cd8f85289c90",
+            "where": "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+            "who": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          }
+        ],
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x58C1F7Bc62Bb63fb137bc8F6d8ea6321a0501d29",
+        "$pastUpgrades": [
+          [
+            "2026-08-17T01:52:59.000Z",
+            "0x462d1f6a604859fe289698f04dac0bce77cb22bfad707580e5f2ea333a948a82",
+            ["eth:0x58C1F7Bc62Bb63fb137bc8F6d8ea6321a0501d29"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "adminPluginExecutors": [
+          "eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018",
+          "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593"
+        ],
+        "adminTargetManagers": [
+          "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+        ],
+        "conditionRuleManagers": [
+          "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+        ],
+        "daoExecutors": [
+          "eth:0xF21e25455988887EE797050080141eba67B33920",
+          "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb"
+        ],
+        "daoRootHolders": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"],
+        "daoUpgraders": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"],
+        "daoURI": "",
+        "EXECUTE_PERMISSION_ID": "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+        "getTrustedForwarder": "eth:0x0000000000000000000000000000000000000000",
+        "multisigSettingsAdmins": [],
+        "multisigTargetConfigAdmins": [
+          {
+            "where": "eth:0xF21e25455988887EE797050080141eba67B33920",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+          },
+          {
+            "where": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+          },
+          {
+            "where": "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+          }
+        ],
+        "protocolVersion": [1, 4, 0],
+        "publicProposalCreators": [
+          "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb"
+        ],
+        "publicProposalExecutors": [
+          "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+          "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC"
+        ],
+        "REGISTER_STANDARD_CALLBACK_PERMISSION_ID": "0xfaf505be9907aa6951c2ebe5b0312f4980e14f21912ed355372103cc8bd683bc",
+        "ROOT_PERMISSION_ID": "0x815fe80e4b37c8582a3b773d1d7071f983eacfd56b5965db654f3087c25ada33",
+        "SET_METADATA_PERMISSION_ID": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+        "SET_TRUSTED_FORWARDER_PERMISSION_ID": "0x06d294bc8cbad2e393408b20dd019a772661f60b8d633e56761157cb1ec85f8c",
+        "sppAdvancers": ["eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF"],
+        "sppExecutors": ["eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF"],
+        "sppProposalCreators": [
+          "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF"
+        ],
+        "sppStageManagers": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"],
+        "sppTargetManagers": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"],
+        "sppTrustedForwarderManagers": [
+          "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+        ],
+        "sppUpgraders": [],
+        "tokenVotingExecutors": [
+          "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF"
+        ],
+        "tokenVotingProposalCreators": [
+          "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb"
+        ],
+        "tokenVotingSettingsManagers": [
+          "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+        ],
+        "tokenVotingTargetManagers": [
+          "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+        ],
+        "tokenVotingUpgraders": [],
+        "UPGRADE_DAO_PERMISSION_ID": "0x1f53edd44352e5d15bad2b29233baa93bcd595e09457780bc7c5445bbbe751cc",
+        "VALIDATE_SIGNATURE_PERMISSION_ID": "0x968c17ebf04aa1b7544168e69314cdab6b69ba813bb6080d49c0c40a65560f58"
+      },
+      "fieldMeta": {
+        "$activePermissions": {
+          "severity": "HIGH",
+          "description": "Active Aragon grants reconstructed from Granted and Revoked events. The permissionId, target contract (where), grantee (who), and optional condition are preserved.",
+          "type": "PERMISSION"
+        },
+        "multisigSettingsAdmins": {
+          "severity": "HIGH",
+          "description": "Current multisig-settings grantees derived from Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "multisigTargetConfigAdmins": {
+          "severity": "HIGH",
+          "description": "Current multisig target-configuration grantees derived from Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "publicProposalCreators": {
+          "severity": "LOW",
+          "description": "Multisig plugins with public proposal creation configured through Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "publicProposalExecutors": {
+          "severity": "LOW",
+          "description": "Multisig plugins with public proposal execution configured through Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "daoExecutors": {
+          "description": "Current grantees of Aragon's EXECUTE_PERMISSION on this DAO, reconstructed from grant and revoke events.",
+          "type": "PERMISSION"
+        },
+        "daoRootHolders": {
+          "description": "Current grantees of Aragon's ROOT_PERMISSION on this DAO, reconstructed from grant and revoke events.",
+          "type": "PERMISSION"
+        },
+        "daoUpgraders": {
+          "description": "Current grantees of Aragon's UPGRADE_DAO_PERMISSION on this DAO, reconstructed from grant and revoke events.",
+          "type": "PERMISSION"
+        },
+        "adminPluginExecutors": {
+          "description": "Addresses that can drive the armed Admin plugin without a DAO vote, reconstructed from Aragon grant and revoke events.",
+          "type": "PERMISSION"
+        },
+        "adminTargetManagers": {
+          "description": "Current grantees allowed to redirect the Admin plugin's execution target.",
+          "type": "PERMISSION"
+        },
+        "sppStageManagers": {
+          "description": "Current grantees allowed to replace the staged proposal process.",
+          "type": "PERMISSION"
+        },
+        "sppProposalCreators": {
+          "description": "Current grantees allowed to create proposals in the staged proposal processor. Conditional grants remain visible in $activePermissions.",
+          "type": "PERMISSION"
+        },
+        "sppAdvancers": {
+          "description": "Current grantees allowed to advance proposals whose configured stage conditions have passed.",
+          "type": "PERMISSION"
+        },
+        "sppExecutors": {
+          "description": "Current grantees allowed to execute a staged proposal after its configured stages have passed.",
+          "type": "PERMISSION"
+        },
+        "sppTargetManagers": {
+          "description": "Current grantees allowed to redirect the staged processor's execution target.",
+          "type": "PERMISSION"
+        },
+        "sppTrustedForwarderManagers": {
+          "description": "Current grantees allowed to replace the staged processor's trusted meta-transaction forwarder.",
+          "type": "PERMISSION"
+        },
+        "sppUpgraders": {
+          "description": "Current grantees of the UPGRADE_PLUGIN permission on the staged proposal processor.",
+          "type": "PERMISSION"
+        },
+        "tokenVotingSettingsManagers": {
+          "description": "Current grantees allowed to change public token-voting thresholds and duration.",
+          "type": "PERMISSION"
+        },
+        "tokenVotingProposalCreators": {
+          "description": "Current grantees allowed to open token-voting proposals.",
+          "type": "PERMISSION"
+        },
+        "tokenVotingExecutors": {
+          "description": "Current grantees allowed to execute a successful token-voting proposal.",
+          "type": "PERMISSION"
+        },
+        "tokenVotingTargetManagers": {
+          "description": "Current grantees allowed to redirect the token-voting plugin's execution target.",
+          "type": "PERMISSION"
+        },
+        "tokenVotingUpgraders": {
+          "description": "Current grantees of the UPGRADE_PLUGIN permission on the token-voting plugin.",
+          "type": "PERMISSION"
+        },
+        "conditionRuleManagers": {
+          "description": "Current grantees allowed to replace the public proposal-creation condition.",
+          "type": "PERMISSION"
+        }
+      },
+      "implementationNames": {
+        "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e": "ERC1967Proxy",
+        "eth:0x58C1F7Bc62Bb63fb137bc8F6d8ea6321a0501d29": "DAO"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "VotingEscrow",
+      "address": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+      "type": "Contract",
+      "template": "interfold/VotingEscrow",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0xbc6579b4c42accae5c7400219895c015a3d275afd13088b59e85b094038ba821"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable veFOLD escrow that custodies locked FOLD, issues lock NFTs and calculates the voting power consumed by BondedVotes through EscrowVotesAdapter.",
+      "ignoreInWatchMode": [
+        "currentExitingAmount",
+        "lastLockId",
+        "totalLocked",
+        "totalVotingPower"
+      ],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x201d4c1cd48F2fC1297eEa56B14A29a039164a91",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0x201d4c1cd48F2fC1297eEa56B14A29a039164a91"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "clock": "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166",
+        "currentExitingAmount": 0,
+        "curve": "eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9",
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "decimals": 18,
+        "ESCROW_ADMIN_ROLE": "0x5153bc4ddea3acc82e49822cf2356cf42e16e0ba80c942840692ca4dd7db5995",
+        "implementation": "eth:0x201d4c1cd48F2fC1297eEa56B14A29a039164a91",
+        "ivotesAdapter": "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc",
+        "lastLockId": 2,
+        "lockNFT": "eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E",
+        "minDeposit": "1000000000000000000",
+        "paused": false,
+        "PAUSER_ROLE": "0x539440820030c4994db4e31b6b800deafd503688728f932addfe7a410515c14c",
+        "queue": "eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f",
+        "SPLIT_WHITELIST_ANY_ADDRESS": "eth:0x89203EDb30c2eCF12612E709afB87C85a170dA0a",
+        "SWEEPER_ROLE": "0xfdecf383ad5026ade6d21db07b04781efb7ede2811d8b5fe299044cc4bb91fc9",
+        "token": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+        "totalLocked": "24042000000000000000000",
+        "totalVotingPower": "24042000000000000000000",
+        "voter": "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0"
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose permission manager grants the escrow's admin, pause, sweep and upgrade roles."
+        },
+        "token": { "description": "FOLD token custodied by the escrow." },
+        "ivotesAdapter": {
+          "description": "Adapter exposing the escrow's voting power through IVotes."
+        },
+        "clock": {
+          "description": "Upgradeable epoch clock used for voting checkpoints and lock timing."
+        },
+        "curve": {
+          "description": "Upgradeable voting-power curve applied to locked FOLD."
+        },
+        "lockNFT": {
+          "description": "Upgradeable ERC-721 representing FOLD lock positions."
+        },
+        "queue": {
+          "description": "Upgradeable exit queue controlling withdrawal cooldowns and fees."
+        },
+        "voter": {
+          "description": "Gauge-voting plugin allowed to update a lock's voting state."
+        },
+        "paused": {
+          "description": "Whether lock and voting-power operations are paused.",
+          "type": "RISK_PARAMETER"
+        },
+        "minDeposit": {
+          "description": "Minimum FOLD amount accepted for a voting-escrow lock.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12": "ERC1967Proxy",
+        "eth:0x201d4c1cd48F2fC1297eEa56B14A29a039164a91": "VotingEscrowV1_2_0"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0x7b4273f9291aEAC9ea85f44093Aca5fC873A7Cf5",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "VotingEscrowExitQueue",
+      "address": "eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f",
+      "type": "Contract",
+      "template": "interfold/VotingEscrowExitQueue",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0xdf4efbc40c77de7dfb353dd7185741bdbf420c9381f9f561b47120d1ed0ffd97"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable queue applying cooldowns and optional fees to withdrawals from VotingEscrow.",
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x037c00ba58D4d2A4870017aeaD7f79A0D23A294f",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0x037c00ba58D4d2A4870017aeaD7f79A0D23A294f"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "clock": "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166",
+        "cooldown": 2592000,
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "escrow": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+        "feePercent": 0,
+        "implementation": "eth:0x037c00ba58D4d2A4870017aeaD7f79A0D23A294f",
+        "minCooldown": 2592000,
+        "minFeePercent": 0,
+        "minLock": 1,
+        "QUEUE_ADMIN_ROLE": "0xc394c78f190ebf6a0034c84aafb4c6893f1e601de9d700227b16d74a628ac114",
+        "WITHDRAW_ROLE": "0x5d8e12c39142ff96d79d04d15d1ba1269e4fe57bb9d26f43523628b34ba108ec"
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose queue roles control fees, cooldowns, withdrawals and upgrades."
+        },
+        "escrow": {
+          "description": "VotingEscrow that creates and completes withdrawal requests."
+        },
+        "clock": { "description": "Epoch clock used for exit timing." },
+        "cooldown": {
+          "description": "Current base withdrawal cooldown.",
+          "type": "RISK_PARAMETER"
+        },
+        "minCooldown": {
+          "description": "Minimum configurable withdrawal cooldown.",
+          "type": "RISK_PARAMETER"
+        },
+        "minLock": {
+          "description": "Minimum lock duration required by the queue.",
+          "type": "RISK_PARAMETER"
+        },
+        "feePercent": {
+          "description": "Current withdrawal fee ratio.",
+          "type": "RISK_PARAMETER"
+        },
+        "minFeePercent": {
+          "description": "Minimum configurable withdrawal fee ratio.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f": "ERC1967Proxy",
+        "eth:0x037c00ba58D4d2A4870017aeaD7f79A0D23A294f": "DynamicExitQueue"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "CRISPProgram",
+      "address": "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f",
+      "type": "Contract",
+      "unverified": true,
+      "proxyType": "immutable",
+      "description": "CRISP encrypted-ballot application. It verifies ballot eligibility and encryption proofs, commits ciphertext inputs, checks that a RISC Zero tally is bound to its input root and parameters, and decodes the threshold-decrypted tally.",
+      "deployerAddress": "eth:0x762D0A181d7184d5e224d3320fa7fF82D56a7dc6",
+      "sinceTimestamp": 1787420051,
+      "sinceBlock": 25812209,
+      "values": {
+        "$immutable": true,
+        "imageId": "0x7ed0ddeb0cafa64228b51399dff5ea00696c2617f28636b05bd67e6c1506eac3",
+        "interfold": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "risc0Verifier": "eth:0x082263Bb53463Ca6c7082bDAFEd51EfA9509cde0"
+      },
+      "fieldMeta": {
+        "owner": {
+          "description": "Account controlling application-level proof configuration and requester-supplied census roots.",
+          "type": "PERMISSION"
+        },
+        "interfold": { "description": "Permanently bound E3 coordinator." },
+        "risc0Verifier": {
+          "description": "Application-level RISC Zero verifier. The external RISC Zero deployment is outside this discovery perimeter.",
+          "type": "CODE_CHANGE"
+        },
+        "imageId": {
+          "description": "Application-level RISC Zero guest image ID. It must agree with the protocol ciphertext verifier for successful completion.",
+          "type": "CODE_CHANGE"
+        }
+      },
+      "implementationNames": {
+        "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f": ""
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0x89203EDb30c2eCF12612E709afB87C85a170dA0a",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "GnosisSafe",
+      "address": "eth:0x8B405dBf2F30844B608b08DaD20447A6955A6C6E",
+      "type": "Contract",
+      "template": "GnosisSafe",
+      "sourceHashes": [
+        "0xd5a33441170541b7df25812e0e3dff6562b2f09ab835a6b431cb9e7198a47605",
+        "0xf42960f0c75309d8d7eeb913a74aa31fbb2e07cfa48c7ebad54152a7194d2425"
+      ],
+      "proxyType": "gnosis safe",
+      "ignoreInWatchMode": ["nonce"],
+      "deployerAddress": "eth:0xd714Dd60e22BbB1cbAFD0e40dE5Cfa7bBDD3F3C8",
+      "sinceTimestamp": 1602165619,
+      "sinceBlock": 11015311,
+      "values": {
+        "$immutable": false,
+        "$implementation": "eth:0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+        "$members": [
+          "eth:0xE171DC4dfb6445f847e13EFCc2536Bf62b9c51FA",
+          "eth:0x9Aa6Db877742aD8D8c7fE209F561fbd2bE19D5F4",
+          "eth:0xd714Dd60e22BbB1cbAFD0e40dE5Cfa7bBDD3F3C8"
+        ],
+        "$threshold": 2,
+        "domainSeparator": "0x115b382fb5d48e1c70926b5f0d7b42d8d6827e037567bbda1ad3d3d08f73fa4e",
+        "getModules": [],
+        "GnosisSafe_modules": [],
+        "multisigThreshold": "2 of 3 (67%)",
+        "NAME": "Gnosis Safe",
+        "nonce": 22,
+        "VERSION": "1.1.1"
+      },
+      "implementationNames": {
+        "eth:0x8B405dBf2F30844B608b08DaD20447A6955A6C6E": "Proxy",
+        "eth:0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F": "GnosisSafe"
+      }
+    },
+    {
+      "name": "InterfoldSafeB",
+      "address": "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593",
+      "type": "Contract",
+      "template": "GnosisSafe",
+      "sourceHashes": [
+        "0xfe0725afd3cf2e5fb7627005a6bcf13ef7e35f78034eed2211edbffdb6a9aab5",
+        "0xe23c519b7324d6dc9132c8567ac55ae72bdf168c914d22825c7614d822364b0f"
+      ],
+      "proxyType": "gnosis safe",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "replace collateral assets and protocol dependencies; change bond, ticket, eligibility and exit parameters; authorize slashing managers and reward distributors; clear bans from old managers; withdraw slashed funds; and replace the slashed-funds treasury.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "description": "change the work-allocation split, coordinator and treasury without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "description": "pause or unpause new requests; replace the registry, bonding, slashing and refund dependencies; allow fee assets and E3 programs; replace proof verifiers; and change pricing, timeouts, parameter sets and committee thresholds without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change support, participation, duration, proposer-power and minimum-approval requirements for future votes.",
+          "role": ".tokenVotingSettingsManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "grant and revoke permissions in the DAO.",
+          "role": ".daoRootHolders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect calls made by the Admin plugin to another executor or target.",
+          "role": ".adminTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed proposal actions to another executor or target.",
+          "role": ".sppTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed vote actions to another executor or target.",
+          "role": ".tokenVotingTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the address trusted to append the effective caller to proposal transactions.",
+          "role": ".sppTrustedForwarderManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the rules that gate public creation of staged proposals.",
+          "role": ".conditionRuleManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the stages, bodies, thresholds and timing rules for future public proposals.",
+          "role": ".sppStageManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f",
+          "description": "set the eligible-voter Merkle root once per requester-census E3 and replace the application RISC Zero verifier or guest image ID immediately. Such replacement cannot change the verifier snapshotted by Interfold, but can make an in-flight round fail.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "create or disable slash policies, grant or revoke evidence slashers, resolve appeals, close E3 assignments and propose, confirm or remove operator bans.",
+          "role": ".governanceMembers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "replace the coordinator, bonding registry, ciphernode registry and refund manager, and grant or revoke governance membership. A transfer of the default-admin role itself has the configured delay.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change cooldowns and exit fees and upgrade the voting-escrow exit queue.",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin settings.",
+          "role": ".multisigSettingsAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change transfer whitelist settings and upgrade the voting-lock NFT.",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting epochs and upgrade the voting-escrow Clock.",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting-power curve parameters and upgrade the Curve implementation.",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "complete queued voting-escrow withdrawals.",
+          "role": ".exitQueueWithdrawers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "grant and revoke permissions in the voting-escrow DAO.",
+          "role": ".veDaoRootHolders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "manage gauge metadata and the voting-power update hook.",
+          "role": ".gaugeAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause and unpause voting-escrow operations.",
+          "role": ".votingEscrowPausers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause the escrow voting-power adapter, manage delegation settings and upgrade its implementation.",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "replace voting-power dependencies, change minimum deposits and split rules, and upgrade VotingEscrow.",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "sweep unaccounted tokens and NFTs from VotingEscrow.",
+          "role": ".votingEscrowSweepers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "update delegated voting power through the escrow voting adapter.",
+          "role": ".delegationTokenManagers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+          "description": "schedule and activate a registry replacement after one day when all ticket liabilities are zero, and rescue ERC-20s other than the underlying sUSDS.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "replace the coordinator, bonding and slashing dependencies; add or remove ciphernodes; change the sortition window; and update the DKG verifier and accusation-vote validity parameters. DKG-verifier replacement and risk-reducing accusation-window changes use a two-day propose/commit delay, while other changes are immediate.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "role": ".daoUpgraders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".gaugeUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".veDaoUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        }
+      ],
+      "directlyReceivedPermissions": [
+        {
+          "permission": "act",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "execute arbitrary DAO actions through the armed Admin plugin without a vote or an onchain delay.",
+          "role": ".adminPluginExecutors"
+        }
+      ],
+      "ignoreInWatchMode": ["nonce"],
+      "deployerAddress": "eth:0x732D5F9155A524C29fe7b17a45C794C4F48abb9e",
+      "sinceTimestamp": 1781272931,
+      "sinceBlock": 25301851,
+      "values": {
+        "$immutable": false,
+        "$implementation": "eth:0x41675C099F32341bf84BFc5382aF534df5C7461a",
+        "$members": [
+          "eth:0xCb83ef506989534463a0E3F6E5526a8FE26897B3",
+          "eth:0xA8C3c4B6aE7f31193057A6d8833980853Ef71f85",
+          "eth:0xC3F8EBC47A4C47D91b643a4C64d34eA7B2584260",
+          "eth:0x26f8034baBfbcA2233350a0Dca1CCcE3d01Fa41F",
+          "eth:0x7b4273f9291aEAC9ea85f44093Aca5fC873A7Cf5"
+        ],
+        "$threshold": 3,
+        "domainSeparator": "0x323a7eaa84d02194b787222b9a891b5f73c417cd6206a7b276d4bf72793aa17f",
+        "getChainId": 1,
+        "GnosisSafe_modules": [],
+        "multisigThreshold": "3 of 5 (60%)",
+        "nonce": 30,
+        "VERSION": "1.4.1"
+      },
+      "implementationNames": {
+        "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593": "SafeProxy",
+        "eth:0x41675C099F32341bf84BFc5382aF534df5C7461a": "Safe"
+      }
+    },
+    {
+      "address": "eth:0x8d138c01765483cB79d787ce5933F609CbFDabcF",
+      "type": "EOA",
+      "sourceHashes": [
+        "0x1f44812af62d28f019e30e8eb2af596fb36c7db9d34576972c0405e110a6ef45"
+      ],
+      "proxyType": "EIP7702 EOA",
+      "values": {
+        "$implementation": "eth:0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B",
+        "delegationManager": "eth:0xdb9B1e94B5b69Df7e401DDbedE43491141047dB3",
+        "DOMAIN_VERSION": "1",
+        "eip712Domain": {
+          "fields": "0x0f",
+          "name": "EIP7702StatelessDeleGator",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "eth:0x8d138c01765483cB79d787ce5933F609CbFDabcF",
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "extensions": []
+        },
+        "entryPoint": "eth:0x0000000071727De22E5E9d8BAf0edAc6f37da032",
+        "getDeposit": 0,
+        "getDomainHash": "0x826e2f68c6a9e5587f1aedc5fbb89a2606fb593e7c6aafabd66e01ad4deffbf0",
+        "getNonce": 0,
+        "NAME": "EIP7702StatelessDeleGator",
+        "PACKED_USER_OP_TYPEHASH": "0xbc37962d8bd1d319c95199bdfda6d3f92baa8903a61b32d5f4ec1f4b36a3bc18",
+        "VERSION": "1.3.0"
+      }
+    },
+    {
+      "name": "EscrowVotesAdapter",
+      "address": "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc",
+      "type": "Contract",
+      "template": "interfold/EscrowVotesAdapter",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0x3e89d3203385dde7d25cf452e705dd2aa1ea29318d45bb4f9ea783d843cefbc9"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable IVotes adapter that exposes voting power from veFOLD locks. BondedVotes uses it as its primary voting-power source.",
+      "ignoreInWatchMode": ["clock"],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0xB67C1ABaC78686c67b91bBd1032813D86047104B",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0xB67C1ABaC78686c67b91bBd1032813D86047104B"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "clock": 1787653811,
+        "CLOCK_MODE": "mode=timestamp",
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "DELEGATION_ADMIN_ROLE": "0xc4a19b785a540c2c44664ee81553e51ce4d2ff785f770bea0ef0e33e9fc2e896",
+        "DELEGATION_TOKEN_ROLE": "0x4e4bdb05aa372e853fafb37a727873f403f7f9b7c0c697830b63f63502b87535",
+        "escrow": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+        "escrowClock": "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166",
+        "implementation": "eth:0xB67C1ABaC78686c67b91bBd1032813D86047104B",
+        "MAX_EPOCHS": 52,
+        "paused": false,
+        "SHARED_CONSTANT_COEFFICIENT": "1000000000000000000",
+        "SHARED_LINEAR_COEFFICIENT": 0,
+        "SHARED_QUADRATIC_COEFFICIENT": 0
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose permission manager grants delegation administration and upgrade roles."
+        },
+        "escrow": {
+          "description": "VotingEscrow from which lock balances and ownership are read."
+        },
+        "escrowClock": {
+          "description": "Clock used for timestamp-indexed voting checkpoints."
+        },
+        "paused": {
+          "description": "Whether delegation updates through the adapter are paused.",
+          "type": "RISK_PARAMETER"
+        },
+        "MAX_EPOCHS": {
+          "description": "Maximum number of epochs traversed by voting-power calculations.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc": "ERC1967Proxy",
+        "eth:0xB67C1ABaC78686c67b91bBd1032813D86047104B": "EscrowIVotesAdapter"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "ProxyAdmin",
+      "address": "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E",
+      "type": "Contract",
+      "template": "global/ProxyAdmin",
+      "sourceHashes": [
+        "0x8fd8f837bb320bd2a7463c103bea2ff207b0969b5795f320a6c868858aa92074"
+      ],
+      "proxyType": "immutable",
+      "directlyReceivedPermissions": [
+        {
+          "permission": "upgrade",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "role": "admin"
+        }
+      ],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109131,
+      "sinceBlock": 25786384,
+      "values": {
+        "$immutable": true,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "UPGRADE_INTERFACE_VERSION": "5.0.0"
+      },
+      "implementationNames": {
+        "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E": "ProxyAdmin"
+      }
+    },
+    {
+      "address": "eth:0x95A53aa925FDd6f1733830EbB7A586B33CbD4355",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "SlashingManager",
+      "address": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+      "type": "Contract",
+      "template": "interfold/SlashingManager",
+      "sourceHashes": [
+        "0x6c22fa41562f0c1711c54cad35a5dc279f856b8cd1e3f329e8ede042eda17f1c"
+      ],
+      "proxyType": "immutable",
+      "description": "Non-upgradeable policy and evidence router for ciphernode penalties, appeals and bans. Slashing is effective only for reasons with an enabled policy and through a manager authorized by the BondingRegistry.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "slash operator ticket collateral and FOLD bonds, ban operators and manage slash-routing state.",
+          "role": ".authorizedSlashingManagerAt"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "expel selected members from active committees.",
+          "role": ".slashingManager"
+        }
+      ],
+      "ignoreInWatchMode": [
+        "activeBanCount",
+        "activeE3Assignments",
+        "totalProposals"
+      ],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109023,
+      "sinceBlock": 25786375,
+      "values": {
+        "$immutable": true,
+        "accessControl": {
+          "DEFAULT_ADMIN_ROLE": {
+            "adminRole": "DEFAULT_ADMIN_ROLE",
+            "members": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"]
+          },
+          "GOVERNANCE_ROLE": {
+            "adminRole": "DEFAULT_ADMIN_ROLE",
+            "members": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"]
+          },
+          "SLASHER_ROLE": { "adminRole": "GOVERNANCE_ROLE", "members": [] }
+        },
+        "ACCUSATION_REPORTING_WINDOW": 86400,
+        "activeBanCount": 0,
+        "activeE3Assignments": 0,
+        "APPEAL_RESOLUTION_GRACE": 604800,
+        "attestationDomainSeparator": "0xe670e3dbea66324ce925fdc720a7dead8fdb9cf33b7b1bc5cc186fcf3f88e223",
+        "bannedNodes": [],
+        "bondingRegistry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "ciphernodeRegistry": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+        "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "defaultAdmin": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "defaultAdminDelay": 172800,
+        "defaultAdminDelayIncreaseWait": 432000,
+        "defaultAdmins": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"],
+        "DOMAIN_NAME_HASH": "0x7095a59edd8cacb738b8513d8813a0b0e354ecb90ee4c98cc0333e8d23ca8966",
+        "DOMAIN_VERSION_HASH": "0xc89efdaa54c0f20c7adf612882df0950f5a951637e0307cdcb4c672f298b8bc6",
+        "e3RefundManager": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+        "EIP712_DOMAIN_NAME": "InterfoldSlashing",
+        "EIP712_DOMAIN_TYPEHASH": "0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f",
+        "EIP712_DOMAIN_VERSION": "1",
+        "eip712Domain": {
+          "fields": "0x0f",
+          "name": "InterfoldSlashing",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "extensions": []
+        },
+        "GOVERNANCE_ROLE": "0x71840dc4906352362b0cdaf79870196c8e42acafade72d5d5a6d59291253ceb1",
+        "governanceMembers": ["eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"],
+        "interfold": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+        "MAX_APPEAL_WINDOW": 2592000,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "pendingDefaultAdmin": {
+          "newAdmin": "eth:0x0000000000000000000000000000000000000000",
+          "schedule": 0
+        },
+        "pendingDefaultAdminDelay": { "newDelay": 0, "schedule": 0 },
+        "PROOF_PAYLOAD_TYPEHASH": "0xab434307b5141420c222a231fb024deb0adb4022d9cb04b4244704ea67b44b51",
+        "SLASHER_ROLE": "0x12b42e8a160f6064dc959c6f251e3af0750ad213dbecf573b4710d67d6c28e39",
+        "slashers": [],
+        "SLASHING_MANAGER_API_VERSION": 1,
+        "slashPolicies": {},
+        "totalProposals": 0,
+        "VOTE_TYPEHASH": "0x2e073ee263d4a8f6f1a00cb4c7023460ce671f3dc214fddca4ef3d56e9d4740b"
+      },
+      "fieldMeta": {
+        "accessControl": {
+          "description": "Current role administrators and members."
+        },
+        "defaultAdmins": {
+          "description": "Members of DEFAULT_ADMIN_ROLE.",
+          "type": "PERMISSION"
+        },
+        "governanceMembers": {
+          "description": "Members of GOVERNANCE_ROLE.",
+          "type": "PERMISSION"
+        },
+        "slashers": {
+          "description": "Members of SLASHER_ROLE.",
+          "type": "PERMISSION"
+        },
+        "slashPolicies": {
+          "description": "Latest configured slashing policy for each reason. An empty map means no ticket or FOLD penalty can currently be proposed through this manager.",
+          "type": "RISK_PARAMETER"
+        },
+        "bannedNodes": {
+          "description": "Currently banned operator keys reconstructed from ban-status events."
+        },
+        "defaultAdminDelay": {
+          "description": "Delay for transferring DEFAULT_ADMIN_ROLE. It does not delay calls made by the current admin or governance-role members.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9": "SlashingManager"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "GnosisSafe",
+      "address": "eth:0x97843608a00e2bbc75ab0C1911387E002565DEDE",
+      "type": "Contract",
+      "template": "GnosisSafe",
+      "sourceHashes": [
+        "0xd5a33441170541b7df25812e0e3dff6562b2f09ab835a6b431cb9e7198a47605",
+        "0x22c7fb8365a538c05d34b77dd9c1967d1ddb7427eda69f84989d4c56603312b7"
+      ],
+      "proxyType": "gnosis safe",
+      "ignoreInWatchMode": ["nonce"],
+      "deployerAddress": "eth:0x34aA3F359A9D614239015126635CE7732c18fDF3",
+      "sinceTimestamp": 1602341754,
+      "sinceBlock": 11028339,
+      "values": {
+        "$immutable": false,
+        "$implementation": "eth:0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+        "$members": [
+          "eth:0x466bfA89bC742c840bc4660890D679d96D65613c",
+          "eth:0x60583563D5879C2E59973E5718c7DE2147971807",
+          "eth:0x11E91FB4793047a68dFff29158387229eA313ffE",
+          "eth:0x60Ca282757BA67f3aDbF21F3ba2eBe4Ab3eb01fc",
+          "eth:0xa81a6a910FeD20374361B35C451a4a44F86CeD46",
+          "eth:0x34aA3F359A9D614239015126635CE7732c18fDF3"
+        ],
+        "$threshold": 3,
+        "domainSeparator": "0xa683c43ad796ea5bf167e36ae190b2cf9b5895397a91c50e130d7520f0255cdb",
+        "getChainId": 1,
+        "GnosisSafe_modules": [],
+        "multisigThreshold": "3 of 6 (50%)",
+        "nonce": 290,
+        "VERSION": "1.3.0"
+      },
+      "implementationNames": {
+        "eth:0x97843608a00e2bbc75ab0C1911387E002565DEDE": "Proxy",
+        "eth:0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552": "GnosisSafe"
+      }
+    },
+    {
+      "address": "eth:0x980AaA907E51a4e3cc89b8FF8e37Aa0D55D46597",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "member",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties.",
+          "role": ".activeOperators"
+        },
+        {
+          "permission": "member",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption.",
+          "role": ".$members"
+        }
+      ]
+    },
+    {
+      "address": "eth:0x9Aa6Db877742aD8D8c7fE209F561fbd2bE19D5F4",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "PublicStagedProposalProcessor",
+      "address": "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb",
+      "type": "Contract",
+      "template": "interfold/StagedProposalProcessor",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0x001b18ae4604ab644ca37dc856974c6b97fb66cfbff5f17ade7109694d1ee295"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable Aragon staged-proposal plugin that executes DAO actions after proposals pass its configured sequence of voting or manual bodies, thresholds and timing windows.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "replace collateral assets and protocol dependencies; change bond, ticket, eligibility and exit parameters; authorize slashing managers and reward distributors; clear bans from old managers; withdraw slashed funds; and replace the slashed-funds treasury.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "description": "change the work-allocation split, coordinator and treasury without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "description": "pause or unpause new requests; replace the registry, bonding, slashing and refund dependencies; allow fee assets and E3 programs; replace proof verifiers; and change pricing, timeouts, parameter sets and committee thresholds without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change support, participation, duration, proposer-power and minimum-approval requirements for future votes.",
+          "role": ".tokenVotingSettingsManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "grant and revoke permissions in the DAO.",
+          "role": ".daoRootHolders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "open a token vote using the caller-supplied proposal payload.",
+          "role": ".tokenVotingProposalCreators"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect calls made by the Admin plugin to another executor or target.",
+          "role": ".adminTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed proposal actions to another executor or target.",
+          "role": ".sppTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed vote actions to another executor or target.",
+          "role": ".tokenVotingTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the address trusted to append the effective caller to proposal transactions.",
+          "role": ".sppTrustedForwarderManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the rules that gate public creation of staged proposals.",
+          "role": ".conditionRuleManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the stages, bodies, thresholds and timing rules for future public proposals.",
+          "role": ".sppStageManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f",
+          "description": "set the eligible-voter Merkle root once per requester-census E3 and replace the application RISC Zero verifier or guest image ID immediately. Such replacement cannot change the verifier snapshotted by Interfold, but can make an in-flight round fail.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "create or disable slash policies, grant or revoke evidence slashers, resolve appeals, close E3 assignments and propose, confirm or remove operator bans.",
+          "role": ".governanceMembers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "replace the coordinator, bonding registry, ciphernode registry and refund manager, and grant or revoke governance membership. A transfer of the default-admin role itself has the configured delay.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change cooldowns and exit fees and upgrade the voting-escrow exit queue.",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin settings.",
+          "role": ".multisigSettingsAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change transfer whitelist settings and upgrade the voting-lock NFT.",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting epochs and upgrade the voting-escrow Clock.",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting-power curve parameters and upgrade the Curve implementation.",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "complete queued voting-escrow withdrawals.",
+          "role": ".exitQueueWithdrawers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "grant and revoke permissions in the voting-escrow DAO.",
+          "role": ".veDaoRootHolders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "manage gauge metadata and the voting-power update hook.",
+          "role": ".gaugeAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause and unpause voting-escrow operations.",
+          "role": ".votingEscrowPausers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause the escrow voting-power adapter, manage delegation settings and upgrade its implementation.",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "replace voting-power dependencies, change minimum deposits and split rules, and upgrade VotingEscrow.",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "sweep unaccounted tokens and NFTs from VotingEscrow.",
+          "role": ".votingEscrowSweepers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "update delegated voting power through the escrow voting adapter.",
+          "role": ".delegationTokenManagers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+          "description": "schedule and activate a registry replacement after one day when all ticket liabilities are zero, and rescue ERC-20s other than the underlying sUSDS.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "replace the coordinator, bonding and slashing dependencies; add or remove ciphernodes; change the sortition window; and update the DKG verifier and accusation-vote validity parameters. DKG-verifier replacement and risk-reducing accusation-window changes use a two-day propose/commit delay, while other changes are immediate.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "role": ".daoUpgraders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".gaugeUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".veDaoUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        }
+      ],
+      "directlyReceivedPermissions": [
+        {
+          "permission": "act",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "execute arbitrary calls from the DAO, including calls to protocol owners and ProxyAdmins.",
+          "role": ".daoExecutors"
+        }
+      ],
+      "deployerAddress": "eth:0x732D5F9155A524C29fe7b17a45C794C4F48abb9e",
+      "sinceTimestamp": 1787251955,
+      "sinceBlock": 25798247,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0xCB895791C84484530d9fC9f68652b9bCC9D5288d",
+        "$pastUpgrades": [
+          [
+            "2026-08-20T18:52:35.000Z",
+            "0x799bb6c90febb29f8252b94d12ae0e5aa3c13e1b9928c7a359b693c8dc335724",
+            ["eth:0xCB895791C84484530d9fC9f68652b9bCC9D5288d"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "currentStages": [
+          [
+            [
+              ["eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC", false, true, 1]
+            ],
+            3024000,
+            0,
+            432000,
+            1,
+            0,
+            false,
+            false
+          ],
+          [
+            [["eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593", true, true, 1]],
+            5184000,
+            0,
+            2592000,
+            1,
+            0,
+            false,
+            false
+          ]
+        ],
+        "customProposalParamsABI": "(bytes[][] subBodiesCustomProposalParamsABI)",
+        "dao": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "getCurrentConfigIndex": 1,
+        "getCurrentTargetConfig": {
+          "target": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "operation": 0
+        },
+        "getMetadata": "0x697066733a2f2f516d58437642534a57545832433454444a4d74433939736956595739747857575a4e57796b5446544d3739633765",
+        "getTargetConfig": {
+          "target": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "operation": 0
+        },
+        "getTrustedForwarder": "eth:0x0000000000000000000000000000000000000000",
+        "implementation": "eth:0xCB895791C84484530d9fC9f68652b9bCC9D5288d",
+        "pluginType": 0,
+        "protocolVersion": [1, 4, 0],
+        "SET_METADATA_PERMISSION_ID": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+        "SET_TARGET_CONFIG_PERMISSION_ID": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+        "UPGRADE_PLUGIN_PERMISSION_ID": "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5"
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose permission manager controls proposal creation, configuration, advancement and upgrades."
+        },
+        "currentStages": {
+          "description": "Latest proposal-stage configuration reconstructed from events, including voting bodies, approval and veto thresholds, timing windows, and edit/cancel flags.",
+          "type": "RISK_PARAMETER"
+        },
+        "getCurrentConfigIndex": {
+          "description": "Index of the stage configuration used by newly created proposals. Existing proposals retain their earlier snapshot."
+        },
+        "getCurrentTargetConfig": {
+          "description": "Stored target and call operation for passed proposal actions. A zero target resolves to the DAO; delegatecall changes the security context.",
+          "type": "CODE_CHANGE"
+        },
+        "getTrustedForwarder": {
+          "description": "Address trusted to append the effective caller to proposal transactions."
+        }
+      },
+      "implementationNames": {
+        "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb": "ERC1967Proxy",
+        "eth:0xCB895791C84484530d9fC9f68652b9bCC9D5288d": "StagedProposalProcessor"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "DkgAggregatorVerifier",
+      "address": "eth:0x9e58443eB40A1B08D07f89D36bf69909d401a542",
+      "type": "Contract",
+      "template": "interfold/DkgAggregatorVerifier",
+      "sourceHashes": [
+        "0xbfdaa6f199a3036bf6b0b70808e87690fa7894d4669c609e43c510c02b499e9f"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable generated Honk verifier for the BFV distributed-key-generation aggregation circuit.",
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109275,
+      "sinceBlock": 25786396,
+      "values": { "$immutable": true },
+      "implementationNames": {
+        "eth:0x9e58443eB40A1B08D07f89D36bf69909d401a542": "DkgAggregatorVerifier"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "VotingEscrowDAO",
+      "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+      "type": "Contract",
+      "template": "zama/ZamaDAO",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0xd54ad871bfd08607d81e0a9bad74aa0f9fa3dc9e2331986a47281d6ca0ae07a7"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Aragon DAO that stores governance state and executes proposal action batches.",
+      "directlyReceivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change cooldowns and exit fees and upgrade the voting-escrow exit queue.",
+          "role": ".exitQueueAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin settings.",
+          "role": ".multisigSettingsAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change transfer whitelist settings and upgrade the voting-lock NFT.",
+          "role": ".lockAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting epochs and upgrade the voting-escrow Clock.",
+          "role": ".clockAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting-power curve parameters and upgrade the Curve implementation.",
+          "role": ".curveAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "complete queued voting-escrow withdrawals.",
+          "role": ".exitQueueWithdrawers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "grant and revoke permissions in the voting-escrow DAO.",
+          "role": ".veDaoRootHolders"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "manage gauge metadata and the voting-power update hook.",
+          "role": ".gaugeAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause and unpause voting-escrow operations.",
+          "role": ".votingEscrowPausers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause the escrow voting-power adapter, manage delegation settings and upgrade its implementation.",
+          "role": ".votesAdapterAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "replace voting-power dependencies, change minimum deposits and split rules, and upgrade VotingEscrow.",
+          "role": ".votingEscrowAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "sweep unaccounted tokens and NFTs from VotingEscrow.",
+          "role": ".votingEscrowSweepers"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "update delegated voting power through the escrow voting adapter.",
+          "role": ".delegationTokenManagers"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".clockAdmins"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".curveAdmins"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".exitQueueAdmins"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".gaugeUpgraders"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".lockAdmins"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".veDaoUpgraders"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votesAdapterAdmins"
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votingEscrowAdmins"
+        }
+      ],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$activePermissions": [
+          {
+            "permissionId": "0x815fe80e4b37c8582a3b773d1d7071f983eacfd56b5965db654f3087c25ada33",
+            "where": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x1f53edd44352e5d15bad2b29233baa93bcd595e09457780bc7c5445bbbe751cc",
+            "where": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x06d294bc8cbad2e393408b20dd019a772661f60b8d633e56761157cb1ec85f8c",
+            "where": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+            "where": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xfaf505be9907aa6951c2ebe5b0312f4980e14f21912ed355372103cc8bd683bc",
+            "where": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xb1750e46d35a0069c8465b8643e7838d2149a842a2db8ee233d9835590040cad",
+            "where": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+            "where": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "who": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x8c433a4cd6b51969eca37f974940894297b9fcf4b282a213fea5cd8f85289c90",
+            "where": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "who": "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+            "condition": "eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76"
+          },
+          {
+            "permissionId": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+            "where": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+            "where": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+            "where": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "who": "eth:0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xfda1ae526c1fb38407f23e8b7712f7cfacc146f3e340a04221488331e0d42014",
+            "where": "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x5153bc4ddea3acc82e49822cf2356cf42e16e0ba80c942840692ca4dd7db5995",
+            "where": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xc394c78f190ebf6a0034c84aafb4c6893f1e601de9d700227b16d74a628ac114",
+            "where": "eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x065385aea91ea94bccc193b44dcdc1da3bcab7e7328692e0b12cda00df64eac4",
+            "where": "eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5",
+            "where": "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x440d025ee487c9fe654894f3750aeb18132e334d52d7a9c0a3f6a5c77450a9b5",
+            "where": "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x54e26bc44f032b9c63f050973076cd279ea75ee2dceeaee6367075804fd03838",
+            "where": "eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xc4a19b785a540c2c44664ee81553e51ce4d2ff785f770bea0ef0e33e9fc2e896",
+            "where": "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x4e4bdb05aa372e853fafb37a727873f403f7f9b7c0c697830b63f63502b87535",
+            "where": "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x539440820030c4994db4e31b6b800deafd503688728f932addfe7a410515c14c",
+            "where": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xfdecf383ad5026ade6d21db07b04781efb7ede2811d8b5fe299044cc4bb91fc9",
+            "where": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0x5d8e12c39142ff96d79d04d15d1ba1269e4fe57bb9d26f43523628b34ba108ec",
+            "where": "eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          },
+          {
+            "permissionId": "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+            "where": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+            "who": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+            "condition": "eth:0x0000000000000000000000000000000000000002"
+          }
+        ],
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x58C1F7Bc62Bb63fb137bc8F6d8ea6321a0501d29",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0x58C1F7Bc62Bb63fb137bc8F6d8ea6321a0501d29"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "clockAdmins": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "curveAdmins": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "daoURI": "",
+        "delegationTokenManagers": [
+          "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+        ],
+        "EXECUTE_PERMISSION_ID": "0xbf04b4486c9663d805744005c3da000eda93de6e3308a4a7a812eb565327b78d",
+        "exitQueueAdmins": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "exitQueueWithdrawers": [
+          "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+        ],
+        "gaugeAdmins": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "gaugeUpgraders": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "getTrustedForwarder": "eth:0x0000000000000000000000000000000000000000",
+        "lockAdmins": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "multisigSettingsAdmins": [
+          {
+            "where": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+          }
+        ],
+        "multisigTargetConfigAdmins": [
+          {
+            "where": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+            "who": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+          }
+        ],
+        "protocolVersion": [1, 4, 0],
+        "publicProposalCreators": [
+          "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C"
+        ],
+        "publicProposalExecutors": [
+          "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C"
+        ],
+        "REGISTER_STANDARD_CALLBACK_PERMISSION_ID": "0xfaf505be9907aa6951c2ebe5b0312f4980e14f21912ed355372103cc8bd683bc",
+        "ROOT_PERMISSION_ID": "0x815fe80e4b37c8582a3b773d1d7071f983eacfd56b5965db654f3087c25ada33",
+        "SET_METADATA_PERMISSION_ID": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+        "SET_TRUSTED_FORWARDER_PERMISSION_ID": "0x06d294bc8cbad2e393408b20dd019a772661f60b8d633e56761157cb1ec85f8c",
+        "UPGRADE_DAO_PERMISSION_ID": "0x1f53edd44352e5d15bad2b29233baa93bcd595e09457780bc7c5445bbbe751cc",
+        "VALIDATE_SIGNATURE_PERMISSION_ID": "0x968c17ebf04aa1b7544168e69314cdab6b69ba813bb6080d49c0c40a65560f58",
+        "veDaoExecutors": [
+          "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+          "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e"
+        ],
+        "veDaoRootHolders": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "veDaoUpgraders": ["eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"],
+        "veMultisigUpgraders": [],
+        "votesAdapterAdmins": [
+          "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+        ],
+        "votingEscrowAdmins": [
+          "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+        ],
+        "votingEscrowPausers": [
+          "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+        ],
+        "votingEscrowSweepers": [
+          "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B"
+        ]
+      },
+      "fieldMeta": {
+        "$activePermissions": {
+          "severity": "HIGH",
+          "description": "Active Aragon grants reconstructed from Granted and Revoked events. The permissionId, target contract (where), grantee (who), and optional condition are preserved.",
+          "type": "PERMISSION"
+        },
+        "multisigSettingsAdmins": {
+          "severity": "HIGH",
+          "description": "Current multisig-settings grantees derived from Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "multisigTargetConfigAdmins": {
+          "severity": "HIGH",
+          "description": "Current multisig target-configuration grantees derived from Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "publicProposalCreators": {
+          "severity": "LOW",
+          "description": "Multisig plugins with public proposal creation configured through Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "publicProposalExecutors": {
+          "severity": "LOW",
+          "description": "Multisig plugins with public proposal execution configured through Aragon grant/revoke events.",
+          "type": "PERMISSION"
+        },
+        "veDaoExecutors": {
+          "description": "Current grantees of EXECUTE_PERMISSION on the voting-escrow DAO.",
+          "type": "PERMISSION"
+        },
+        "veDaoRootHolders": {
+          "description": "Current grantees of ROOT_PERMISSION on the voting-escrow DAO.",
+          "type": "PERMISSION"
+        },
+        "veDaoUpgraders": {
+          "description": "Current grantees of UPGRADE_DAO_PERMISSION on the voting-escrow DAO.",
+          "type": "PERMISSION"
+        },
+        "votingEscrowAdmins": {
+          "description": "Current holders of the VotingEscrow ESCROW_ADMIN role.",
+          "type": "PERMISSION"
+        },
+        "votingEscrowPausers": {
+          "description": "Current holders of the VotingEscrow PAUSER role.",
+          "type": "PERMISSION"
+        },
+        "votingEscrowSweepers": {
+          "description": "Current holders of the VotingEscrow SWEEPER role.",
+          "type": "PERMISSION"
+        },
+        "votesAdapterAdmins": {
+          "description": "Current holders of the EscrowIVotesAdapter DELEGATION_ADMIN role.",
+          "type": "PERMISSION"
+        },
+        "delegationTokenManagers": {
+          "description": "Current holders of the EscrowIVotesAdapter DELEGATION_TOKEN role.",
+          "type": "PERMISSION"
+        },
+        "clockAdmins": {
+          "description": "Current holders of the voting-escrow Clock admin role.",
+          "type": "PERMISSION"
+        },
+        "curveAdmins": {
+          "description": "Current holders of the voting-power Curve admin role.",
+          "type": "PERMISSION"
+        },
+        "lockAdmins": {
+          "description": "Current holders of the voting-escrow Lock NFT admin role.",
+          "type": "PERMISSION"
+        },
+        "exitQueueAdmins": {
+          "description": "Current holders of the voting-escrow exit-queue admin role.",
+          "type": "PERMISSION"
+        },
+        "exitQueueWithdrawers": {
+          "description": "Current holders of the voting-escrow exit-queue withdrawal role.",
+          "type": "PERMISSION"
+        },
+        "gaugeAdmins": {
+          "description": "Current holders of the voting-escrow gauge-voter admin role.",
+          "type": "PERMISSION"
+        },
+        "gaugeUpgraders": {
+          "description": "Current grantees of UPGRADE_PLUGIN permission on the voting-escrow gauge voter.",
+          "type": "PERMISSION"
+        },
+        "veMultisigUpgraders": {
+          "description": "Current grantees of UPGRADE_PLUGIN permission on the voting-escrow multisig plugin.",
+          "type": "PERMISSION"
+        }
+      },
+      "implementationNames": {
+        "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B": "ERC1967Proxy",
+        "eth:0x58C1F7Bc62Bb63fb137bc8F6d8ea6321a0501d29": "DAO"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0xA303d8Cb0CE470F772A459b4a87AcB11b2978DB8",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "member",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties.",
+          "role": ".activeOperators"
+        },
+        {
+          "permission": "member",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption.",
+          "role": ".$members"
+        }
+      ]
+    },
+    {
+      "address": "eth:0xa81a6a910FeD20374361B35C451a4a44F86CeD46",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0xA8C3c4B6aE7f31193057A6d8833980853Ef71f85",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0xABFBc9eE2Df6cDd236741BedfdF34fDB3D9AED3E",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "ProxyAdmin",
+      "address": "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580",
+      "type": "Contract",
+      "template": "global/ProxyAdmin",
+      "sourceHashes": [
+        "0x8fd8f837bb320bd2a7463c103bea2ff207b0969b5795f320a6c868858aa92074"
+      ],
+      "proxyType": "immutable",
+      "directlyReceivedPermissions": [
+        {
+          "permission": "upgrade",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "role": "admin"
+        }
+      ],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109107,
+      "sinceBlock": 25786382,
+      "values": {
+        "$immutable": true,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "UPGRADE_INTERFACE_VERSION": "5.0.0"
+      },
+      "implementationNames": {
+        "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580": "ProxyAdmin"
+      }
+    },
+    {
+      "name": "BfvPkVerifier",
+      "address": "eth:0xBA1854fDA7A5c127606572e43Dc7B37b7A15bdFf",
+      "type": "Contract",
+      "template": "interfold/BfvPkVerifier",
+      "sourceHashes": [
+        "0x13506be90fff7c3922e3b110f61dcfe0114bdaeda4e9e883448e30f4969cd771"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable BFV public-key proof wrapper. It binds the generated circuit verifier to the expected DKG-fold and C5 verification-key hashes.",
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109299,
+      "sinceBlock": 25786398,
+      "values": {
+        "$immutable": true,
+        "circuitVerifier": "eth:0x9e58443eB40A1B08D07f89D36bf69909d401a542",
+        "expectedC5KeyHash": "0x2f2dd8535a4787ea8794523842a3a4f45cd84bc85749861fb660801b495b3270",
+        "expectedNodesFoldKeyHash": "0x224ce3d9bca060eeade7369297dcc3b23ac24e688fb6d20b500077dca6b9e353",
+        "h": 2
+      },
+      "fieldMeta": {
+        "circuitVerifier": {
+          "description": "Generated onchain verifier for the BFV distributed-key-generation proof.",
+          "type": "CODE_CHANGE"
+        },
+        "expectedNodesFoldKeyHash": {
+          "description": "Immutable hash binding the accepted nodes-fold verification key.",
+          "type": "CODE_CHANGE"
+        },
+        "expectedC5KeyHash": {
+          "description": "Immutable hash binding the accepted C5 verification key.",
+          "type": "CODE_CHANGE"
+        },
+        "h": {
+          "description": "Immutable circuit parameter used by the BFV public-key proof.",
+          "type": "CODE_CHANGE"
+        }
+      },
+      "implementationNames": {
+        "eth:0xBA1854fDA7A5c127606572e43Dc7B37b7A15bdFf": "BfvPkVerifier"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0xBb66Ff0728ec074f3E374947246e8Daa7e6AA587",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0xBB7BBED93D75613E206D5aE4743a47214356d6Ef",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "InterfoldTicketToken",
+      "address": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+      "type": "Contract",
+      "template": "interfold/InterfoldTicketToken",
+      "sourceHashes": [
+        "0xef3cd5cf8d395de14d8015a8da3ca3bbc44246f18e69d4a8c53de0d84174f9c4"
+      ],
+      "proxyType": "immutable",
+      "description": "Non-transferable ERC-20 Votes wrapper for sUSDS used as ciphernode ticket collateral. Only the configured BondingRegistry can deposit, mint, burn, withdraw or pay out the underlying asset.",
+      "ignoreInWatchMode": ["clock", "payableBalance", "totalSupply"],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787108987,
+      "sinceBlock": 25786372,
+      "values": {
+        "$immutable": true,
+        "clock": 1787653811,
+        "CLOCK_MODE": "mode=timestamp",
+        "decimals": 18,
+        "eip712Domain": {
+          "fields": "0x0f",
+          "name": "Interfold Ticket Token",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "extensions": []
+        },
+        "name": "Interfold Ticket Token",
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "payableBalance": 0,
+        "pendingOwner": "eth:0x0000000000000000000000000000000000000000",
+        "pendingRegistry": "eth:0x0000000000000000000000000000000000000000",
+        "pendingRegistryActivationTime": 0,
+        "registry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "REGISTRY_CHANGE_DELAY": 86400,
+        "registryLocked": true,
+        "symbol": "tFOLD",
+        "totalSupply": "12000000000000000000000",
+        "underlying": "eth:0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD"
+      },
+      "fieldMeta": {
+        "registry": {
+          "description": "Contract exclusively allowed to move the underlying collateral and mint or burn ticket tokens.",
+          "type": "PERMISSION"
+        },
+        "owner": {
+          "description": "Account that can transfer ownership, rescue unrelated ERC-20s and manage the registry address. Because the registry is locked, replacement requires a one-day delay and zero outstanding ticket supply and payable balance.",
+          "type": "PERMISSION"
+        },
+        "underlying": {
+          "description": "External sUSDS token backing ticket collateral one-for-one; its Maker/Sky dependencies are outside the Interfold discovery perimeter."
+        },
+        "registryLocked": {
+          "description": "One-way flag requiring future registry replacements to use the delayed, zero-liability flow.",
+          "type": "RISK_PARAMETER"
+        },
+        "REGISTRY_CHANGE_DELAY": {
+          "description": "Delay between requesting and activating a locked registry replacement.",
+          "type": "RISK_PARAMETER"
+        },
+        "payableBalance": {
+          "description": "Underlying sUSDS reserved after ticket burns and available for protocol-directed payout."
+        }
+      },
+      "implementationNames": {
+        "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D": "InterfoldTicketToken"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0xC3F8EBC47A4C47D91b643a4C64d34eA7B2584260",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "CiphernodeRegistry",
+      "address": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+      "type": "Contract",
+      "template": "interfold/CiphernodeRegistry",
+      "sourceHashes": [
+        "0x3335d1c5141feebb2c3729ab3dc2810d3d9196ee836d49c75be1c2b800a77d81",
+        "0x181143fe8736537b7086ceca31a6731ebb34e2e2612a63c3ff66ef5c7f3816af"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable registry of ciphernodes and per-E3 committees. It performs ticket-weighted committee sortition, records DKG proof anchors and the committee public key, and tracks committee viability.",
+      "ignoreInWatchMode": ["ciphernodes", "root", "treeSize"],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109059,
+      "sinceBlock": 25786378,
+      "values": {
+        "$admin": "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7",
+        "$implementation": "eth:0xB06Aaf9EF87984192490E947078D2f3563399b7B",
+        "$members": [
+          "eth:0xA303d8Cb0CE470F772A459b4a87AcB11b2978DB8",
+          "eth:0x291bD021638B9aef86c6d47e29CdA1cF3804bafb",
+          "eth:0x980AaA907E51a4e3cc89b8FF8e37Aa0D55D46597",
+          "eth:0x0a3E22cb9778A10b188eC2BF149D628ab91A76a9",
+          "eth:0xD81f88b9Ae6261d684f8BfEb6a642692213dAe86",
+          "eth:0x3b62d921EFdbc295B017fAb9Ba8a521457F037d3",
+          "eth:0x252a6c33C87C0b439671b983C3f730D2C46a5F1d"
+        ],
+        "$pastUpgrades": [
+          [
+            "2026-08-19T03:10:59.000Z",
+            "0xc17b85549e721c943dd5667c8ad8a3857c7897b9cc0add6e834539bdd4e7d0d6",
+            ["eth:0xB06Aaf9EF87984192490E947078D2f3563399b7B"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "ACCUSATION_VOTE_VALIDITY_TIMELOCK": 172800,
+        "accusationVoteValidity": 1800,
+        "BLOCKHASH_HISTORY": "eth:0x0000F90827F1C53a10cb7A02335B175320002935",
+        "bondingRegistry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "CIPHERNODE_TREE_WARNING_THRESHOLD": 838860,
+        "ciphernodes": { "maxIndex": 1048575, "numberOfLeaves": 7 },
+        "DEFAULT_ACCUSATION_VOTE_VALIDITY": 1800,
+        "DKG_FOLD_VERIFIER_TIMELOCK": 172800,
+        "dkgFoldAttestationVerifier": "eth:0xE5657c0756B772B600D6c73eDbF046f32129c770",
+        "exitDelayFloor": 600,
+        "getBondingRegistry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "interfold": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+        "MAX_CIPHERNODE_LEAVES": 1048576,
+        "MAX_COMMITTEE_PUBLIC_KEY_BYTES": 262144,
+        "MAX_SORTITION_SUBMISSION_WINDOW": 86400,
+        "MIN_SORTITION_SUBMISSION_WINDOW": 60,
+        "numCiphernodes": 7,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "pendingAccusationVoteValidity": 0,
+        "pendingAccusationVoteValidityAt": 0,
+        "pendingDkgFoldAttestationVerifier": "eth:0x0000000000000000000000000000000000000000",
+        "pendingDkgFoldAttestationVerifierAt": 0,
+        "pendingOwner": "eth:0x0000000000000000000000000000000000000000",
+        "root": "21566062968715035133984466498059665708961681597209426751743703534648845223200",
+        "slashingManager": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+        "sortitionSubmissionWindow": 600,
+        "TREE_DEPTH": 20,
+        "treeSize": 7,
+        "unreleasedCommitteeCount": 0
+      },
+      "fieldMeta": {
+        "owner": {
+          "description": "Account controlling registry configuration.",
+          "type": "PERMISSION"
+        },
+        "$members": {
+          "description": "Current registered ciphernode operator keys reconstructed from add and remove events. Distinct keys do not prove distinct owners or infrastructure.",
+          "type": "PERMISSION"
+        },
+        "dkgFoldAttestationVerifier": {
+          "description": "Verifier that authenticates each selected node's DKG-fold commitment before the aggregate DKG proof is accepted.",
+          "type": "CODE_CHANGE"
+        },
+        "sortitionSubmissionWindow": {
+          "description": "Time after entropy becomes available during which eligible operators submit a ticket for committee sortition.",
+          "type": "RISK_PARAMETER"
+        },
+        "accusationVoteValidity": {
+          "description": "Validity window for committee accusation attestations used by permissionless proof-based slashing.",
+          "type": "RISK_PARAMETER"
+        },
+        "numCiphernodes": {
+          "description": "Number of currently registered ciphernode keys."
+        }
+      },
+      "implementationNames": {
+        "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7": "TransparentUpgradeableProxy",
+        "eth:0xB06Aaf9EF87984192490E947078D2f3563399b7B": "CiphernodeRegistryOwnable"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "VotingEscrowClock",
+      "address": "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166",
+      "type": "Contract",
+      "template": "interfold/VotingEscrowClock",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0x4a40c38873e8dd6be25ae82bbd232864c841271ce308509366c56987196b1c46"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable timestamp clock defining veFOLD epochs, checkpoint cadence and gauge-voting windows.",
+      "ignoreInWatchMode": [
+        "currentEpoch",
+        "elapsedInEpoch",
+        "epochNextCheckpointIn",
+        "epochNextCheckpointTs",
+        "epochPrevCheckpointElapsed",
+        "epochPrevCheckpointTs",
+        "epochStartsIn",
+        "epochStartTs",
+        "epochVoteEndsIn",
+        "epochVoteEndTs",
+        "epochVoteStartsIn",
+        "epochVoteStartTs",
+        "votingActive"
+      ],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0xEC0162045B44C5506954E3A04dbbcdfe39f64f21",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0xEC0162045B44C5506954E3A04dbbcdfe39f64f21"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "checkpointInterval": 604800,
+        "CLOCK_ADMIN_ROLE": "0x440d025ee487c9fe654894f3750aeb18132e334d52d7a9c0a3f6a5c77450a9b5",
+        "currentEpoch": 1477,
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "elapsedInEpoch": 1074611,
+        "epochDuration": 1209600,
+        "epochNextCheckpointIn": 134989,
+        "epochNextCheckpointTs": 1787788800,
+        "epochPrevCheckpointElapsed": 469811,
+        "epochPrevCheckpointTs": 1787184000,
+        "epochStartsIn": 134989,
+        "epochStartTs": 1787788800,
+        "epochVoteEndsIn": 0,
+        "epochVoteEndTs": 1787653811,
+        "epochVoteStartsIn": 138589,
+        "epochVoteStartTs": 1787792400,
+        "implementation": "eth:0xEC0162045B44C5506954E3A04dbbcdfe39f64f21",
+        "voteDuration": 604800,
+        "voteWindowBuffer": 3600,
+        "votingActive": false
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose Clock admin role can change timing and upgrade the implementation."
+        },
+        "epochDuration": {
+          "description": "Duration of a veFOLD epoch.",
+          "type": "RISK_PARAMETER"
+        },
+        "checkpointInterval": {
+          "description": "Interval between voting-power checkpoints.",
+          "type": "RISK_PARAMETER"
+        },
+        "voteDuration": {
+          "description": "Duration of the gauge-voting window in each epoch.",
+          "type": "RISK_PARAMETER"
+        },
+        "voteWindowBuffer": {
+          "description": "Buffer between the epoch boundary and gauge voting.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166": "ERC1967Proxy",
+        "eth:0xEC0162045B44C5506954E3A04dbbcdfe39f64f21": "ClockV1_2_0"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0xCb83ef506989534463a0E3F6E5526a8FE26897B3",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "PublicProposalCondition",
+      "address": "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2",
+      "type": "Contract",
+      "template": "interfold/SPPRuleCondition",
+      "sourceHashes": [
+        "0x820364f6b02461f786e2dfaa81e0059689349246f89bf5b49bf33424d05d117e",
+        "0x820364f6b02461f786e2dfaa81e0059689349246f89bf5b49bf33424d05d117e"
+      ],
+      "proxyType": "EIP1167 proxy",
+      "description": "Non-upgradeable Aragon condition attached to the public CREATE_PROPOSAL permission. Its mutable rule program determines which callers and proposal calls qualify for the otherwise-public grant.",
+      "deployerAddress": "eth:0x732D5F9155A524C29fe7b17a45C794C4F48abb9e",
+      "sinceTimestamp": 1787251955,
+      "sinceBlock": 25798247,
+      "values": {
+        "$implementation": "eth:0xE437E5c7EeB0D49F97CfD040fb8a02A60a61c0f0",
+        "dao": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "getRules": [
+          {
+            "id": 203,
+            "op": 10,
+            "value": 8589934593,
+            "permissionId": "0x0000000000000000000000000000000000000000000000000000000000000000"
+          },
+          {
+            "id": 202,
+            "op": 1,
+            "value": "1141806766504311494734288708693105338288022157410",
+            "permissionId": "0x0000000000000000000000000000000000000000000000000000000000000000"
+          },
+          {
+            "id": 202,
+            "op": 1,
+            "value": "847091883547517599249294440562396633454466361119",
+            "permissionId": "0x0000000000000000000000000000000000000000000000000000000000000000"
+          }
+        ],
+        "protocolVersion": [1, 4, 0],
+        "UPDATE_RULES_PERMISSION_ID": "0xd3d98e95f3486fc234d80c098cf0d2a0a3fb187833d7e9cc930f8c4f8335a0e7"
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose permission manager controls updates to the condition's rule program."
+        },
+        "getRules": {
+          "description": "Current ordered rule program evaluated for public proposal creation.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2": "SPPRuleCondition",
+        "eth:0xE437E5c7EeB0D49F97CfD040fb8a02A60a61c0f0": "SPPRuleCondition"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0xd64271606A20362A3c11d1C7C92897d6e4a5d45C",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0xd714Dd60e22BbB1cbAFD0e40dE5Cfa7bBDD3F3C8",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0xD81f88b9Ae6261d684f8BfEb6a642692213dAe86",
+      "type": "EOA",
+      "proxyType": "EOA",
+      "receivedPermissions": [
+        {
+          "permission": "member",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "submit one chosen eligible ticket per E3 sortition and be selected for ciphernode committee duties.",
+          "role": ".activeOperators"
+        },
+        {
+          "permission": "member",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "eligible for ticket-weighted selection into E3 committees, where selected members create key shares and participate in threshold decryption.",
+          "role": ".$members"
+        }
+      ]
+    },
+    {
+      "name": "BondedCheckpoints",
+      "address": "eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963",
+      "type": "Contract",
+      "template": "interfold/BondedCheckpoints",
+      "sourceHashes": [
+        "0x8ad2ea77f39af5b32c176b962b813d16e18902db7133fb50165d1632c71997f3"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable voting-power checkpoint store updated exclusively by the BondingRegistry so FOLD bonded to ciphernode operators remains visible to governance snapshots.",
+      "ignoreInWatchMode": ["clock"],
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109215,
+      "sinceBlock": 25786391,
+      "values": {
+        "$immutable": true,
+        "clock": 1787653811,
+        "CLOCK_MODE": "mode=timestamp",
+        "registry": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F"
+      },
+      "implementationNames": {
+        "eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963": "BondedCheckpoints"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "VotingEscrowMultisig",
+      "address": "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C",
+      "type": "Contract",
+      "template": "zama/Multisig",
+      "sourceHashes": [
+        "0x9b5c75bebb30e4cabdab308e6f861d278c723802cea6e775d5a3c4791a69c568",
+        "0xfd5e9341b7d3bc08e1c7b6acfc085f9dd1d3ea9cf5428efae0aba758875db1b3"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Aragon multisig plugin for creating proposals and collecting approvals against a configurable threshold.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change cooldowns and exit fees and upgrade the voting-escrow exit queue.",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin settings.",
+          "role": ".multisigSettingsAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin settings.",
+          "role": ".multisigSettingsAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change transfer whitelist settings and upgrade the voting-lock NFT.",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting epochs and upgrade the voting-escrow Clock.",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting-power curve parameters and upgrade the Curve implementation.",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "complete queued voting-escrow withdrawals.",
+          "role": ".exitQueueWithdrawers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "grant and revoke permissions in the voting-escrow DAO.",
+          "role": ".veDaoRootHolders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "manage gauge metadata and the voting-power update hook.",
+          "role": ".gaugeAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause and unpause voting-escrow operations.",
+          "role": ".votingEscrowPausers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause the escrow voting-power adapter, manage delegation settings and upgrade its implementation.",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "replace voting-power dependencies, change minimum deposits and split rules, and upgrade VotingEscrow.",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "sweep unaccounted tokens and NFTs from VotingEscrow.",
+          "role": ".votingEscrowSweepers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "update delegated voting power through the escrow voting adapter.",
+          "role": ".delegationTokenManagers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".gaugeUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".veDaoUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" }
+          ]
+        }
+      ],
+      "directlyReceivedPermissions": [
+        {
+          "permission": "act",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "execute arbitrary calls from the voting-escrow DAO, including administration and upgrades of the voting-power stack.",
+          "role": ".veDaoExecutors"
+        }
+      ],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x517BD0E1fbE9dDf828fD139b19CF9F434Da94371",
+        "$members": ["eth:0x455e3DEFBC6b48D9127CF6acC609F5cEa87cA759"],
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0x517BD0E1fbE9dDf828fD139b19CF9F434Da94371"]
+          ]
+        ],
+        "$threshold": 1,
+        "$upgradeCount": 1,
+        "addresslistLength": 1,
+        "CREATE_PROPOSAL_PERMISSION_ID": "0x8c433a4cd6b51969eca37f974940894297b9fcf4b282a213fea5cd8f85289c90",
+        "customProposalParamsABI": "(uint256 allowFailureMap, bool approveProposal, bool tryExecution)",
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "EXECUTE_PROPOSAL_PERMISSION_ID": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+        "getCurrentTargetConfig": {
+          "target": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "operation": 0
+        },
+        "getMetadata": "0x697066733a2f2f",
+        "getTargetConfig": {
+          "target": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "operation": 0
+        },
+        "hasSucceeded": [],
+        "implementation": "eth:0x517BD0E1fbE9dDf828fD139b19CF9F434Da94371",
+        "lastMultisigSettingsChange": 25779726,
+        "multisigSettings": { "onlyListed": true, "minApprovals": 1 },
+        "pluginType": 0,
+        "protocolVersion": [1, 4, 0],
+        "SET_METADATA_PERMISSION_ID": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+        "SET_TARGET_CONFIG_PERMISSION_ID": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+        "UPDATE_MULTISIG_SETTINGS_PERMISSION_ID": "0xb1750e46d35a0069c8465b8643e7838d2149a842a2db8ee233d9835590040cad",
+        "UPGRADE_PLUGIN_PERMISSION_ID": "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5"
+      },
+      "fieldMeta": {
+        "multisigSettings": {
+          "severity": "HIGH",
+          "description": "Aragon multisig settings: whether proposal creation is restricted to listed members and the minimum approval threshold.",
+          "type": "RISK_PARAMETER"
+        },
+        "addresslistLength": {
+          "severity": "HIGH",
+          "description": "Number of addresses currently listed as multisig members.",
+          "type": "RISK_PARAMETER"
+        },
+        "$members": {
+          "description": "Current multisig members reconstructed from MembersAdded and MembersRemoved events."
+        },
+        "$threshold": {
+          "description": "Minimum approvals required by this multisig plugin."
+        }
+      },
+      "implementationNames": {
+        "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C": "ERC1967Proxy",
+        "eth:0x517BD0E1fbE9dDf828fD139b19CF9F434Da94371": "Multisig"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "VotingEscrowMemberCondition",
+      "address": "eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76",
+      "type": "Contract",
+      "template": "interfold/ListedCheckCondition",
+      "sourceHashes": [
+        "0x3ce47497decc268ba14803a8a7bb936775fb9100ee19ab8efcc0aec0bcb0ac73"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable Aragon condition on the voting-escrow multisig's public proposal grant. When the multisig is configured as only-listed, it restricts proposal creators to current listed members. The associated Multisig address is embedded immutably in bytecode.",
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": { "$immutable": true, "protocolVersion": [1, 4, 0] },
+      "implementationNames": {
+        "eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76": "ListedCheckCondition"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0xE171DC4dfb6445f847e13EFCc2536Bf62b9c51FA",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "FOLD",
+      "address": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+      "type": "Contract",
+      "template": "interfold/InterfoldToken",
+      "sourceHashes": [
+        "0x88be41d416945518f0140f4523687bcd81d2328e011b415781ae47ae97051d82"
+      ],
+      "proxyType": "immutable",
+      "description": "Fixed-cap FOLD governance and ciphernode-bond token. Minting and pre-TGE transfer controls are disabled after the one-way TGE transition, while lock-policy administration can continue until the immutable lock cutoff.",
+      "ignoreInWatchMode": ["clock"],
+      "deployerAddress": "eth:0x0B84D82d10915Da42812e86A9ba33e80ac08c8CB",
+      "sinceTimestamp": 1783340363,
+      "sinceBlock": 25473449,
+      "values": {
+        "$immutable": true,
+        "accessControl": {
+          "DEFAULT_ADMIN_ROLE": {
+            "adminRole": "DEFAULT_ADMIN_ROLE",
+            "members": ["eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018"]
+          },
+          "MINTER_ROLE": {
+            "adminRole": "DEFAULT_ADMIN_ROLE",
+            "members": ["eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018"]
+          },
+          "WHITELIST_ROLE": {
+            "adminRole": "DEFAULT_ADMIN_ROLE",
+            "members": ["eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018"]
+          },
+          "LOCK_MANAGER_ROLE": {
+            "adminRole": "DEFAULT_ADMIN_ROLE",
+            "members": ["eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018"]
+          }
+        },
+        "BONDING_REGISTRY": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+        "CCA_END": 1783692000,
+        "CCA_START": 1783346400,
+        "CLAIM_SOURCE": "eth:0x687Cc38d8279dF3352b64cF3EC1fe8e033933595",
+        "clock": 1787653811,
+        "CLOCK_MODE": "mode=timestamp",
+        "decimals": 18,
+        "DEFAULT_ADMIN_ROLE": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "defaultAdmins": ["eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018"],
+        "DOMAIN_SEPARATOR": "0xb2fd681590966e62e8e5f46220e4414c3c4d2794202139026f905e76e93f1ef6",
+        "eip712Domain": {
+          "fields": "0x0f",
+          "name": "Interfold",
+          "version": "1",
+          "chainId": 1,
+          "verifyingContract": "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904",
+          "salt": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "extensions": []
+        },
+        "LOCK_MANAGER_ROLE": "0xedd99e294ddd0fe3e3a4a63edd3ba9feb6b0849e8d729617cb3d61a0d439b32a",
+        "lockManagers": ["eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018"],
+        "MAX_LOCKS_PER_ACCOUNT": 8,
+        "MAX_QUEUED_LOCKS_PER_ACCOUNT": 8,
+        "MAX_SUPPLY": "1200000000000000000000000000",
+        "MINTER_ROLE": "0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6",
+        "name": "Interfold",
+        "NO_MORE_LOCKS": 1915884000,
+        "owner": "eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018",
+        "PENDING_LOCK_POLICY_ID": "0x50454e44494e4700000000000000000000000000000000000000000000000000",
+        "pendingOwner": "eth:0x0000000000000000000000000000000000000000",
+        "phase": 3,
+        "symbol": "FOLD",
+        "TGE_COOLDOWN": 3456000,
+        "tgeTimestamp": 1787148023,
+        "totalSupply": "1200000000000000000000000000",
+        "WHITELIST_ROLE": "0xdc72ed553f2544c34465af23b847953efeb813428162d767f9ba5f4013be6760"
+      },
+      "fieldMeta": {
+        "accessControl": {
+          "description": "Current role administrators and members. Some launch roles retain membership even where their pre-TGE functions now revert."
+        },
+        "defaultAdmins": {
+          "description": "Members of DEFAULT_ADMIN_ROLE. Admin minting is disabled after TGE, but this role can grant and revoke the remaining roles.",
+          "type": "PERMISSION"
+        },
+        "lockManagers": {
+          "description": "Members of LOCK_MANAGER_ROLE.",
+          "type": "PERMISSION"
+        },
+        "owner": {
+          "description": "Ownable controller. The one-time claim-source setter has already been consumed; the remaining live owner action is ownership transfer."
+        },
+        "phase": {
+          "description": "Token lifecycle phase. Phase 3 is the irreversible live phase in which unrestricted transfers are enabled and minting is closed.",
+          "type": "RISK_PARAMETER"
+        },
+        "CLAIM_SOURCE": {
+          "description": "One-time auction claim source. The completed auction and its dependencies are outside the live Interfold protocol perimeter."
+        },
+        "BONDING_REGISTRY": {
+          "description": "Immutable registry in which bonded FOLD remains included in governance voting power."
+        },
+        "MAX_SUPPLY": { "description": "Immutable maximum FOLD supply." },
+        "NO_MORE_LOCKS": {
+          "description": "Immutable timestamp after which no new token locks can be created or linked."
+        }
+      },
+      "implementationNames": {
+        "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904": "InterfoldToken"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "DkgFoldAttestationVerifier",
+      "address": "eth:0xE5657c0756B772B600D6c73eDbF046f32129c770",
+      "type": "Contract",
+      "template": "interfold/DkgFoldAttestationVerifier",
+      "sourceHashes": [
+        "0x67747087afb0bc510c37bab97808da631f8ed0c3dc65f3f8356e098865077952"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable verifier for EIP-712 attestations that bind selected ciphernode operator keys to the party commitments folded into an E3 distributed-key-generation proof.",
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109347,
+      "sinceBlock": 25786402,
+      "values": { "$immutable": true },
+      "implementationNames": {
+        "eth:0xE5657c0756B772B600D6c73eDbF046f32129c770": "DkgFoldAttestationVerifier"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "address": "eth:0xEaD7F072eEC0b166b65C27329E8FeDE89E5a45f9",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "name": "VotingPowerCurve",
+      "address": "eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9",
+      "type": "Contract",
+      "template": "interfold/VotingPowerCurve",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0x126b3fdbc9562d64b152d03a44f6a560539bbb3c9c35e4f58d91692a00d378e6"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable curve that converts veFOLD lock amount and duration into voting power.",
+      "ignoreInWatchMode": ["globalPointLatestIndex"],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x59417A78C133a6Fddf8a3b5e751378aF8d42e249",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0x59417A78C133a6Fddf8a3b5e751378aF8d42e249"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "clock": "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166",
+        "CURVE_ADMIN_ROLE": "0x065385aea91ea94bccc193b44dcdc1da3bcab7e7328692e0b12cda00df64eac4",
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "escrow": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+        "globalPointLatestIndex": 2,
+        "implementation": "eth:0x59417A78C133a6Fddf8a3b5e751378aF8d42e249",
+        "maxTime": 62899200,
+        "warmupPeriod": 0
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose Curve admin role controls configuration and upgrades."
+        },
+        "escrow": {
+          "description": "VotingEscrow whose lock history is transformed into voting power."
+        },
+        "clock": { "description": "Epoch clock used by curve calculations." },
+        "maxTime": {
+          "description": "Maximum lock duration considered by the voting-power curve.",
+          "type": "RISK_PARAMETER"
+        },
+        "warmupPeriod": {
+          "description": "Warm-up period before newly locked FOLD reaches voting power.",
+          "type": "RISK_PARAMETER"
+        }
+      },
+      "implementationNames": {
+        "eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9": "ERC1967Proxy",
+        "eth:0x59417A78C133a6Fddf8a3b5e751378aF8d42e249": "LinearIncreasingCurve"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "BfvDecryptionVerifier",
+      "address": "eth:0xf143b969ea481Ccf251194D15F82007C67AABc53",
+      "type": "Contract",
+      "template": "interfold/BfvDecryptionVerifier",
+      "sourceHashes": [
+        "0xf0eb04078f1d26488697d2fc81ac7d419765e655d6b38d23b5f8cab946146bee"
+      ],
+      "proxyType": "immutable",
+      "description": "Immutable threshold-decryption proof wrapper. It checks the generated circuit proof and binds its parties and public-key context to the committee recorded by CiphernodeRegistry.",
+      "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
+      "sinceTimestamp": 1787109323,
+      "sinceBlock": 25786400,
+      "values": {
+        "$immutable": true,
+        "ciphernodeRegistry": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+        "circuitVerifier": "eth:0x53Fc34b412E16A1aE05A86934b821F82ca2a10da",
+        "expectedC6FoldKeyHash": "0x0735d58c9896306041928fcb73cd2faeef2a225c22cdcac38d802de73fae0eff",
+        "expectedC7KeyHash": "0x1739d924e1b79deab6c8ab6f90b56b0676891aedb26fd3fddd21e54c0ac32fc7",
+        "threshold": 1
+      },
+      "fieldMeta": {
+        "circuitVerifier": {
+          "description": "Generated onchain verifier for the BFV threshold-decryption proof.",
+          "type": "CODE_CHANGE"
+        },
+        "ciphernodeRegistry": {
+          "description": "Immutable committee and public-key source against which decryption proofs are checked."
+        },
+        "threshold": {
+          "description": "Immutable number of decryption shares required by this proof circuit.",
+          "type": "RISK_PARAMETER"
+        },
+        "expectedC6FoldKeyHash": {
+          "description": "Immutable hash binding the accepted C6-fold verification key.",
+          "type": "CODE_CHANGE"
+        },
+        "expectedC7KeyHash": {
+          "description": "Immutable hash binding the accepted C7 verification key.",
+          "type": "CODE_CHANGE"
+        }
+      },
+      "implementationNames": {
+        "eth:0xf143b969ea481Ccf251194D15F82007C67AABc53": "BfvDecryptionVerifier"
+      },
+      "category": { "name": "Local Infrastructure", "priority": 5 }
+    },
+    {
+      "name": "ProxyAdmin",
+      "address": "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b",
+      "type": "Contract",
+      "template": "global/ProxyAdmin",
+      "sourceHashes": [
+        "0x8fd8f837bb320bd2a7463c103bea2ff207b0969b5795f320a6c868858aa92074"
+      ],
+      "proxyType": "immutable",
+      "directlyReceivedPermissions": [
+        {
+          "permission": "upgrade",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "role": "admin"
+        }
+      ],
+      "deployerAddress": "eth:0x0B84D82d10915Da42812e86A9ba33e80ac08c8CB",
+      "sinceTimestamp": 1783339751,
+      "sinceBlock": 25473398,
+      "values": {
+        "$immutable": true,
+        "owner": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "UPGRADE_INTERFACE_VERSION": "5.0.0"
+      },
+      "implementationNames": {
+        "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b": "ProxyAdmin"
+      }
+    },
+    {
+      "name": "AdminPlugin",
+      "address": "eth:0xF21e25455988887EE797050080141eba67B33920",
+      "type": "Contract",
+      "template": "interfold/AdminPlugin",
+      "sourceHashes": [
+        "0x7204d3a9ce1568e5894d5e7b486018ae887e15c72dfa66f72b9192ce39e2b528",
+        "0x7204d3a9ce1568e5894d5e7b486018ae887e15c72dfa66f72b9192ce39e2b528"
+      ],
+      "proxyType": "EIP1167 proxy",
+      "description": "Non-upgradeable Aragon Admin plugin. Holders of its DAO-granted EXECUTE_PROPOSAL permission can submit actions that the plugin forwards immediately, without a vote or onchain delay.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "description": "replace collateral assets and protocol dependencies; change bond, ticket, eligibility and exit parameters; authorize slashing managers and reward distributors; clear bans from old managers; withdraw slashed funds; and replace the slashed-funds treasury.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "description": "change the work-allocation split, coordinator and treasury without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "description": "pause or unpause new requests; replace the registry, bonding, slashing and refund dependencies; allow fee assets and E3 programs; replace proof verifiers; and change pricing, timeouts, parameter sets and committee thresholds without an onchain delay.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins"
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change support, participation, duration, proposer-power and minimum-approval requirements for future votes.",
+          "role": ".tokenVotingSettingsManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "grant and revoke permissions in the DAO.",
+          "role": ".daoRootHolders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect calls made by the Admin plugin to another executor or target.",
+          "role": ".adminTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed proposal actions to another executor or target.",
+          "role": ".sppTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "redirect passed vote actions to another executor or target.",
+          "role": ".tokenVotingTargetManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the address trusted to append the effective caller to proposal transactions.",
+          "role": ".sppTrustedForwarderManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the rules that gate public creation of staged proposals.",
+          "role": ".conditionRuleManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "replace the stages, bodies, thresholds and timing rules for future public proposals.",
+          "role": ".sppStageManagers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x847A22303639017bcDB7F7E49EEa4a4629c1169f",
+          "description": "set the eligible-voter Merkle root once per requester-census E3 and replace the application RISC Zero verifier or guest image ID immediately. Such replacement cannot change the verifier snapshotted by Interfold, but can make an in-flight round fail.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "create or disable slash policies, grant or revoke evidence slashers, resolve appeals, close E3 assignments and propose, confirm or remove operator bans.",
+          "role": ".governanceMembers",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
+          "description": "replace the coordinator, bonding registry, ciphernode registry and refund manager, and grant or revoke governance membership. A transfer of the default-admin role itself has the configured delay.",
+          "role": ".defaultAdmins",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change cooldowns and exit fees and upgrade the voting-escrow exit queue.",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin settings.",
+          "role": ".multisigSettingsAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change transfer whitelist settings and upgrade the voting-lock NFT.",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting epochs and upgrade the voting-escrow Clock.",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "change voting-power curve parameters and upgrade the Curve implementation.",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "complete queued voting-escrow withdrawals.",
+          "role": ".exitQueueWithdrawers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "grant and revoke permissions in the voting-escrow DAO.",
+          "role": ".veDaoRootHolders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "manage gauge metadata and the voting-power update hook.",
+          "role": ".gaugeAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause and unpause voting-escrow operations.",
+          "role": ".votingEscrowPausers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "pause the escrow voting-power adapter, manage delegation settings and upgrade its implementation.",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "replace voting-power dependencies, change minimum deposits and split rules, and upgrade VotingEscrow.",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "sweep unaccounted tokens and NFTs from VotingEscrow.",
+          "role": ".votingEscrowSweepers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "description": "update delegated voting power through the escrow voting adapter.",
+          "role": ".delegationTokenManagers",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D",
+          "description": "schedule and activate a registry replacement after one day when all ticket liabilities are zero, and rescue ERC-20s other than the underlying sUSDS.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "interact",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "description": "replace the coordinator, bonding and slashing dependencies; add or remove ciphernodes; change the sortition window; and update the DKG verifier and accusation-vote validity parameters. DKG-verifier replacement and risk-reducing accusation-window changes use a two-day propose/commit delay, while other changes are immediate.",
+          "role": ".owner",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "role": ".daoUpgraders",
+          "via": [
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".clockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".curveAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".exitQueueAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".gaugeUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".lockAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".veDaoUpgraders",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votesAdapterAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+          "role": ".votingEscrowAdmins",
+          "via": [
+            { "address": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        },
+        {
+          "permission": "upgrade",
+          "from": "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7",
+          "role": "admin",
+          "via": [
+            { "address": "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7" },
+            { "address": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e" }
+          ]
+        }
+      ],
+      "directlyReceivedPermissions": [
+        {
+          "permission": "act",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "execute arbitrary calls from the DAO, including calls to protocol owners and ProxyAdmins.",
+          "role": ".daoExecutors"
+        }
+      ],
+      "deployerAddress": "eth:0x0B84D82d10915Da42812e86A9ba33e80ac08c8CB",
+      "sinceTimestamp": 1786931579,
+      "sinceBlock": 25771635,
+      "values": {
+        "$implementation": "eth:0xdB3c40bb17e9AD1f51178AF5A66eF32d19176A1c",
+        "customProposalParamsABI": "(uint256 allowFailureMap)",
+        "dao": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "EXECUTE_PROPOSAL_PERMISSION_ID": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+        "getCurrentTargetConfig": {
+          "target": "eth:0x0000000000000000000000000000000000000000",
+          "operation": 0
+        },
+        "getTargetConfig": {
+          "target": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "operation": 0
+        },
+        "pluginType": 1,
+        "protocolVersion": [1, 4, 0],
+        "SET_TARGET_CONFIG_PERMISSION_ID": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7"
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose permission manager authorizes the plugin and its callers."
+        },
+        "getCurrentTargetConfig": {
+          "description": "Stored execution target and operation. A zero target resolves to the DAO; delegatecall changes the security context.",
+          "type": "CODE_CHANGE"
+        }
+      },
+      "implementationNames": {
+        "eth:0xF21e25455988887EE797050080141eba67B33920": "Admin",
+        "eth:0xdB3c40bb17e9AD1f51178AF5A66eF32d19176A1c": "Admin"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "VotingEscrowLockNFT",
+      "address": "eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E",
+      "type": "Contract",
+      "template": "interfold/VotingEscrowLockNFT",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0x424f4df711b03adc7fa8ac4d99ece4e185fec69f61ab6beac1b7047c52275678"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable ERC-721 whose tokens represent individual veFOLD lock positions.",
+      "ignoreInWatchMode": ["totalSupply"],
+      "deployerAddress": "eth:0xe78baC4Ca761A57DD876cf6e24b52275F4cA7A41",
+      "sinceTimestamp": 1787028983,
+      "sinceBlock": 25779726,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0x5F8a4394415a7630e715B8eb6F84b73c6172881a",
+        "$pastUpgrades": [
+          [
+            "2026-08-18T04:56:23.000Z",
+            "0xd83f0141bd15b5bdc5c5c531218d3bbe1523ae0c80ea16e3d493259017e17e6e",
+            ["eth:0x5F8a4394415a7630e715B8eb6F84b73c6172881a"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "dao": "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B",
+        "escrow": "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12",
+        "implementation": "eth:0x5F8a4394415a7630e715B8eb6F84b73c6172881a",
+        "LOCK_ADMIN_ROLE": "0x54e26bc44f032b9c63f050973076cd279ea75ee2dceeaee6367075804fd03838",
+        "name": "Vote Escrow FOLD",
+        "symbol": "veFOLD",
+        "totalSupply": 2,
+        "WHITELIST_ANY_ADDRESS": "eth:0x95A53aa925FDd6f1733830EbB7A586B33CbD4355"
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose Lock admin role controls whitelist configuration and upgrades."
+        },
+        "escrow": {
+          "description": "VotingEscrow exclusively responsible for minting and burning lock positions."
+        },
+        "WHITELIST_ANY_ADDRESS": {
+          "description": "Sentinel used by the transfer whitelist."
+        }
+      },
+      "implementationNames": {
+        "eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E": "ERC1967Proxy",
+        "eth:0x5F8a4394415a7630e715B8eb6F84b73c6172881a": "LockV1_2_0"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "name": "PublicTokenVoting",
+      "address": "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC",
+      "type": "Contract",
+      "template": "interfold/TokenVoting",
+      "sourceHashes": [
+        "0xe38a79e097149d54c3a08cd674ba5ffe929d1e8fc3c0c6c436ab5df7efcb1858",
+        "0x9154a89d8adf05af1d4ecc3635433d4611c6c8381ab1cd5ed06e52913ed42f89"
+      ],
+      "proxyType": "EIP1967 proxy",
+      "description": "Upgradeable Aragon majority-voting plugin used as the voting body in Interfold's public staged proposal path. Voting power comes from the immutable BondedVotes adapter.",
+      "receivedPermissions": [
+        {
+          "permission": "interact",
+          "from": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+          "description": "change multisig plugin target execution configuration.",
+          "role": ".multisigTargetConfigAdmins"
+        }
+      ],
+      "deployerAddress": "eth:0x732D5F9155A524C29fe7b17a45C794C4F48abb9e",
+      "sinceTimestamp": 1787251955,
+      "sinceBlock": 25798247,
+      "values": {
+        "$admin": "eth:0x0000000000000000000000000000000000000000",
+        "$implementation": "eth:0xbbc277951D93e866700471f71616b2c9D304E6F6",
+        "$pastUpgrades": [
+          [
+            "2026-08-20T18:52:35.000Z",
+            "0x799bb6c90febb29f8252b94d12ae0e5aa3c13e1b9928c7a359b693c8dc335724",
+            ["eth:0xbbc277951D93e866700471f71616b2c9D304E6F6"]
+          ]
+        ],
+        "$upgradeCount": 1,
+        "CREATE_PROPOSAL_PERMISSION_ID": "0x8c433a4cd6b51969eca37f974940894297b9fcf4b282a213fea5cd8f85289c90",
+        "customProposalParamsABI": "(uint256 allowFailureMap, uint8 voteOption, bool tryEarlyExecution)",
+        "dao": "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e",
+        "EXECUTE_PROPOSAL_PERMISSION_ID": "0xf281525e53675515a6ba7cc7bea8a81e649b3608423ee2d73be1752cea887889",
+        "getCurrentTargetConfig": {
+          "target": "eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4",
+          "operation": 1
+        },
+        "getMetadata": "0x697066733a2f2f516d534d35475734764e5378356b7a3139593342313776375a43453661743369426a457654334d6367674b466957",
+        "getTargetConfig": {
+          "target": "eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4",
+          "operation": 1
+        },
+        "getVotingToken": "eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E",
+        "implementation": "eth:0xbbc277951D93e866700471f71616b2c9D304E6F6",
+        "minApproval": 0,
+        "minDuration": 432000,
+        "minParticipation": 20000,
+        "minProposerVotingPower": "12000000000000000000000",
+        "pluginType": 0,
+        "protocolVersion": [1, 4, 0],
+        "SET_METADATA_PERMISSION_ID": "0x4707e94b25cfce1a7c363508fbb838c35864388ad77284b248282b9746982b9b",
+        "SET_TARGET_CONFIG_PERMISSION_ID": "0x568cc693d84eb1901f8bcecba154cbdef23ca3cf67efc0a0b698528a06c660f7",
+        "supportThreshold": 500000,
+        "tokenIndexedByTimestamp": true,
+        "UPDATE_VOTING_SETTINGS_PERMISSION_ID": "0xbba35d41610b7d25c8e486006535c76bd423091563e694d206ae3d71ce949fe5",
+        "UPGRADE_PLUGIN_PERMISSION_ID": "0x821b6e3a557148015a918c89e5d092e878a69854a2d1a410635f771bd5a8a3f5",
+        "votingMode": 2
+      },
+      "fieldMeta": {
+        "dao": {
+          "description": "Aragon DAO whose permission manager controls voting settings, targets and upgrades."
+        },
+        "getVotingToken": {
+          "description": "Immutable IVotes source used for proposal snapshots and vote weights."
+        },
+        "votingMode": {
+          "description": "Early-execution mode applied to newly created votes.",
+          "type": "RISK_PARAMETER"
+        },
+        "supportThreshold": {
+          "description": "Required yes-vote ratio over yes plus no votes, using Aragon's 10^6 ratio base.",
+          "type": "RISK_PARAMETER"
+        },
+        "minParticipation": {
+          "description": "Minimum participating voting power relative to the snapshotted total supply, using Aragon's 10^6 ratio base.",
+          "type": "RISK_PARAMETER"
+        },
+        "minDuration": {
+          "description": "Minimum voting duration in seconds.",
+          "type": "RISK_PARAMETER"
+        },
+        "minProposerVotingPower": {
+          "description": "Minimum voting power the creator must hold at the proposal snapshot.",
+          "type": "RISK_PARAMETER"
+        },
+        "minApproval": {
+          "description": "Absolute minimum yes-vote requirement for a proposal to succeed.",
+          "type": "RISK_PARAMETER"
+        },
+        "tokenIndexedByTimestamp": {
+          "description": "Whether proposal snapshots use timestamp-based rather than block-number-based voting checkpoints.",
+          "type": "RISK_PARAMETER"
+        },
+        "getCurrentTargetConfig": {
+          "description": "Stored execution target and call operation for successful voting proposals.",
+          "type": "CODE_CHANGE"
+        }
+      },
+      "implementationNames": {
+        "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC": "ERC1967Proxy",
+        "eth:0xbbc277951D93e866700471f71616b2c9D304E6F6": "TokenVoting"
+      },
+      "category": { "name": "Governance", "priority": 3 }
+    },
+    {
+      "address": "eth:0xFeb99E2C46b9A5fDA836e6d4374A59fc61a5E221",
+      "type": "EOA",
+      "proxyType": "EOA"
+    },
+    {
+      "address": "eth:0xFfE6D9d29480D0673C4FC46da22D21E245C8E731",
+      "type": "EOA",
+      "proxyType": "EOA"
+    }
+  ],
+  "abis": {
+    "eth:0x028deEA644258c78b1B5B2eacF469F5D781Fb43E": [
+      "constructor(address _token, address _votesSource, address _checkpoints)",
+      "error ClockMismatch(uint48 tokenClock, uint48 checkpointsClock)",
+      "error DelegationNotSupported()",
+      "error LockedBalancesUnsupported(address votingToken)",
+      "error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value)",
+      "error TokenMismatch(address ciphernodeBondToken, address votingToken)",
+      "error VotesExpiredSignature(uint256 expiry)",
+      "error VotesSourceMismatch(address escrowToken, address votingToken)",
+      "error ZeroAddress()",
+      "event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate)",
+      "event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes)",
+      "function CLOCK_MODE() view returns (string)",
+      "function balanceOf(address account) view returns (uint256)",
+      "function checkpoints() view returns (address)",
+      "function clock() view returns (uint48)",
+      "function decimals() view returns (uint8)",
+      "function delegate(address) pure",
+      "function delegateBySig(address, uint256, uint256, uint8, bytes32, bytes32) pure",
+      "function delegates(address account) view returns (address)",
+      "function escrow() view returns (address)",
+      "function getPastTotalSupply(uint256 timepoint) view returns (uint256)",
+      "function getPastVotes(address account, uint256 timepoint) view returns (uint256)",
+      "function getVotes(address account) view returns (uint256)",
+      "function name() view returns (string)",
+      "function registry() view returns (address)",
+      "function symbol() view returns (string)",
+      "function token() view returns (address)",
+      "function totalSupply() view returns (uint256)",
+      "function votesSource() view returns (address)"
+    ],
+    "eth:0x037c00ba58D4d2A4870017aeaD7f79A0D23A294f": [
+      "constructor()",
+      "error AlreadyQueued()",
+      "error CannotCancelExit()",
+      "error CannotExit()",
+      "error CooldownTooShort()",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error EarlyExitDisabled()",
+      "error FeePercentTooHigh(uint256 maxAllowed)",
+      "error InvalidFeeParameters()",
+      "error LegacyFunctionDeprecated()",
+      "error MinCooldownNotMet()",
+      "error MinLockNotReached(uint256 tokenId, uint48 minLock, uint48 earliestExitDate)",
+      "error MinLockOutOfBounds()",
+      "error NoLockBalance()",
+      "error OnlyEscrow()",
+      "error ZeroAddress()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Exit(uint256 indexed tokenId, uint256 fee)",
+      "event ExitCancelled(uint256 indexed tokenId, address indexed holder)",
+      "event ExitFeePercentAdjusted(uint256 maxFeePercent, uint256 minFeePercent, uint48 minCooldown, uint8 feeType)",
+      "event ExitQueued(uint256 indexed tokenId, address indexed holder, uint256 exitDate)",
+      "event ExitQueuedV2(uint256 indexed tokenId, address indexed holder, uint48 queuedAt)",
+      "event Initialized(uint8 version)",
+      "event MinLockSet(uint48 minLock)",
+      "event Upgraded(address indexed implementation)",
+      "function QUEUE_ADMIN_ROLE() view returns (bytes32)",
+      "function WITHDRAW_ROLE() view returns (bytes32)",
+      "function calculateFee(uint256 _tokenId) view returns (uint256)",
+      "function canExit(uint256 _tokenId) view returns (bool)",
+      "function cancelExit(uint256 _tokenId)",
+      "function clock() view returns (address)",
+      "function cooldown() view returns (uint48)",
+      "function dao() view returns (address)",
+      "function escrow() view returns (address)",
+      "function exit(uint256 _tokenId) returns (uint256 fee)",
+      "function feePercent() view returns (uint256)",
+      "function getTimeBasedFee(uint256 timeElapsed) view returns (uint256)",
+      "function implementation() view returns (address)",
+      "function initialize(address _escrow, uint48 _cooldown, address _dao, uint256 _feePercent, address _clock, uint48 _minLock)",
+      "function isCool(uint256 _tokenId) view returns (bool)",
+      "function minCooldown() view returns (uint48)",
+      "function minFeePercent() view returns (uint256)",
+      "function minLock() view returns (uint48)",
+      "function proxiableUUID() view returns (bytes32)",
+      "function queue(uint256 _tokenId) view returns (tuple(address holder, uint48 queuedAt, uint48 minCooldown, uint48 cooldown, uint16 feePercent, uint16 minFeePercent, uint256 slope))",
+      "function queueExit(uint256 _tokenId, address _ticketHolder)",
+      "function setDynamicExitFeePercent(uint256 _minFeePercent, uint256 _maxFeePercent, uint48 _cooldown, uint48 _minCooldown)",
+      "function setFixedExitFeePercent(uint256 _feePercent, uint48 _minCooldown)",
+      "function setMinLock(uint48 _minLock)",
+      "function setTieredExitFeePercent(uint256 _baseFeePercent, uint256 _earlyFeePercent, uint48 _cooldown, uint48 _minCooldown)",
+      "function ticketHolder(uint256 _tokenId) view returns (address)",
+      "function timeToMinLock(uint256 _tokenId) view returns (uint48)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable",
+      "function withdraw(uint256 _amount)"
+    ],
+    "eth:0x0A32454FC578e3CAFeE86F6E03f267b25ad0bAf0": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x0ec90465095C21830BEcED07e032809A2Bd2915F": [
+      "constructor(address _logic, address initialOwner, bytes _data) payable",
+      "error AddressEmptyCode(address target)",
+      "error ERC1967InvalidAdmin(address admin)",
+      "error ERC1967InvalidImplementation(address implementation)",
+      "error ERC1967NonPayable()",
+      "error FailedCall()",
+      "error ProxyDeniedAdminAccess()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x1940eF168f4E0B3dA24BEca539856684793B0F6e": [
+      "constructor(address _logic, address initialOwner, bytes _data) payable",
+      "error AddressEmptyCode(address target)",
+      "error ERC1967InvalidAdmin(address admin)",
+      "error ERC1967InvalidImplementation(address implementation)",
+      "error ERC1967NonPayable()",
+      "error FailedCall()",
+      "error ProxyDeniedAdminAccess()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x201d4c1cd48F2fC1297eEa56B14A29a039164a91": [
+      "constructor()",
+      "error AddressAlreadySet()",
+      "error AlreadyVoted()",
+      "error AmountTooSmall()",
+      "error CannotExit()",
+      "error CannotMerge(uint256 _from, uint256 _to)",
+      "error CannotWithdrawInSameBlock()",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error LockNFTAlreadySet()",
+      "error MustBe18Decimals()",
+      "error NoLockFound()",
+      "error NoOwner()",
+      "error NonExistentToken()",
+      "error NotApprovedOrOwner()",
+      "error NotOwner()",
+      "error NotSameOwner()",
+      "error NotTicketHolder()",
+      "error NotVoter()",
+      "error NothingToSweep()",
+      "error OnlyIVotesAdapter()",
+      "error OnlyLockNFT()",
+      "error OwnershipChange()",
+      "error SameAddress()",
+      "error SameNFT()",
+      "error SplitAmountTooBig()",
+      "error SplitNotWhitelisted()",
+      "error TransferBalanceIncorrect()",
+      "error ZeroAddress()",
+      "error ZeroAmount()",
+      "error ZeroBalance()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Deposit(address indexed depositor, uint256 indexed tokenId, uint256 indexed startTs, uint256 value, uint256 newTotalLocked)",
+      "event Initialized(uint8 version)",
+      "event Merged(address indexed _sender, uint256 indexed _from, uint256 indexed _to, uint208 _amountFrom, uint208 _amountTo, uint208 _amountFinal)",
+      "event MinDepositSet(uint256 minDeposit)",
+      "event Paused(address account)",
+      "event Split(uint256 indexed _from, uint256 indexed newTokenId, address _sender, uint208 _splitAmount1, uint208 _splitAmount2)",
+      "event SplitWhitelistSet(address indexed account, bool status)",
+      "event Sweep(address indexed to, uint256 amount)",
+      "event SweepNFT(address indexed to, uint256 tokenId)",
+      "event Unpaused(address account)",
+      "event Upgraded(address indexed implementation)",
+      "event Withdraw(address indexed depositor, uint256 indexed tokenId, uint256 value, uint256 ts, uint256 newTotalLocked)",
+      "function ESCROW_ADMIN_ROLE() view returns (bytes32)",
+      "function PAUSER_ROLE() view returns (bytes32)",
+      "function SPLIT_WHITELIST_ANY_ADDRESS() view returns (address)",
+      "function SWEEPER_ROLE() view returns (bytes32)",
+      "function beginWithdrawal(uint256 _tokenId)",
+      "function canMerge(tuple(uint208 amount, uint48 start) _fromLocked, tuple(uint208 amount, uint48 start) _toLocked) view returns (bool)",
+      "function canSplit(address _account) view returns (bool)",
+      "function cancelWithdrawalRequest(uint256 _tokenId)",
+      "function clock() view returns (address)",
+      "function createLock(uint256 _value) returns (uint256)",
+      "function createLockFor(uint256 _value, address _to) returns (uint256)",
+      "function currentExitingAmount() view returns (uint256 total)",
+      "function curve() view returns (address)",
+      "function dao() view returns (address)",
+      "function decimals() view returns (uint8)",
+      "function enableSplit()",
+      "function implementation() view returns (address)",
+      "function initialize(address _token, address _dao, address _clock, uint256 _initialMinDeposit)",
+      "function isApprovedOrOwner(address _spender, uint256 _tokenId) view returns (bool)",
+      "function isVoting(uint256 _tokenId) view returns (bool)",
+      "function ivotesAdapter() view returns (address)",
+      "function lastLockId() view returns (uint256)",
+      "function lockNFT() view returns (address)",
+      "function locked(uint256 _tokenId) view returns (tuple(uint208 amount, uint48 start))",
+      "function merge(uint256 _from, uint256 _to)",
+      "function minDeposit() view returns (uint256)",
+      "function moveDelegateVotes(address _from, address _to, uint256 _tokenId)",
+      "function ownedTokens(address _owner) view returns (uint256[] tokenIds)",
+      "function pause()",
+      "function paused() view returns (bool)",
+      "function proxiableUUID() view returns (bytes32)",
+      "function queue() view returns (address)",
+      "function resetVotesAndBeginWithdrawal(uint256 _tokenId)",
+      "function setClock(address _clock)",
+      "function setCurve(address _curve)",
+      "function setEnableSplit(address _account, bool _isWhitelisted)",
+      "function setIVotesAdapter(address _ivotesAdapter)",
+      "function setLockNFT(address _nft)",
+      "function setMinDeposit(uint256 _minDeposit)",
+      "function setQueue(address _queue)",
+      "function setVoter(address _voter)",
+      "function split(uint256 _from, uint256 _value) returns (uint256)",
+      "function splitWhitelisted(address) view returns (bool)",
+      "function sweep()",
+      "function sweepNFT(uint256 _tokenId, address _to)",
+      "function token() view returns (address)",
+      "function totalLocked() view returns (uint256)",
+      "function totalVotingPower() view returns (uint256)",
+      "function totalVotingPowerAt(uint256 _timestamp) view returns (uint256)",
+      "function unpause()",
+      "function updateVotingPower(address _from, address _to)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable",
+      "function voter() view returns (address)",
+      "function votingPower(uint256 _tokenId) view returns (uint256)",
+      "function votingPowerAt(uint256 _tokenId, uint256 _t) view returns (uint256)",
+      "function votingPowerForAccount(address _account) view returns (uint256 accountVotingPower)",
+      "function withdraw(uint256 _tokenId)"
+    ],
+    "eth:0x28cF63B459e6218C69EA97ea7D90541cf648c715": [
+      "constructor(address _logic, address initialOwner, bytes _data) payable",
+      "error AddressEmptyCode(address target)",
+      "error ERC1967InvalidAdmin(address admin)",
+      "error ERC1967InvalidImplementation(address implementation)",
+      "error ERC1967NonPayable()",
+      "error FailedCall()",
+      "error ProxyDeniedAdminAccess()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x2DFb93A8C3cE68Be3d8129479d7870646d89aDa7": [
+      "constructor(address initialOwner)",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "function UPGRADE_INTERFACE_VERSION() view returns (string)",
+      "function owner() view returns (address)",
+      "function renounceOwnership()",
+      "function transferOwnership(address newOwner)",
+      "function upgradeAndCall(address proxy, address implementation, bytes data) payable"
+    ],
+    "eth:0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F": [
+      "constructor()",
+      "event AddedOwner(address owner)",
+      "event ApproveHash(bytes32 indexed approvedHash, address indexed owner)",
+      "event ChangedMasterCopy(address masterCopy)",
+      "event ChangedThreshold(uint256 threshold)",
+      "event DisabledModule(address module)",
+      "event EnabledModule(address module)",
+      "event ExecutionFailure(bytes32 txHash, uint256 payment)",
+      "event ExecutionFromModuleFailure(address indexed module)",
+      "event ExecutionFromModuleSuccess(address indexed module)",
+      "event ExecutionSuccess(bytes32 txHash, uint256 payment)",
+      "event RemovedOwner(address owner)",
+      "event SignMsg(bytes32 indexed msgHash)",
+      "function NAME() view returns (string)",
+      "function VERSION() view returns (string)",
+      "function addOwnerWithThreshold(address owner, uint256 _threshold)",
+      "function approveHash(bytes32 hashToApprove)",
+      "function approvedHashes(address, bytes32) view returns (uint256)",
+      "function changeMasterCopy(address _masterCopy)",
+      "function changeThreshold(uint256 _threshold)",
+      "function disableModule(address prevModule, address module)",
+      "function domainSeparator() view returns (bytes32)",
+      "function enableModule(address module)",
+      "function encodeTransactionData(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes)",
+      "function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) returns (bool success)",
+      "function execTransactionFromModule(address to, uint256 value, bytes data, uint8 operation) returns (bool success)",
+      "function execTransactionFromModuleReturnData(address to, uint256 value, bytes data, uint8 operation) returns (bool success, bytes returnData)",
+      "function getMessageHash(bytes message) view returns (bytes32)",
+      "function getModules() view returns (address[])",
+      "function getModulesPaginated(address start, uint256 pageSize) view returns (address[] array, address next)",
+      "function getOwners() view returns (address[])",
+      "function getThreshold() view returns (uint256)",
+      "function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes32)",
+      "function isOwner(address owner) view returns (bool)",
+      "function isValidSignature(bytes _data, bytes _signature) returns (bytes4)",
+      "function nonce() view returns (uint256)",
+      "function removeOwner(address prevOwner, address owner, uint256 _threshold)",
+      "function requiredTxGas(address to, uint256 value, bytes data, uint8 operation) returns (uint256)",
+      "function setFallbackHandler(address handler)",
+      "function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver)",
+      "function signMessage(bytes _data)",
+      "function signedMessages(bytes32) view returns (uint256)",
+      "function swapOwner(address prevOwner, address oldOwner, address newOwner)"
+    ],
+    "eth:0x41675C099F32341bf84BFc5382aF534df5C7461a": [
+      "constructor()",
+      "event AddedOwner(address indexed owner)",
+      "event ApproveHash(bytes32 indexed approvedHash, address indexed owner)",
+      "event ChangedFallbackHandler(address indexed handler)",
+      "event ChangedGuard(address indexed guard)",
+      "event ChangedThreshold(uint256 threshold)",
+      "event DisabledModule(address indexed module)",
+      "event EnabledModule(address indexed module)",
+      "event ExecutionFailure(bytes32 indexed txHash, uint256 payment)",
+      "event ExecutionFromModuleFailure(address indexed module)",
+      "event ExecutionFromModuleSuccess(address indexed module)",
+      "event ExecutionSuccess(bytes32 indexed txHash, uint256 payment)",
+      "event RemovedOwner(address indexed owner)",
+      "event SafeReceived(address indexed sender, uint256 value)",
+      "event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler)",
+      "event SignMsg(bytes32 indexed msgHash)",
+      "function VERSION() view returns (string)",
+      "function addOwnerWithThreshold(address owner, uint256 _threshold)",
+      "function approveHash(bytes32 hashToApprove)",
+      "function approvedHashes(address, bytes32) view returns (uint256)",
+      "function changeThreshold(uint256 _threshold)",
+      "function checkNSignatures(bytes32 dataHash, bytes data, bytes signatures, uint256 requiredSignatures) view",
+      "function checkSignatures(bytes32 dataHash, bytes data, bytes signatures) view",
+      "function disableModule(address prevModule, address module)",
+      "function domainSeparator() view returns (bytes32)",
+      "function enableModule(address module)",
+      "function encodeTransactionData(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes)",
+      "function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) payable returns (bool success)",
+      "function execTransactionFromModule(address to, uint256 value, bytes data, uint8 operation) returns (bool success)",
+      "function execTransactionFromModuleReturnData(address to, uint256 value, bytes data, uint8 operation) returns (bool success, bytes returnData)",
+      "function getChainId() view returns (uint256)",
+      "function getModulesPaginated(address start, uint256 pageSize) view returns (address[] array, address next)",
+      "function getOwners() view returns (address[])",
+      "function getStorageAt(uint256 offset, uint256 length) view returns (bytes)",
+      "function getThreshold() view returns (uint256)",
+      "function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes32)",
+      "function isModuleEnabled(address module) view returns (bool)",
+      "function isOwner(address owner) view returns (bool)",
+      "function nonce() view returns (uint256)",
+      "function removeOwner(address prevOwner, address owner, uint256 _threshold)",
+      "function setFallbackHandler(address handler)",
+      "function setGuard(address guard)",
+      "function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver)",
+      "function signedMessages(bytes32) view returns (uint256)",
+      "function simulateAndRevert(address targetContract, bytes calldataPayload)",
+      "function swapOwner(address prevOwner, address oldOwner, address newOwner)"
+    ],
+    "eth:0x41d565fcC636805E3addDa99714067cB020F09Aa": [
+      "constructor()",
+      "error AlreadyInitialized()",
+      "error AlreadyVoted(address _address)",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error DelegateCallFailed()",
+      "error DoubleVote()",
+      "error GaugeActivationUnchanged()",
+      "error GaugeDoesNotExist(address _pool)",
+      "error GaugeExists()",
+      "error GaugeInactive(address _gauge)",
+      "error InvalidTargetConfig(tuple(address target, uint8 operation) targetConfig)",
+      "error NoVotes()",
+      "error NoVotingPower()",
+      "error NotApprovedOrOwner()",
+      "error NotCurrentlyVoting()",
+      "error OnlyEscrow()",
+      "error UpdateVotingPowerHookNotEnabled()",
+      "error VotingInactive()",
+      "error ZeroGauge()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event GaugeActivated(address indexed gauge)",
+      "event GaugeCreated(address indexed gauge, address indexed creator, string metadataURI)",
+      "event GaugeDeactivated(address indexed gauge)",
+      "event GaugeMetadataUpdated(address indexed gauge, string metadataURI)",
+      "event Initialized(uint8 version)",
+      "event Paused(address account)",
+      "event Reset(address indexed voter, address indexed gauge, uint256 indexed epoch, uint256 votingPowerRemovedFromGauge, uint256 totalVotingPowerInGauge, uint256 totalVotingPowerInContract, uint256 timestamp)",
+      "event TargetSet(tuple(address target, uint8 operation) newTargetConfig)",
+      "event Unpaused(address account)",
+      "event Upgraded(address indexed implementation)",
+      "event Voted(address indexed voter, address indexed gauge, uint256 indexed epoch, uint256 votingPowerCastForGauge, uint256 totalVotingPowerInGauge, uint256 totalVotingPowerInContract, uint256 timestamp)",
+      "function GAUGE_ADMIN_ROLE() view returns (bytes32)",
+      "function SET_TARGET_CONFIG_PERMISSION_ID() view returns (bytes32)",
+      "function UPGRADE_PLUGIN_PERMISSION_ID() view returns (bytes32)",
+      "function activateGauge(address _gauge)",
+      "function clock() view returns (address)",
+      "function createGauge(address _gauge, string _metadataURI) returns (address gauge)",
+      "function currentEpochStart() view returns (uint256)",
+      "function dao() view returns (address)",
+      "function deactivateGauge(address _gauge)",
+      "function enableUpdateVotingPowerHook() view returns (bool)",
+      "function epochGaugeVotes(uint256, address) view returns (uint256)",
+      "function epochId() view returns (uint256)",
+      "function epochStart() view returns (uint256)",
+      "function epochTotalVotingPowerCast(uint256) view returns (uint256)",
+      "function epochVoteEnd() view returns (uint256)",
+      "function epochVoteStart() view returns (uint256)",
+      "function escrow() view returns (address)",
+      "function gaugeExists(address _gauge) view returns (bool)",
+      "function gaugeList(uint256) view returns (address)",
+      "function gaugeVotes(uint256 _epoch, address _address) view returns (uint256)",
+      "function gaugeVotes(address _address) view returns (uint256)",
+      "function gauges(address) view returns (bool active, uint256 created, string metadataURI)",
+      "function gaugesVotedFor(address _address) view returns (address[])",
+      "function getAllGauges() view returns (address[])",
+      "function getCurrentTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getGauge(address _gauge) view returns (tuple(bool active, uint256 created, string metadataURI))",
+      "function getTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getWriteEpochId() view returns (uint256)",
+      "function implementation() view returns (address)",
+      "function initialize(address _dao, address _escrow, bool _startPaused, address _clock, address _ivotesAdapter, bool _enableUpdateVotingPowerHook)",
+      "function isActive(address _gauge) view returns (bool)",
+      "function isVoting(address _address) view returns (bool)",
+      "function ivotesAdapter() view returns (address)",
+      "function pause()",
+      "function paused() view returns (bool)",
+      "function pluginType() pure returns (uint8)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function proxiableUUID() view returns (bytes32)",
+      "function reset()",
+      "function setEnableUpdateVotingPowerHook(bool _enableUpdateVotingPowerHook)",
+      "function setIVotesAdapter(address _ivotesAdapter)",
+      "function setTargetConfig(tuple(address target, uint8 operation) _targetConfig)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function totalVotingPowerCast() view returns (uint256)",
+      "function unpause()",
+      "function updateGaugeMetadata(address _gauge, string _metadataURI)",
+      "function updateVotingPower(address _from, address _to)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable",
+      "function usedVotingPower(address _address) view returns (uint256)",
+      "function vote(tuple(uint256 weight, address gauge)[] _votes)",
+      "function votes(address _address, address _gauge) view returns (uint256)",
+      "function votingActive() view returns (bool)"
+    ],
+    "eth:0x4976E5E47852eFCe6851d35B95A1A2E19456F3D7": [
+      "event InputPublished(uint256 indexed e3Id, address indexed publisher, bytes data)",
+      "function ENCRYPTION_SCHEME_ID() view returns (bytes32)",
+      "function publishInput(uint256 e3Id, bytes data)",
+      "function validate(uint256, uint256, bytes, bytes, bytes) pure returns (bytes32)",
+      "function verify(uint256, bytes32, bytes32, bytes) pure returns (bool success)"
+    ],
+    "eth:0x4FF6e77A10E8f06C11a4DD2A71b6AB55394640e4": [
+      "constructor()",
+      "error AlreadyRegistered()",
+      "error ArrayLengthMismatch()",
+      "error AssetConfigurationInUse(address manager, uint256 e3Assignments, uint256 openSlashLocks, uint256 pendingRoutes)",
+      "error AssetTransferMismatch(address asset, uint256 expected, uint256 actual)",
+      "error BondOwnerAlreadySet(address operator, address bondOwner)",
+      "error BondOwnerTransferViolatesLock(address bondOwner, uint256 lockedBalance, uint256 controlledBalance)",
+      "error BondingAssetDecimalsMismatch(address asset, uint8 expected, uint8 actual)",
+      "error BondingAssetDecimalsUnavailable(address asset)",
+      "error CiphernodeBanned()",
+      "error E3AssignmentNotFound(address manager, uint256 e3Id)",
+      "error E3AssignmentNotTerminal(uint256 e3Id)",
+      "error ExitDelayMustExceedSortitionWindow(uint256 exitDelay, uint256 requiredDelay)",
+      "error ExitDelayOutOfBounds(uint64 exitDelay)",
+      "error ExitInProgress()",
+      "error ExitNotReady()",
+      "error IncompatibleCiphernodeBondToken(address token)",
+      "error IncompatibleSlashingManager(address manager)",
+      "error InsufficientBalance()",
+      "error InvalidAmount()",
+      "error InvalidBondingAsset(address asset)",
+      "error InvalidConfiguration()",
+      "error InvalidInitialization()",
+      "error ManagerHasActiveBans(address manager, uint256 count)",
+      "error ManagerHasE3Assignments(address manager, uint256 count)",
+      "error ManagerHasOpenSlashLocks(address manager, uint256 count)",
+      "error ManagerHasPendingSlashRoutes(address manager, uint256 count)",
+      "error MaxAuthorizedDistributors()",
+      "error NoPendingDeregistration()",
+      "error NotBondOwner(address caller, address operator)",
+      "error NotCiphernodeBonded()",
+      "error NotInitializing()",
+      "error NotRegistered()",
+      "error OnlyRewardDistributor()",
+      "error OperatorInActiveCommittee()",
+      "error OperatorUnderSlash()",
+      "error OutstandingAssetLiabilities(address asset, uint256 amount)",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "error ReentrancyGuardReentrantCall()",
+      "error RenounceOwnershipDisabled()",
+      "error ReservedSlashedFunds()",
+      "error SafeERC20FailedOperation(address token)",
+      "error SlashLockAlreadyExists(address manager, uint256 proposalId)",
+      "error SlashLockNotFound(address manager, uint256 proposalId)",
+      "error SlashReservationAlreadyExists(address manager, uint256 proposalId)",
+      "error SlashReservationNotFound(address manager, uint256 proposalId)",
+      "error SlashRouteDestinationNotFound(address manager, uint256 e3Id)",
+      "error SlashingManagerBondingMismatch(address manager, address configuredBondingRegistry)",
+      "error TicketTokenRegistryMismatch(address configured, address expected)",
+      "error TimestampOverflow()",
+      "error TooManyTranches()",
+      "error Unauthorized()",
+      "error ZeroAddress()",
+      "error ZeroAmount()",
+      "event AssetsClaimed(address indexed operator, uint256 ticketAmount, uint256 ciphernodeBondAmount)",
+      "event AssetsQueuedForExit(address indexed operator, uint256 ticketAmount, uint256 ciphernodeBondAmount, uint64 unlockTimestamp)",
+      "event BondOwnerSet(address indexed operator, address indexed bondOwner)",
+      "event BondOwnerTransferProposed(address indexed operator, address indexed currentOwner, address indexed pendingOwner)",
+      "event BondedCheckpointsDetached(address indexed previousCheckpoints)",
+      "event BondedCheckpointsSet(address indexed checkpoints)",
+      "event BondingAssetConfigUpdated(address indexed ticketToken, address indexed ciphernodeBondToken, uint256 ticketPrice, uint256 requiredCiphernodeBond, uint8 expectedTicketDecimals, uint8 expectedCiphernodeBondDecimals, uint64 indexed configurationVersion)",
+      "event CiphernodeBondSurplusSwept(address indexed token, address indexed to, uint256 amount)",
+      "event CiphernodeBondUpdated(address indexed operator, int256 delta, uint256 newBond, bytes32 indexed reason)",
+      "event CiphernodeDeregistrationRequested(address indexed operator, uint64 unlockAt)",
+      "event CommitteeObligationUpdated(uint256 indexed e3Id, address indexed registry, address indexed operator, bool active)",
+      "event ConfigurationUpdated(bytes32 indexed parameter, uint256 oldValue, uint256 newValue)",
+      "event EligibilityConfigurationVersionUpdated(uint256 indexed version)",
+      "event Initialized(uint64 version)",
+      "event ManagerBanUpdated(address indexed slashingManager, address indexed operator, bool banned)",
+      "event OperatorActivationChanged(address indexed operator, bool active)",
+      "event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "event PendingAssetsSlashed(address indexed operator, uint256 ticketAmount, uint256 ciphernodeBondAmount, bool includedLockedAssets)",
+      "event RegistrySet(address indexed registry)",
+      "event ReservedSlashedTicketFundsRouted(address indexed slashingManager, uint256 indexed proposalId, address indexed refundManager, uint256 amount)",
+      "event RewardDistributorUpdated(address indexed distributor, bool authorized)",
+      "event SlashLockUpdated(address indexed slashingManager, uint256 indexed proposalId, address indexed operator, bool active)",
+      "event SlashRouteDestinationReleased(address indexed slashingManager, uint256 indexed e3Id)",
+      "event SlashRouteDestinationSnapshotted(address indexed slashingManager, uint256 indexed e3Id, address indexed refundManager)",
+      "event SlashedFundsTreasurySet(address indexed treasury)",
+      "event SlashedFundsWithdrawn(address indexed to, uint256 ticketAmount, uint256 ciphernodeBondAmount)",
+      "event SlashedTicketFundsReserved(address indexed slashingManager, uint256 indexed proposalId, uint256 indexed e3Id, address refundManager, uint256 amount)",
+      "event SlashingManagerAuthorizationUpdated(address indexed slashingManager, bool authorized)",
+      "event SlashingManagerUpdated(address indexed previous, address indexed next)",
+      "event TicketBalanceUpdated(address indexed operator, int256 delta, uint256 newBalance, bytes32 indexed reason)",
+      "function MAX_AUTHORIZED_DISTRIBUTORS() view returns (uint256)",
+      "function MAX_AUTHORIZED_SLASHING_MANAGERS() view returns (uint256)",
+      "function MAX_EXIT_DELAY() view returns (uint64)",
+      "function MIN_EXIT_DELAY() view returns (uint64)",
+      "function acceptBondOwner(address operator)",
+      "function acceptOwnership()",
+      "function addTicketBalanceFor(address operator, uint256 amount)",
+      "function authorizedDistributorCount() view returns (uint256)",
+      "function authorizedDistributors(address distributor) view returns (bool authorized)",
+      "function authorizedSlashingManagerAt(uint256 index) view returns (address)",
+      "function authorizedSlashingManagerCount() view returns (uint256)",
+      "function availableTickets(address operator) view returns (uint256)",
+      "function bondCiphernodeFor(address operator, uint256 amount)",
+      "function bondOwnerOf(address operator) view returns (address)",
+      "function bondedCheckpoints() view returns (address)",
+      "function bondingAssetConfigurationVersion() view returns (uint64)",
+      "function ciphernodeBondActiveBps() view returns (uint256)",
+      "function ciphernodeBondToken() view returns (address)",
+      "function claimExitsFor(address operator, uint256 maxTicketAmount, uint256 maxCiphernodeBondAmount)",
+      "function clearSlashingManagerBan(address manager, address operator)",
+      "function closeSlashLock(uint256 proposalId, address operator)",
+      "function deregisterOperatorFor(address operator)",
+      "function distributeRewards(address rewardToken, address[] recipients, uint256[] amounts)",
+      "function eligibilityAt(address operator, uint256 timepoint) view returns (bool active, uint256 activeOperatorCount)",
+      "function eligibilityConfigurationVersion() view returns (uint256)",
+      "function exitDelay() view returns (uint64)",
+      "function getCiphernodeBond(address operator) view returns (uint256)",
+      "function getCiphernodeBondToken() view returns (address)",
+      "function getSlashedTicketReservation(address manager, uint256 proposalId) view returns (uint256 e3Id, address refundManager, uint256 amount)",
+      "function getTicketBalance(address operator) view returns (uint256)",
+      "function getTicketBalanceAtBlock(address operator, uint256 timepoint) view returns (uint256)",
+      "function getTicketToken() view returns (address)",
+      "function hasExitInProgress(address operator) view returns (bool)",
+      "function initialize(address _owner, tuple(address ticketToken, address ciphernodeBondToken, uint256 ticketPrice, uint256 requiredCiphernodeBond, uint8 expectedTicketDecimals, uint8 expectedCiphernodeBondDecimals) assetConfig, address _registry, address _slashedFundsTreasury, uint256 _minTicketBalance, uint64 _exitDelay)",
+      "function isActive(address operator) view returns (bool)",
+      "function isAuthorizedSlashingManager(address candidate) view returns (bool)",
+      "function isCiphernodeBonded(address operator) view returns (bool)",
+      "function isRegistered(address operator) view returns (bool)",
+      "function minTicketBalance() view returns (uint256)",
+      "function numActiveOperators() view returns (uint256)",
+      "function numRegisteredOperators() view returns (uint256)",
+      "function openSlashLock(uint256 e3Id, uint256 proposalId, address operator)",
+      "function owner() view returns (address)",
+      "function pendingBondOwnerOf(address operator) view returns (address)",
+      "function pendingExits(address operator) view returns (uint256 ticket, uint256 ciphernodeBond)",
+      "function pendingOwner() view returns (address)",
+      "function pendingSlashRouteCount(address manager) view returns (uint256)",
+      "function previewClaimable(address operator) view returns (uint256 ticket, uint256 ciphernodeBond)",
+      "function proposeBondOwner(address operator, address newOwner)",
+      "function redirectReservedSlashedTicketFunds(uint256 proposalId)",
+      "function refreshOperatorStatus(address operator)",
+      "function refreshOperatorStatuses(address[] operatorList)",
+      "function registerOperatorFor(address operator)",
+      "function registry() view returns (address)",
+      "function releaseSlashRouteDestination(uint256 e3Id)",
+      "function removeTicketBalanceFor(address operator, uint256 amount)",
+      "function renounceOwnership() view",
+      "function requiredCiphernodeBond() view returns (uint256)",
+      "function reserveSlashedTicketFunds(uint256 proposalId, uint256 e3Id, uint256 amount)",
+      "function reservedSlashedTicketBalance() view returns (uint256)",
+      "function resyncBondedCheckpoint(address bondOwner)",
+      "function revokeRewardDistributor(address distributor)",
+      "function revokeSlashingManager(address oldSlashingManager)",
+      "function setBondOwner(address bondOwner)",
+      "function setBondedCheckpoints(address newCheckpoints)",
+      "function setBondingAssetConfig(tuple(address ticketToken, address ciphernodeBondToken, uint256 ticketPrice, uint256 requiredCiphernodeBond, uint8 expectedTicketDecimals, uint8 expectedCiphernodeBondDecimals) config)",
+      "function setCiphernodeBondActiveBps(uint256 newBps)",
+      "function setCommitteeObligation(uint256 e3Id, address operator, bool active)",
+      "function setExitDelay(uint64 newExitDelay)",
+      "function setMinTicketBalance(uint256 newMinTicketBalance)",
+      "function setOperatorBan(address operator, bool banned)",
+      "function setRegistry(address newRegistry)",
+      "function setRewardDistributor(address newRewardDistributor)",
+      "function setSlashedFundsTreasury(address newSlashedFundsTreasury)",
+      "function setSlashingManager(address newSlashingManager)",
+      "function slashCiphernodeBond(address operator, uint256 requestedSlashAmount, bytes32 slashReason) returns (uint256)",
+      "function slashTicketBalance(address operator, uint256 requestedSlashAmount, bytes32 slashReason) returns (uint256)",
+      "function slashedCiphernodeBond() view returns (uint256)",
+      "function slashedFundsTreasury() view returns (address)",
+      "function slashedTicketBalance() view returns (uint256)",
+      "function slashingManager() view returns (address)",
+      "function snapshotSlashRouteDestination(uint256 e3Id, address refundManager, address interfold)",
+      "function supportsInterface(bytes4 interfaceId) pure returns (bool)",
+      "function sweepCiphernodeBondSurplus() returns (uint256 amount)",
+      "function ticketPrice() view returns (uint256)",
+      "function ticketToken() view returns (address)",
+      "function totalBonded(address account) view returns (uint256)",
+      "function totalCiphernodeBondLiability() view returns (uint256)",
+      "function transferOwnership(address newOwner)",
+      "function unbondCiphernodeFor(address operator, uint256 amount)",
+      "function unresolvedCommitteeCount() view returns (uint256)",
+      "function withdrawSlashedFunds(uint256 ticketAmount, uint256 ciphernodeBondAmount)"
+    ],
+    "eth:0x517BD0E1fbE9dDf828fD139b19CF9F434Da94371": [
+      "error AddresslistLengthOutOfBounds(uint16 limit, uint256 actual)",
+      "error AlreadyInitialized()",
+      "error ApprovalCastForbidden(uint256 proposalId, address sender)",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error DateOutOfBounds(uint64 limit, uint64 actual)",
+      "error DelegateCallFailed()",
+      "error FunctionDeprecated()",
+      "error InvalidAddresslistUpdate(address member)",
+      "error InvalidTargetConfig(tuple(address target, uint8 operation) targetConfig)",
+      "error MinApprovalsOutOfBounds(uint16 limit, uint16 actual)",
+      "error NonexistentProposal(uint256 proposalId)",
+      "error ProposalAlreadyExists(uint256 proposalId)",
+      "error ProposalCreationForbidden(address sender)",
+      "error ProposalExecutionForbidden(uint256 proposalId)",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event Approved(uint256 indexed proposalId, address indexed approver)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Initialized(uint8 version)",
+      "event MembersAdded(address[] members)",
+      "event MembersRemoved(address[] members)",
+      "event MembershipContractAnnounced(address indexed definingContract)",
+      "event MetadataSet(bytes metadata)",
+      "event MultisigSettingsUpdated(bool onlyListed, uint16 indexed minApprovals)",
+      "event ProposalCreated(uint256 indexed proposalId, address indexed creator, uint64 startDate, uint64 endDate, bytes metadata, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap)",
+      "event ProposalExecuted(uint256 indexed proposalId)",
+      "event TargetSet(tuple(address target, uint8 operation) newTargetConfig)",
+      "event Upgraded(address indexed implementation)",
+      "function CREATE_PROPOSAL_PERMISSION_ID() view returns (bytes32)",
+      "function EXECUTE_PROPOSAL_PERMISSION_ID() view returns (bytes32)",
+      "function SET_METADATA_PERMISSION_ID() view returns (bytes32)",
+      "function SET_TARGET_CONFIG_PERMISSION_ID() view returns (bytes32)",
+      "function UPDATE_MULTISIG_SETTINGS_PERMISSION_ID() view returns (bytes32)",
+      "function UPGRADE_PLUGIN_PERMISSION_ID() view returns (bytes32)",
+      "function addAddresses(address[] _members)",
+      "function addresslistLength() view returns (uint256)",
+      "function addresslistLengthAtBlock(uint256 _blockNumber) view returns (uint256)",
+      "function approve(uint256 _proposalId, bool _tryExecution)",
+      "function canApprove(uint256 _proposalId, address _account) view returns (bool)",
+      "function canExecute(uint256 _proposalId) view returns (bool)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint64 _startDate, uint64 _endDate, bytes _data) returns (uint256 proposalId)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint256 _allowFailureMap, bool _approveProposal, bool _tryExecution, uint64 _startDate, uint64 _endDate) returns (uint256 proposalId)",
+      "function customProposalParamsABI() pure returns (string)",
+      "function dao() view returns (address)",
+      "function execute(uint256 _proposalId)",
+      "function getCurrentTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getMetadata() view returns (bytes)",
+      "function getProposal(uint256 _proposalId) view returns (bool executed, uint16 approvals, tuple(uint16 minApprovals, uint64 snapshotBlock, uint64 startDate, uint64 endDate) parameters, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap, tuple(address target, uint8 operation) targetConfig)",
+      "function getTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function hasApproved(uint256 _proposalId, address _account) view returns (bool)",
+      "function hasSucceeded(uint256 _proposalId) view returns (bool)",
+      "function implementation() view returns (address)",
+      "function initialize(address _dao, address[] _members, tuple(bool onlyListed, uint16 minApprovals) _multisigSettings, tuple(address target, uint8 operation) _targetConfig, bytes _pluginMetadata)",
+      "function initializeFrom(uint16 _fromBuild, bytes _initData)",
+      "function isListed(address _account) view returns (bool)",
+      "function isListedAtBlock(address _account, uint256 _blockNumber) view returns (bool)",
+      "function isMember(address _account) view returns (bool)",
+      "function lastMultisigSettingsChange() view returns (uint64)",
+      "function multisigSettings() view returns (bool onlyListed, uint16 minApprovals)",
+      "function pluginType() pure returns (uint8)",
+      "function proposalCount() view returns (uint256)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function proxiableUUID() view returns (bytes32)",
+      "function removeAddresses(address[] _members)",
+      "function setMetadata(bytes _metadata)",
+      "function setTargetConfig(tuple(address target, uint8 operation) _targetConfig)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function updateMultisigSettings(tuple(bool onlyListed, uint16 minApprovals) _multisigSettings)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable"
+    ],
+    "eth:0x53Fc34b412E16A1aE05A86934b821F82ca2a10da": [
+      "constructor()",
+      "error ConsistencyCheckFailed()",
+      "error GeminiChallengeInSubgroup()",
+      "error InvertOfZero()",
+      "error NotPowerOfTwo()",
+      "error PointAtInfinity()",
+      "error ProofLengthWrongWithLogN(uint256 logN, uint256 actualLength, uint256 expectedLength)",
+      "error PublicInputsLengthWrong()",
+      "error ShpleminiFailed()",
+      "error SumcheckFailed()",
+      "error ValueGeFieldOrder()",
+      "error ValueGeGroupOrder()",
+      "error ValueGeLimbMax()",
+      "error VerificationKeyConfigurationMismatch()",
+      "function verify(bytes proof, bytes32[] publicInputs) view returns (bool verified)"
+    ],
+    "eth:0x5429D8c7fD14023f3c414126F94BbE25A05fC018": [
+      "constructor(address _singleton)"
+    ],
+    "eth:0x56ce4D8006292Abf418291FaE813C1E3769240A4": [
+      "constructor()",
+      "error ActionFailed(uint256 index)",
+      "error InsufficientGas()",
+      "error ReentrantCall()",
+      "error TooManyActions()",
+      "event Executed(address indexed actor, bytes32 callId, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap, uint256 failureMap, bytes[] execResults)",
+      "function execute(bytes32 _callId, tuple(address to, uint256 value, bytes data)[] _actions, uint256 _allowFailureMap) returns (bytes[] execResults, uint256 failureMap)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)"
+    ],
+    "eth:0x58C1F7Bc62Bb63fb137bc8F6d8ea6321a0501d29": [
+      "constructor()",
+      "error ActionFailed(uint256 index)",
+      "error AlreadyInitialized()",
+      "error AnyAddressDisallowedForWhoAndWhere()",
+      "error ConditionInterfaceNotSupported(address condition)",
+      "error ConditionNotAContract(address condition)",
+      "error FunctionRemoved()",
+      "error GrantWithConditionNotSupported()",
+      "error InsufficientGas()",
+      "error NativeTokenDepositAmountMismatch(uint256 expected, uint256 actual)",
+      "error PermissionAlreadyGrantedForDifferentCondition(address where, address who, bytes32 permissionId, address currentCondition, address newCondition)",
+      "error PermissionsForAnyAddressDisallowed()",
+      "error ProtocolVersionUpgradeNotSupported(uint8[3] protocolVersion)",
+      "error ReentrantCall()",
+      "error TooManyActions()",
+      "error Unauthorized(address where, address who, bytes32 permissionId)",
+      "error UnknownCallback(bytes4 callbackSelector, bytes4 magicNumber)",
+      "error ZeroAmount()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event CallbackReceived(address sender, bytes4 indexed sig, bytes data)",
+      "event Deposited(address indexed sender, address indexed token, uint256 amount, string _reference)",
+      "event Executed(address indexed actor, bytes32 callId, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap, uint256 failureMap, bytes[] execResults)",
+      "event Granted(bytes32 indexed permissionId, address indexed here, address where, address indexed who, address condition)",
+      "event Initialized(uint8 version)",
+      "event MetadataSet(bytes metadata)",
+      "event NativeTokenDeposited(address sender, uint256 amount)",
+      "event NewURI(string daoURI)",
+      "event Revoked(bytes32 indexed permissionId, address indexed here, address where, address indexed who)",
+      "event StandardCallbackRegistered(bytes4 interfaceId, bytes4 callbackSelector, bytes4 magicNumber)",
+      "event TrustedForwarderSet(address forwarder)",
+      "event Upgraded(address indexed implementation)",
+      "function EXECUTE_PERMISSION_ID() view returns (bytes32)",
+      "function REGISTER_STANDARD_CALLBACK_PERMISSION_ID() view returns (bytes32)",
+      "function ROOT_PERMISSION_ID() view returns (bytes32)",
+      "function SET_METADATA_PERMISSION_ID() view returns (bytes32)",
+      "function SET_TRUSTED_FORWARDER_PERMISSION_ID() view returns (bytes32)",
+      "function UPGRADE_DAO_PERMISSION_ID() view returns (bytes32)",
+      "function VALIDATE_SIGNATURE_PERMISSION_ID() view returns (bytes32)",
+      "function applyMultiTargetPermissions(tuple(uint8 operation, address where, address who, address condition, bytes32 permissionId)[] _items)",
+      "function applySingleTargetPermissions(address _where, tuple(uint8 operation, address who, bytes32 permissionId)[] items)",
+      "function daoURI() view returns (string)",
+      "function deposit(address _token, uint256 _amount, string _reference) payable",
+      "function execute(bytes32 _callId, tuple(address to, uint256 value, bytes data)[] _actions, uint256 _allowFailureMap) returns (bytes[] execResults, uint256 failureMap)",
+      "function getTrustedForwarder() view returns (address)",
+      "function grant(address _where, address _who, bytes32 _permissionId)",
+      "function grantWithCondition(address _where, address _who, bytes32 _permissionId, address _condition)",
+      "function hasPermission(address _where, address _who, bytes32 _permissionId, bytes _data) view returns (bool)",
+      "function initialize(bytes _metadata, address _initialOwner, address _trustedForwarder, string daoURI_)",
+      "function initializeFrom(uint8[3] _previousProtocolVersion, bytes _initData)",
+      "function isGranted(address _where, address _who, bytes32 _permissionId, bytes _data) view returns (bool)",
+      "function isValidSignature(bytes32 _hash, bytes _signature) view returns (bytes4)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function proxiableUUID() view returns (bytes32)",
+      "function registerStandardCallback(bytes4 _interfaceId, bytes4 _callbackSelector, bytes4 _magicNumber)",
+      "function revoke(address _where, address _who, bytes32 _permissionId)",
+      "function setDaoURI(string newDaoURI)",
+      "function setMetadata(bytes _metadata)",
+      "function setSignatureValidator(address) pure",
+      "function setTrustedForwarder(address _newTrustedForwarder)",
+      "function supportsInterface(bytes4 interfaceId) view returns (bool)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable"
+    ],
+    "eth:0x59417A78C133a6Fddf8a3b5e751378aF8d42e249": [
+      "constructor(int256[3] _coefficients, uint256 _maxEpochs)",
+      "error CheckpointOnDepositIntervalNotAllowed()",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error Deprecated()",
+      "error InvalidCheckpoint()",
+      "error InvalidLocks(uint256 tokenId, tuple(uint208 amount, uint48 start) fromLocked, tuple(uint208 amount, uint48 start) newLocked)",
+      "error InvalidTokenId()",
+      "error OnlyEscrow()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Initialized(uint8 version)",
+      "event Upgraded(address indexed implementation)",
+      "function CURVE_ADMIN_ROLE() view returns (bytes32)",
+      "function _getBiasAndSlope(uint256 _timeElapsed, uint256 _amount) view returns (int256, int256)",
+      "function checkpoint(uint256 _tokenId, tuple(uint208 amount, uint48 start) _oldLocked, tuple(uint208 amount, uint48 start) _newLocked)",
+      "function clock() view returns (address)",
+      "function dao() view returns (address)",
+      "function escrow() view returns (address)",
+      "function getBias(uint256 timeElapsed, uint256 amount) view returns (uint256)",
+      "function getCoefficients(uint256 amount) view returns (int256[3])",
+      "function globalPointHistory(uint256 _index) view returns (tuple(int256 bias, int256 slope, uint48 writtenTs))",
+      "function globalPointLatestIndex() view returns (uint256)",
+      "function implementation() view returns (address)",
+      "function initialize(address _escrow, address _dao, address _clock)",
+      "function isWarm(uint256) pure returns (bool)",
+      "function isWarm(uint256, uint48) pure returns (bool)",
+      "function maxTime() view returns (uint256)",
+      "function previewMaxBias(uint256 amount) view returns (uint256)",
+      "function proxiableUUID() view returns (bytes32)",
+      "function setWarmupPeriod(uint48) pure",
+      "function slopeChanges(uint256) view returns (int256)",
+      "function supplyAt(uint256 _timestamp) view returns (uint256)",
+      "function tokenPointHistory(uint256 _tokenId, uint256 _index) view returns (tuple(uint256 bias, uint128 checkpointTs, uint128 writtenTs, int256[3] coefficients) point)",
+      "function tokenPointIntervals(uint256 _tokenId) view returns (uint256)",
+      "function tokenPointLatestIndex(uint256) view returns (uint256)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable",
+      "function votingPowerAt(uint256 _tokenId, uint256 _t) view returns (uint256)",
+      "function warmupPeriod() view returns (uint48)"
+    ],
+    "eth:0x5A7FC11397E9a8AD41BF10bf13F22B0a63f96f6d": [
+      "event LogErr(address indexed to, uint256 value, bytes data, bytes returnData)",
+      "event LogPrivilegeChanged(address indexed addr, bytes32 priv)",
+      "function execute(tuple(address to, uint256 value, bytes data)[] calls, bytes signature) payable",
+      "function executeBySelf(tuple(address to, uint256 value, bytes data)[] calls) payable",
+      "function executeBySelfSingle(tuple(address to, uint256 value, bytes data) call) payable",
+      "function executeBySender(tuple(address to, uint256 value, bytes data)[] calls) payable",
+      "function executeMultiple(tuple(tuple(address to, uint256 value, bytes data)[] calls, bytes signature)[] toExec) payable",
+      "function isValidSignature(bytes32 hash, bytes signature) view returns (bytes4)",
+      "function nonce() view returns (uint256)",
+      "function onERC1155BatchReceived(address, address, uint256[], uint256[], bytes) pure returns (bytes4)",
+      "function onERC1155Received(address, address, uint256, uint256, bytes) pure returns (bytes4)",
+      "function onERC721Received(address, address, uint256, bytes) pure returns (bytes4)",
+      "function privileges(address key) view returns (bytes32)",
+      "function setAddrPrivilege(address addr, bytes32 priv) payable",
+      "function supportsInterface(bytes4 interfaceID) pure returns (bool)",
+      "function tryCatch(address to, uint256 value, bytes data) payable",
+      "function tryCatchLimit(address to, uint256 value, bytes data, uint256 gasLimit) payable",
+      "function validateUserOp(tuple(address sender, uint256 nonce, bytes initCode, bytes callData, bytes32 accountGasLimits, uint256 preVerificationGas, bytes32 gasFees, bytes paymasterAndData, bytes signature) op, bytes32 userOpHash, uint256 missingAccountFunds) payable returns (uint256)"
+    ],
+    "eth:0x5F8a4394415a7630e715B8eb6F84b73c6172881a": [
+      "constructor()",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error ForbiddenWhitelistAddress()",
+      "error NotWhitelisted()",
+      "error OnlyEscrow()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId)",
+      "event ApprovalForAll(address indexed owner, address indexed operator, bool approved)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Initialized(uint8 version)",
+      "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
+      "event Upgraded(address indexed implementation)",
+      "event WhitelistSet(address indexed account, bool status)",
+      "function LOCK_ADMIN_ROLE() view returns (bytes32)",
+      "function WHITELIST_ANY_ADDRESS() view returns (address)",
+      "function approve(address to, uint256 tokenId)",
+      "function balanceOf(address owner) view returns (uint256)",
+      "function burn(uint256 _tokenId)",
+      "function dao() view returns (address)",
+      "function enableTransfers()",
+      "function escrow() view returns (address)",
+      "function getApproved(uint256 tokenId) view returns (address)",
+      "function implementation() view returns (address)",
+      "function initialize(address _escrow, string _name, string _symbol, address _dao)",
+      "function isApprovedForAll(address owner, address operator) view returns (bool)",
+      "function isApprovedOrOwner(address _spender, uint256 _tokenId) view returns (bool)",
+      "function mint(address _to, uint256 _tokenId)",
+      "function name() view returns (string)",
+      "function ownerOf(uint256 tokenId) view returns (address)",
+      "function proxiableUUID() view returns (bytes32)",
+      "function safeTransferFrom(address from, address to, uint256 tokenId)",
+      "function safeTransferFrom(address from, address to, uint256 tokenId, bytes data)",
+      "function setApprovalForAll(address operator, bool approved)",
+      "function setWhitelisted(address _account, bool _isWhitelisted)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function symbol() view returns (string)",
+      "function tokenByIndex(uint256 index) view returns (uint256)",
+      "function tokenOfOwnerByIndex(address owner, uint256 index) view returns (uint256)",
+      "function tokenURI(uint256 tokenId) view returns (string)",
+      "function totalSupply() view returns (uint256)",
+      "function transferFrom(address from, address to, uint256 tokenId)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable",
+      "function whitelisted(address) view returns (bool)"
+    ],
+    "eth:0x612373D7003d694220f7800EeaF8E3924c0951D3": [
+      "error AllowanceExceeded()",
+      "error CallFailed(bytes reason)",
+      "error CannotRegisterRootKey()",
+      "error CannotUpdateRootKey()",
+      "error ExcessiveInvalidation()",
+      "error FnSelectorNotRecognized()",
+      "error IncorrectSender()",
+      "error IndexOutOfBounds()",
+      "error InvalidHookResponse()",
+      "error InvalidNonce()",
+      "error InvalidSignature()",
+      "error KeyDoesNotExist()",
+      "error KeyExpired(uint40 expiration)",
+      "error NotEntryPoint()",
+      "error OnlyAdminCanSelfCall()",
+      "error SignatureExpired()",
+      "error TransferNativeFailed()",
+      "error Unauthorized()",
+      "error UnsupportedExecutionMode()",
+      "event ApproveNative(address indexed owner, address indexed spender, uint256 value)",
+      "event ApproveNativeTransient(address indexed owner, address indexed spender, uint256 value)",
+      "event EIP712DomainChanged()",
+      "event EntryPointUpdated(address indexed newEntryPoint)",
+      "event KeySettingsUpdated(bytes32 indexed keyHash, uint256 settings)",
+      "event NativeAllowanceUpdated(address indexed spender, uint256 value)",
+      "event NonceInvalidated(uint256 nonce)",
+      "event Registered(bytes32 indexed keyHash, tuple(uint8 keyType, bytes publicKey) key)",
+      "event Revoked(bytes32 indexed keyHash)",
+      "event TransferFromNative(address indexed from, address indexed to, uint256 value)",
+      "event TransferFromNativeTransient(address indexed from, address indexed to, uint256 value)",
+      "function CUSTOM_STORAGE_ROOT() view returns (bytes32)",
+      "function ENTRY_POINT() view returns (address)",
+      "function approveNative(address spender, uint256 amount) returns (bool)",
+      "function approveNativeTransient(address spender, uint256 amount) returns (bool)",
+      "function domainBytes() view returns (bytes)",
+      "function domainSeparator() view returns (bytes32)",
+      "function eip712Domain() view returns (bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)",
+      "function execute(tuple(tuple(address to, uint256 value, bytes data)[] calls, bool revertOnFailure) batchedCall) payable",
+      "function execute(tuple(tuple(tuple(address to, uint256 value, bytes data)[] calls, bool revertOnFailure) batchedCall, uint256 nonce, bytes32 keyHash, address executor, uint256 deadline) signedBatchedCall, bytes wrappedSignature) payable",
+      "function execute(bytes32 mode, bytes executionData) payable",
+      "function executeUserOp(tuple(address sender, uint256 nonce, bytes initCode, bytes callData, bytes32 accountGasLimits, uint256 preVerificationGas, bytes32 gasFees, bytes paymasterAndData, bytes signature) userOp, bytes32)",
+      "function getKey(bytes32 keyHash) view returns (tuple(uint8 keyType, bytes publicKey))",
+      "function getKeySettings(bytes32 keyHash) view returns (uint256)",
+      "function getSeq(uint256 key) view returns (uint256 seq)",
+      "function hashTypedData(bytes32 hash) view returns (bytes32)",
+      "function invalidateNonce(uint256 newNonce)",
+      "function isRegistered(bytes32 keyHash) view returns (bool)",
+      "function isValidSignature(bytes32 digest, bytes wrappedSignature) view returns (bytes4)",
+      "function keyAt(uint256 i) view returns (tuple(uint8 keyType, bytes publicKey))",
+      "function keyCount() view returns (uint256)",
+      "function keyHashes() view returns (uint256 _spacer)",
+      "function multicall(bytes[] data) payable returns (bytes[] results)",
+      "function namespaceAndVersion() pure returns (string)",
+      "function nativeAllowance(address spender) view returns (uint256 allowance)",
+      "function nonceSequenceNumber(uint256 key) view returns (uint256 seq)",
+      "function register(tuple(uint8 keyType, bytes publicKey) key)",
+      "function revoke(bytes32 keyHash)",
+      "function supportsExecutionMode(bytes32 mode) pure returns (bool result)",
+      "function transferFromNative(address from, address recipient, uint256 amount) returns (bool)",
+      "function transferFromNativeTransient(address from, address recipient, uint256 amount) returns (bool)",
+      "function transientNativeAllowance(address spender) view returns (uint256)",
+      "function update(bytes32 keyHash, uint256 settings)",
+      "function updateEntryPoint(address entryPoint)",
+      "function updateSalt(uint96 prefix)",
+      "function validateUserOp(tuple(address sender, uint256 nonce, bytes initCode, bytes callData, bytes32 accountGasLimits, uint256 preVerificationGas, bytes32 gasFees, bytes paymasterAndData, bytes signature) userOp, bytes32 userOpHash, uint256 missingAccountFunds) returns (uint256 validationData)"
+    ],
+    "eth:0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B": [
+      "constructor(address _delegationManager, address _entryPoint)",
+      "error ECDSAInvalidSignature()",
+      "error ECDSAInvalidSignatureLength(uint256 length)",
+      "error ECDSAInvalidSignatureS(bytes32 s)",
+      "error ExecutionFailed()",
+      "error InvalidEIP712NameLength()",
+      "error InvalidEIP712VersionLength()",
+      "error InvalidShortString()",
+      "error NotDelegationManager()",
+      "error NotEntryPoint()",
+      "error NotEntryPointOrSelf()",
+      "error NotSelf()",
+      "error StringTooLong(string str)",
+      "error UnauthorizedCallContext()",
+      "error UnsupportedCallType(bytes1 callType)",
+      "error UnsupportedExecType(bytes1 execType)",
+      "event EIP712DomainChanged()",
+      "event SentPrefund(address indexed sender, uint256 amount, bool success)",
+      "event SetDelegationManager(address indexed newDelegationManager)",
+      "event SetEntryPoint(address indexed entryPoint)",
+      "event TryExecuteUnsuccessful(uint256 batchExecutionindex, bytes result)",
+      "function DOMAIN_VERSION() view returns (string)",
+      "function NAME() view returns (string)",
+      "function PACKED_USER_OP_TYPEHASH() view returns (bytes32)",
+      "function VERSION() view returns (string)",
+      "function addDeposit() payable",
+      "function delegationManager() view returns (address)",
+      "function disableDelegation(tuple(address delegate, address delegator, bytes32 authority, tuple(address enforcer, bytes terms, bytes args)[] caveats, uint256 salt, bytes signature) _delegation)",
+      "function eip712Domain() view returns (bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)",
+      "function enableDelegation(tuple(address delegate, address delegator, bytes32 authority, tuple(address enforcer, bytes terms, bytes args)[] caveats, uint256 salt, bytes signature) _delegation)",
+      "function entryPoint() view returns (address)",
+      "function execute(tuple(address target, uint256 value, bytes callData) _execution) payable",
+      "function execute(bytes32 _mode, bytes _executionCalldata) payable",
+      "function executeFromExecutor(bytes32 _mode, bytes _executionCalldata) payable returns (bytes[] returnData_)",
+      "function getDeposit() view returns (uint256)",
+      "function getDomainHash() view returns (bytes32)",
+      "function getNonce(uint192 _key) view returns (uint256)",
+      "function getNonce() view returns (uint256)",
+      "function getPackedUserOperationHash(tuple(address sender, uint256 nonce, bytes initCode, bytes callData, bytes32 accountGasLimits, uint256 preVerificationGas, bytes32 gasFees, bytes paymasterAndData, bytes signature) _userOp) view returns (bytes32)",
+      "function getPackedUserOperationTypedDataHash(tuple(address sender, uint256 nonce, bytes initCode, bytes callData, bytes32 accountGasLimits, uint256 preVerificationGas, bytes32 gasFees, bytes paymasterAndData, bytes signature) _userOp) view returns (bytes32)",
+      "function isDelegationDisabled(bytes32 _delegationHash) view returns (bool)",
+      "function isValidSignature(bytes32 _hash, bytes _signature) view returns (bytes4 magicValue_)",
+      "function onERC1155BatchReceived(address, address, uint256[], uint256[], bytes) view returns (bytes4)",
+      "function onERC1155Received(address, address, uint256, uint256, bytes) view returns (bytes4)",
+      "function onERC721Received(address, address, uint256, bytes) view returns (bytes4)",
+      "function redeemDelegations(bytes[] _permissionContexts, bytes32[] _modes, bytes[] _executionCallDatas)",
+      "function supportsExecutionMode(bytes32 _mode) view returns (bool)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function validateUserOp(tuple(address sender, uint256 nonce, bytes initCode, bytes callData, bytes32 accountGasLimits, uint256 preVerificationGas, bytes32 gasFees, bytes paymasterAndData, bytes signature) _userOp, bytes32, uint256 _missingAccountFunds) returns (uint256 validationData_)",
+      "function withdrawDeposit(address _withdrawAddress, uint256 _withdrawAmount)"
+    ],
+    "eth:0x652a31c669f9AB37f6040f279139a75D04F2679e": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x71360F335e4Ec9c010e29bA7171bc62c9B4c1F12": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x8095C0B90Be4abCBF5CA7371f588fe1637E02b7f": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x8AcBf712513C802eFFc255FEa588ED21DC7A61bA": [
+      "constructor()",
+      "error AssetTransferMismatch(address token, uint256 expected, uint256 actual)",
+      "error BelowMinCommitteeSize(uint256 size, uint256 minimum)",
+      "error BelowMinThreshold(uint256 threshold, uint256 minimum)",
+      "error BpsExceedsMax(uint256 value)",
+      "error CiphertextOutputAlreadyPublished(uint256 e3Id)",
+      "error CiphertextOutputNotPublished(uint256 e3Id)",
+      "error CommitteeDutiesCompleted(uint256 e3Id, uint256 expiration)",
+      "error CommitteeSelectionFailed()",
+      "error CommitteeSizeNotConfigured(uint8 committeeSize)",
+      "error CommitteeSizeTooSmall(uint8 committeeSize)",
+      "error ComputeDeadlinePrecedesCommitteeFinalization(uint256 computeDeadline, uint256 committeeDeadline)",
+      "error CryptoConfigChanged(bytes32 expected, bytes32 actual)",
+      "error DKGDeadlinePassed(uint256 e3Id, uint256 deadline)",
+      "error DependencyConfigurationMismatch()",
+      "error DependencyGenerationNotDrained()",
+      "error E3AlreadyComplete(uint256 e3Id)",
+      "error E3AlreadyFailed(uint256 e3Id)",
+      "error E3DoesNotExist(uint256 e3Id)",
+      "error E3IdSpaceExhausted()",
+      "error E3NotCancellable(uint256 e3Id, uint8 stage)",
+      "error E3NotFailed(uint256 e3Id)",
+      "error E3ProgramNotAllowed(address e3Program)",
+      "error FailureConditionNotMet(uint256 e3Id)",
+      "error FeeExceedsMaximum(uint256 fee, uint256 maximum)",
+      "error FeeTokenChanged(address expected, address actual)",
+      "error FeeTokenDecimalsMismatch(address feeToken, uint8 expected, uint8 actual)",
+      "error FeeTokenDecimalsUnavailable(address feeToken)",
+      "error FeeTokenNotAllowed(address token)",
+      "error InputDeadlineNotReached(uint256 e3Id, uint256 inputDeadline)",
+      "error InvalidBondingRegistry(address bondingRegistry)",
+      "error InvalidCiphernodeRegistry(address ciphernodeRegistry)",
+      "error InvalidDuration(uint256 duration)",
+      "error InvalidEncryptionScheme(bytes32 encryptionSchemeId)",
+      "error InvalidFailureReason(uint8 reason)",
+      "error InvalidFeeToken(address feeToken)",
+      "error InvalidInitialization()",
+      "error InvalidInputDeadline(uint256 deadline)",
+      "error InvalidInputDeadlineEnd(uint256 end)",
+      "error InvalidInputDeadlineStart(uint256 start)",
+      "error InvalidOutput(bytes output)",
+      "error InvalidStage(uint256 e3Id, uint8 expected, uint8 actual)",
+      "error InvalidThresholdValues()",
+      "error InvalidTimeoutWindow()",
+      "error MarkE3FailedInGracePeriod(uint256 e3Id, uint256 gracePeriodEnds)",
+      "error MinSizeBelowMinThreshold()",
+      "error ModuleAlreadyEnabled(address module)",
+      "error NoPaymentToRefund(uint256 e3Id)",
+      "error NotInitializing()",
+      "error NotRequester(uint256 e3Id, address caller)",
+      "error NothingToClaim()",
+      "error OnlyCiphernodeRegistry()",
+      "error OnlyCiphernodeRegistryOrSlashingManager()",
+      "error OnlySlashingManager()",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "error ParamSetAlreadyRegistered(uint8 paramSet)",
+      "error PaymentRequired(uint256 value)",
+      "error PlaintextOutputAlreadyPublished(uint256 e3Id)",
+      "error ProofRequired()",
+      "error ReentrancyGuardReentrantCall()",
+      "error RenounceOwnershipDisabled()",
+      "error RequestsPaused()",
+      "error ThresholdTooSmall(uint256 threshold)",
+      "error TreasuryRequired()",
+      "error UnsupportedCryptoConfig()",
+      "error UtilizationBpsExceedsMax(uint256 value)",
+      "error VerifierThresholdMismatch(uint256 actual, uint256 expected)",
+      "event BondingRegistrySet(address bondingRegistry)",
+      "event CiphernodeRegistrySet(address ciphernodeRegistry)",
+      "event CiphertextOutputPublished(uint256 indexed e3Id, bytes ciphertextOutput, bytes32 ciphertextCommitment)",
+      "event CiphertextVerifierSet(bytes32 indexed encryptionSchemeId, address indexed ciphertextVerifier)",
+      "event CommitteeFinalized(uint256 indexed e3Id)",
+      "event CommitteeFormed(uint256 indexed e3Id)",
+      "event CommitteeThresholdsUpdated(uint8 indexed size, uint32[2] threshold)",
+      "event E3Failed(uint256 indexed e3Id, uint8 failedAtStage, uint8 reason)",
+      "event E3FailureProcessed(uint256 indexed e3Id, uint256 paymentAmount, uint256 honestNodeCount)",
+      "event E3ProgramRegistered(address e3Program)",
+      "event E3RefundManagerSet(address indexed e3RefundManager)",
+      "event E3Requested(uint256 e3Id, tuple(uint256 seed, uint8 committeeSize, uint256 requestBlock, uint256[2] inputWindow, bytes32 encryptionSchemeId, address e3Program, uint8 paramSet, bytes customParams, address decryptionVerifier, address pkVerifier, bytes32 committeePublicKey, bytes32 ciphertextOutput, bytes plaintextOutput, address requester, bytes32 ciphertextCommitment) e3, bytes32 indexed cryptoConfigId)",
+      "event E3StageChanged(uint256 indexed e3Id, uint8 previousStage, uint8 newStage)",
+      "event EncryptionSchemeEnabled(bytes32 encryptionSchemeId)",
+      "event FeeAssetConfigUpdated(address indexed token, uint8 expectedDecimals, tuple(uint256 keyGenFixedPerNode, uint256 keyGenPerEncryptionProof, uint256 coordinationPerPair, uint256 availabilityPerNodePerSec, uint256 decryptionPerNode, uint256 publicationBase, uint256 verificationPerProof, address protocolTreasury, uint16 marginBps, uint16 protocolShareBps, uint16 dkgUtilizationBps, uint16 computeUtilizationBps, uint16 decryptUtilizationBps, uint32 minCommitteeSize, uint32 minThreshold) pricing)",
+      "event FeeTokenAllowed(address indexed token, bool allowed)",
+      "event Initialized(uint64 version)",
+      "event InputPublished(uint256 indexed e3Id, bytes data, uint256 inputHash, uint256 index)",
+      "event MarkFailedGracePeriodSet(uint256 gracePeriod)",
+      "event MaxDurationSet(uint256 maxDuration)",
+      "event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "event ParamSetRegistered(uint8 paramSet, bytes encodedParams)",
+      "event PkVerifierSet(bytes32 indexed encryptionSchemeId, address indexed pkVerifier)",
+      "event PlaintextOutputPublished(uint256 indexed e3Id, bytes plaintextOutput, bytes proof)",
+      "event RequestsPausedSet(bool paused)",
+      "event RewardClaimed(uint256 indexed e3Id, address indexed account, address indexed token, uint256 amount)",
+      "event RewardCredited(uint256 indexed e3Id, address indexed account, address indexed token, uint256 amount)",
+      "event RewardsDistributed(uint256 indexed e3Id, address[] nodes, uint256[] amounts)",
+      "event SlashedFundsEscrowed(uint256 indexed e3Id, address indexed token, uint256 amount)",
+      "event SlashingManagerSet(address indexed slashingManager)",
+      "event TimeoutConfigUpdated(tuple(uint256 dkgWindow, uint256 computeWindow, uint256 decryptionWindow) config)",
+      "event TreasuryClaimed(address indexed treasury, address indexed token, uint256 amount)",
+      "event TreasuryCredited(uint256 indexed e3Id, address indexed treasury, address indexed token, uint256 amount)",
+      "function MAX_COMMITTEE_SIZE() view returns (uint32)",
+      "function MAX_DURATION_CAP() view returns (uint256)",
+      "function MAX_MARGIN_BPS() view returns (uint16)",
+      "function MAX_PROTOCOL_SHARE_BPS() view returns (uint16)",
+      "function MAX_TIMEOUT_WINDOW() view returns (uint256)",
+      "function acceptOwnership()",
+      "function activeCryptoConfigId() pure returns (bytes32)",
+      "function activeE3Count() view returns (uint256)",
+      "function bondingRegistry() view returns (address)",
+      "function cancelE3(uint256 e3Id)",
+      "function checkFailureCondition(uint256 e3Id) view returns (bool canFail, uint8 reason)",
+      "function ciphernodeRegistry() view returns (address)",
+      "function claimReward(uint256 e3Id) returns (uint256 amount)",
+      "function claimRewards(uint256[] e3Ids)",
+      "function committeeThresholds(uint8, uint256) view returns (uint32 threshold)",
+      "function decryptionVerifiers(bytes32 encryptionSchemeId) view returns (address decryptionVerifier)",
+      "function e3CryptoConfigIds(uint256 e3Id) view returns (bytes32 configId)",
+      "function e3Payments(uint256 e3Id) view returns (uint256 e3Payment)",
+      "function e3Programs(address e3Program) view returns (bool allowed)",
+      "function e3RefundManager() view returns (address)",
+      "function e3s(uint256 e3Id) view returns (uint256 seed, uint8 committeeSize, uint256 requestBlock, bytes32 encryptionSchemeId, address e3Program, uint8 paramSet, bytes customParams, address decryptionVerifier, address pkVerifier, bytes32 committeePublicKey, bytes32 ciphertextOutput, bytes plaintextOutput, address requester, bytes32 ciphertextCommitment)",
+      "function escrowSlashedFunds(uint256 e3Id, uint256 proposalId, address operator, address token, uint256 amount)",
+      "function feeToken() view returns (address)",
+      "function feeTokenDecimals() view returns (uint8)",
+      "function getCiphertextVerifier(bytes32 encryptionSchemeId) view returns (address)",
+      "function getDeadlines(uint256 e3Id) view returns (tuple(uint256 dkgDeadline, uint256 computeDeadline, uint256 decryptionDeadline) deadlines)",
+      "function getDecryptionVerifier(bytes32 encryptionSchemeId) view returns (address)",
+      "function getE3(uint256 e3Id) view returns (tuple(uint256 seed, uint8 committeeSize, uint256 requestBlock, uint256[2] inputWindow, bytes32 encryptionSchemeId, address e3Program, uint8 paramSet, bytes customParams, address decryptionVerifier, address pkVerifier, bytes32 committeePublicKey, bytes32 ciphertextOutput, bytes plaintextOutput, address requester, bytes32 ciphertextCommitment) e3)",
+      "function getE3LifecycleDeadline(uint256 e3Id) view returns (uint256 deadline)",
+      "function getE3Quote(tuple(uint8 committeeSize, uint256[2] inputWindow, address e3Program, uint8 paramSet, bytes computeProviderParams, bytes customParams, address expectedFeeToken, bytes32 expectedCryptoConfigId, uint256 maxFee) requestParams) view returns (uint256 fee)",
+      "function getE3Stage(uint256 e3Id) view returns (uint8 stage)",
+      "function getE3TimeoutConfig(uint256 e3Id) view returns (tuple(uint256 dkgWindow, uint256 computeWindow, uint256 decryptionWindow) config)",
+      "function getFailureReason(uint256 e3Id) view returns (uint8 reason)",
+      "function getPkVerifier(bytes32 encryptionSchemeId) view returns (address)",
+      "function getPricingConfig() view returns (tuple(uint256 keyGenFixedPerNode, uint256 keyGenPerEncryptionProof, uint256 coordinationPerPair, uint256 availabilityPerNodePerSec, uint256 decryptionPerNode, uint256 publicationBase, uint256 verificationPerProof, address protocolTreasury, uint16 marginBps, uint16 protocolShareBps, uint16 dkgUtilizationBps, uint16 computeUtilizationBps, uint16 decryptUtilizationBps, uint32 minCommitteeSize, uint32 minThreshold))",
+      "function getRequester(uint256 e3Id) view returns (address requester)",
+      "function getTimeoutConfig() view returns (tuple(uint256 dkgWindow, uint256 computeWindow, uint256 decryptionWindow) config)",
+      "function initialize(address _owner, address _ciphernodeRegistry, address _bondingRegistry, address _e3RefundManager, tuple(address token, uint8 expectedDecimals, tuple(uint256 keyGenFixedPerNode, uint256 keyGenPerEncryptionProof, uint256 coordinationPerPair, uint256 availabilityPerNodePerSec, uint256 decryptionPerNode, uint256 publicationBase, uint256 verificationPerProof, address protocolTreasury, uint16 marginBps, uint16 protocolShareBps, uint16 dkgUtilizationBps, uint16 computeUtilizationBps, uint16 decryptUtilizationBps, uint32 minCommitteeSize, uint32 minThreshold) pricing) feeAssetConfig, uint256 _maxDuration, tuple(uint256 dkgWindow, uint256 computeWindow, uint256 decryptionWindow) config, address initialE3Program)",
+      "function isFeeTokenAllowed(address token) view returns (bool)",
+      "function markE3Failed(uint256 e3Id) returns (uint8 reason)",
+      "function markFailedGracePeriod() view returns (uint256)",
+      "function maxDuration() view returns (uint256)",
+      "function nexte3Id() view returns (uint256)",
+      "function onCommitteeFinalized(uint256 e3Id)",
+      "function onCommitteePublished(uint256 e3Id, bytes32 committeePublicKey)",
+      "function onE3Failed(uint256 e3Id, uint8 reason)",
+      "function owner() view returns (address)",
+      "function paramSetRegistry(uint8) view returns (bytes)",
+      "function pendingOwner() view returns (address)",
+      "function pendingReward(uint256 e3Id, address account) view returns (uint256)",
+      "function pendingTreasuryClaim(address treasury, address token) view returns (uint256)",
+      "function pkVerifiers(bytes32 encryptionSchemeId) view returns (address pkVerifier)",
+      "function processE3Failure(uint256 e3Id)",
+      "function publishCiphertextOutput(uint256 e3Id, bytes ciphertextOutput, bytes32 ciphertextCommitment, bytes proof) returns (bool success)",
+      "function publishPlaintextOutput(uint256 e3Id, bytes plaintextOutput, bytes proof) returns (bool success)",
+      "function registerE3Program(address e3Program)",
+      "function renounceOwnership() view",
+      "function request(tuple(uint8 committeeSize, uint256[2] inputWindow, address e3Program, uint8 paramSet, bytes computeProviderParams, bytes customParams, address expectedFeeToken, bytes32 expectedCryptoConfigId, uint256 maxFee) requestParams) returns (uint256 e3Id, tuple(uint256 seed, uint8 committeeSize, uint256 requestBlock, uint256[2] inputWindow, bytes32 encryptionSchemeId, address e3Program, uint8 paramSet, bytes customParams, address decryptionVerifier, address pkVerifier, bytes32 committeePublicKey, bytes32 ciphertextOutput, bytes plaintextOutput, address requester, bytes32 ciphertextCommitment) e3)",
+      "function requestsPaused() view returns (bool)",
+      "function setBondingRegistry(address _bondingRegistry)",
+      "function setCiphernodeRegistry(address _ciphernodeRegistry)",
+      "function setCiphertextVerifier(bytes32 encryptionSchemeId, address ciphertextVerifier)",
+      "function setCommitteeThresholds(uint8 size, uint32[2] threshold)",
+      "function setDecryptionVerifier(bytes32 encryptionSchemeId, address decryptionVerifier)",
+      "function setE3RefundManager(address _e3RefundManager)",
+      "function setFeeAssetConfig(tuple(address token, uint8 expectedDecimals, tuple(uint256 keyGenFixedPerNode, uint256 keyGenPerEncryptionProof, uint256 coordinationPerPair, uint256 availabilityPerNodePerSec, uint256 decryptionPerNode, uint256 publicationBase, uint256 verificationPerProof, address protocolTreasury, uint16 marginBps, uint16 protocolShareBps, uint16 dkgUtilizationBps, uint16 computeUtilizationBps, uint16 decryptUtilizationBps, uint32 minCommitteeSize, uint32 minThreshold) pricing) config)",
+      "function setFeeTokenAllowed(address token, bool allowed)",
+      "function setMarkFailedGracePeriod(uint256 gracePeriod)",
+      "function setMaxDuration(uint256 _maxDuration)",
+      "function setParamSet(uint8 paramSet, bytes encodedParams)",
+      "function setPkVerifier(bytes32 encryptionSchemeId, address pkVerifier)",
+      "function setRequestsPaused(bool paused)",
+      "function setSlashingManager(address _slashingManager)",
+      "function setTimeoutConfig(tuple(uint256 dkgWindow, uint256 computeWindow, uint256 decryptionWindow) config)",
+      "function slashingManager() view returns (address)",
+      "function supportsInterface(bytes4 interfaceId) pure returns (bool)",
+      "function transferOwnership(address newOwner)",
+      "function treasuryClaim(address token) returns (uint256 amount)"
+    ],
+    "eth:0x8B405dBf2F30844B608b08DaD20447A6955A6C6E": [
+      "constructor(address _masterCopy)"
+    ],
+    "eth:0x8B43b2852fc5031D01DDfCDF702973D93A2FF593": [
+      "constructor(address _singleton)"
+    ],
+    "eth:0x8f141B4D294d39e7D1530916A3eD65B3970C6FEc": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x9393573a9EF85c9A37d91E32702a340084A48b6E": [
+      "constructor(address initialOwner)",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "function UPGRADE_INTERFACE_VERSION() view returns (string)",
+      "function owner() view returns (address)",
+      "function renounceOwnership()",
+      "function transferOwnership(address newOwner)",
+      "function upgradeAndCall(address proxy, address implementation, bytes data) payable"
+    ],
+    "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9": [
+      "constructor(uint48 initialDelay, address admin)",
+      "error AccessControlBadConfirmation()",
+      "error AccessControlEnforcedDefaultAdminDelay(uint48 schedule)",
+      "error AccessControlEnforcedDefaultAdminRules()",
+      "error AccessControlInvalidDefaultAdmin(address defaultAdmin)",
+      "error AccessControlUnauthorizedAccount(address account, bytes32 neededRole)",
+      "error AccusationIssuedInFuture()",
+      "error AccusationSlashingDisabled()",
+      "error AccusationWindowOpen(uint256 e3Id, uint256 closesAt)",
+      "error AlreadyAppealed()",
+      "error AlreadyExecuted()",
+      "error AlreadyResolved()",
+      "error AppealPending()",
+      "error AppealResolutionWindowActive()",
+      "error AppealUpheld()",
+      "error AppealWindowActive()",
+      "error AppealWindowExpired()",
+      "error BanRequiresConfirmation()",
+      "error ChainIdMismatch()",
+      "error CiphernodeBanned()",
+      "error DuplicateEvidence()",
+      "error DuplicateVoter()",
+      "error EquivocationDetected()",
+      "error InsufficientAttestations()",
+      "error InsufficientRoutingGas()",
+      "error InvalidAccusationWindow()",
+      "error InvalidPolicy()",
+      "error InvalidProof()",
+      "error InvalidProposal()",
+      "error InvalidShortString()",
+      "error InvalidVoteSignature()",
+      "error NoPendingBan()",
+      "error OperatorNotInCommittee()",
+      "error OperatorUnderSlash()",
+      "error PartyIdNotInDkgAnchors()",
+      "error ProofIsValid()",
+      "error ProofRequired()",
+      "error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value)",
+      "error SignatureExpired()",
+      "error SignerIsNotOperator()",
+      "error SlashPolicyAssetConfigurationMismatch(bytes32 reason)",
+      "error SlashReasonDisabled()",
+      "error SlashReasonNotFound()",
+      "error SlashSubmissionDeadlinePassed()",
+      "error StringTooLong(string str)",
+      "error Unauthorized()",
+      "error VerifierCallFailed()",
+      "error VerifierMismatch()",
+      "error VerifierNotSet()",
+      "error VoterIsAccused()",
+      "error VoterNotInCommittee()",
+      "error ZeroAddress()",
+      "event AppealFiled(uint256 indexed proposalId, address indexed operator, bytes32 indexed reason, string evidence)",
+      "event AppealResolved(uint256 indexed proposalId, address indexed operator, bool appealUpheld, address resolver, string resolution)",
+      "event BanCancelled(address indexed node, address canceller)",
+      "event BanProposed(address indexed node, bytes32 indexed reason, address proposer)",
+      "event BondingRegistrySet(address indexed bondingRegistry)",
+      "event BondingRegistryUpdated(address indexed previous, address indexed next)",
+      "event CiphernodeRegistrySet(address indexed ciphernodeRegistry)",
+      "event CiphernodeRegistryUpdated(address indexed previous, address indexed next)",
+      "event DefaultAdminDelayChangeCanceled()",
+      "event DefaultAdminDelayChangeScheduled(uint48 newDelay, uint48 effectSchedule)",
+      "event DefaultAdminTransferCanceled()",
+      "event DefaultAdminTransferScheduled(address indexed newAdmin, uint48 acceptSchedule)",
+      "event E3DependenciesReleased(uint256 indexed e3Id)",
+      "event E3RefundManagerSet(address indexed e3RefundManager)",
+      "event E3RefundManagerUpdated(address indexed previous, address indexed next)",
+      "event EIP712DomainChanged()",
+      "event InterfoldSet(address indexed interfold)",
+      "event InterfoldUpdated(address indexed previous, address indexed next)",
+      "event NodeBanUpdated(address indexed node, bool status, bytes32 indexed reason, address updater)",
+      "event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)",
+      "event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)",
+      "event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)",
+      "event RoutingFailed(uint256 indexed e3Id, uint256 amount)",
+      "event SlashExecuted(uint256 indexed proposalId, uint256 e3Id, address indexed operator, bytes32 indexed reason, uint256 ticketAmount, uint256 ciphernodeBondAmount, bool executed, uint8 lane)",
+      "event SlashPolicyUpdated(bytes32 indexed reason, tuple(uint256 ticketPenalty, uint256 ciphernodeBondPenalty, bool requiresProof, address proofVerifier, bool banNode, uint256 appealWindow, bool enabled, bool affectsCommittee, uint8 failureReason) policy)",
+      "event SlashProposed(uint256 indexed proposalId, uint256 indexed e3Id, address indexed operator, bytes32 reason, uint256 ticketAmount, uint256 ciphernodeBondAmount, uint256 executableAt, address proposer, uint8 lane)",
+      "event SlashRouteCompleted(uint256 indexed proposalId, uint256 indexed e3Id, address indexed token, uint256 amount)",
+      "event SlashRoutePending(uint256 indexed proposalId, uint256 indexed e3Id, address indexed token, uint256 amount)",
+      "event SlashedFundsEscrowedToRefund(uint256 indexed e3Id, address indexed token, uint256 amount)",
+      "function ACCUSATION_REPORTING_WINDOW() view returns (uint64)",
+      "function APPEAL_RESOLUTION_GRACE() view returns (uint64)",
+      "function DEFAULT_ADMIN_ROLE() view returns (bytes32)",
+      "function DOMAIN_NAME_HASH() view returns (bytes32)",
+      "function DOMAIN_VERSION_HASH() view returns (bytes32)",
+      "function EIP712_DOMAIN_NAME() view returns (string)",
+      "function EIP712_DOMAIN_TYPEHASH() view returns (bytes32)",
+      "function EIP712_DOMAIN_VERSION() view returns (string)",
+      "function GOVERNANCE_ROLE() view returns (bytes32)",
+      "function MAX_APPEAL_WINDOW() view returns (uint64)",
+      "function PROOF_PAYLOAD_TYPEHASH() view returns (bytes32)",
+      "function SLASHER_ROLE() view returns (bytes32)",
+      "function SLASHING_MANAGER_API_VERSION() view returns (uint256)",
+      "function VOTE_TYPEHASH() view returns (bytes32)",
+      "function acceptDefaultAdminTransfer()",
+      "function activeBanCount() view returns (uint256)",
+      "function activeE3Assignments() view returns (uint256)",
+      "function addSlasher(address slasher)",
+      "function attestationDomainSeparator() view returns (bytes32)",
+      "function banned(address node) view returns (bool banned)",
+      "function beginDefaultAdminTransfer(address newAdmin)",
+      "function bondingRegistry() view returns (address)",
+      "function cancelBan(address node)",
+      "function cancelDefaultAdminTransfer()",
+      "function changeDefaultAdminDelay(uint48 newDelay)",
+      "function ciphernodeRegistry() view returns (address)",
+      "function closeE3(uint256 e3Id)",
+      "function confirmBan(address node, bytes32 reason)",
+      "function defaultAdmin() view returns (address)",
+      "function defaultAdminDelay() view returns (uint48)",
+      "function defaultAdminDelayIncreaseWait() view returns (uint48)",
+      "function e3RefundManager() view returns (address)",
+      "function eip712Domain() view returns (bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)",
+      "function evidenceConsumed(bytes32 evidenceKey) view returns (bool consumed)",
+      "function executeSlash(uint256 proposalId)",
+      "function expireAppeal(uint256 proposalId)",
+      "function fileAppeal(uint256 proposalId, string evidence)",
+      "function getE3AccusationWindow(uint256 e3Id) view returns (uint64 voteValidity, uint64 submissionDeadline)",
+      "function getE3Dependencies(uint256 e3Id) view returns (address bonding, address registry, address interfoldContract, address refundManager)",
+      "function getPendingSlashRoute(uint256 proposalId) view returns (tuple(uint256 e3Id, address token, uint256 amount, bool pending, address operator))",
+      "function getRoleAdmin(bytes32 role) view returns (bytes32)",
+      "function getSlashPolicy(bytes32 reason) view returns (tuple(uint256 ticketPenalty, uint256 ciphernodeBondPenalty, bool requiresProof, address proofVerifier, bool banNode, uint256 appealWindow, bool enabled, bool affectsCommittee, uint8 failureReason))",
+      "function getSlashProposal(uint256 proposalId) view returns (tuple(uint256 e3Id, address operator, bytes32 reason, uint256 ticketAmount, uint256 ciphernodeBondAmount, bool executed, bool appealed, bool resolved, bool appealUpheld, uint256 proposedAt, uint256 executableAt, address proposer, bytes32 proofHash, bool proofVerified, bool banNode, bool affectsCommittee, uint8 failureReason))",
+      "function grantRole(bytes32 role, address account)",
+      "function hasOpenSlashProposal(address operator) view returns (bool)",
+      "function hasRole(bytes32 role, address account) view returns (bool)",
+      "function interfold() view returns (address)",
+      "function isBanned(address node) view returns (bool)",
+      "function owner() view returns (address)",
+      "function pendingDefaultAdmin() view returns (address newAdmin, uint48 schedule)",
+      "function pendingDefaultAdminDelay() view returns (uint48 newDelay, uint48 schedule)",
+      "function proposeBan(address node, bytes32 reason)",
+      "function proposeSlash(uint256 e3Id, address operator, bytes proof) returns (uint256 proposalId)",
+      "function proposeSlashByDkgParty(uint256 e3Id, uint256 partyId, bytes proof) returns (uint256 proposalId)",
+      "function proposeSlashEvidence(uint256 e3Id, address operator, bytes32 reason, bytes evidence) returns (uint256 proposalId)",
+      "function removeSlasher(address slasher)",
+      "function renounceRole(bytes32 role, address account)",
+      "function resolveAppeal(uint256 proposalId, bool appealUpheld, string resolution)",
+      "function retrySlashRoute(uint256 proposalId) returns (bool routed)",
+      "function revokeRole(bytes32 role, address account)",
+      "function rollbackDefaultAdminDelay()",
+      "function routePendingSlashFunds(uint256 proposalId) returns (bool routed)",
+      "function setBondingRegistry(address newBondingRegistry)",
+      "function setCiphernodeRegistry(address newCiphernodeRegistry)",
+      "function setE3RefundManager(address newRefundManager)",
+      "function setInterfold(address newInterfold)",
+      "function setSlashPolicy(bytes32 reason, tuple(uint256 ticketPenalty, uint256 ciphernodeBondPenalty, bool requiresProof, address proofVerifier, bool banNode, uint256 appealWindow, bool enabled, bool affectsCommittee, uint8 failureReason) policy)",
+      "function slashPolicies(bytes32 reason) view returns (uint256 ticketPenalty, uint256 ciphernodeBondPenalty, bool requiresProof, address proofVerifier, bool banNode, uint256 appealWindow, bool enabled, bool affectsCommittee, uint8 failureReason)",
+      "function slashPolicyAssetContexts(bytes32 reason) view returns (address bondingRegistry, uint64 configurationVersion)",
+      "function snapshotE3Dependencies(uint256 e3Id)",
+      "function supportsInterface(bytes4 interfaceId) view returns (bool)",
+      "function totalProposals() view returns (uint256)",
+      "function unbanNode(address node, bytes32 reason)",
+      "function updateBanStatus(address node, bool status, bytes32 reason)"
+    ],
+    "eth:0x97843608a00e2bbc75ab0C1911387E002565DEDE": [
+      "constructor(address _masterCopy)"
+    ],
+    "eth:0x9c0Ff283399Bd1D3111E6c9C689066759b7AccDb": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0x9e58443eB40A1B08D07f89D36bf69909d401a542": [
+      "constructor()",
+      "error ConsistencyCheckFailed()",
+      "error GeminiChallengeInSubgroup()",
+      "error InvertOfZero()",
+      "error NotPowerOfTwo()",
+      "error PointAtInfinity()",
+      "error ProofLengthWrongWithLogN(uint256 logN, uint256 actualLength, uint256 expectedLength)",
+      "error PublicInputsLengthWrong()",
+      "error ShpleminiFailed()",
+      "error SumcheckFailed()",
+      "error ValueGeFieldOrder()",
+      "error ValueGeGroupOrder()",
+      "error ValueGeLimbMax()",
+      "error VerificationKeyConfigurationMismatch()",
+      "function verify(bytes proof, bytes32[] publicInputs) view returns (bool verified)"
+    ],
+    "eth:0x9e9617418DFb9E4daD00E2D1e8f21e214901989B": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0xB06Aaf9EF87984192490E947078D2f3563399b7B": [
+      "constructor()",
+      "error AccusationVoteValidityDecreaseRequiresTimelock()",
+      "error AccusationVoteValidityMismatch(uint256 pending, uint256 provided)",
+      "error AccusationVoteValidityProposalExpired(uint256 expiredAt, uint256 nowAt)",
+      "error AccusationVoteValidityTimelockActive(uint256 readyAt, uint256 nowAt)",
+      "error AttestationBindingCountMismatch()",
+      "error BondingRegistryNotSet()",
+      "error CiphernodeNotEnabled(address node)",
+      "error CiphernodeTreeExhausted()",
+      "error CommitteeAlreadyFinalized()",
+      "error CommitteeAlreadyPublished()",
+      "error CommitteeAlreadyRequested()",
+      "error CommitteeDeadlineReached()",
+      "error CommitteeNotFinalized()",
+      "error CommitteeNotInitializedOrFinalized()",
+      "error CommitteeNotPublished()",
+      "error CommitteeNotRequested()",
+      "error CommitteeObligationsAlreadyReleased(uint256 e3Id)",
+      "error DkgProofRequired()",
+      "error E3NotTerminal(uint256 e3Id)",
+      "error ExitDelayMustExceedSortitionWindow(uint256 exitDelay, uint256 requiredDelay)",
+      "error FoldAttestationVerifierAlreadySet()",
+      "error FoldAttestationVerifierNotSet()",
+      "error FoldAttestationsRequired()",
+      "error InsufficientCiphernodes(uint256 requested, uint256 available)",
+      "error InvalidDkgProof()",
+      "error InvalidFoldAttestation()",
+      "error InvalidInitialization()",
+      "error InvalidProof()",
+      "error InvalidPublicKeyLength(uint256 supplied, uint256 maximum)",
+      "error InvalidTicketNumber()",
+      "error NoPendingAccusationVoteValidityUpdate()",
+      "error NoPendingVerifierUpdate()",
+      "error NodeAlreadySubmitted()",
+      "error NodeNotBonded(address node)",
+      "error NodeNotEligible()",
+      "error NodeNotSubmitted()",
+      "error NotInitializing()",
+      "error NotOwnerOrBondingRegistry()",
+      "error NotSlashingManager()",
+      "error OnlyInterfold()",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "error PartyIdNotInProof()",
+      "error PartyIdOutOfBounds(uint256 partyId, uint256 committeeSize)",
+      "error PkCommitmentRequired()",
+      "error RegistryGenerationNotDrained()",
+      "error RenounceOwnershipDisabled()",
+      "error SortitionSeedUnavailable(uint256 e3Id, uint256 entropyBlock)",
+      "error SortitionSubmissionWindowOutOfBounds(uint256 window)",
+      "error SubmissionWindowClosed()",
+      "error SubmissionWindowNotClosed()",
+      "error ThresholdNotMet()",
+      "error Unauthorized()",
+      "error VerifierMismatch(address pending, address provided)",
+      "error VerifierUpdateTimelockActive(uint256 readyAt, uint256 nowAt)",
+      "error ZeroAddress()",
+      "event AccusationVoteValidityProposalCancelled(uint256 accusationVoteValidity)",
+      "event AccusationVoteValidityProposed(uint256 accusationVoteValidity, uint256 readyAt)",
+      "event AccusationVoteValiditySet(uint256 accusationVoteValidity)",
+      "event BondingRegistrySet(address indexed bondingRegistry)",
+      "event CiphernodeAdded(address indexed node, uint256 index, uint256 numNodes, uint256 size)",
+      "event CiphernodeRemoved(address indexed node, uint256 index, uint256 numNodes, uint256 size)",
+      "event CiphernodeTreeCapacityWarning(uint256 size, uint256 capacity)",
+      "event CommitteeActivationChanged(uint256 indexed e3Id, bool active)",
+      "event CommitteeFormationFailed(uint256 indexed e3Id, uint256 nodesSubmitted, uint256 thresholdRequired)",
+      "event CommitteeMemberExpelled(uint256 indexed e3Id, address indexed node, bytes32 reason, uint256 activeCountAfter)",
+      "event CommitteeProofPublished(uint256 indexed e3Id, address[] nodes, bytes32 pkCommitment, bytes proof)",
+      "event CommitteePublished(uint256 indexed e3Id, address[] nodes, bytes publicKey, bytes32 pkCommitment, bytes proof)",
+      "event CommitteeRequested(uint256 indexed e3Id, uint256 entropyBlock, uint32[2] threshold, uint256 requestBlock, uint256 committeeDeadline, uint256 ticketPrice)",
+      "event CommitteeViabilityUpdated(uint256 indexed e3Id, uint256 activeCount, uint256 thresholdM, bool viable)",
+      "event DkgFoldAttestationContextEstablished(uint256 indexed e3Id, address indexed registry, address indexed dkgFoldAttestationVerifier)",
+      "event DkgFoldAttestationVerifierProposalCancelled(address indexed verifier)",
+      "event DkgFoldAttestationVerifierProposed(address indexed verifier, uint256 readyAt)",
+      "event DkgFoldAttestationVerifierUpdated(address indexed verifier)",
+      "event Initialized(uint64 version)",
+      "event InterfoldSet(address indexed interfold)",
+      "event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "event RegistrySlashingManagerSet(address indexed slashingManager)",
+      "event SlashingManagerSet(address indexed slashingManager)",
+      "event SortitionCommitteeFinalized(uint256 indexed e3Id, address[] committee, uint256[] scores)",
+      "event SortitionSubmissionWindowSet(uint256 sortitionSubmissionWindow)",
+      "event TicketSubmitted(uint256 indexed e3Id, address indexed node, uint256 ticketId, uint256 score)",
+      "function ACCUSATION_VOTE_VALIDITY_TIMELOCK() view returns (uint256)",
+      "function BLOCKHASH_HISTORY() view returns (address)",
+      "function CIPHERNODE_TREE_WARNING_THRESHOLD() view returns (uint256)",
+      "function DEFAULT_ACCUSATION_VOTE_VALIDITY() view returns (uint256)",
+      "function DKG_FOLD_VERIFIER_TIMELOCK() view returns (uint256)",
+      "function MAX_CIPHERNODE_LEAVES() view returns (uint256)",
+      "function MAX_COMMITTEE_PUBLIC_KEY_BYTES() view returns (uint256)",
+      "function MAX_SORTITION_SUBMISSION_WINDOW() view returns (uint256)",
+      "function MIN_SORTITION_SUBMISSION_WINDOW() view returns (uint256)",
+      "function TREE_DEPTH() view returns (uint8)",
+      "function acceptOwnership()",
+      "function accusationVoteValidity() view returns (uint256)",
+      "function addCiphernode(address node)",
+      "function bondingRegistry() view returns (address)",
+      "function cancelAccusationVoteValidityProposal()",
+      "function cancelDkgFoldAttestationVerifierProposal()",
+      "function canonicalCommitteeNodeAt(uint256 e3Id, uint256 partyId) view returns (address)",
+      "function ciphernodeEnabled(address node) view returns (bool enabled)",
+      "function ciphernodeTreeIndex(address node) view returns (uint40 index)",
+      "function ciphernodes() view returns (uint40 maxIndex, uint40 numberOfLeaves)",
+      "function commitAccusationVoteValidity(uint256 _accusationVoteValidity)",
+      "function commitDkgFoldAttestationVerifier(address verifier)",
+      "function committeePublicKey(uint256 e3Id) view returns (bytes32 publicKeyHash)",
+      "function committeeThresholdMet(uint256 e3Id) view returns (bool)",
+      "function dkgFoldAttestationVerifier() view returns (address)",
+      "function dkgFoldAttestationVerifierFor(uint256 e3Id) view returns (address)",
+      "function exitDelayFloor() view returns (uint256 floor)",
+      "function expelCommitteeMember(uint256 e3Id, address node, bytes32 reason) returns (uint256 activeCount, uint32 thresholdM)",
+      "function finalizeCommittee(uint256 e3Id) returns (bool success)",
+      "function getActiveCommitteeNodes(uint256 e3Id) view returns (address[] nodes, uint256[] scores)",
+      "function getBondingRegistry() view returns (address)",
+      "function getCommitteeDeadline(uint256 e3Id) view returns (uint256)",
+      "function getCommitteeHash(uint256 e3Id) view returns (bytes32 committeeHash)",
+      "function getCommitteeNodes(uint256 e3Id) view returns (address[] nodes)",
+      "function getCommitteeViability(uint256 e3Id) view returns (uint256 activeCount, uint32 thresholdM, uint32 thresholdN, bool viable)",
+      "function getDkgAnchors(uint256 e3Id) view returns (uint256[] partyIds, bytes32[] skAggCommits, bytes32[] esmAggCommits)",
+      "function initialize(address _owner, uint256 _submissionWindow)",
+      "function interfold() view returns (address)",
+      "function isCiphernodeEligible(address node) view returns (bool)",
+      "function isCommitteeMember(uint256 e3Id, address node) view returns (bool)",
+      "function isCommitteeMemberActive(uint256 e3Id, address node) view returns (bool)",
+      "function isEnabled(address node) view returns (bool)",
+      "function isOpen(uint256 e3Id) view returns (bool)",
+      "function numCiphernodes() view returns (uint256)",
+      "function owner() view returns (address)",
+      "function pendingAccusationVoteValidity() view returns (uint256)",
+      "function pendingAccusationVoteValidityAt() view returns (uint256)",
+      "function pendingDkgFoldAttestationVerifier() view returns (address)",
+      "function pendingDkgFoldAttestationVerifierAt() view returns (uint256)",
+      "function pendingOwner() view returns (address)",
+      "function proposeAccusationVoteValidity(uint256 _accusationVoteValidity)",
+      "function proposeDkgFoldAttestationVerifier(address verifier)",
+      "function publicKeyHashes(uint256 e3Id) view returns (bytes32 publicKeyHash)",
+      "function publishCommittee(uint256 e3Id, bytes32 pkCommitment, bytes proof, bytes dkgAttestationBundle)",
+      "function publishCommitteePublicKey(uint256 e3Id, bytes publicKey)",
+      "function releaseCommittee(uint256 e3Id)",
+      "function removeCiphernode(address node)",
+      "function renounceOwnership() view",
+      "function requestCommittee(uint256 e3Id, uint256, uint32[2] threshold) returns (bool success)",
+      "function root() view returns (uint256)",
+      "function rootAt(uint256 e3Id) view returns (uint256)",
+      "function roots(uint256 e3Id) view returns (uint256 root)",
+      "function setAccusationVoteValidity(uint256 _accusationVoteValidity)",
+      "function setBondingRegistry(address _bondingRegistry)",
+      "function setInitialDkgFoldAttestationVerifier(address verifier)",
+      "function setInterfold(address _interfold)",
+      "function setSlashingManager(address _slashingManager)",
+      "function setSortitionSubmissionWindow(uint256 _sortitionSubmissionWindow)",
+      "function slashingManager() view returns (address)",
+      "function sortitionEntropyBlocks(uint256 e3Id) view returns (uint256 blockNumber)",
+      "function sortitionSeed(uint256 e3Id) view returns (bool ready, uint256 seed)",
+      "function sortitionSeedResolved(uint256 e3Id) view returns (bool resolved)",
+      "function sortitionSubmissionWindow() view returns (uint256)",
+      "function sortitionTicketPrices(uint256 e3Id) view returns (uint256 ticketPrice)",
+      "function submitTicket(uint256 e3Id, uint256 ticketNumber)",
+      "function supportsInterface(bytes4 interfaceId) pure returns (bool)",
+      "function transferOwnership(address newOwner)",
+      "function treeSize() view returns (uint256)",
+      "function unreleasedCommitteeCount() view returns (uint256)"
+    ],
+    "eth:0xB3985D7fF844FA0F5E0aaC5feb5DD8BE15e88580": [
+      "constructor(address initialOwner)",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "function UPGRADE_INTERFACE_VERSION() view returns (string)",
+      "function owner() view returns (address)",
+      "function renounceOwnership()",
+      "function transferOwnership(address newOwner)",
+      "function upgradeAndCall(address proxy, address implementation, bytes data) payable"
+    ],
+    "eth:0xB67C1ABaC78686c67b91bBd1032813D86047104B": [
+      "constructor(int256[3] _coefficients, uint256 _maxEpochs)",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error DelegateBySigNotSupported()",
+      "error DelegateeNotSet()",
+      "error DelegationNotAllowed()",
+      "error IncorrectTokenIds()",
+      "error InvalidTokenId()",
+      "error NotOwner()",
+      "error OnlyEscrow()",
+      "error TokenAlreadyDelegated(uint256 tokenId)",
+      "error TokenListEmpty()",
+      "error TokenNotDelegated(uint256 tokenId)",
+      "error VotingPowerZero(uint256 tokenId)",
+      "error ZeroTransition()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event AutoDelegationDisabledSet(address indexed delegate, bool enabled)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate)",
+      "event DelegateVotesChanged(address indexed delegate, uint256 previousBalance, uint256 newBalance)",
+      "event Initialized(uint8 version)",
+      "event Paused(address account)",
+      "event TokensDelegated(address indexed sender, address indexed delegatee, uint256[] tokenIds)",
+      "event TokensUndelegated(address indexed sender, address indexed delegatee, uint256[] tokenIds)",
+      "event Unpaused(address account)",
+      "event Upgraded(address indexed implementation)",
+      "function CLOCK_MODE() pure returns (string)",
+      "function DELEGATION_ADMIN_ROLE() view returns (bytes32)",
+      "function DELEGATION_TOKEN_ROLE() view returns (bytes32)",
+      "function MAX_EPOCHS() view returns (uint256)",
+      "function SHARED_CONSTANT_COEFFICIENT() view returns (int256)",
+      "function SHARED_LINEAR_COEFFICIENT() view returns (int256)",
+      "function SHARED_QUADRATIC_COEFFICIENT() view returns (int256)",
+      "function autoDelegationDisabled(address _account) view returns (bool)",
+      "function balanceOf(address _account) view returns (uint256)",
+      "function checkpointTransition(address _delegatee, uint256 _transitionCount)",
+      "function clock() view returns (uint48)",
+      "function dao() view returns (address)",
+      "function delegate(uint256[] _tokenIds)",
+      "function delegate(address _delegatee)",
+      "function delegateBySig(address, uint256, uint256, uint8, bytes32, bytes32)",
+      "function delegates(address _account) view returns (address)",
+      "function escrow() view returns (address)",
+      "function escrowClock() view returns (address)",
+      "function getDelegatedTokens(uint256[] _tokenIds) view returns (uint256[])",
+      "function getPastTotalSupply(uint256 _timestamp) view returns (uint256)",
+      "function getPastVotes(address _account, uint256 _timestamp) view returns (uint256)",
+      "function getVotes(address _account) view returns (uint256)",
+      "function implementation() view returns (address)",
+      "function initialize(address _dao, address _escrow, address _clock, bool _startPaused)",
+      "function latestPointIndex(address) view returns (uint256)",
+      "function mergeDelegateVotes(tuple(address account, uint256 tokenId, tuple(uint208 amount, uint48 start) locked) _from, tuple(address account, uint256 tokenId, tuple(uint208 amount, uint48 start) locked) _to)",
+      "function moveDelegateVotes(address _from, address _to, uint256 _tokenId, tuple(uint208 amount, uint48 start) _locked)",
+      "function numberOfDelegatedTokens(address) view returns (uint256)",
+      "function pause()",
+      "function paused() view returns (bool)",
+      "function pointHistory(address, uint256) view returns (int256 bias, int256 slope, uint48 writtenTs)",
+      "function proxiableUUID() view returns (bytes32)",
+      "function setAutoDelegationDisabled(bool _disabled)",
+      "function setDelegateAddress(address _delegatee)",
+      "function splitDelegateVotes(tuple(address account, uint256 tokenId, tuple(uint208 amount, uint48 start) locked) _from, tuple(address account, uint256 tokenId, tuple(uint208 amount, uint48 start) locked) _to)",
+      "function tokenIsDelegated(uint256 tokenId) view returns (bool)",
+      "function undelegate(uint256[] _tokenIds)",
+      "function unpause()",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable"
+    ],
+    "eth:0xBA1854fDA7A5c127606572e43Dc7B37b7A15bdFf": [
+      "constructor(address _circuitVerifier, bytes32 _expectedNodesFoldKeyHash, bytes32 _expectedC5KeyHash, uint256 _h)",
+      "error DomainBindingMismatch()",
+      "error InvalidCircuitVerifier(address verifier)",
+      "error InvalidProof()",
+      "error InvalidPublicInputsLength()",
+      "error InvalidVerificationKeyHash()",
+      "error PkCommitmentMismatch()",
+      "error VkHashMismatch()",
+      "function circuitVerifier() view returns (address)",
+      "function expectedC5KeyHash() view returns (bytes32)",
+      "function expectedNodesFoldKeyHash() view returns (bytes32)",
+      "function h() view returns (uint256)",
+      "function verify(uint256 e3Id, uint256 committeeRoot, address[] sortedNodes, bytes32 pkCommitment, bytes32 committeeHash, bytes proof) view returns (bool)"
+    ],
+    "eth:0xbbc277951D93e866700471f71616b2c9D304E6F6": [
+      "error AlreadyInitialized()",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error DateOutOfBounds(uint64 limit, uint64 actual)",
+      "error DelegateCallFailed()",
+      "error FunctionDeprecated()",
+      "error InvalidTargetConfig(tuple(address target, uint8 operation) targetConfig)",
+      "error MinDurationOutOfBounds(uint64 limit, uint64 actual)",
+      "error NoVotingPower()",
+      "error NonexistentProposal(uint256 proposalId)",
+      "error ProposalAlreadyExists(uint256 proposalId)",
+      "error ProposalExecutionForbidden(uint256 proposalId)",
+      "error RatioOutOfBounds(uint256 limit, uint256 actual)",
+      "error TokenClockMismatch()",
+      "error VoteCastForbidden(uint256 proposalId, address account, uint8 voteOption)",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event ExcludedFromSupply(address[] accounts)",
+      "event Initialized(uint8 version)",
+      "event MembersAdded(address[] members)",
+      "event MembersRemoved(address[] members)",
+      "event MembershipContractAnnounced(address indexed definingContract)",
+      "event MetadataSet(bytes metadata)",
+      "event ProposalCreated(uint256 indexed proposalId, address indexed creator, uint64 startDate, uint64 endDate, bytes metadata, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap)",
+      "event ProposalExecuted(uint256 indexed proposalId)",
+      "event TargetSet(tuple(address target, uint8 operation) newTargetConfig)",
+      "event Upgraded(address indexed implementation)",
+      "event VoteCast(uint256 indexed proposalId, address indexed voter, uint8 voteOption, uint256 votingPower)",
+      "event VotingMinApprovalUpdated(uint256 minApprovals)",
+      "event VotingSettingsUpdated(uint8 votingMode, uint32 supportThreshold, uint32 minParticipation, uint64 minDuration, uint256 minProposerVotingPower)",
+      "function CREATE_PROPOSAL_PERMISSION_ID() view returns (bytes32)",
+      "function EXECUTE_PROPOSAL_PERMISSION_ID() view returns (bytes32)",
+      "function SET_METADATA_PERMISSION_ID() view returns (bytes32)",
+      "function SET_TARGET_CONFIG_PERMISSION_ID() view returns (bytes32)",
+      "function UPDATE_VOTING_SETTINGS_PERMISSION_ID() view returns (bytes32)",
+      "function UPGRADE_PLUGIN_PERMISSION_ID() view returns (bytes32)",
+      "function canExecute(uint256 _proposalId) view returns (bool)",
+      "function canVote(uint256 _proposalId, address _account, uint8 _voteOption) view returns (bool)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint256 _allowFailureMap, uint64 _startDate, uint64 _endDate, uint8 _voteOption, bool _tryEarlyExecution) returns (uint256 proposalId)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint64 _startDate, uint64 _endDate, bytes _data) returns (uint256 proposalId)",
+      "function customProposalParamsABI() pure returns (string)",
+      "function dao() view returns (address)",
+      "function execute(uint256 _proposalId)",
+      "function getCurrentTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getMetadata() view returns (bytes)",
+      "function getProposal(uint256 _proposalId) view returns (bool open, bool executed, tuple(uint8 votingMode, uint32 supportThreshold, uint64 startDate, uint64 endDate, uint64 snapshotTimepoint, uint256 minVotingPower) parameters, tuple(uint256 abstain, uint256 yes, uint256 no) tally, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap, tuple(address target, uint8 operation) targetConfig)",
+      "function getTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getVoteOption(uint256 _proposalId, address _voter) view returns (uint8)",
+      "function getVotingToken() view returns (address)",
+      "function hasSucceeded(uint256 _proposalId) view returns (bool)",
+      "function implementation() view returns (address)",
+      "function initialize(address _dao, tuple(uint8 votingMode, uint32 supportThreshold, uint32 minParticipation, uint64 minDuration, uint256 minProposerVotingPower) _votingSettings, address _token, tuple(address target, uint8 operation) _targetConfig, uint256 _minApprovals, bytes _pluginMetadata, address[] _excludedAccounts)",
+      "function initializeFrom(uint16 _fromBuild, bytes _initData)",
+      "function isMember(address _account) view returns (bool)",
+      "function isMinApprovalReached(uint256 _proposalId) view returns (bool)",
+      "function isMinParticipationReached(uint256 _proposalId) view returns (bool)",
+      "function isSupportThresholdReached(uint256 _proposalId) view returns (bool)",
+      "function isSupportThresholdReachedEarly(uint256 _proposalId) view returns (bool)",
+      "function minApproval() view returns (uint256)",
+      "function minDuration() view returns (uint64)",
+      "function minParticipation() view returns (uint32)",
+      "function minProposerVotingPower() view returns (uint256)",
+      "function pluginType() pure returns (uint8)",
+      "function proposalCount() view returns (uint256)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function proxiableUUID() view returns (bytes32)",
+      "function setMetadata(bytes _metadata)",
+      "function setTargetConfig(tuple(address target, uint8 operation) _targetConfig)",
+      "function supportThreshold() view returns (uint32)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function tokenIndexedByTimestamp() view returns (bool)",
+      "function totalVotingPower(uint256 _timePoint) view returns (uint256)",
+      "function updateMinApprovals(uint256 _minApprovals)",
+      "function updateVotingSettings(tuple(uint8 votingMode, uint32 supportThreshold, uint32 minParticipation, uint64 minDuration, uint256 minProposerVotingPower) _votingSettings)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable",
+      "function vote(uint256 _proposalId, uint8 _voteOption, bool _tryEarlyExecution)",
+      "function votingMode() view returns (uint8)"
+    ],
+    "eth:0xC0B5b49a3949eC4B520eF21BaCFE16e3695F3B5D": [
+      "constructor(address baseToken, address registry_, address initialOwner_)",
+      "error CannotRescueUnderlying()",
+      "error CheckpointUnorderedInsertion()",
+      "error DelegationLocked()",
+      "error ERC20ExceededSafeSupply(uint256 increasedSupply, uint256 cap)",
+      "error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)",
+      "error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)",
+      "error ERC20InvalidApprover(address approver)",
+      "error ERC20InvalidReceiver(address receiver)",
+      "error ERC20InvalidSender(address sender)",
+      "error ERC20InvalidSpender(address spender)",
+      "error ERC20InvalidUnderlying(address token)",
+      "error ERC5805FutureLookup(uint256 timepoint, uint48 clock)",
+      "error ERC6372InconsistentClock()",
+      "error InvalidAccountNonce(address account, uint256 currentNonce)",
+      "error InvalidShortString()",
+      "error NoPendingRegistry()",
+      "error NotRegistry()",
+      "error OutstandingPayableBalance(uint256 amount)",
+      "error OutstandingTicketSupply(uint256 amount)",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "error ReentrancyGuardReentrantCall()",
+      "error RegistryAlreadyLocked()",
+      "error RegistryChangeNotReady()",
+      "error RegistryChangePending()",
+      "error RegistryLockAlreadySet()",
+      "error RegistryNotLocked()",
+      "error RenounceOwnershipDisabled()",
+      "error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value)",
+      "error SafeERC20FailedOperation(address token)",
+      "error SameRegistry()",
+      "error StringTooLong(string str)",
+      "error TransferNotAllowed()",
+      "error UnderlyingTransferMismatch(uint256 expected, uint256 actual)",
+      "error VotesExpiredSignature(uint256 expiry)",
+      "error ZeroAddress()",
+      "event Approval(address indexed owner, address indexed spender, uint256 value)",
+      "event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate)",
+      "event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes)",
+      "event EIP712DomainChanged()",
+      "event ERC20Rescued(address indexed token, address indexed to, uint256 amount)",
+      "event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "event Payout(address indexed to, uint256 amount)",
+      "event RegistryChangeCancelled(address indexed pendingRegistry)",
+      "event RegistryChangeRequested(address indexed newRegistry, uint64 activatesAt)",
+      "event RegistryChanged(address indexed oldRegistry, address indexed newRegistry)",
+      "event RegistryLocked()",
+      "event Transfer(address indexed from, address indexed to, uint256 value)",
+      "function CLOCK_MODE() pure returns (string)",
+      "function REGISTRY_CHANGE_DELAY() view returns (uint64)",
+      "function acceptOwnership()",
+      "function activateRegistryChange()",
+      "function allowance(address owner, address spender) view returns (uint256)",
+      "function approve(address, uint256) pure returns (bool)",
+      "function balanceOf(address account) view returns (uint256)",
+      "function burnTickets(address operator, uint256 amount)",
+      "function cancelRegistryChange()",
+      "function checkpoints(address account, uint32 pos) view returns (tuple(uint48 _key, uint208 _value))",
+      "function clock() view returns (uint48)",
+      "function decimals() view returns (uint8)",
+      "function delegate(address delegatee)",
+      "function delegateBySig(address, uint256, uint256, uint8, bytes32, bytes32) pure",
+      "function delegates(address account) view returns (address)",
+      "function depositFor(address operator, uint256 amount) returns (bool success)",
+      "function depositFrom(address from, address to, uint256 amount) returns (bool)",
+      "function eip712Domain() view returns (bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)",
+      "function getPastTotalSupply(uint256 timepoint) view returns (uint256)",
+      "function getPastVotes(address account, uint256 timepoint) view returns (uint256)",
+      "function getVotes(address account) view returns (uint256)",
+      "function lockRegistry()",
+      "function name() view returns (string)",
+      "function nonces(address owner) view returns (uint256)",
+      "function numCheckpoints(address account) view returns (uint32)",
+      "function owner() view returns (address)",
+      "function payableBalance() view returns (uint256)",
+      "function payout(address to, uint256 amount)",
+      "function pendingOwner() view returns (address)",
+      "function pendingRegistry() view returns (address)",
+      "function pendingRegistryActivationTime() view returns (uint64)",
+      "function registry() view returns (address)",
+      "function registryLocked() view returns (bool)",
+      "function renounceOwnership() view",
+      "function requestRegistryChange(address newRegistry)",
+      "function rescueERC20(address token, address to, uint256 amount)",
+      "function setRegistry(address newRegistry)",
+      "function symbol() view returns (string)",
+      "function totalSupply() view returns (uint256)",
+      "function transfer(address to, uint256 value) returns (bool)",
+      "function transferFrom(address from, address to, uint256 value) returns (bool)",
+      "function transferOwnership(address newOwner)",
+      "function underlying() view returns (address)",
+      "function withdrawTo(address receiver, uint256 amount) returns (bool success)"
+    ],
+    "eth:0xC927A5B2d8F68697bC28C0670df05178c93df2d7": [
+      "constructor(address _logic, address initialOwner, bytes _data) payable",
+      "error AddressEmptyCode(address target)",
+      "error ERC1967InvalidAdmin(address admin)",
+      "error ERC1967InvalidImplementation(address implementation)",
+      "error ERC1967NonPayable()",
+      "error FailedCall()",
+      "error ProxyDeniedAdminAccess()",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0xc9707d36C07c3E0C4215a4574DB760b4e0E79166": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0xCB895791C84484530d9fC9f68652b9bCC9D5288d": [
+      "error AlreadyInitialized()",
+      "error BodyResultTypeNotSet(address body)",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error DelegateCallFailed()",
+      "error DuplicateBodyAddress(uint256 stageId, address body)",
+      "error FunctionDeprecated()",
+      "error InsufficientGas()",
+      "error InterfaceNotSupported()",
+      "error InvalidTargetConfig(tuple(address target, uint8 operation) targetConfig)",
+      "error NonexistentProposal(uint256 proposalId)",
+      "error ProposalAdvanceForbidden(uint256 proposalId)",
+      "error ProposalAlreadyExists(uint256 proposalId)",
+      "error ProposalCanNotBeCancelled(uint256 proposalId, uint16 stageId)",
+      "error ProposalCanNotBeEdited(uint256 proposalId, uint16 stageId)",
+      "error ProposalExecutionForbidden(uint256 proposalId)",
+      "error StageCountZero()",
+      "error StageDurationsInvalid()",
+      "error StageIdInvalid(uint64 currentStageId, uint64 reportedStageId)",
+      "error StageThresholdsInvalid()",
+      "error StartDateInvalid(uint64)",
+      "error Uint16MaxSizeExceeded()",
+      "error UnexpectedProposalState(uint256 proposalId, uint8 currentState, bytes32 allowedStates)",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Initialized(uint8 version)",
+      "event MetadataSet(bytes metadata)",
+      "event ProposalAdvanced(uint256 indexed proposalId, uint16 indexed stageId, address indexed sender)",
+      "event ProposalCanceled(uint256 indexed proposalId, uint16 indexed stageId, address indexed sender)",
+      "event ProposalCreated(uint256 indexed proposalId, address indexed creator, uint64 startDate, uint64 endDate, bytes metadata, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap)",
+      "event ProposalEdited(uint256 indexed proposalId, uint16 indexed stageId, address indexed sender, bytes metadata, tuple(address to, uint256 value, bytes data)[] actions)",
+      "event ProposalExecuted(uint256 indexed proposalId)",
+      "event ProposalResultReported(uint256 indexed proposalId, uint16 indexed stageId, address indexed body)",
+      "event StagesUpdated(tuple(tuple(address addr, bool isManual, bool tryAdvance, uint8 resultType)[] bodies, uint64 maxAdvance, uint64 minAdvance, uint64 voteDuration, uint16 approvalThreshold, uint16 vetoThreshold, bool cancelable, bool editable)[] stages)",
+      "event SubProposalCreated(uint256 indexed proposalId, uint16 indexed stageId, address indexed body, uint256 bodyProposalId)",
+      "event SubProposalNotCreated(uint256 indexed proposalId, uint16 indexed stageId, address indexed body, bytes reason)",
+      "event TargetSet(tuple(address target, uint8 operation) newTargetConfig)",
+      "event TrustedForwarderUpdated(address indexed forwarder)",
+      "event Upgraded(address indexed implementation)",
+      "function SET_METADATA_PERMISSION_ID() view returns (bytes32)",
+      "function SET_TARGET_CONFIG_PERMISSION_ID() view returns (bytes32)",
+      "function UPGRADE_PLUGIN_PERMISSION_ID() view returns (bytes32)",
+      "function advanceProposal(uint256 _proposalId)",
+      "function canExecute(uint256 _proposalId) view returns (bool)",
+      "function canProposalAdvance(uint256 _proposalId) view returns (bool)",
+      "function cancel(uint256 _proposalId)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint128 _allowFailureMap, uint64 _startDate, bytes[][] _proposalParams) returns (uint256 proposalId)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint64 _startDate, uint64, bytes _data) returns (uint256 proposalId)",
+      "function customProposalParamsABI() pure returns (string)",
+      "function dao() view returns (address)",
+      "function edit(uint256 _proposalId, bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions)",
+      "function execute(uint256 _proposalId)",
+      "function getBodyProposalId(uint256 _proposalId, uint16 _stageId, address _body) view returns (uint256)",
+      "function getBodyResult(uint256 _proposalId, uint16 _stageId, address _body) view returns (uint8)",
+      "function getCreateProposalParams(uint256 _proposalId, uint16 _stageId, uint256 _index) view returns (bytes)",
+      "function getCurrentConfigIndex() view returns (uint16)",
+      "function getCurrentTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getMetadata() view returns (bytes)",
+      "function getProposal(uint256 _proposalId) view returns (tuple(uint128 allowFailureMap, uint64 lastStageTransition, uint16 currentStage, uint16 stageConfigIndex, bool executed, bool canceled, address creator, tuple(address to, uint256 value, bytes data)[] actions, tuple(address target, uint8 operation) targetConfig))",
+      "function getProposalTally(uint256 _proposalId, uint16 _stageId) view returns (uint256 approvals, uint256 vetoes)",
+      "function getStages(uint256 _index) view returns (tuple(tuple(address addr, bool isManual, bool tryAdvance, uint8 resultType)[] bodies, uint64 maxAdvance, uint64 minAdvance, uint64 voteDuration, uint16 approvalThreshold, uint16 vetoThreshold, bool cancelable, bool editable)[])",
+      "function getTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getTrustedForwarder() view returns (address)",
+      "function hasAdvancePermission(address _account) view returns (bool)",
+      "function hasExecutePermission(address _account) view returns (bool)",
+      "function hasSucceeded(uint256 _proposalId) view returns (bool)",
+      "function implementation() view returns (address)",
+      "function initialize(address _dao, address _trustedForwarder, tuple(tuple(address addr, bool isManual, bool tryAdvance, uint8 resultType)[] bodies, uint64 maxAdvance, uint64 minAdvance, uint64 voteDuration, uint16 approvalThreshold, uint16 vetoThreshold, bool cancelable, bool editable)[] _stages, bytes _pluginMetadata, tuple(address target, uint8 operation) _targetConfig)",
+      "function isTrustedForwarder(address _forwarder) view returns (bool)",
+      "function pluginType() pure returns (uint8)",
+      "function proposalCount() view returns (uint256)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function proxiableUUID() view returns (bytes32)",
+      "function reportProposalResult(uint256 _proposalId, uint16 _stageId, uint8 _resultType, bool _tryAdvance)",
+      "function setMetadata(bytes _metadata)",
+      "function setTargetConfig(tuple(address target, uint8 operation) _targetConfig)",
+      "function setTrustedForwarder(address _forwarder)",
+      "function state(uint256 _proposalId) view returns (uint8)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function updateStages(tuple(tuple(address addr, bool isManual, bool tryAdvance, uint8 resultType)[] bodies, uint64 maxAdvance, uint64 minAdvance, uint64 voteDuration, uint16 approvalThreshold, uint16 vetoThreshold, bool cancelable, bool editable)[] _stages)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable"
+    ],
+    "eth:0xD0C2A1f94f7c584f0BF5588a519E82AD71dC1EC2": [
+      "constructor(address _dao, tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] _rules)",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "event Initialized(uint8 version)",
+      "event RulesUpdated(tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] rules)",
+      "function UPDATE_RULES_PERMISSION_ID() view returns (bytes32)",
+      "function dao() view returns (address)",
+      "function decodeRuleValue(uint256 _x) pure returns (uint32 a, uint32 b, uint32 c)",
+      "function encodeIfElse(uint256 startingRuleIndex, uint256 successRuleIndex, uint256 failureRuleIndex) pure returns (uint240)",
+      "function encodeLogicalOperator(uint256 ruleIndex1, uint256 ruleIndex2) pure returns (uint240)",
+      "function getRules() view returns (tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[])",
+      "function initialize(address _dao, tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] _rules)",
+      "function isGranted(address _where, address _who, bytes32 _permissionId, bytes) view returns (bool isPermitted)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function updateRules(tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] _rules)"
+    ],
+    "eth:0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552": [
+      "constructor()",
+      "event AddedOwner(address owner)",
+      "event ApproveHash(bytes32 indexed approvedHash, address indexed owner)",
+      "event ChangedFallbackHandler(address handler)",
+      "event ChangedGuard(address guard)",
+      "event ChangedThreshold(uint256 threshold)",
+      "event DisabledModule(address module)",
+      "event EnabledModule(address module)",
+      "event ExecutionFailure(bytes32 txHash, uint256 payment)",
+      "event ExecutionFromModuleFailure(address indexed module)",
+      "event ExecutionFromModuleSuccess(address indexed module)",
+      "event ExecutionSuccess(bytes32 txHash, uint256 payment)",
+      "event RemovedOwner(address owner)",
+      "event SafeReceived(address indexed sender, uint256 value)",
+      "event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler)",
+      "event SignMsg(bytes32 indexed msgHash)",
+      "function VERSION() view returns (string)",
+      "function addOwnerWithThreshold(address owner, uint256 _threshold)",
+      "function approveHash(bytes32 hashToApprove)",
+      "function approvedHashes(address, bytes32) view returns (uint256)",
+      "function changeThreshold(uint256 _threshold)",
+      "function checkNSignatures(bytes32 dataHash, bytes data, bytes signatures, uint256 requiredSignatures) view",
+      "function checkSignatures(bytes32 dataHash, bytes data, bytes signatures) view",
+      "function disableModule(address prevModule, address module)",
+      "function domainSeparator() view returns (bytes32)",
+      "function enableModule(address module)",
+      "function encodeTransactionData(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes)",
+      "function execTransaction(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, bytes signatures) payable returns (bool success)",
+      "function execTransactionFromModule(address to, uint256 value, bytes data, uint8 operation) returns (bool success)",
+      "function execTransactionFromModuleReturnData(address to, uint256 value, bytes data, uint8 operation) returns (bool success, bytes returnData)",
+      "function getChainId() view returns (uint256)",
+      "function getModulesPaginated(address start, uint256 pageSize) view returns (address[] array, address next)",
+      "function getOwners() view returns (address[])",
+      "function getStorageAt(uint256 offset, uint256 length) view returns (bytes)",
+      "function getThreshold() view returns (uint256)",
+      "function getTransactionHash(address to, uint256 value, bytes data, uint8 operation, uint256 safeTxGas, uint256 baseGas, uint256 gasPrice, address gasToken, address refundReceiver, uint256 _nonce) view returns (bytes32)",
+      "function isModuleEnabled(address module) view returns (bool)",
+      "function isOwner(address owner) view returns (bool)",
+      "function nonce() view returns (uint256)",
+      "function removeOwner(address prevOwner, address owner, uint256 _threshold)",
+      "function requiredTxGas(address to, uint256 value, bytes data, uint8 operation) returns (uint256)",
+      "function setFallbackHandler(address handler)",
+      "function setGuard(address guard)",
+      "function setup(address[] _owners, uint256 _threshold, address to, bytes data, address fallbackHandler, address paymentToken, uint256 payment, address paymentReceiver)",
+      "function signedMessages(bytes32) view returns (uint256)",
+      "function simulateAndRevert(address targetContract, bytes calldataPayload)",
+      "function swapOwner(address prevOwner, address oldOwner, address newOwner)"
+    ],
+    "eth:0xdB3c40bb17e9AD1f51178AF5A66eF32d19176A1c": [
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error DelegateCallFailed()",
+      "error FunctionDeprecated()",
+      "error FunctionNotSupported()",
+      "error InvalidTargetConfig(tuple(address target, uint8 operation) targetConfig)",
+      "event Initialized(uint8 version)",
+      "event MembersAdded(address[] members)",
+      "event MembersRemoved(address[] members)",
+      "event MembershipContractAnnounced(address indexed definingContract)",
+      "event ProposalCreated(uint256 indexed proposalId, address indexed creator, uint64 startDate, uint64 endDate, bytes metadata, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap)",
+      "event ProposalExecuted(uint256 indexed proposalId)",
+      "event TargetSet(tuple(address target, uint8 operation) newTargetConfig)",
+      "function EXECUTE_PROPOSAL_PERMISSION_ID() view returns (bytes32)",
+      "function SET_TARGET_CONFIG_PERMISSION_ID() view returns (bytes32)",
+      "function canExecute(uint256) view returns (bool)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint64, uint64, bytes _data) returns (uint256 proposalId)",
+      "function customProposalParamsABI() pure returns (string)",
+      "function dao() view returns (address)",
+      "function execute(uint256) view",
+      "function executeProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint256 _allowFailureMap) returns (uint256 proposalId)",
+      "function getCurrentTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function hasSucceeded(uint256) view returns (bool)",
+      "function initialize(address _dao, tuple(address target, uint8 operation) _targetConfig)",
+      "function isMember(address _account) view returns (bool)",
+      "function pluginType() pure returns (uint8)",
+      "function proposalCount() view returns (uint256)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function setTargetConfig(tuple(address target, uint8 operation) _targetConfig)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)"
+    ],
+    "eth:0xDbCaeec5B040A134314FfD43aA2ca0D16006f963": [
+      "constructor(address _registry)",
+      "error CheckpointUnorderedInsertion()",
+      "error FutureLookup(uint256 timepoint, uint48 clock)",
+      "error OnlyRegistry(address caller)",
+      "error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value)",
+      "error ZeroAddress()",
+      "event BondedCheckpointed(address indexed bondOwner, uint48 indexed timepoint, uint256 amount)",
+      "function CLOCK_MODE() pure returns (string)",
+      "function bonded(address account) view returns (uint256)",
+      "function clock() view returns (uint48)",
+      "function getPastBonded(address account, uint256 timepoint) view returns (uint256)",
+      "function registry() view returns (address)",
+      "function sync(address bondOwner, uint256 amount)"
+    ],
+    "eth:0xDE2C723Ada1363575c716aFB9477A777B2a2bd7C": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0xde423A95f7955CcA8848e0eDCA773F6A2FBA2d76": [
+      "constructor(address _multisig)",
+      "function isGranted(address _where, address _who, bytes32 _permissionId, bytes _data) view returns (bool)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)"
+    ],
+    "eth:0xE172e9B6cfBeeB5593bDcE3f077356FDb33af904": [
+      "constructor(address initialOwner_, uint64 ccaStart_, uint64 ccaEnd_, uint64 noMoreLocks_, address bondingRegistry_)",
+      "error AccessControlBadConfirmation()",
+      "error AccessControlUnauthorizedAccount(address account, bytes32 neededRole)",
+      "error AlreadyLive()",
+      "error CheckpointUnorderedInsertion()",
+      "error ClaimLockExemptQueuedLocks(address account)",
+      "error ClaimSourceAlreadySet(address current)",
+      "error ConflictingQueuedClaimPolicy(bytes32 existingPolicyId, bytes32 newPolicyId)",
+      "error ECDSAInvalidSignature()",
+      "error ECDSAInvalidSignatureLength(uint256 length)",
+      "error ECDSAInvalidSignatureS(bytes32 s)",
+      "error ERC20ExceededSafeSupply(uint256 increasedSupply, uint256 cap)",
+      "error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed)",
+      "error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed)",
+      "error ERC20InvalidApprover(address approver)",
+      "error ERC20InvalidReceiver(address receiver)",
+      "error ERC20InvalidSender(address sender)",
+      "error ERC20InvalidSpender(address spender)",
+      "error ERC2612ExpiredSignature(uint256 deadline)",
+      "error ERC2612InvalidSigner(address signer, address owner)",
+      "error ERC5805FutureLookup(uint256 timepoint, uint48 clock)",
+      "error ERC6372InconsistentClock()",
+      "error InsufficientUnlockedBalance(address account, uint256 spendable, uint256 value)",
+      "error InvalidAccountNonce(address account, uint256 currentNonce)",
+      "error InvalidBondingRegistry(address registry)",
+      "error InvalidCcaWindow(uint64 ccaStart, uint64 ccaEnd)",
+      "error InvalidNoMoreLocks(uint256 noMoreLocks, uint256 minimum)",
+      "error InvalidPolicy()",
+      "error InvalidShortString()",
+      "error MaxSupplyExceeded()",
+      "error MintingClosed()",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "error PolicyAlreadyDefined(bytes32 policyId)",
+      "error PolicyNotDefined(bytes32 policyId)",
+      "error RelinkAmountExceeded()",
+      "error RelinkSourceAlreadyVested(bytes32 policyId)",
+      "error RenounceOwnershipDisabled()",
+      "error RenounceRoleDisabledForOwner()",
+      "error SafeCastOverflowedUintDowncast(uint8 bits, uint256 value)",
+      "error StringTooLong(string str)",
+      "error TgeTooEarly(uint64 current, uint64 notBefore)",
+      "error TooManyLocks()",
+      "error TooManyQueuedLocks()",
+      "error TransferRestricted(address from, address to)",
+      "error VotesExpiredSignature(uint256 expiry)",
+      "error ZeroAddress()",
+      "error ZeroAmount()",
+      "event ActiveLockRelinked(address indexed account, bytes32 indexed fromPolicyId, bytes32 indexed toPolicyId, uint256 amount)",
+      "event ActiveLockUpdated(address indexed account, bytes32 indexed policyId, uint256 amount)",
+      "event AllocationMinted(address indexed recipient, uint256 amount, bytes32 indexed policyId, bytes32 indexed label)",
+      "event Approval(address indexed owner, address indexed spender, uint256 value)",
+      "event ClaimLockExemptUpdated(address indexed account, bool exempt)",
+      "event ClaimSourceSet(address indexed claimSource)",
+      "event DelegateChanged(address indexed delegator, address indexed fromDelegate, address indexed toDelegate)",
+      "event DelegateVotesChanged(address indexed delegate, uint256 previousVotes, uint256 newVotes)",
+      "event EIP712DomainChanged()",
+      "event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "event PolicyDefined(bytes32 indexed policyId, tuple(uint64 holdUntil, tuple(uint8 anchor, uint64 start, uint64 cliffDuration, uint64 vestDuration) unlock) policy)",
+      "event QueuedLockUpdated(address indexed account, bytes32 indexed policyId, uint256 amount)",
+      "event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole)",
+      "event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender)",
+      "event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender)",
+      "event TgeTriggered(uint64 timestamp)",
+      "event Transfer(address indexed from, address indexed to, uint256 value)",
+      "event TransferWhitelistUpdated(address indexed account, bool whitelisted)",
+      "function BONDING_REGISTRY() view returns (address)",
+      "function CCA_END() view returns (uint64)",
+      "function CCA_START() view returns (uint64)",
+      "function CLAIM_SOURCE() view returns (address)",
+      "function CLOCK_MODE() pure returns (string)",
+      "function DEFAULT_ADMIN_ROLE() view returns (bytes32)",
+      "function DOMAIN_SEPARATOR() view returns (bytes32)",
+      "function LOCK_MANAGER_ROLE() view returns (bytes32)",
+      "function MAX_LOCKS_PER_ACCOUNT() view returns (uint256)",
+      "function MAX_QUEUED_LOCKS_PER_ACCOUNT() view returns (uint256)",
+      "function MAX_SUPPLY() view returns (uint256)",
+      "function MINTER_ROLE() view returns (bytes32)",
+      "function NO_MORE_LOCKS() view returns (uint64)",
+      "function PENDING_LOCK_POLICY_ID() view returns (bytes32)",
+      "function TGE_COOLDOWN() view returns (uint64)",
+      "function WHITELIST_ROLE() view returns (bytes32)",
+      "function acceptOwnership()",
+      "function allowance(address owner, address spender) view returns (uint256)",
+      "function approve(address spender, uint256 value) returns (bool)",
+      "function balanceOf(address account) view returns (uint256)",
+      "function checkpoints(address account, uint32 pos) view returns (tuple(uint48 _key, uint208 _value))",
+      "function claimLockExempt(address account) view returns (bool exempt)",
+      "function clock() view returns (uint48)",
+      "function createLockPolicy(bytes32 policyId, tuple(uint64 holdUntil, tuple(uint8 anchor, uint64 start, uint64 cliffDuration, uint64 vestDuration) unlock) policy)",
+      "function decimals() view returns (uint8)",
+      "function delegate(address delegatee)",
+      "function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s)",
+      "function delegates(address account) view returns (address)",
+      "function eip712Domain() view returns (bytes1 fields, string name, string version, uint256 chainId, address verifyingContract, bytes32 salt, uint256[] extensions)",
+      "function getPastTotalSupply(uint256 timepoint) view returns (uint256)",
+      "function getPastVotes(address account, uint256 timepoint) view returns (uint256)",
+      "function getRoleAdmin(bytes32 role) view returns (bytes32)",
+      "function getVotes(address account) view returns (uint256)",
+      "function grantRole(bytes32 role, address account)",
+      "function hasRole(bytes32 role, address account) view returns (bool)",
+      "function linkClaim(address account, uint256 amount, bytes32 policyId)",
+      "function lockCount(address account) view returns (uint256)",
+      "function lockPolicyOf(bytes32 policyId) view returns (tuple(uint64 holdUntil, tuple(uint8 anchor, uint64 start, uint64 cliffDuration, uint64 vestDuration) unlock))",
+      "function lockedBalanceAt(address account, uint64 timestamp) view returns (uint256 lockedBalance)",
+      "function lockedBalanceOf(address account) view returns (uint256)",
+      "function locks(address account, uint256) view returns (bytes32 policyId, uint256 amount)",
+      "function mint(address recipient, uint256 amount, bytes32 label)",
+      "function mintAllocations(tuple(address recipient, uint256 amount, bytes32 policyId, bytes32 label)[] allocations)",
+      "function name() view returns (string)",
+      "function nonces(address owner) view returns (uint256)",
+      "function numCheckpoints(address account) view returns (uint32)",
+      "function owner() view returns (address)",
+      "function pendingOwner() view returns (address)",
+      "function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)",
+      "function phase() view returns (uint8)",
+      "function queuedLockCount(address account) view returns (uint256)",
+      "function queuedLocks(address account, uint256) view returns (bytes32 policyId, uint256 amount)",
+      "function relinkActiveLock(address account, bytes32 fromPolicyId, bytes32 toPolicyId, uint256 amount)",
+      "function renounceOwnership() view",
+      "function renounceRole(bytes32 role, address callerConfirmation)",
+      "function revokeRole(bytes32 role, address account)",
+      "function setClaimLockExempt(address account, bool exempt)",
+      "function setClaimSource(address claimSource)",
+      "function setTransferWhitelisted(address account, bool whitelisted)",
+      "function supportsInterface(bytes4 interfaceId) view returns (bool)",
+      "function symbol() view returns (string)",
+      "function tge()",
+      "function tgeTimestamp() view returns (uint64)",
+      "function totalSupply() view returns (uint256)",
+      "function transfer(address to, uint256 value) returns (bool)",
+      "function transferFrom(address from, address to, uint256 value) returns (bool)",
+      "function transferOwnership(address newOwner)",
+      "function transferWhitelist(address account) view returns (bool whitelisted)",
+      "function transferableBalanceOf(address account) view returns (uint256)"
+    ],
+    "eth:0xE437E5c7EeB0D49F97CfD040fb8a02A60a61c0f0": [
+      "constructor(address _dao, tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] _rules)",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "event Initialized(uint8 version)",
+      "event RulesUpdated(tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] rules)",
+      "function UPDATE_RULES_PERMISSION_ID() view returns (bytes32)",
+      "function dao() view returns (address)",
+      "function decodeRuleValue(uint256 _x) pure returns (uint32 a, uint32 b, uint32 c)",
+      "function encodeIfElse(uint256 startingRuleIndex, uint256 successRuleIndex, uint256 failureRuleIndex) pure returns (uint240)",
+      "function encodeLogicalOperator(uint256 ruleIndex1, uint256 ruleIndex2) pure returns (uint240)",
+      "function getRules() view returns (tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[])",
+      "function initialize(address _dao, tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] _rules)",
+      "function isGranted(address _where, address _who, bytes32 _permissionId, bytes) view returns (bool isPermitted)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)",
+      "function updateRules(tuple(uint8 id, uint8 op, uint240 value, bytes32 permissionId)[] _rules)"
+    ],
+    "eth:0xE506249Ba5ede04A68b702b92704a0b88054f86A": [
+      "constructor()",
+      "error AlreadyClaimed(uint256 e3Id, address claimant)",
+      "error AssetTransferMismatch(address token, uint256 expected, uint256 actual)",
+      "error E3NotFailed(uint256 e3Id)",
+      "error ExpulsionProposalNotPending(uint256 e3Id, uint256 proposalId)",
+      "error InsolventToken(address token, uint256 liability, uint256 balance)",
+      "error InvalidFailureReason(uint8 reason)",
+      "error InvalidInitialization()",
+      "error InvalidSlashingManager()",
+      "error NoRefundAvailable(uint256 e3Id)",
+      "error NotHonestNode(uint256 e3Id, address caller)",
+      "error NotInitializing()",
+      "error NotRequester(uint256 e3Id, address caller)",
+      "error NothingToClaim()",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "error RefundNotCalculated(uint256 e3Id)",
+      "error RenounceOwnershipDisabled()",
+      "error RewardPendingExpulsion(uint256 e3Id, address operator)",
+      "error RewardRecipientAlreadySnapshotted(uint256 e3Id, address operator)",
+      "error RewardRecipientNotSnapshotted(uint256 e3Id, address operator)",
+      "error RewardTokenMismatch(address expected, address actual)",
+      "error SafeERC20FailedOperation(address token)",
+      "error SlashTokenMismatch(address expected, address actual)",
+      "error Unauthorized()",
+      "event E3PolicySnapshotted(uint256 indexed e3Id, uint64 indexed version, address indexed treasury, address interfold, address registry, address bondingRegistry, address slashingManager, tuple(uint16 committeeFormationBps, uint16 dkgBps, uint16 decryptionBps, uint16 protocolBps, uint16 successSlashedNodeBps) allocation)",
+      "event ExpulsionProposalStatusChanged(uint256 indexed e3Id, uint256 indexed proposalId, address indexed operator, bool pending, bool expelled)",
+      "event HeldSuccessRewardClaimed(uint256 indexed e3Id, address indexed account, address indexed token, uint256 amount)",
+      "event Initialized(uint64 version)",
+      "event InterfoldSet(address indexed interfold)",
+      "event InterfoldUpdated(address indexed previous, address indexed next)",
+      "event OwnershipTransferStarted(address indexed previousOwner, address indexed newOwner)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "event RefundClaimed(uint256 indexed e3Id, address indexed claimant, uint256 amount, bytes32 claimType)",
+      "event RefundDistributionCalculated(uint256 indexed e3Id, uint256 requesterAmount, uint256 honestNodeAmount, uint256 protocolAmount, uint256 totalSlashed)",
+      "event RewardRecipientSnapshotted(uint256 indexed e3Id, address indexed operator, address indexed recipient)",
+      "event SlashedFundsApplied(uint256 indexed e3Id, address indexed token, uint256 toRequester, uint256 toHonestNodes)",
+      "event SlashedFundsClaimed(uint256 indexed e3Id, address indexed account, address indexed token, uint256 amount)",
+      "event SlashedFundsCredited(uint256 indexed e3Id, address indexed account, address indexed token, uint256 amount)",
+      "event SlashedFundsDistributedOnSuccess(uint256 indexed e3Id, address indexed token, uint256 toNodes, uint256 toProtocol)",
+      "event SlashedFundsEscrowed(uint256 indexed e3Id, address indexed token, uint256 amount)",
+      "event SuccessRewardHeld(uint256 indexed e3Id, address indexed operator, address indexed token, uint256 amount)",
+      "event TreasurySet(address indexed treasury)",
+      "event TreasurySlashedClaimed(address indexed treasury, address indexed token, uint256 amount)",
+      "event TreasurySlashedCredited(address indexed treasury, address indexed token, uint256 amount)",
+      "event TreasuryUpdated(address indexed previous, address indexed next)",
+      "event WorkAllocationUpdated(tuple(uint16 committeeFormationBps, uint16 dkgBps, uint16 decryptionBps, uint16 protocolBps, uint16 successSlashedNodeBps) allocation)",
+      "function MAX_PROTOCOL_BPS() view returns (uint16)",
+      "function acceptOwnership()",
+      "function bondingRegistry() view returns (address)",
+      "function calculateRefund(uint256 e3Id, uint256 originalPayment, address[] honestNodes, address paymentToken)",
+      "function calculateWorkValue(uint8 stage) view returns (uint16 workCompletedBps, uint16 workRemainingBps)",
+      "function claimHeldSuccessReward(uint256 e3Id) returns (uint256 amount)",
+      "function claimHonestNodeReward(uint256 e3Id, address operator) returns (uint256 amount)",
+      "function claimRequesterRefund(uint256 e3Id) returns (uint256 amount)",
+      "function claimSlashedFunds(uint256 e3Id, address token) returns (uint256 amount)",
+      "function distributeSlashedFundsOnSuccess(uint256 e3Id, address paymentToken)",
+      "function escrowSlashedFunds(uint256 e3Id, uint256 proposalId, address operator, address token, uint256 amount)",
+      "function getE3PolicySnapshot(uint256 e3Id) view returns (tuple(tuple(uint16 committeeFormationBps, uint16 dkgBps, uint16 decryptionBps, uint16 protocolBps, uint16 successSlashedNodeBps) allocation, address treasury, address interfold, address registry, uint64 version, bool initialized, address bondingRegistry, address slashingManager) snapshot)",
+      "function getFailurePayer(uint8 reason) pure returns (uint8 payer)",
+      "function getRefundDistribution(uint256 e3Id) view returns (tuple(uint256 requesterAmount, uint256 honestNodeAmount, uint256 protocolAmount, uint256 totalSlashed, uint256 honestNodeCount, bool calculated, address feeToken, uint256 originalPayment, uint256 perNodeAmount))",
+      "function getWorkAllocation() view returns (tuple(uint16 committeeFormationBps, uint16 dkgBps, uint16 decryptionBps, uint16 protocolBps, uint16 successSlashedNodeBps))",
+      "function hasHonestNodeClaimed(uint256 e3Id, address operator) view returns (bool)",
+      "function hasRequesterClaimed(uint256 e3Id, address claimant) view returns (bool)",
+      "function holdSuccessReward(uint256 e3Id, address operator, address token, uint256 amount)",
+      "function initialize(address _owner, address _interfold, address _treasury)",
+      "function interfold() view returns (address)",
+      "function openExpulsionProposal(uint256 e3Id, uint256 proposalId, address operator)",
+      "function owner() view returns (address)",
+      "function pendingHeldSuccessReward(uint256 e3Id, address account) view returns (uint256 amount)",
+      "function pendingOwner() view returns (address)",
+      "function pendingSlashedClaim(uint256 e3Id, address token, address account) view returns (uint256)",
+      "function pendingSlashedFunds(uint256 e3Id, address token) view returns (uint256)",
+      "function pendingTreasuryClaim(address treasuryAddr, address token) view returns (uint256)",
+      "function policyVersion() view returns (uint64)",
+      "function renounceOwnership() view",
+      "function resolveExpulsionProposal(uint256 e3Id, uint256 proposalId, bool expelled)",
+      "function rewardDisposition(uint256 e3Id, address operator) view returns (address recipient, bool held)",
+      "function rewardRecipient(uint256 e3Id, address operator) view returns (address recipient)",
+      "function setInterfold(address _interfold)",
+      "function setTreasury(address _treasury)",
+      "function setWorkAllocation(tuple(uint16 committeeFormationBps, uint16 dkgBps, uint16 decryptionBps, uint16 protocolBps, uint16 successSlashedNodeBps) allocation)",
+      "function settleSlashedFunds(uint256 e3Id, uint256 proposalId)",
+      "function snapshotE3Policy(uint256 e3Id, address registry)",
+      "function snapshotRewardRecipients(uint256 e3Id, address[] operators)",
+      "function supportsInterface(bytes4 interfaceId) pure returns (bool)",
+      "function tokenLiability(address token) view returns (uint256)",
+      "function transferOwnership(address newOwner)",
+      "function treasury() view returns (address)",
+      "function treasuryClaim(address token) returns (uint256 amount)"
+    ],
+    "eth:0xE5657c0756B772B600D6c73eDbF046f32129c770": [
+      "error AttestationBindingCountMismatch()",
+      "error ECDSAInvalidSignature()",
+      "error ECDSAInvalidSignatureLength(uint256 length)",
+      "error ECDSAInvalidSignatureS(bytes32 s)",
+      "error InvalidFoldAttestation()",
+      "error PartyIdNotInProof()",
+      "function decodeAttestationBundle(bytes dkgAttestationBundle) pure returns (tuple(uint256 partyId, bytes32 skAggCommit, bytes32 esmAggCommit, bytes signature)[] attestations, tuple(uint256 partyId, address node)[] bindings)",
+      "function decodeProofPublicInputs(bytes proof) pure returns (bytes32[] publicInputs)",
+      "function verify(address registry, uint256 chainId, uint256 e3Id, bytes proof, bytes dkgAttestationBundle) view returns (uint256[] partyIds, bytes32[] skAggCommits, bytes32[] esmAggCommits)"
+    ],
+    "eth:0xEC0162045B44C5506954E3A04dbbcdfe39f64f21": [
+      "constructor()",
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Initialized(uint8 version)",
+      "event Upgraded(address indexed implementation)",
+      "function CLOCK_ADMIN_ROLE() view returns (bytes32)",
+      "function checkpointInterval() pure returns (uint256)",
+      "function currentEpoch() view returns (uint256)",
+      "function dao() view returns (address)",
+      "function elapsedInEpoch() view returns (uint256)",
+      "function epochDuration() pure returns (uint256)",
+      "function epochNextCheckpointIn() view returns (uint256)",
+      "function epochNextCheckpointTs() view returns (uint256)",
+      "function epochPrevCheckpointElapsed() view returns (uint256)",
+      "function epochPrevCheckpointTs() view returns (uint256)",
+      "function epochStartTs() view returns (uint256)",
+      "function epochStartsIn() view returns (uint256)",
+      "function epochVoteEndTs() view returns (uint256)",
+      "function epochVoteEndsIn() view returns (uint256)",
+      "function epochVoteStartTs() view returns (uint256)",
+      "function epochVoteStartsIn() view returns (uint256)",
+      "function implementation() view returns (address)",
+      "function initialize(address _dao)",
+      "function proxiableUUID() view returns (bytes32)",
+      "function resolveElapsedInEpoch(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpoch(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochNextCheckpointIn(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochNextCheckpointTs(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochPrevCheckpointElapsed(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochPrevCheckpointTs(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochStartTs(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochStartsIn(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochVoteEndTs(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochVoteEndsIn(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochVoteStartTs(uint256 timestamp) pure returns (uint256)",
+      "function resolveEpochVoteStartsIn(uint256 timestamp) pure returns (uint256)",
+      "function resolveVotingActive(uint256 timestamp) pure returns (bool)",
+      "function upgradeTo(address newImplementation)",
+      "function upgradeToAndCall(address newImplementation, bytes data) payable",
+      "function voteDuration() pure returns (uint256)",
+      "function voteWindowBuffer() pure returns (uint256)",
+      "function votingActive() view returns (bool)"
+    ],
+    "eth:0xf023390C78CF95a77A8910187d5B09BBC05F37e9": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0xf143b969ea481Ccf251194D15F82007C67AABc53": [
+      "constructor(address _circuitVerifier, address _ciphernodeRegistry, bytes32 _expectedC6FoldKeyHash, bytes32 _expectedC7KeyHash, uint256 _threshold)",
+      "error CiphertextCommitmentMismatch()",
+      "error DkgAnchorMismatch()",
+      "error DkgAnchorNotFound()",
+      "error DomainBindingMismatch()",
+      "error InvalidCircuitVerifier(address verifier)",
+      "error InvalidProof()",
+      "error InvalidPublicInputsLength()",
+      "error InvalidVerificationKeyHash()",
+      "error MessageCoefficientOutOfRange(uint256 index)",
+      "error NonCanonicalPublicInput(uint256 index)",
+      "error PlaintextHashMismatch()",
+      "error VkHashMismatch()",
+      "function ciphernodeRegistry() view returns (address)",
+      "function circuitVerifier() view returns (address)",
+      "function expectedC6FoldKeyHash() view returns (bytes32)",
+      "function expectedC7KeyHash() view returns (bytes32)",
+      "function threshold() view returns (uint256)",
+      "function verify(uint256 e3Id, bytes32 decryptionDomain, bytes32 plaintextOutputHash, bytes32 committeeHash, bytes32 ciphertextCommitment, bytes proof) view returns (bool)"
+    ],
+    "eth:0xf1511Fc32abf7Bd3a3213ddCF08C07259b53972b": [
+      "constructor(address initialOwner)",
+      "error OwnableInvalidOwner(address owner)",
+      "error OwnableUnauthorizedAccount(address account)",
+      "event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)",
+      "function UPGRADE_INTERFACE_VERSION() view returns (string)",
+      "function owner() view returns (address)",
+      "function renounceOwnership()",
+      "function transferOwnership(address newOwner)",
+      "function upgradeAndCall(address proxy, address implementation, bytes data) payable"
+    ],
+    "eth:0xF21e25455988887EE797050080141eba67B33920": [
+      "error DaoUnauthorized(address dao, address where, address who, bytes32 permissionId)",
+      "error DelegateCallFailed()",
+      "error FunctionDeprecated()",
+      "error FunctionNotSupported()",
+      "error InvalidTargetConfig(tuple(address target, uint8 operation) targetConfig)",
+      "event Initialized(uint8 version)",
+      "event MembersAdded(address[] members)",
+      "event MembersRemoved(address[] members)",
+      "event MembershipContractAnnounced(address indexed definingContract)",
+      "event ProposalCreated(uint256 indexed proposalId, address indexed creator, uint64 startDate, uint64 endDate, bytes metadata, tuple(address to, uint256 value, bytes data)[] actions, uint256 allowFailureMap)",
+      "event ProposalExecuted(uint256 indexed proposalId)",
+      "event TargetSet(tuple(address target, uint8 operation) newTargetConfig)",
+      "function EXECUTE_PROPOSAL_PERMISSION_ID() view returns (bytes32)",
+      "function SET_TARGET_CONFIG_PERMISSION_ID() view returns (bytes32)",
+      "function canExecute(uint256) view returns (bool)",
+      "function createProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint64, uint64, bytes _data) returns (uint256 proposalId)",
+      "function customProposalParamsABI() pure returns (string)",
+      "function dao() view returns (address)",
+      "function execute(uint256) view",
+      "function executeProposal(bytes _metadata, tuple(address to, uint256 value, bytes data)[] _actions, uint256 _allowFailureMap) returns (uint256 proposalId)",
+      "function getCurrentTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function getTargetConfig() view returns (tuple(address target, uint8 operation))",
+      "function hasSucceeded(uint256) view returns (bool)",
+      "function initialize(address _dao, tuple(address target, uint8 operation) _targetConfig)",
+      "function isMember(address _account) view returns (bool)",
+      "function pluginType() pure returns (uint8)",
+      "function proposalCount() view returns (uint256)",
+      "function protocolVersion() pure returns (uint8[3])",
+      "function setTargetConfig(tuple(address target, uint8 operation) _targetConfig)",
+      "function supportsInterface(bytes4 _interfaceId) view returns (bool)"
+    ],
+    "eth:0xF3eeE0f5E721b8c0073C8d85bf26A3d6EC293A0E": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ],
+    "eth:0xfb4e1e518E5F7F8903233e639662110F31Db0BDC": [
+      "constructor(address _logic, bytes _data) payable",
+      "event AdminChanged(address previousAdmin, address newAdmin)",
+      "event BeaconUpgraded(address indexed beacon)",
+      "event Upgraded(address indexed implementation)"
+    ]
+  },
+  "usedTemplates": {
+    "global/ProxyAdmin": "0x7d24ef68050bed263f4cfd0471631d16b2f33814fbbd4e9aadf666c81bbf0c2d",
+    "GnosisSafe": "0x12db59bec64fa8de67bbeb6a6e913f6c5ff1598c0a5fba90282afaf08e2a748c",
+    "interfold/AdminPlugin": "0xeb97b344f92a6893418d119daba2374375a4b8784f8f20b894a6ffd7cf50931b",
+    "interfold/AragonExecutor": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
+    "interfold/BfvDecryptionVerifier": "0xaf4a1131904fe4daaa6bbff6ae264ef0934d354c8f34543400f13b8b3ddc008b",
+    "interfold/BfvPkVerifier": "0x5b399d37f16f3a92a1a983ad874e6ec7b82dd2eef214b61328c7fffcc1f58fdf",
+    "interfold/BondedCheckpoints": "0xe6c229b46bf9c90035a806064d3363aa3d3d2f6da263ba7c7e536368afba4d98",
+    "interfold/BondedVotes": "0xfac0485d490c70596b698b188666552d13f860f15af50deec8c76e68bfa161bd",
+    "interfold/BondingRegistry": "0xb026ea753a46fead40a2ab06cfc90ec2736adfc3edf42d63f16469b962346f97",
+    "interfold/CiphernodeRegistry": "0x6df456d0c897010421578026694c651940c41650054b57567aaa0a947bfb0671",
+    "interfold/DecryptionAggregatorVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
+    "interfold/DkgAggregatorVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
+    "interfold/DkgFoldAttestationVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
+    "interfold/E3RefundManager": "0x855bd52811ecbdce8287a6e031b9bc6af760fd2e4918c6b243080d4b043c66a1",
+    "interfold/EscrowVotesAdapter": "0xc0fcfd319841f6937a3f8cb19a9667b0a98ae0242a228bb95f5fa611d026d742",
+    "interfold/Interfold": "0xdece5c720b2d9e197e6f73dab0c7b428c5adb674bce3071ffcfba257ccbedf35",
+    "interfold/InterfoldTicketToken": "0xdbb50b3322880f5d78622512b57176b8ddac288df786babb28eb8189ed3379c5",
+    "interfold/InterfoldToken": "0x4c2298a429359011baf43e387dc7bf32acbfa98825e4f38b88d4895f5b82192a",
+    "interfold/ListedCheckCondition": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
+    "interfold/MockE3Program": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
+    "interfold/SlashingManager": "0xe8a82c7bf37c143628d9d4f14bd81a00194072daa9b4361d4a4b2850740917a2",
+    "interfold/SPPRuleCondition": "0x5e910f30e18719b1a14370f9e12ccac1f498bd55b02348624de7347dff0cdb73",
+    "interfold/StagedProposalProcessor": "0xd824b8bbc830230c07c7c06ac81fa5461a6b09475bf6bd31c4739d5fbbea3471",
+    "interfold/TokenVoting": "0x1d36005684c22db4d3cb3c4c38d11ed3095d16a382607161055eab88b93367b9",
+    "interfold/VotingEscrow": "0x987985d61b4ce8ed47a8a0e84274daa4d4b714394d4ef60ef8497d91f7320a79",
+    "interfold/VotingEscrowClock": "0xb3d1f3e3be53f0cb5bc84a51619a274edc28b8db6a90290fc9e97dc48c07ebbf",
+    "interfold/VotingEscrowExitQueue": "0x13fc8814bd2cc6e0d77552735d3729ece3aec94e26bfad7304ca0f09f107600c",
+    "interfold/VotingEscrowGaugeVoter": "0x138207b49fad1549c035ccf3c3a3bd88ae6612bfbf0d97017cfac6bd36186705",
+    "interfold/VotingEscrowLockNFT": "0x8ccc68e1358a507858b1ebb37bce7d67d1577128bc34db2cbfbc5de1e79f893c",
+    "interfold/VotingPowerCurve": "0x70bdcb75529eae783d822b5d4b22cc188405c27fad11508f98df8fbb60440696",
+    "zama/Multisig": "0xfacece6ea884ad4d49a3d294d69053b6102e847852204f7f3a65f9980facf297",
+    "zama/ZamaDAO": "0xfdc0657fce067cffceacf21c2bc38f8c430c7c5ac4ebbe75f97dca7436e0f4b8"
+  },
+  "usedBlockNumbers": { "ethereum": 25831624 },
+  "permissionsConfigHash": "0xad8678317ef07577238accdf3222b74868ee09efdfda3fe8b2a31001167658d4"
+}

--- a/packages/config/src/projects/interfold/discovered.json
+++ b/packages/config/src/projects/interfold/discovered.json
@@ -4054,7 +4054,7 @@
         "0x181143fe8736537b7086ceca31a6731ebb34e2e2612a63c3ff66ef5c7f3816af"
       ],
       "proxyType": "EIP1967 proxy",
-      "description": "Upgradeable registry of ciphernodes and per-E3 committees. It performs ticket-weighted committee sortition, records DKG proof anchors and the committee public key, and tracks committee viability.",
+      "description": "Registry of ciphernodes and E3 committees. It performs ticket-weighted committee selection, records DKG (distributed key generation) proof anchors and the committee public key (to which cyphertexts can be encrypted), and tracks committee viability.",
       "ignoreInWatchMode": ["ciphernodes", "root", "treeSize"],
       "deployerAddress": "eth:0x53bcFaEd43441C7bB6149563eC11f756739C9f6A",
       "sinceTimestamp": 1787109059,
@@ -4078,6 +4078,7 @@
             ["eth:0xB06Aaf9EF87984192490E947078D2f3563399b7B"]
           ]
         ],
+        "$threshold": 2,
         "$upgradeCount": 1,
         "ACCUSATION_VOTE_VALIDITY_TIMELOCK": 172800,
         "accusationVoteValidity": 1800,
@@ -4103,6 +4104,7 @@
         "pendingDkgFoldAttestationVerifierAt": 0,
         "pendingOwner": "eth:0x0000000000000000000000000000000000000000",
         "root": "21566062968715035133984466498059665708961681597209426751743703534648845223200",
+        "selectedCommitteeSize": 3,
         "slashingManager": "eth:0x974E865B1BB24AF2a9ef8204AdEA9251Cc7C5FD9",
         "sortitionSubmissionWindow": 600,
         "TREE_DEPTH": 20,
@@ -4115,8 +4117,15 @@
           "type": "PERMISSION"
         },
         "$members": {
-          "description": "Current registered ciphernode operator keys reconstructed from add and remove events. Distinct keys do not prove distinct owners or infrastructure.",
+          "description": "Current registered ciphernode operator keys reconstructed from add and remove events. Distinct keys do not prove distinct owners or infrastructure. For each E3, the active configuration selects three of these keys; $threshold applies to that selected committee, not to the full registry.",
           "type": "PERMISSION"
+        },
+        "$threshold": {
+          "description": "Decryption shares required within each newly selected minimum-size committee. This represents two of the selected three ciphernodes, not two of all registered $members."
+        },
+        "selectedCommitteeSize": {
+          "description": "Number of ciphernodes selected from $members for each minimum-size committee.",
+          "type": "RISK_PARAMETER"
         },
         "dkgFoldAttestationVerifier": {
           "description": "Verifier that authenticates each selected node's DKG-fold commitment before the aggregate DKG proof is accepted.",
@@ -8028,7 +8037,7 @@
     "interfold/BondedCheckpoints": "0xe6c229b46bf9c90035a806064d3363aa3d3d2f6da263ba7c7e536368afba4d98",
     "interfold/BondedVotes": "0xfac0485d490c70596b698b188666552d13f860f15af50deec8c76e68bfa161bd",
     "interfold/BondingRegistry": "0xb026ea753a46fead40a2ab06cfc90ec2736adfc3edf42d63f16469b962346f97",
-    "interfold/CiphernodeRegistry": "0x6df456d0c897010421578026694c651940c41650054b57567aaa0a947bfb0671",
+    "interfold/CiphernodeRegistry": "0x576e4859e27ec869c0f45315643a88670ed40d4429bb02701422d74c6bf4b67b",
     "interfold/DecryptionAggregatorVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
     "interfold/DkgAggregatorVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
     "interfold/DkgFoldAttestationVerifier": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",

--- a/packages/config/src/test/discovery/config.test.ts
+++ b/packages/config/src/test/discovery/config.test.ts
@@ -46,6 +46,7 @@ export const onChainProjects: string[] = [
   'railgun',
   'tornado-cash',
   'butternetwork',
+  'interfold',
 ]
 
 describe('discovery config.jsonc', () => {


### PR DESCRIPTION
some contracts [are live on ethereum, but paused atm](https://pr12662-discoui-v2.previews.l2beat.com/ui/p/interfold)
they do **ephemeral programmably private offchain execution**


**voting** is a potential application and is currently deployed:
1. 'cyphernodes' create a 2/3 public key (threshold crypto + FHE)
2. voters encrypt their ballots to that pubkey and post the cyphertext onchain (FHE)
3. coprocessor does FHE execution, adding the ballots together (onchain RISC0 validity proof binds it to the cyphertext inputs and attests application exec validity)
4. public key is validated onchain with Honk proof (validity of committee selection and per-node commitments)
5. tally is submitted onchain, then threshold decrypted by 2/3 cyphernodes
6. onchain honk aggregation proof attests that the decryption is valid (binds cyphertext to plaintext tally)