### PR TITLE
Extract BubbleHolesClip and clip roads to bubble holes

### DIFF
--- a/packages/frontend/src/pages/interop/components/flows/graph/BackgroundRoads.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/graph/BackgroundRoads.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react'
+import { useId, useMemo } from 'react'
 import { useInteropFlows } from '../utils/InteropFlowsContext'
+import { BubbleHolesClip } from './BubbleHolesClip'
 import type { FlowsGraphLayout } from './utils/computeGraphLayout'
 import {
   BIDIRECTIONAL_OFFSET,
@@ -19,6 +20,7 @@ interface Props {
  */
 export function BackgroundRoads({ chainIds, layout, centerX, centerY }: Props) {
   const { highlightedChains } = useInteropFlows()
+  const clipId = `roads-clip-${useId().replace(/\W/g, '')}`
 
   const { activePaths, inactivePaths } = useMemo(() => {
     const active: string[] = []
@@ -72,7 +74,8 @@ export function BackgroundRoads({ chainIds, layout, centerX, centerY }: Props) {
   const activeStrokeWidth = highlightedChains.length > 0 ? 1.5 : 0.5
 
   return (
-    <g pointerEvents="none" aria-hidden="true">
+    <g pointerEvents="none" aria-hidden="true" clipPath={`url(#${clipId})`}>
+      <BubbleHolesClip id={clipId} chainIds={chainIds} layout={layout} />
       {inactivePaths && (
         <path
           d={inactivePaths}

--- a/packages/frontend/src/pages/interop/components/flows/graph/BubbleHolesClip.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/graph/BubbleHolesClip.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react'
 import type { FlowsGraphLayout } from './utils/computeGraphLayout'
 
+const BUBBLE_RADIUS = 4
+
 interface Props {
   id: string
   chainIds: string[]
@@ -19,8 +21,8 @@ export function BubbleHolesClip({ id, chainIds, layout }: Props) {
       .map((chainId) => layout.get(chainId))
       .filter((node) => node !== undefined)
       .map(
-        ({ x, y, radius: r }) =>
-          `M ${x - r} ${y} a ${r} ${r} 0 1 0 ${2 * r} 0 a ${r} ${r} 0 1 0 ${-2 * r} 0 Z`,
+        ({ x, y }) =>
+          `M ${x - BUBBLE_RADIUS} ${y} a ${BUBBLE_RADIUS} ${BUBBLE_RADIUS} 0 1 0 ${2 * BUBBLE_RADIUS} 0 a ${BUBBLE_RADIUS} ${BUBBLE_RADIUS} 0 1 0 ${-2 * BUBBLE_RADIUS} 0 Z`,
       )
       .join(' ')
     return `M -1e4 -1e4 H 1e4 V 1e4 H -1e4 Z ${bubbleHoles}`

--- a/packages/frontend/src/pages/interop/components/flows/graph/BubbleHolesClip.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/graph/BubbleHolesClip.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react'
+import type { FlowsGraphLayout } from './utils/computeGraphLayout'
+
+interface Props {
+  id: string
+  chainIds: string[]
+  layout: FlowsGraphLayout
+}
+
+/**
+ * Clip path covering everything outside the bubble discs. Layers drawn
+ * beneath the bubbles (roads, particles) use it so they never paint under
+ * icons with transparent middles.
+ */
+export function BubbleHolesClip({ id, chainIds, layout }: Props) {
+  const d = useMemo(() => {
+    // Even-odd: a huge rect with one circle subpath per bubble punched out
+    const bubbleHoles = chainIds
+      .map((chainId) => layout.get(chainId))
+      .filter((node) => node !== undefined)
+      .map(
+        ({ x, y, radius: r }) =>
+          `M ${x - r} ${y} a ${r} ${r} 0 1 0 ${2 * r} 0 a ${r} ${r} 0 1 0 ${-2 * r} 0 Z`,
+      )
+      .join(' ')
+    return `M -1e4 -1e4 H 1e4 V 1e4 H -1e4 Z ${bubbleHoles}`
+  }, [chainIds, layout])
+
+  return (
+    <defs>
+      <clipPath id={id}>
+        <path d={d} clipRule="evenodd" />
+      </clipPath>
+    </defs>
+  )
+}

--- a/packages/frontend/src/pages/interop/components/flows/graph/ParticleLayer.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/graph/ParticleLayer.tsx
@@ -6,6 +6,7 @@ import type {
 } from '~/server/features/layer2s/interop/getInteropFlows'
 import type { InteropChainWithIcon } from '../../chain-selector/types'
 import { useInteropFlows } from '../utils/InteropFlowsContext'
+import { BubbleHolesClip } from './BubbleHolesClip'
 import type { FlowsGraphLayout } from './utils/computeGraphLayout'
 import { getChainColor } from './utils/getChainColor'
 import {
@@ -67,17 +68,6 @@ export function ParticleLayer({
   const particleRadius = isSmallScreen ? 1.5 : 2
   const clipId = `particles-clip-${useId().replace(/\W/g, '')}`
 
-  // This exists to hide dots below the project bubbles
-  const bubbleHoles = visibleChainIds
-    .map((id) => layout.get(id))
-    .filter((node) => node !== undefined)
-    .map(
-      ({ x, y, radius: r }) =>
-        `M ${x - r} ${y} a ${r} ${r} 0 1 0 ${2 * r} 0 a ${r} ${r} 0 1 0 ${-2 * r} 0 Z`,
-    )
-    .join(' ')
-  const clipPathD = `M -1e4 -1e4 H 1e4 V 1e4 H -1e4 Z ${bubbleHoles}`
-
   const { flowsParticles } = useScaledParticleCounts(
     visibleChainIds,
     chainData,
@@ -87,11 +77,7 @@ export function ParticleLayer({
 
   return (
     <g pointerEvents="none" aria-hidden="true" clipPath={`url(#${clipId})`}>
-      <defs>
-        <clipPath id={clipId}>
-          <path d={clipPathD} clipRule="evenodd" />
-        </clipPath>
-      </defs>
+      <BubbleHolesClip id={clipId} chainIds={visibleChainIds} layout={layout} />
       {flows.map((flow) => {
         const src = layout.get(flow.srcChain)
         const dst = layout.get(flow.dstChain)


### PR DESCRIPTION
## Summary
- Extract the bubble-hole clip-path logic out of `ParticleLayer` into a shared `BubbleHolesClip` component
- Apply the same clip path to `BackgroundRoads` so road paths no longer render under project bubble icons with transparent centers
- `ParticleLayer` now reuses `BubbleHolesClip` instead of duplicating the clip-path markup

## Testing
- Not run: no automated tests cover SVG rendering for the interop flows graph
- Not run: manual visual check in browser that roads are clipped under bubbles and particles still animate correctly