### PR TITLE
Cut redundant getBlockByNumber calls in block sync and activity

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -48,6 +48,7 @@ export class Application {
       providers,
       db,
       blockProcessors: [],
+      blockObservers: [],
     }
 
     // Modules with TRPC

--- a/packages/backend/src/modules/activity/ActivityModule.ts
+++ b/packages/backend/src/modules/activity/ActivityModule.ts
@@ -18,6 +18,7 @@ export function initActivityModule({
   db: database,
   clock,
   providers,
+  blockObservers,
 }: ModuleDependencies): ApplicationModule | undefined {
   if (!config.activity) {
     logger.info('Activity module disabled')
@@ -58,6 +59,12 @@ export function initActivityModule({
         )
 
         const provider = providers.activityBlock.getProvider(project.chainName)
+        if (
+          provider.blockObserver &&
+          !blockObservers.includes(provider.blockObserver)
+        ) {
+          blockObservers.push(provider.blockObserver)
+        }
         const txsCountService = new BlockTxsCountService(
           {
             provider,

--- a/packages/backend/src/modules/activity/services/txs/types.ts
+++ b/packages/backend/src/modules/activity/services/txs/types.ts
@@ -1,4 +1,5 @@
 import type { UnixTime } from '@l2beat/shared-pure'
+import type { BlockProcessor } from '../../../types'
 
 export interface ActivityBlock {
   number: number
@@ -11,4 +12,6 @@ export interface ActivityBlockProvider {
   chain: string
   /** Returns blocks in ascending block-number order. */
   getBlocks(from: number, to: number): Promise<ActivityBlock[]>
+  /** Lets the provider reuse blocks that block sync fetches anyway. */
+  blockObserver?: BlockProcessor
 }

--- a/packages/backend/src/modules/block-sync/BlockIndexer.test.ts
+++ b/packages/backend/src/modules/block-sync/BlockIndexer.test.ts
@@ -106,6 +106,46 @@ describe(BlockIndexer.name, () => {
       expect(processBlock).toHaveBeenCalledWith(block2, [log2])
     })
 
+    it('passes consistent blocks to observers and survives their failures', async () => {
+      const block1 = makeBlock(10, 1_000)
+      const block2 = makeBlock(11, 2_000)
+      const observe = mockFn()
+        .rejectsWithOnce(new Error('observer error'))
+        .resolvesTo(undefined)
+      const processBlock = mockFn().resolvesTo(undefined)
+
+      const indexer = createIndexer({
+        blockProvider: mockObject<BlockProvider>({
+          getBlockWithTransactions: mockFn()
+            .resolvesToOnce(block1)
+            .resolvesToOnce(block2),
+        }),
+        logsProvider: mockObject<LogsProvider>({
+          getLogs: mockFn().resolvesTo([
+            makeLog(block1, 1),
+            makeLog(block2, 2),
+          ]),
+        }),
+        blockProcessors: [
+          mockObject<BlockProcessor>({ chain: 'ethereum', processBlock }),
+        ],
+        blockObservers: [
+          mockObject<BlockProcessor>({
+            chain: 'ethereum',
+            processBlock: observe,
+          }),
+        ],
+      })
+
+      const result = await indexer.update(10, 11)
+
+      expect(result).toEqual(11)
+      expect(observe).toHaveBeenCalledTimes(2)
+      expect(observe).toHaveBeenNthCalledWith(1, block1, [makeLog(block1, 1)])
+      expect(observe).toHaveBeenNthCalledWith(2, block2, [makeLog(block2, 2)])
+      expect(processBlock).toHaveBeenCalledTimes(2)
+    })
+
     it('throws without processing when first block exceeds configured timestamp', async () => {
       const block = makeBlock(10, 3_000)
       const log = makeLog(block, 1)
@@ -145,6 +185,7 @@ function createIndexer(overrides: Partial<BlockIndexerDeps> = {}) {
       getLogs: mockFn().resolvesTo([]),
     }),
     blockProcessors: [],
+    blockObservers: [],
     stopBlockIndexerAtTimestampMs: undefined,
     batchSize: 50,
     minHeight: 1,

--- a/packages/backend/src/modules/block-sync/BlockIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockIndexer.ts
@@ -15,6 +15,8 @@ export interface BlockIndexerDeps
   blockProvider: BlockProvider
   logsProvider: LogsProvider
   blockProcessors: BlockProcessor[]
+  /** Cheap listeners that only get the block; failures are logged, nothing else */
+  blockObservers: BlockProcessor[]
   stopBlockIndexerAtTimestampMs?: number
   /** The number of blocks/days to process at once. In case of error this is the maximum amount of blocks/days we will need to refetch */
   batchSize: number
@@ -119,6 +121,17 @@ export class BlockIndexer extends ManagedChildIndexer {
           )
         }
         break
+      }
+
+      for (const observer of this.$.blockObservers) {
+        try {
+          await observer.processBlock(block, logs)
+        } catch (error) {
+          this.logger.error('Observer failed', {
+            blockNumber: block.number,
+            error,
+          })
+        }
       }
 
       for (const processor of this.$.blockProcessors) {

--- a/packages/backend/src/modules/block-sync/BlockNumberIndexer.test.ts
+++ b/packages/backend/src/modules/block-sync/BlockNumberIndexer.test.ts
@@ -1,0 +1,127 @@
+import { Logger } from '@l2beat/backend-tools'
+import type { BlockHeader, BlockProvider } from '@l2beat/shared'
+import { UnixTime } from '@l2beat/shared-pure'
+import { type InstalledClock, install } from '@sinonjs/fake-timers'
+import { expect, mockObject } from 'earl'
+import { BlockNumberIndexer } from './BlockNumberIndexer'
+
+const START = UnixTime(1_700_000_000)
+const BLOCK_TIME = 10
+const DELAY = 300
+const INTERVAL_MS = 10_000
+
+describe(BlockNumberIndexer.name, () => {
+  let time: InstalledClock
+
+  beforeEach(() => {
+    time = install({ now: START * 1000 })
+  })
+
+  afterEach(() => {
+    time.uninstall()
+  })
+
+  it('finds the block at the delayed timestamp using only headers', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+
+    const result = await indexer.tick()
+
+    // block 970 is exactly DELAY seconds old
+    expect(result).toEqual(970)
+    expect(chain.requested).toInclude('latest')
+    expect(chain.requested.length).toBeLessThanOrEqual(12)
+  })
+
+  it('returns the latest block when it is already old enough', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain, 0)
+
+    const result = await indexer.tick()
+
+    expect(result).toEqual(1000)
+    expect(chain.requested).toEqual(['latest'])
+  })
+
+  it('advances with a single call per tick once polled headers are old enough', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    let previous = indexer.blockHeight
+    let lastTickCalls = 0
+    for (let i = 1; i <= DELAY / (INTERVAL_MS / 1000) + 1; i++) {
+      time.tick(INTERVAL_MS)
+      chain.latest = 1000 + i
+      chain.requested.length = 0
+      const result = await indexer.tick()
+      expect(result).toBeGreaterThanOrEqual(previous)
+      previous = result
+      lastTickCalls = chain.requested.length
+    }
+
+    // block 1001 became DELAY seconds old on the last tick and was polled on the first
+    expect(previous).toEqual(1001)
+    expect(lastTickCalls).toEqual(1)
+  })
+
+  it('searches for the exact block when polls were missed', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    time.tick(600_000)
+    chain.latest = 1060
+    const result = await indexer.tick()
+
+    expect(result).toEqual(1030)
+  })
+
+  it('never lowers the height when the node reports a stale tip', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    chain.latest = 990
+    const result = await indexer.tick()
+
+    expect(result).toEqual(970)
+  })
+})
+
+function createIndexer(chain: FakeChain, delay = DELAY) {
+  const blockProvider = mockObject<BlockProvider>({
+    chain: 'ethereum',
+    getBlockHeader: async (x) => chain.header(x),
+  })
+  return new BlockNumberIndexer(
+    blockProvider,
+    'ethereum',
+    Logger.SILENT,
+    delay,
+    INTERVAL_MS,
+  )
+}
+
+interface FakeChain {
+  latest: number
+  requested: (number | 'latest')[]
+  header(x: number | 'latest'): BlockHeader
+}
+
+// Block 1000 is mined at START and every BLOCK_TIME seconds another one
+function fakeChain(latest: number): FakeChain {
+  return {
+    latest,
+    requested: [],
+    header(x) {
+      this.requested.push(x)
+      const number = x === 'latest' ? this.latest : x
+      return {
+        number,
+        hash: `0x${number}`,
+        timestamp: START + (number - 1000) * BLOCK_TIME,
+      }
+    },
+  }
+}

--- a/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
@@ -1,11 +1,18 @@
 import type { Logger } from '@l2beat/backend-tools'
-import type { BlockProvider } from '@l2beat/shared'
+import {
+  type BlockHeader,
+  type BlockProvider,
+  getBlockNumberAtOrBefore,
+} from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import { Indexer, RootIndexer } from '@l2beat/uif'
 import { withBlockSyncRpcMetricsContext } from './blockSyncRpcMetrics'
 
 export class BlockNumberIndexer extends RootIndexer {
   blockHeight = -1
+  // Each tick fetches only the latest header. Headers seen on earlier ticks
+  // are what tells us which block is already old enough, without more calls
+  private readonly headers = new Map<number, BlockHeader>()
 
   constructor(
     private readonly blockProvider: BlockProvider,
@@ -33,16 +40,57 @@ export class BlockNumberIndexer extends RootIndexer {
       },
       async () => {
         const timestamp = UnixTime.now() - this.delayFromTipInSeconds
-        const blockNumber = await this.blockProvider.getBlockNumberAtOrBefore(
-          timestamp,
-          Math.max(this.blockHeight, 1),
-        )
+        const blockNumber = await this.findBlockNumberAtOrBefore(timestamp)
         if (blockNumber > this.blockHeight) {
           this.blockHeight = blockNumber
           this.logger.info('Advanced block number', { blockNumber })
         }
+        for (const number of this.headers.keys()) {
+          if (number < this.blockHeight) this.headers.delete(number)
+        }
         return this.blockHeight
       },
     )
+  }
+
+  private async findBlockNumberAtOrBefore(
+    timestamp: UnixTime,
+  ): Promise<number> {
+    const latest = await this.getHeader('latest')
+    if (latest.timestamp <= timestamp) return latest.number
+
+    let before: BlockHeader | undefined
+    let after = latest
+    for (const header of this.headers.values()) {
+      if (header.timestamp <= timestamp) {
+        if (!before || header.number > before.number) before = header
+      } else if (header.number < after.number) {
+        after = header
+      }
+    }
+
+    if (!before) return await this.search(timestamp, 1, after.number)
+    // Consecutive polls bracket the timestamp within one interval, so the
+    // newest block known to be old enough is close enough. A wider gap means
+    // polls were missed and the exact block is worth a few calls
+    const maxGap = (2 * this.checkIntervalMs) / 1000
+    if (after.timestamp - before.timestamp > maxGap) {
+      return await this.search(timestamp, before.number, after.number)
+    }
+    return before.number
+  }
+
+  private search(timestamp: UnixTime, from: number, to: number) {
+    return getBlockNumberAtOrBefore(timestamp, from, to, (number) =>
+      this.getHeader(number),
+    )
+  }
+
+  private async getHeader(x: number | 'latest'): Promise<BlockHeader> {
+    const known = x !== 'latest' ? this.headers.get(x) : undefined
+    if (known) return known
+    const header = await this.blockProvider.getBlockHeader(x)
+    this.headers.set(header.number, header)
+    return header
   }
 }

--- a/packages/backend/src/modules/block-sync/BlockSyncModule.ts
+++ b/packages/backend/src/modules/block-sync/BlockSyncModule.ts
@@ -12,6 +12,7 @@ export function createBlockSyncModule({
   db,
   providers,
   blockProcessors,
+  blockObservers,
 }: ModuleDependencies): ApplicationModule | undefined {
   if (blockProcessors.length === 0) {
     // This module is special in that it is only created if other modules
@@ -53,6 +54,7 @@ export function createBlockSyncModule({
         minHeight: 1,
         parents: [blockNumberIndexer],
         blockProcessors: blockProcessors.filter((x) => x.chain === chain),
+        blockObservers: blockObservers.filter((x) => x.chain === chain),
         source: chain,
         blockProvider: providers.block.getBlockProvider(chain),
         logsProvider: providers.logs.getLogsProvider(chain),

--- a/packages/backend/src/modules/interop/examples/snapshot/replay.ts
+++ b/packages/backend/src/modules/interop/examples/snapshot/replay.ts
@@ -70,6 +70,10 @@ export class RpcReplay implements Omit<RpcClientCompat, 'ethRpcClient'> {
     throw new ReplayError(key)
   }
 
+  getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock> {
+    return this.getBlock(blockNumber, false)
+  }
+
   getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const key = this.buildSnapshotKey([
       'blockParentBeaconRoot',

--- a/packages/backend/src/modules/types.ts
+++ b/packages/backend/src/modules/types.ts
@@ -28,6 +28,8 @@ export interface ModuleDependencies {
   providers: Providers
   db: Database
   blockProcessors: BlockProcessor[]
+  /** Receive blocks of chains synced for blockProcessors without causing any chain to be synced */
+  blockObservers: BlockProcessor[]
 }
 
 export interface BlockProcessor {

--- a/packages/backend/src/providers/ActivityBlockCache.test.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.test.ts
@@ -1,0 +1,42 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { ActivityBlockCache } from './ActivityBlockCache'
+
+describe(ActivityBlockCache.name, () => {
+  it('returns stored blocks and undefined for unknown ones', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(10, 5))
+
+    expect(cache.get(10)).toEqual(block(10, 5))
+    expect(cache.get(11)).toEqual(undefined)
+  })
+
+  it('keeps a null uops count', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(10, null))
+
+    expect(cache.get(10)).toEqual(block(10, null))
+  })
+
+  it('evicts the older block sharing a slot', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(1, 1))
+    cache.set(block(5, 2))
+
+    expect(cache.get(1)).toEqual(undefined)
+    expect(cache.get(5)).toEqual(block(5, 2))
+  })
+
+  it('is empty before anything is stored', () => {
+    expect(new ActivityBlockCache(4).get(0)).toEqual(undefined)
+  })
+})
+
+function block(number: number, uopsCount: number | null) {
+  return {
+    number,
+    timestamp: UnixTime(1_700_000_000 + number),
+    txsCount: number * 2,
+    uopsCount,
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockCache.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.ts
@@ -1,0 +1,50 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { ActivityBlock } from '../modules/activity/services/txs/types'
+
+const DEFAULT_CAPACITY = 100_000
+
+interface Slots {
+  numbers: Float64Array
+  timestamps: Float64Array
+  txsCounts: Int32Array
+  uopsCounts: Int32Array
+}
+
+/**
+ * Summaries of the newest blocks of a chain, stored in typed arrays so that
+ * the default capacity costs ~2.4 MB. A block lives in the slot
+ * `number % capacity`; a newer block landing in the same slot evicts it.
+ */
+export class ActivityBlockCache {
+  private slots: Slots | undefined
+
+  constructor(private readonly capacity = DEFAULT_CAPACITY) {}
+
+  set(block: ActivityBlock) {
+    this.slots ??= {
+      numbers: new Float64Array(this.capacity).fill(-1),
+      timestamps: new Float64Array(this.capacity),
+      txsCounts: new Int32Array(this.capacity),
+      uopsCounts: new Int32Array(this.capacity),
+    }
+
+    const slot = block.number % this.capacity
+    this.slots.numbers[slot] = block.number
+    this.slots.timestamps[slot] = block.timestamp
+    this.slots.txsCounts[slot] = block.txsCount
+    this.slots.uopsCounts[slot] = block.uopsCount ?? -1
+  }
+
+  get(number: number): ActivityBlock | undefined {
+    const slot = number % this.capacity
+    if (!this.slots || this.slots.numbers[slot] !== number) return undefined
+
+    const uopsCount = this.slots.uopsCounts[slot]
+    return {
+      number,
+      timestamp: UnixTime(this.slots.timestamps[slot]),
+      txsCount: this.slots.txsCounts[slot],
+      uopsCount: uopsCount === -1 ? null : uopsCount,
+    }
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockProviders.test.ts
+++ b/packages/backend/src/providers/ActivityBlockProviders.test.ts
@@ -1,5 +1,5 @@
 import type { AztecBlockProvider, BlockProvider } from '@l2beat/shared'
-import { UnixTime } from '@l2beat/shared-pure'
+import { type Block, UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
 import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
 import {
@@ -66,6 +66,40 @@ describe(StandardActivityBlockProvider.name, () => {
       },
     ])
   })
+
+  it('serves blocks seen by the block observer without fetching them', async () => {
+    const blockProvider = mockObject<BlockProvider>({
+      chain: 'ethereum',
+      getBlockWithTransactions: mockFn().resolvesToOnce(block(11, 1)),
+    })
+    const uopsAnalyzer = mockObject<UopsAnalyzer>({
+      calculateUops: (block: Block) => block.transactions.length * 2,
+    })
+    const provider = new StandardActivityBlockProvider(
+      blockProvider,
+      uopsAnalyzer,
+    )
+
+    await provider.blockObserver.processBlock(block(10, 3), [])
+    const result = await provider.getBlocks(10, 11)
+
+    expect(provider.blockObserver.chain).toEqual('ethereum')
+    expect(blockProvider.getBlockWithTransactions).toHaveBeenOnlyCalledWith(11)
+    expect(result).toEqual([
+      {
+        number: 10,
+        timestamp: UnixTime(1_700_000_010),
+        txsCount: 3,
+        uopsCount: 6,
+      },
+      {
+        number: 11,
+        timestamp: UnixTime(1_700_000_011),
+        txsCount: 1,
+        uopsCount: 2,
+      },
+    ])
+  })
 })
 
 describe(AztecActivityBlockProvider.name, () => {
@@ -98,3 +132,13 @@ describe(AztecActivityBlockProvider.name, () => {
     ])
   })
 })
+
+function block(number: number, txsCount: number): Block {
+  return {
+    number,
+    hash: `0x${number}`,
+    logsBloom: '0x',
+    timestamp: UnixTime(1_700_000_000 + number),
+    transactions: Array.from({ length: txsCount }, () => ({})),
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockProviders.ts
+++ b/packages/backend/src/providers/ActivityBlockProviders.ts
@@ -1,11 +1,13 @@
 import type { AztecBlockProvider, BlockProvider } from '@l2beat/shared'
-import { assert } from '@l2beat/shared-pure'
+import { assert, type Block } from '@l2beat/shared-pure'
 import range from 'lodash/range'
 import type {
   ActivityBlock,
   ActivityBlockProvider,
 } from '../modules/activity/services/txs/types'
 import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
+import type { BlockProcessor } from '../modules/types'
+import { ActivityBlockCache } from './ActivityBlockCache'
 import type { AztecBlockProviders } from './AztecBlockProviders'
 import type { BlockProviders } from './BlockProviders'
 import type { UopsAnalyzers } from './UopsAnalyzers'
@@ -47,10 +49,22 @@ export class ActivityBlockProviders {
 }
 
 export class StandardActivityBlockProvider implements ActivityBlockProvider {
+  private readonly cache = new ActivityBlockCache()
+  /** Blocks that block sync already fetched are summarized here instead of being fetched again */
+  readonly blockObserver: BlockProcessor
+
   constructor(
     private readonly provider: BlockProvider,
     private readonly uopsAnalyzer: UopsAnalyzer | undefined,
-  ) {}
+  ) {
+    this.blockObserver = {
+      chain: provider.chain,
+      processBlock: (block) => {
+        this.cache.set(this.toActivityBlock(block))
+        return Promise.resolve()
+      },
+    }
+  }
 
   get chain(): string {
     return this.provider.chain
@@ -58,16 +72,23 @@ export class StandardActivityBlockProvider implements ActivityBlockProvider {
 
   async getBlocks(from: number, to: number): Promise<ActivityBlock[]> {
     return await Promise.all(
-      range(from, to + 1).map(async (number) => {
-        const block = await this.provider.getBlockWithTransactions(number)
-        return {
-          number: block.number,
-          timestamp: block.timestamp,
-          txsCount: block.transactions.length,
-          uopsCount: this.uopsAnalyzer?.calculateUops(block) ?? null,
-        }
-      }),
+      range(from, to + 1).map(
+        async (number) =>
+          this.cache.get(number) ??
+          this.toActivityBlock(
+            await this.provider.getBlockWithTransactions(number),
+          ),
+      ),
     )
+  }
+
+  private toActivityBlock(block: Block): ActivityBlock {
+    return {
+      number: block.number,
+      timestamp: block.timestamp,
+      txsCount: block.transactions.length,
+      uopsCount: this.uopsAnalyzer?.calculateUops(block) ?? null,
+    }
   }
 }
 

--- a/packages/shared/src/clients/rpc/RpcClient.test.ts
+++ b/packages/shared/src/clients/rpc/RpcClient.test.ts
@@ -83,6 +83,34 @@ describe(RpcClient.name, () => {
     })
   })
 
+  describe(RpcClient.prototype.getBlockHeader.name, () => {
+    it('fetches block without tx bodies', async () => {
+      const http = mockObject<HttpClient>({
+        fetch: async () => mockResponse(100),
+      })
+      const rpc = mockClient({ http, generateId: () => 'unique-id' })
+
+      const result = await rpc.getBlockHeader(100)
+
+      expect(result).toEqual({
+        timestamp: 100,
+        hash: '0xabcdef',
+        logsBloom: `0x${'0'.repeat(512)}`,
+        number: 100,
+        parentBeaconBlockRoot: '0x123',
+      })
+
+      expect(http.fetch.calls[0].args[1]?.body).toEqual(
+        JSON.stringify({
+          method: 'eth_getBlockByNumber',
+          params: ['0x64', false],
+          id: 'unique-id',
+          jsonrpc: '2.0',
+        }),
+      )
+    })
+  })
+
   describe(RpcClient.prototype.getTransaction.name, () => {
     it('fetches tx from rpc and parses response', async () => {
       const http = mockObject<HttpClient>({

--- a/packages/shared/src/clients/rpc/RpcClient.ts
+++ b/packages/shared/src/clients/rpc/RpcClient.ts
@@ -76,6 +76,10 @@ export class RpcClient extends ClientCore implements IRpcClient {
     return await this.getBlock(blockNumber, true)
   }
 
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock> {
+    return await this.getBlock(blockNumber, false)
+  }
+
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const block = await this.getBlock(blockNumber, false)
 

--- a/packages/shared/src/clients/types.ts
+++ b/packages/shared/src/clients/types.ts
@@ -1,9 +1,17 @@
 import type { Block, Log, UnixTime } from '@l2beat/shared-pure'
 import type { SvmBlock } from './rpc-svm/types'
 
+export interface BlockHeader {
+  number: number
+  hash: string
+  timestamp: number
+}
+
 export interface BlockClient {
   getLatestBlockNumber(): Promise<number>
   getBlockWithTransactions(blockNumber: number | 'latest'): Promise<Block>
+  /** Optional capability: fetch a block without transaction bodies. */
+  getBlockHeader?(blockNumber: number | 'latest'): Promise<BlockHeader>
   /** Optional capability: batch-fetch block timestamps. Implementations are
    *  expected to chunk requests internally. */
   getBlockTimestamps?(blockNumbers: number[]): Promise<Map<number, number>>

--- a/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
+++ b/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
@@ -49,6 +49,7 @@ export interface IRpcClient extends BlockClient, LogsClient {
   getBlockWithTransactions(
     blockNumber: number | 'latest',
   ): Promise<EVMBlockWithTransactions>
+  getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock>
   getBlockParentBeaconRoot(blockNumber: number): Promise<string>
   getBlock(blockNumber: 'latest' | number, includeTxs: false): Promise<EVMBlock>
   getBlock(
@@ -129,6 +130,10 @@ export class RpcClientCompat implements IRpcClient {
     blockNumber: number | 'latest',
   ): Promise<EVMBlockWithTransactions> {
     return await this.getBlock(blockNumber, true)
+  }
+
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock> {
+    return await this.getBlock(blockNumber, false)
   }
 
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -62,13 +62,123 @@ describe(BlockProvider.name, () => {
     })
   })
 
-  describe(BlockProvider.prototype.getBlockNumberAtOrBefore.name, () => {
-    it('finds the closest block number to given timestamp', async () => {
+  describe(BlockProvider.prototype.getBlockHeader.name, () => {
+    it('returns header from client', async () => {
       const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => header(x === 'latest' ? 1000 : x),
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      expect(await provider.getBlockHeader(5)).toEqual(header(5))
+      expect(await provider.getBlockHeader('latest')).toEqual(header(1000))
+    })
+
+    it('falls back to full blocks for clients without header support', async () => {
+      const client = mockObject<BlockClient>({
+        getBlockHeader: undefined,
         getLatestBlockNumber: async () => 1000,
         getBlockWithTransactions: async (n: number) => block(n),
       })
+      const provider = new BlockProvider('chain', [client])
 
+      expect(await provider.getBlockHeader('latest')).toEqual(block(1000))
+      expect(await provider.getBlockHeader(5)).toEqual(block(5))
+      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+    })
+
+    it('rejects a header of a different block', async () => {
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async () => header(7),
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      await expect(provider.getBlockHeader(5)).toBeRejectedWith(
+        'expected block number 5, got 7',
+      )
+    })
+  })
+
+  describe(BlockProvider.prototype.getBlockNumberAtOrBefore.name, () => {
+    it('finds the closest block number to given timestamp', async () => {
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(800 * 100),
+      )
+
+      expect(blockNumber).toEqual(800)
+      expect(getBlockHeader).toHaveBeenCalledWith('latest')
+    })
+
+    it('returns the latest block when timestamp is not earlier', async () => {
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(1000 * 100 + 5),
+      )
+
+      expect(blockNumber).toEqual(1000)
+      expect(getBlockHeader).toHaveBeenOnlyCalledWith('latest')
+    })
+
+    it('starts the next search from the previous result', async () => {
+      const requested: (number | 'latest')[] = []
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => {
+          requested.push(x)
+          return header(x === 'latest' ? 1000 : x)
+        },
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      await provider.getBlockNumberAtOrBefore(UnixTime(500 * 100))
+      expect(requested).toInclude(1)
+
+      requested.length = 0
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(600 * 100),
+      )
+
+      expect(blockNumber).toEqual(600)
+      const numbers = requested.filter((x) => typeof x === 'number')
+      expect(Math.min(...numbers)).toBeGreaterThanOrEqual(500)
+    })
+
+    it('does not reuse the previous result for an earlier timestamp', async () => {
+      const requested: (number | 'latest')[] = []
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => {
+          requested.push(x)
+          return header(x === 'latest' ? 1000 : x)
+        },
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      await provider.getBlockNumberAtOrBefore(UnixTime(600 * 100))
+
+      requested.length = 0
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(300 * 100),
+      )
+
+      expect(blockNumber).toEqual(300)
+      expect(requested).toInclude(1)
+    })
+
+    it('uses full blocks for clients without header support', async () => {
+      const client = mockObject<BlockClient>({
+        getBlockHeader: undefined,
+        getLatestBlockNumber: async () => 1000,
+        getBlockWithTransactions: async (n: number) => block(n),
+      })
       const provider = new BlockProvider('chain', [client])
 
       const blockNumber = await provider.getBlockNumberAtOrBefore(
@@ -80,64 +190,42 @@ describe(BlockProvider.name, () => {
     })
 
     it('calls other client when there are errors', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 1000,
-        getBlockWithTransactions: mockFn().rejectsWith(new Error('error')),
-      })
-
-      const client2 = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 1000,
-        getBlockWithTransactions: async (n: number) => block(n),
-      })
-
-      const provider = new BlockProvider('chain', [client, client2])
+      const failing = mockFn().rejectsWith(new Error('error'))
+      const working = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const provider = new BlockProvider('chain', [
+        mockObject<BlockClient>({ getBlockHeader: failing }),
+        mockObject<BlockClient>({ getBlockHeader: working }),
+      ])
 
       const blockNumber = await provider.getBlockNumberAtOrBefore(
         UnixTime(800 * 100),
       )
 
       expect(blockNumber).toEqual(800)
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client2.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-    })
-
-    it('falls back to 0 when start is above client latest', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 500,
-        getBlockWithTransactions: async (n: number) => block(n),
-      })
-
-      const provider = new BlockProvider('chain', [client])
-
-      const blockNumber = await provider.getBlockNumberAtOrBefore(
-        UnixTime(300 * 100),
-        800,
-      )
-
-      expect(blockNumber).toEqual(300)
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+      expect(failing).toHaveBeenCalledTimes(1)
+      expect(working).toHaveBeenCalledWith('latest')
     })
 
     it('throws error when run out of fallbacks', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('1')),
-      })
-      const client2 = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('2')),
-      })
-      const client3 = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('3')),
-      })
-
-      const provider = new BlockProvider('chain', [client, client2, client3])
+      const failing = [1, 2, 3].map((i) =>
+        mockFn().rejectsWith(new Error(i.toString())),
+      )
+      const provider = new BlockProvider(
+        'chain',
+        failing.map((getBlockHeader) =>
+          mockObject<BlockClient>({ getBlockHeader }),
+        ),
+      )
 
       await expect(
         async () => await provider.getBlockNumberAtOrBefore(UnixTime(800)),
       ).toBeRejectedWith('3')
 
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client2.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client3.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+      for (const getBlockHeader of failing) {
+        expect(getBlockHeader).toHaveBeenCalledTimes(1)
+      }
     })
   })
 })
@@ -148,6 +236,14 @@ function block(x: number) {
     transactions: [],
     hash: '0x' + x.toString(),
     logsBloom: `0x${'0'.repeat(512)}`,
+    timestamp: x * 100,
+  }
+}
+
+function header(x: number) {
+  return {
+    number: x,
+    hash: '0x' + x.toString(),
     timestamp: x * 100,
   }
 }

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -1,8 +1,12 @@
 import { assert, type Block, UnixTime } from '@l2beat/shared-pure'
-import type { BlockClient } from '../../clients'
+import type { BlockClient, BlockHeader } from '../../clients'
 import { getBlockNumberAtOrBefore } from '../../tools/getBlockNumberAtOrBefore'
 
 export class BlockProvider {
+  // Consumers ask for hourly, increasing timestamps, so the previous answer is
+  // a much better lower bound for the next search than block 1
+  private lastFound: BlockHeader | undefined
+
   constructor(
     readonly chain: string,
     private readonly clients: BlockClient[],
@@ -11,52 +15,77 @@ export class BlockProvider {
   }
 
   async getLatestBlockNumber(): Promise<number> {
-    for (const [index, client] of this.clients.entries()) {
-      try {
-        return await client.getLatestBlockNumber()
-      } catch (error) {
-        if (index === this.clients.length - 1) throw error
-      }
-    }
-
-    throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+    return await this.withClient((client) => client.getLatestBlockNumber())
   }
 
   async getBlockWithTransactions(x: number | 'latest'): Promise<Block> {
-    for (const [index, client] of this.clients.entries()) {
-      try {
-        const block = await client.getBlockWithTransactions(x)
-        if (typeof x === 'number') {
-          assert(
-            block.number === x,
-            `Invalid response: expected block number ${x}, got ${block.number}`,
-          )
-        }
-        return block
-      } catch (error) {
-        if (index === this.clients.length - 1) throw error
-      }
-    }
+    return await this.withClient(async (client) => {
+      const block = await client.getBlockWithTransactions(x)
+      assertBlockNumber(block, x)
+      return block
+    })
+  }
 
-    throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+  async getBlockHeader(x: number | 'latest'): Promise<BlockHeader> {
+    return await this.withClient((client) => getBlockHeader(client, x))
   }
 
   async getBlockTimestamps(
     blockNumbers: number[],
   ): Promise<Map<number, UnixTime>> {
+    return await this.withClient(async (client) => {
+      assert(
+        client.getBlockTimestamps,
+        'Client does not support batch fetching of block timestamps',
+      )
+      const out = new Map<number, UnixTime>()
+      const timestamps = await client.getBlockTimestamps(blockNumbers)
+      for (const [n, ts] of timestamps) {
+        out.set(n, UnixTime(ts))
+      }
+      assert(out.size === blockNumbers.length, 'Missing block timestamps')
+      return out
+    })
+  }
+
+  async getBlockNumberAtOrBefore(timestamp: UnixTime): Promise<number> {
+    return await this.withClient(async (client) => {
+      const known = new Map<number, BlockHeader>()
+      const getHeader = async (x: number | 'latest') => {
+        const cached = x !== 'latest' ? known.get(x) : undefined
+        if (cached) return cached
+        const header = await getBlockHeader(client, x)
+        known.set(header.number, header)
+        return header
+      }
+
+      const latest = await getHeader('latest')
+      if (timestamp >= latest.timestamp) return latest.number
+
+      let start = 1
+      const seed = this.lastFound
+      if (seed && seed.timestamp <= timestamp && seed.number < latest.number) {
+        known.set(seed.number, seed)
+        start = seed.number
+      }
+
+      const found = await getBlockNumberAtOrBefore(
+        timestamp,
+        start,
+        latest.number,
+        getHeader,
+      )
+      this.lastFound = known.get(found)
+      return found
+    })
+  }
+
+  private async withClient<T>(
+    callback: (client: BlockClient) => Promise<T>,
+  ): Promise<T> {
     for (const [index, client] of this.clients.entries()) {
       try {
-        assert(
-          client.getBlockTimestamps,
-          'Client does not support batch fetching of block timestamps',
-        )
-        const out = new Map<number, UnixTime>()
-        const timestamps = await client.getBlockTimestamps(blockNumbers)
-        for (const [n, ts] of timestamps) {
-          out.set(n, UnixTime(ts))
-        }
-        assert(out.size === blockNumbers.length, 'Missing block timestamps')
-        return out
+        return await callback(client)
       } catch (error) {
         if (index === this.clients.length - 1) throw error
       }
@@ -64,27 +93,29 @@ export class BlockProvider {
 
     throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
   }
+}
 
-  async getBlockNumberAtOrBefore(
-    timestamp: UnixTime,
-    start = 1,
-  ): Promise<number> {
-    for (const [index, client] of this.clients.entries()) {
-      try {
-        const end = await client.getLatestBlockNumber()
-        const effectiveStart = start >= end ? 1 : start
+async function getBlockHeader(
+  client: BlockClient,
+  x: number | 'latest',
+): Promise<BlockHeader> {
+  if (client.getBlockHeader) {
+    const header = await client.getBlockHeader(x)
+    assertBlockNumber(header, x)
+    return header
+  }
+  // Non-EVM clients only accept concrete block numbers
+  const number = x === 'latest' ? await client.getLatestBlockNumber() : x
+  const block = await client.getBlockWithTransactions(number)
+  assertBlockNumber(block, number)
+  return block
+}
 
-        return await getBlockNumberAtOrBefore(
-          timestamp,
-          effectiveStart,
-          end,
-          (number: number) => client.getBlockWithTransactions(number),
-        )
-      } catch (error) {
-        if (index === this.clients.length - 1) throw error
-      }
-    }
-
-    throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+function assertBlockNumber(block: { number: number }, x: number | 'latest') {
+  if (typeof x === 'number') {
+    assert(
+      block.number === x,
+      `Invalid response: expected block number ${x}, got ${block.number}`,
+    )
   }
 }


### PR DESCRIPTION
## Summary
- Add `blockObservers` to `ModuleDependencies`/`Application` so activity can piggyback on blocks block-sync already fetches, instead of re-fetching them via `StandardActivityBlockProvider.blockObserver` backed by a new fixed-size `ActivityBlockCache`
- Rework `BlockNumberIndexer` to track polled block headers and locate the tip with header-only RPC calls, falling back to a bounded binary search only when polls were missed or the tip regressed
- Add `getBlockHeader` (fetches a block without tx bodies) to `BlockClient`/`RpcClient`/`RpcClientCompat`/`BlockProvider`, and reuse the last found block as the lower search bound in `BlockProvider.getBlockNumberAtOrBefore`
- `BlockIndexer` now runs `blockObservers` before `blockProcessors` per block, logging and swallowing observer failures so they never affect indexing

## Testing
- Added/updated unit tests: `BlockIndexer.test.ts`, `BlockNumberIndexer.test.ts` (new), `ActivityBlockCache.test.ts` (new), `ActivityBlockProviders.test.ts`, `RpcClient.test.ts`, `BlockProvider.test.ts`
- Not run: full backend/shared test suites and lint/typecheck locally