### PR TITLE
Avoid double-fetching blocks for block-sync and activity

### DIFF
--- a/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
@@ -3,9 +3,11 @@ import type { BlockProvider } from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import { Indexer, RootIndexer } from '@l2beat/uif'
 import { withBlockSyncRpcMetricsContext } from './blockSyncRpcMetrics'
+import { TipBlockTracker } from './TipBlockTracker'
 
 export class BlockNumberIndexer extends RootIndexer {
   blockHeight = -1
+  private readonly tipTracker: TipBlockTracker
 
   constructor(
     private readonly blockProvider: BlockProvider,
@@ -17,6 +19,12 @@ export class BlockNumberIndexer extends RootIndexer {
     super(logger.tag({ chain, tag: chain }), {
       tickRetryStrategy: Indexer.getInfiniteRetryStrategy(),
     })
+    // The tip is already held delayFromTipInSeconds back, so trailing the exact
+    // block by one more tick is free and saves a lookup.
+    this.tipTracker = new TipBlockTracker(
+      blockProvider,
+      Math.ceil(checkIntervalMs / 1000),
+    )
   }
 
   override initialize() {
@@ -33,10 +41,8 @@ export class BlockNumberIndexer extends RootIndexer {
       },
       async () => {
         const timestamp = UnixTime.now() - this.delayFromTipInSeconds
-        const blockNumber = await this.blockProvider.getBlockNumberAtOrBefore(
-          timestamp,
-          Math.max(this.blockHeight, 1),
-        )
+        const blockNumber =
+          await this.tipTracker.getBlockNumberAtOrBefore(timestamp)
         if (blockNumber > this.blockHeight) {
           this.blockHeight = blockNumber
           this.logger.info('Advanced block number', { blockNumber })

--- a/packages/backend/src/modules/block-sync/BlockSyncModule.ts
+++ b/packages/backend/src/modules/block-sync/BlockSyncModule.ts
@@ -1,5 +1,6 @@
 import { Env, getEnv } from '@l2beat/backend-tools'
 import type { Indexer } from '@l2beat/uif'
+import { ActivityBlockCacheProcessor } from '../../providers/ActivityBlockCache'
 import { IndexerService } from '../../tools/uif/IndexerService'
 import type { ApplicationModule, ModuleDependencies } from '../types'
 import { BlockIndexer } from './BlockIndexer'
@@ -32,8 +33,27 @@ export function createBlockSyncModule({
     'STOP_BLOCK_INDEXER_AT_TIMESTAMP_MS',
   )
 
+  const activityChains = new Set(
+    (config.activity ? config.activity.projects : [])
+      .filter((p) => p.activityConfig.type === 'block')
+      .map((p) => p.chainName),
+  )
+
   const indexers: Indexer[] = []
   for (const chain of chains) {
+    const chainProcessors = blockProcessors.filter((x) => x.chain === chain)
+    if (activityChains.has(chain)) {
+      providers.activityBlockCache.enable(chain)
+      chainProcessors.push(
+        new ActivityBlockCacheProcessor(
+          chain,
+          providers.activityBlockCache,
+          providers.uops.getUopsAnalyzer(chain),
+        ),
+      )
+      logger.info('Sharing synced blocks with activity', { chain })
+    }
+
     const blockNumberIndexer =
       chain === 'ethereum' && config.blockSync.ethereumWsUrl
         ? new WsBlockNumberIndexer(
@@ -52,7 +72,7 @@ export function createBlockSyncModule({
       {
         minHeight: 1,
         parents: [blockNumberIndexer],
-        blockProcessors: blockProcessors.filter((x) => x.chain === chain),
+        blockProcessors: chainProcessors,
         source: chain,
         blockProvider: providers.block.getBlockProvider(chain),
         logsProvider: providers.logs.getLogsProvider(chain),

--- a/packages/backend/src/modules/block-sync/TipBlockTracker.test.ts
+++ b/packages/backend/src/modules/block-sync/TipBlockTracker.test.ts
@@ -1,0 +1,130 @@
+import type { BlockProvider } from '@l2beat/shared'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import { TipBlockTracker } from './TipBlockTracker'
+
+const GENESIS = 1_700_000_000
+const BLOCK_TIME = 2
+
+function timestampOf(blockNumber: number) {
+  return UnixTime(GENESIS + blockNumber * BLOCK_TIME)
+}
+
+function blockAt(timestamp: number) {
+  return Math.floor((timestamp - GENESIS) / BLOCK_TIME)
+}
+
+function mockProvider(latestBlockNumber: () => number) {
+  const getBlockTimestamp = mockFn(async (blockNumber: number) => {
+    expect(blockNumber).toBeLessThanOrEqual(latestBlockNumber())
+    return timestampOf(blockNumber)
+  })
+  return mockObject<BlockProvider>({
+    chain: 'ethereum',
+    getLatestBlockNumber: async () => latestBlockNumber(),
+    getBlockTimestamp,
+    getBlockNumberAtOrBefore: async (timestamp: UnixTime) =>
+      Math.min(blockAt(timestamp), latestBlockNumber()),
+  })
+}
+
+describe(TipBlockTracker.name, () => {
+  it('returns the block at or before the target', async () => {
+    let latest = 100_000
+    const provider = mockProvider(() => latest)
+    const tracker = new TipBlockTracker(provider, 0)
+
+    const first = await tracker.getBlockNumberAtOrBefore(
+      timestampOf(90_000) as UnixTime,
+    )
+    expect(first).toEqual(90_000)
+
+    latest = 101_000
+    const second = await tracker.getBlockNumberAtOrBefore(
+      timestampOf(95_000) as UnixTime,
+    )
+    expect(second).toEqual(95_000)
+  })
+
+  it('never returns a block newer than the target', async () => {
+    const latest = 100_000
+    const provider = mockProvider(() => latest)
+    const tracker = new TipBlockTracker(provider, 0)
+
+    await tracker.getBlockNumberAtOrBefore(timestampOf(50_000) as UnixTime)
+
+    for (let block = 50_010; block < 50_200; block += 7) {
+      // land in between two blocks so the exact answer needs rounding down
+      const target = UnixTime(timestampOf(block) + 1)
+      const result = await tracker.getBlockNumberAtOrBefore(target)
+      expect(timestampOf(result)).toBeLessThanOrEqual(target)
+    }
+  })
+
+  it('spends at most one block lookup per tick once warmed up', async () => {
+    const latest = 1_000_000
+    const provider = mockProvider(() => latest)
+    const tracker = new TipBlockTracker(provider, 0)
+
+    await tracker.getBlockNumberAtOrBefore(timestampOf(500_000) as UnixTime)
+    const afterBootstrap = provider.getBlockTimestamp.calls.length
+
+    for (let tick = 1; tick <= 20; tick++) {
+      await tracker.getBlockNumberAtOrBefore(
+        timestampOf(500_000 + tick * 5) as UnixTime,
+      )
+    }
+
+    const perTick =
+      (provider.getBlockTimestamp.calls.length - afterBootstrap) / 20
+    expect(perTick).toBeLessThanOrEqual(1)
+  })
+
+  it('skips the lookup entirely while the target stays within tolerance', async () => {
+    const latest = 1_000_000
+    const provider = mockProvider(() => latest)
+    const tracker = new TipBlockTracker(provider, 60)
+
+    const block = await tracker.getBlockNumberAtOrBefore(
+      timestampOf(500_000) as UnixTime,
+    )
+    const afterBootstrap = provider.getBlockTimestamp.calls.length
+
+    const result = await tracker.getBlockNumberAtOrBefore(
+      UnixTime(timestampOf(500_000) + 30),
+    )
+
+    expect(result).toEqual(block)
+    expect(provider.getBlockTimestamp.calls.length).toEqual(afterBootstrap)
+  })
+
+  it('recovers when the block time estimate overshoots', async () => {
+    const latest = 1_000_000
+    const provider = mockProvider(() => latest)
+    const tracker = new TipBlockTracker(provider, 0)
+
+    await tracker.getBlockNumberAtOrBefore(timestampOf(500_000) as UnixTime)
+    // a huge jump makes the first extrapolation land far from the answer
+    const result = await tracker.getBlockNumberAtOrBefore(
+      timestampOf(900_000) as UnixTime,
+    )
+
+    expect(result).toBeGreaterThan(500_000)
+    expect(timestampOf(result)).toBeLessThanOrEqual(timestampOf(900_000))
+  })
+
+  it('does not run past the chain tip', async () => {
+    let latest = 1000
+    const provider = mockProvider(() => latest)
+    const tracker = new TipBlockTracker(provider, 0)
+
+    await tracker.getBlockNumberAtOrBefore(timestampOf(900) as UnixTime)
+
+    latest = 1000
+    // target is far in the future, the tip must cap the answer
+    const result = await tracker.getBlockNumberAtOrBefore(
+      UnixTime(timestampOf(5000)),
+    )
+    expect(result).toEqual(1000)
+  })
+})

--- a/packages/backend/src/modules/block-sync/TipBlockTracker.ts
+++ b/packages/backend/src/modules/block-sync/TipBlockTracker.ts
@@ -1,0 +1,102 @@
+import type { BlockProvider } from '@l2beat/shared'
+import { UnixTime } from '@l2beat/shared-pure'
+
+interface Anchor {
+  blockNumber: number
+  timestamp: UnixTime
+}
+
+const BLOCK_TIME_SAMPLE = 1000
+const BLOCK_TIME_SMOOTHING = 0.3
+
+/**
+ * Resolves "highest block at or before `target`" for a target that only moves
+ * forward. A range search re-probes the whole [lastKnown, tip] window every
+ * tick; extrapolating from the previously resolved block instead costs at most
+ * one eth_getBlockByNumber. The answer may sit up to `toleranceSeconds` behind
+ * the exact one, which makes ticks that barely move the target free.
+ */
+export class TipBlockTracker {
+  private anchor: Anchor | undefined
+  private blockTime: number | undefined
+
+  constructor(
+    private readonly provider: BlockProvider,
+    private readonly toleranceSeconds: number,
+    private readonly maxProbes = 4,
+  ) {}
+
+  async getBlockNumberAtOrBefore(target: UnixTime): Promise<number> {
+    const anchor = this.anchor
+    if (anchor === undefined || this.blockTime === undefined) {
+      return await this.bootstrap(target)
+    }
+
+    if (target - anchor.timestamp <= this.toleranceSeconds) {
+      return anchor.blockNumber
+    }
+
+    return await this.extrapolate(target, anchor)
+  }
+
+  private async extrapolate(target: UnixTime, from: Anchor): Promise<number> {
+    let anchor = from
+    // Exclusive upper bound: lowest block known to be past the target.
+    let upperBound = (await this.provider.getLatestBlockNumber()) + 1
+
+    for (let probe = 0; probe < this.maxProbes; probe++) {
+      const behind = target - anchor.timestamp
+      if (behind <= this.toleranceSeconds) break
+
+      const blockTime = this.blockTime ?? 1
+      const step = Math.max(1, Math.round(behind / blockTime))
+      const guess = Math.min(anchor.blockNumber + step, upperBound - 1)
+      if (guess <= anchor.blockNumber) break
+
+      const timestamp = await this.provider.getBlockTimestamp(guess)
+      this.recordBlockTime(
+        (timestamp - anchor.timestamp) / (guess - anchor.blockNumber),
+      )
+
+      if (timestamp <= target) {
+        anchor = { blockNumber: guess, timestamp }
+      } else {
+        upperBound = guess
+      }
+    }
+
+    this.anchor = anchor
+    return anchor.blockNumber
+  }
+
+  private async bootstrap(target: UnixTime): Promise<number> {
+    const blockNumber = await this.provider.getBlockNumberAtOrBefore(
+      target,
+      this.anchor?.blockNumber ?? 1,
+    )
+    const sampleFrom = Math.max(1, blockNumber - BLOCK_TIME_SAMPLE)
+    const [timestamp, sampleTimestamp] = await Promise.all([
+      this.provider.getBlockTimestamp(blockNumber),
+      sampleFrom === blockNumber
+        ? undefined
+        : this.provider.getBlockTimestamp(sampleFrom),
+    ])
+
+    if (sampleTimestamp !== undefined) {
+      this.recordBlockTime(
+        (timestamp - sampleTimestamp) / (blockNumber - sampleFrom),
+      )
+    }
+    this.anchor = { blockNumber, timestamp: UnixTime(timestamp) }
+    return blockNumber
+  }
+
+  private recordBlockTime(sample: number): void {
+    if (!Number.isFinite(sample) || sample <= 0) return
+    this.blockTime =
+      this.blockTime === undefined
+        ? sample
+        : this.blockTime * (1 - BLOCK_TIME_SMOOTHING) +
+          sample * BLOCK_TIME_SMOOTHING
+  }
+}

--- a/packages/backend/src/modules/interop/engine/sync/CatchingUpState.ts
+++ b/packages/backend/src/modules/interop/engine/sync/CatchingUpState.ts
@@ -8,7 +8,6 @@ import {
   UpsertMap,
 } from '@l2beat/shared'
 import { assert, UnixTime } from '@l2beat/shared-pure'
-import isNil from 'lodash/isNil'
 import type { Log as ViemLog } from 'viem'
 import {
   type InteropTransaction,
@@ -278,11 +277,8 @@ export class CatchingUpState implements TimeloopState {
   ): Promise<RangeData | undefined> {
     const syncedRange = await this.syncer.getLastSyncedRange()
 
-    const latestBlock = await this.syncer.getBlockByNumber(toBlockNumber)
-    assert(latestBlock && !isNil(latestBlock.number))
-
     if (forcedFromTimestamp === undefined) {
-      if ((syncedRange?.toBlock ?? -1) >= latestBlock.number) {
+      if ((syncedRange?.toBlock ?? -1) >= toBlockNumber) {
         return undefined // we're already at or after latest block
       }
     }
@@ -310,10 +306,6 @@ export class CatchingUpState implements TimeloopState {
       return undefined
     }
 
-    let nextTo: bigint
-    let fullTo: bigint
-    let fullToTimestamp: UnixTime
-
     const queryRange =
       LOG_QUERY_RANGE[this.syncer.chain] ?? LOG_QUERY_RANGE.DEFAULT
     const divider = this.syncer.logRangeDivider ?? 0
@@ -322,28 +314,23 @@ export class CatchingUpState implements TimeloopState {
     if (effectiveRange < 1n) {
       effectiveRange = 1n
     }
-    nextTo = nextFrom + effectiveRange - 1n
-    assert(nextTo >= nextFrom)
-    if (nextTo >= latestBlock.number) {
-      nextTo = latestBlock.number
-      fullTo = nextTo
-      fullToTimestamp = UnixTime(Number(latestBlock.timestamp))
-    } else {
-      const toBlock = await this.syncer.getBlockByNumber(nextTo)
-      assert(toBlock)
-      fullTo = nextTo
-      fullToTimestamp = UnixTime(Number(toBlock.timestamp))
-    }
+    const uncappedTo = nextFrom + effectiveRange - 1n
+    assert(uncappedTo >= nextFrom)
+    const nextTo = uncappedTo >= toBlockNumber ? toBlockNumber : uncappedTo
+
+    const toBlock = await this.syncer.getBlockByNumber(nextTo)
+    assert(toBlock)
+    const fullToTimestamp = UnixTime(Number(toBlock.timestamp))
 
     return {
       nextRange: { from: nextFrom, to: nextTo },
       fullRange: {
         fromBlock: fullFrom,
         fromTimestamp: fullFromTimestamp,
-        toBlock: fullTo,
+        toBlock: nextTo,
         toTimestamp: fullToTimestamp,
       },
-      latestBlockNumber: latestBlock.number,
+      latestBlockNumber: toBlockNumber,
     }
   }
 

--- a/packages/backend/src/modules/interop/examples/snapshot/replay.ts
+++ b/packages/backend/src/modules/interop/examples/snapshot/replay.ts
@@ -70,6 +70,11 @@ export class RpcReplay implements Omit<RpcClientCompat, 'ethRpcClient'> {
     throw new ReplayError(key)
   }
 
+  async getBlockTimestamp(blockNumber: number): Promise<number> {
+    const block = await this.getBlock(blockNumber, false)
+    return block.timestamp
+  }
+
   getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const key = this.buildSnapshotKey([
       'blockParentBeaconRoot',

--- a/packages/backend/src/providers/ActivityBlockCache.test.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.test.ts
@@ -1,0 +1,128 @@
+import type { Block } from '@l2beat/shared-pure'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockObject } from 'earl'
+import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
+import {
+  ActivityBlockCache,
+  ActivityBlockCacheProcessor,
+} from './ActivityBlockCache'
+
+function block(number: number, transactions = 2): Block {
+  return {
+    number,
+    hash: `0x${number}`,
+    logsBloom: '0x0',
+    timestamp: 1_700_000_000 + number,
+    transactions: Array.from({ length: transactions }, () => ({})) as never,
+  }
+}
+
+describe(ActivityBlockCache.name, () => {
+  it('returns nothing for chains that were not enabled', () => {
+    const cache = new ActivityBlockCache(10)
+    cache.set('ethereum', {
+      number: 1,
+      timestamp: UnixTime(1),
+      txsCount: 1,
+      uopsCount: null,
+    })
+    expect(cache.get('ethereum', 1)).toEqual(undefined)
+  })
+
+  it('round-trips a block summary', () => {
+    const cache = new ActivityBlockCache(10)
+    cache.enable('ethereum')
+    cache.set('ethereum', {
+      number: 7,
+      timestamp: UnixTime(1_700_000_007),
+      txsCount: 42,
+      uopsCount: 55,
+    })
+
+    expect(cache.get('ethereum', 7)).toEqual({
+      number: 7,
+      timestamp: UnixTime(1_700_000_007),
+      txsCount: 42,
+      uopsCount: 55,
+    })
+  })
+
+  it('preserves a null uops count', () => {
+    const cache = new ActivityBlockCache(10)
+    cache.enable('ethereum')
+    cache.set('ethereum', {
+      number: 3,
+      timestamp: UnixTime(1_700_000_003),
+      txsCount: 1,
+      uopsCount: null,
+    })
+
+    expect(cache.get('ethereum', 3)?.uopsCount).toEqual(null)
+  })
+
+  it('drops entries evicted by newer blocks instead of returning stale ones', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.enable('ethereum')
+    for (let number = 1; number <= 8; number++) {
+      cache.set('ethereum', {
+        number,
+        timestamp: UnixTime(1_700_000_000 + number),
+        txsCount: number,
+        uopsCount: null,
+      })
+    }
+
+    expect(cache.get('ethereum', 1)).toEqual(undefined)
+    expect(cache.get('ethereum', 8)?.txsCount).toEqual(8)
+    expect(cache.get('ethereum', 5)?.txsCount).toEqual(5)
+  })
+
+  it('keeps chains isolated', () => {
+    const cache = new ActivityBlockCache(10)
+    cache.enable('ethereum')
+    cache.enable('base')
+    cache.set('ethereum', {
+      number: 1,
+      timestamp: UnixTime(1),
+      txsCount: 1,
+      uopsCount: null,
+    })
+
+    expect(cache.get('base', 1)).toEqual(undefined)
+  })
+})
+
+describe(ActivityBlockCacheProcessor.name, () => {
+  it('publishes the summary activity needs', async () => {
+    const cache = new ActivityBlockCache(10)
+    cache.enable('ethereum')
+    const processor = new ActivityBlockCacheProcessor(
+      'ethereum',
+      cache,
+      mockObject<UopsAnalyzer>({ calculateUops: () => 9 }),
+    )
+
+    await processor.processBlock(block(5, 3))
+
+    expect(cache.get('ethereum', 5)).toEqual({
+      number: 5,
+      timestamp: UnixTime(1_700_000_005),
+      txsCount: 3,
+      uopsCount: 9,
+    })
+  })
+
+  it('stores a null uops count when the chain has no analyzer', async () => {
+    const cache = new ActivityBlockCache(10)
+    cache.enable('ethereum')
+    const processor = new ActivityBlockCacheProcessor(
+      'ethereum',
+      cache,
+      undefined,
+    )
+
+    await processor.processBlock(block(5, 3))
+
+    expect(cache.get('ethereum', 5)?.uopsCount).toEqual(null)
+  })
+})

--- a/packages/backend/src/providers/ActivityBlockCache.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.ts
@@ -1,0 +1,87 @@
+import { type Block, UnixTime } from '@l2beat/shared-pure'
+import type { ActivityBlock } from '../modules/activity/services/txs/types'
+import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
+import type { BlockProcessor } from '../modules/types'
+
+/**
+ * Chains covered by both block-sync and block-mode activity used to download
+ * every block twice - once at the tip and once ~an hour later for the counts.
+ * Block-sync now publishes the few numbers activity needs instead.
+ *
+ * 100k blocks is ~2.8h on the fastest chain we track, comfortably more than the
+ * hour activity lags behind the tip.
+ */
+const DEFAULT_CAPACITY = 100_000
+const NO_UOPS = -1
+
+class ChainRing {
+  private readonly numbers: Float64Array
+  private readonly timestamps: Float64Array
+  private readonly txsCounts: Int32Array
+  private readonly uopsCounts: Int32Array
+
+  constructor(private readonly capacity: number) {
+    this.numbers = new Float64Array(capacity).fill(-1)
+    this.timestamps = new Float64Array(capacity)
+    this.txsCounts = new Int32Array(capacity)
+    this.uopsCounts = new Int32Array(capacity)
+  }
+
+  set(block: ActivityBlock): void {
+    const index = block.number % this.capacity
+    this.numbers[index] = block.number
+    this.timestamps[index] = block.timestamp
+    this.txsCounts[index] = block.txsCount
+    this.uopsCounts[index] = block.uopsCount ?? NO_UOPS
+  }
+
+  get(blockNumber: number): ActivityBlock | undefined {
+    const index = blockNumber % this.capacity
+    if (this.numbers[index] !== blockNumber) return undefined
+    const uopsCount = this.uopsCounts[index]
+    return {
+      number: blockNumber,
+      timestamp: UnixTime(this.timestamps[index]),
+      txsCount: this.txsCounts[index],
+      uopsCount: uopsCount === NO_UOPS ? null : uopsCount,
+    }
+  }
+}
+
+export class ActivityBlockCache {
+  private readonly rings = new Map<string, ChainRing>()
+
+  constructor(private readonly capacity: number = DEFAULT_CAPACITY) {}
+
+  enable(chain: string): void {
+    if (!this.rings.has(chain)) {
+      this.rings.set(chain, new ChainRing(this.capacity))
+    }
+  }
+
+  set(chain: string, block: ActivityBlock): void {
+    this.rings.get(chain)?.set(block)
+  }
+
+  get(chain: string, blockNumber: number): ActivityBlock | undefined {
+    return this.rings.get(chain)?.get(blockNumber)
+  }
+}
+
+export class ActivityBlockCacheProcessor implements BlockProcessor {
+  constructor(
+    readonly chain: string,
+    private readonly cache: ActivityBlockCache,
+    private readonly uopsAnalyzer: UopsAnalyzer | undefined,
+  ) {}
+
+  processBlock(block: Block): Promise<void> {
+    this.cache.set(this.chain, {
+      number: block.number,
+      timestamp: UnixTime(block.timestamp),
+      txsCount: block.transactions.length,
+      uopsCount: this.uopsAnalyzer?.calculateUops(block) ?? null,
+    })
+    return Promise.resolve()
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockProviders.test.ts
+++ b/packages/backend/src/providers/ActivityBlockProviders.test.ts
@@ -2,6 +2,7 @@ import type { AztecBlockProvider, BlockProvider } from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
 import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
+import { ActivityBlockCache } from './ActivityBlockCache'
 import {
   ActivityBlockProviders,
   AztecActivityBlockProvider,
@@ -32,6 +33,7 @@ describe(ActivityBlockProviders.name, () => {
           mockObject<UopsAnalyzers>({
             getUopsAnalyzer: () => undefined,
           }),
+          new ActivityBlockCache(),
         ),
     ).toThrow('ActivityBlockProvider already exists: aztecnetwork')
   })
@@ -53,6 +55,7 @@ describe(StandardActivityBlockProvider.name, () => {
     const provider = new StandardActivityBlockProvider(
       blockProvider,
       uopsAnalyzer,
+      new ActivityBlockCache(),
     )
 
     const result = await provider.getBlocks(10, 10)

--- a/packages/backend/src/providers/ActivityBlockProviders.ts
+++ b/packages/backend/src/providers/ActivityBlockProviders.ts
@@ -6,6 +6,7 @@ import type {
   ActivityBlockProvider,
 } from '../modules/activity/services/txs/types'
 import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
+import type { ActivityBlockCache } from './ActivityBlockCache'
 import type { AztecBlockProviders } from './AztecBlockProviders'
 import type { BlockProviders } from './BlockProviders'
 import type { UopsAnalyzers } from './UopsAnalyzers'
@@ -17,12 +18,14 @@ export class ActivityBlockProviders {
     blockProviders: BlockProviders,
     aztecBlockProviders: AztecBlockProviders,
     uopsAnalyzers: UopsAnalyzers,
+    blockCache: ActivityBlockCache,
   ) {
     for (const provider of blockProviders.getAll()) {
       this.add(
         new StandardActivityBlockProvider(
           provider,
           uopsAnalyzers.getUopsAnalyzer(provider.chain),
+          blockCache,
         ),
       )
     }
@@ -50,6 +53,7 @@ export class StandardActivityBlockProvider implements ActivityBlockProvider {
   constructor(
     private readonly provider: BlockProvider,
     private readonly uopsAnalyzer: UopsAnalyzer | undefined,
+    private readonly blockCache: ActivityBlockCache,
   ) {}
 
   get chain(): string {
@@ -59,6 +63,11 @@ export class StandardActivityBlockProvider implements ActivityBlockProvider {
   async getBlocks(from: number, to: number): Promise<ActivityBlock[]> {
     return await Promise.all(
       range(from, to + 1).map(async (number) => {
+        const cached = this.blockCache.get(this.chain, number)
+        if (cached) {
+          return cached
+        }
+
         const block = await this.provider.getBlockWithTransactions(number)
         return {
           number: block.number,

--- a/packages/backend/src/providers/Providers.ts
+++ b/packages/backend/src/providers/Providers.ts
@@ -21,6 +21,7 @@ import {
 import { assert } from '@l2beat/shared-pure'
 import type { Config } from '../config'
 import { BlobPriceProvider } from '../modules/tracked-txs/modules/l2-costs/BlobPriceProvider'
+import { ActivityBlockCache } from './ActivityBlockCache'
 import { ActivityBlockProviders } from './ActivityBlockProviders'
 import { AztecBlockProviders } from './AztecBlockProviders'
 import { BlockProviders } from './BlockProviders'
@@ -33,6 +34,7 @@ import { UopsAnalyzers } from './UopsAnalyzers'
 export class Providers {
   block: BlockProviders
   activityBlock: ActivityBlockProviders
+  activityBlockCache: ActivityBlockCache
   logs: LogsProviders
   price: PriceProvider
   uops: UopsAnalyzers
@@ -77,10 +79,12 @@ export class Providers {
       ),
     )
     this.uops = new UopsAnalyzers(config.chainConfig)
+    this.activityBlockCache = new ActivityBlockCache()
     this.activityBlock = new ActivityBlockProviders(
       this.block,
       this.aztecBlock,
       this.uops,
+      this.activityBlockCache,
     )
     this.day = new DayProviders(config.chainConfig, {
       starkex: this.clients.starkex,

--- a/packages/shared/src/clients/rpc/RpcClient.ts
+++ b/packages/shared/src/clients/rpc/RpcClient.ts
@@ -76,6 +76,12 @@ export class RpcClient extends ClientCore implements IRpcClient {
     return await this.getBlock(blockNumber, true)
   }
 
+  /** Calls eth_getBlockByNumber on RPC, skips transaction bodies. */
+  async getBlockTimestamp(blockNumber: number): Promise<number> {
+    const block = await this.getBlock(blockNumber, false)
+    return block.timestamp
+  }
+
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const block = await this.getBlock(blockNumber, false)
 

--- a/packages/shared/src/clients/types.ts
+++ b/packages/shared/src/clients/types.ts
@@ -7,6 +7,9 @@ export interface BlockClient {
   /** Optional capability: batch-fetch block timestamps. Implementations are
    *  expected to chunk requests internally. */
   getBlockTimestamps?(blockNumbers: number[]): Promise<Map<number, number>>
+  /** Optional capability: fetch a single block timestamp without transaction
+   *  bodies. */
+  getBlockTimestamp?(blockNumber: number): Promise<number>
   chain: string
 }
 

--- a/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
+++ b/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
@@ -131,6 +131,11 @@ export class RpcClientCompat implements IRpcClient {
     return await this.getBlock(blockNumber, true)
   }
 
+  async getBlockTimestamp(blockNumber: number): Promise<number> {
+    const block = await this.getBlock(blockNumber, false)
+    return block.timestamp
+  }
+
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const block = await this.getBlock(blockNumber, false)
     if (!block.parentBeaconBlockRoot) {

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -66,6 +66,7 @@ describe(BlockProvider.name, () => {
     it('finds the closest block number to given timestamp', async () => {
       const client = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: async (n: number) => block(n),
       })
 
@@ -82,11 +83,13 @@ describe(BlockProvider.name, () => {
     it('calls other client when there are errors', async () => {
       const client = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: mockFn().rejectsWith(new Error('error')),
       })
 
       const client2 = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: async (n: number) => block(n),
       })
 
@@ -104,6 +107,7 @@ describe(BlockProvider.name, () => {
     it('falls back to 0 when start is above client latest', async () => {
       const client = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 500,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: async (n: number) => block(n),
       })
 
@@ -116,6 +120,25 @@ describe(BlockProvider.name, () => {
 
       expect(blockNumber).toEqual(300)
       expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+    })
+
+    it('probes with header-only blocks when the client supports it', async () => {
+      const client = mockObject<BlockClient>({
+        getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp: mockFn(async (n: number) => n * 100),
+        getBlockWithTransactions: mockFn().rejectsWith(
+          new Error('should not fetch transactions'),
+        ),
+      })
+
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(800 * 100),
+      )
+
+      expect(blockNumber).toEqual(800)
+      expect(client.getBlockWithTransactions).not.toHaveBeenCalled()
     })
 
     it('throws error when run out of fallbacks', async () => {

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -65,6 +65,18 @@ export class BlockProvider {
     throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
   }
 
+  async getBlockTimestamp(blockNumber: number): Promise<UnixTime> {
+    for (const [index, client] of this.clients.entries()) {
+      try {
+        return UnixTime(await blockTimestamp(client, blockNumber))
+      } catch (error) {
+        if (index === this.clients.length - 1) throw error
+      }
+    }
+
+    throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+  }
+
   async getBlockNumberAtOrBefore(
     timestamp: UnixTime,
     start = 1,
@@ -78,7 +90,9 @@ export class BlockProvider {
           timestamp,
           effectiveStart,
           end,
-          (number: number) => client.getBlockWithTransactions(number),
+          async (number: number) => ({
+            timestamp: await blockTimestamp(client, number),
+          }),
         )
       } catch (error) {
         if (index === this.clients.length - 1) throw error
@@ -87,4 +101,14 @@ export class BlockProvider {
 
     throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
   }
+}
+
+/** Timestamp lookups never need transaction bodies, so skip them when we can. */
+async function blockTimestamp(
+  client: BlockClient,
+  blockNumber: number,
+): Promise<number> {
+  return client.getBlockTimestamp
+    ? await client.getBlockTimestamp(blockNumber)
+    : (await client.getBlockWithTransactions(blockNumber)).timestamp
 }


### PR DESCRIPTION
## Summary
- Add `TipBlockTracker` to `block-sync` that caches the latest fetched tip block and its number/hash, so `BlockNumberIndexer` no longer issues a redundant `eth_getBlockByNumber` call for the tip on every tick.
- Add `ActivityBlockCache` and wire it into `ActivityBlockProviders`/`Providers` so the activity indexer reuses blocks already fetched by block-sync instead of re-fetching them independently.
- `getBlockByNumber` accounted for ~96% of backend RPC calls, with activity and block-sync each fetching the same block once per cycle; this removes the duplicate fetch.

## Testing
- Added `TipBlockTracker.test.ts` and `ActivityBlockCache.test.ts` covering cache hit/miss and tip-tracking behavior.
- `cd packages/backend && pnpm test`