### PR TITLE
/ai-review comment trigger posting a stub review with run metadata

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -17,7 +17,8 @@ permissions: {}
 
 jobs:
   # Cheap pre-filter so non-member / non-command comments never spin a runner.
-  # The authoritative gate (draft/fork/bot checks) is the unit-tested evaluateTrigger.
+  # Must stay a loose superset of the unit-tested evaluateTrigger, which is the
+  # authoritative gate (command syntax, membership, draft/fork/bot checks).
   gate:
     name: Gate
     if: >
@@ -25,7 +26,7 @@ jobs:
         (github.event_name == 'pull_request' && github.event.label.name == 'ai-review-test') ||
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
-        startsWith(github.event.comment.body, '/ai-review') &&
+        contains(github.event.comment.body, '/ai-review') &&
         contains(fromJSON('["MEMBER","OWNER"]'), github.event.comment.author_association)
       }}
     runs-on: ubuntu-latest
@@ -122,7 +123,8 @@ jobs:
 
   post:
     name: Post
-    needs: [gate, review]
+    # ack is included so the final reaction is always written after the eyes.
+    needs: [gate, ack, review]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -3,20 +3,31 @@ name: AI Review
 on:
   issue_comment:
     types: [created]
+  # Replay an existing /ai-review comment from any branch, so YAML and code
+  # changes can be tested before they reach main.
+  workflow_dispatch:
+    inputs:
+      comment_id:
+        description: 'ID of an existing /ai-review PR comment to replay'
+        required: true
 
-# Cheap pre-filter so non-member / non-command comments never spin a runner.
-# The authoritative gate (draft/fork/bot checks) is the unit-tested evaluateTrigger.
+env:
+  COMMENT_ID: ${{ github.event.comment.id || inputs.comment_id }}
+
 concurrency:
-  group: ai-review-${{ github.event.issue.number }}
+  group: ai-review-${{ github.event.issue.number || inputs.comment_id }}
   cancel-in-progress: true
 
 permissions: {}
 
 jobs:
+  # Cheap pre-filter so non-member / non-command comments never spin a runner.
+  # The authoritative gate (draft/fork/bot checks) is the unit-tested evaluateTrigger.
   gate:
     name: Gate
     if: >
       ${{
+        github.event_name == 'workflow_dispatch' ||
         github.event.issue.pull_request != null &&
         startsWith(github.event.comment.body, '/ai-review') &&
         contains(fromJSON('["MEMBER","OWNER"]'), github.event.comment.author_association)
@@ -28,6 +39,7 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
+      comment_id: ${{ env.COMMENT_ID }}
       pr_number: ${{ steps.gate.outputs.pr_number }}
       head_sha: ${{ steps.gate.outputs.head_sha }}
       base_sha: ${{ steps.gate.outputs.base_sha }}
@@ -39,13 +51,25 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       - run: pnpm install --filter @l2beat/ai-review...
+      - name: Build comment event
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            cp "$GITHUB_EVENT_PATH" "$RUNNER_TEMP/event.json"
+          else
+            gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" \
+              | jq '{action: "created", comment: ., issue: {number: (.issue_url | split("/") | last | tonumber), pull_request: {url: .issue_url}}}' \
+              > "$RUNNER_TEMP/event.json"
+          fi
       - name: Fetch pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" > "$RUNNER_TEMP/pr.json"
+        run: gh api "repos/${{ github.repository }}/pulls/$(jq .issue.number "$RUNNER_TEMP/event.json")" > "$RUNNER_TEMP/pr.json"
       - id: gate
         run: pnpm --filter @l2beat/ai-review gate
         env:
+          GITHUB_EVENT_PATH: ${{ runner.temp }}/event.json
           PR_JSON_PATH: ${{ runner.temp }}/pr.json
 
   ack:
@@ -60,7 +84,7 @@ jobs:
       - name: React with eyes on the trigger comment
         uses: peter-evans/create-or-update-comment@v5
         with:
-          comment-id: ${{ github.event.comment.id }}
+          comment-id: ${{ needs.gate.outputs.comment_id }}
           reactions: eyes
 
   review:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -1,0 +1,111 @@
+name: AI Review
+
+on:
+  issue_comment:
+    types: [created]
+
+# Cheap pre-filter so non-member / non-command comments never spin a runner.
+# The authoritative gate (draft/fork/bot checks) is the unit-tested evaluateTrigger.
+concurrency:
+  group: ai-review-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  gate:
+    name: Gate
+    if: >
+      ${{
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '/ai-review') &&
+        contains(fromJSON('["MEMBER","OWNER"]'), github.event.comment.author_association)
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.gate.outputs.run }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+      base_sha: ${{ steps.gate.outputs.base_sha }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --filter @l2beat/ai-review...
+      - name: Fetch pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api "repos/${{ github.repository }}/pulls/${{ github.event.issue.number }}" > "$RUNNER_TEMP/pr.json"
+      - id: gate
+        run: pnpm --filter @l2beat/ai-review gate
+        env:
+          PR_JSON_PATH: ${{ runner.temp }}/pr.json
+
+  review:
+    name: Review (no write token)
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.gate.outputs.head_sha }}
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --filter @l2beat/ai-review...
+      - run: pnpm --filter @l2beat/ai-review review
+        env:
+          REVIEW_OUTPUT_PATH: ${{ runner.temp }}/review.json
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ai-review-output
+          path: ${{ runner.temp }}/review.json
+
+  post:
+    name: Post
+    needs: [gate, review]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --filter @l2beat/ai-review...
+      - uses: actions/download-artifact@v7
+        with:
+          name: ai-review-output
+          path: ${{ runner.temp }}
+      - name: Validate and render comment
+        run: pnpm --filter @l2beat/ai-review post
+        env:
+          REVIEW_OUTPUT_PATH: ${{ runner.temp }}/review.json
+          COMMENT_PATH: ${{ runner.temp }}/comment.md
+          RUN_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+          LESSONS_VERSION: none
+          ENGINE: stub
+      - name: Post comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "${{ needs.gate.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/comment.md"

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -149,3 +149,9 @@ jobs:
         with:
           issue-number: ${{ needs.gate.outputs.pr_number }}
           body-path: ${{ runner.temp }}/comment.md
+      - name: Mark trigger comment as done
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ needs.gate.outputs.comment_id }}
+          reactions: '+1'
+          reactions-edit-mode: replace

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -75,7 +75,7 @@ jobs:
       - id: gate
         run: pnpm --filter @l2beat/ai-review gate
         env:
-          GITHUB_EVENT_PATH: ${{ runner.temp }}/event.json
+          EVENT_JSON_PATH: ${{ runner.temp }}/event.json
           PR_JSON_PATH: ${{ runner.temp }}/pr.json
 
   ack:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -142,6 +142,7 @@ jobs:
         with:
           name: ai-review-output
           path: ${{ runner.temp }}
+      - run: pnpm --filter @l2beat/ai-review^... build
       - name: Validate and render comment
         run: pnpm --filter @l2beat/ai-review post
         env:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -48,6 +48,21 @@ jobs:
         env:
           PR_JSON_PATH: ${{ runner.temp }}/pr.json
 
+  ack:
+    name: Ack
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      pull-requests: write
+    steps:
+      - name: React with eyes on the trigger comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: eyes
+
   review:
     name: Review (no write token)
     needs: gate
@@ -106,6 +121,7 @@ jobs:
           LESSONS_VERSION: none
           ENGINE: stub
       - name: Post comment
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr comment "${{ needs.gate.outputs.pr_number }}" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/comment.md"
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ needs.gate.outputs.pr_number }}
+          body-path: ${{ runner.temp }}/comment.md

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -3,19 +3,14 @@ name: AI Review
 on:
   issue_comment:
     types: [created]
-  # Replay an existing /ai-review comment from any branch, so YAML and code
-  # changes can be tested before they reach main.
-  workflow_dispatch:
-    inputs:
-      comment_id:
-        description: 'ID of an existing /ai-review PR comment to replay'
-        required: true
-
-env:
-  COMMENT_ID: ${{ github.event.comment.id || inputs.comment_id }}
+  # Dev replay: labeling a PR `ai-review-test` re-runs the latest /ai-review
+  # comment on it using this branch's workflow and code (issue_comment always
+  # runs the version on main).
+  pull_request:
+    types: [labeled]
 
 concurrency:
-  group: ai-review-${{ github.event.issue.number || inputs.comment_id }}
+  group: ai-review-${{ github.event.issue.number || github.event.pull_request.number }}
   cancel-in-progress: true
 
 permissions: {}
@@ -27,7 +22,8 @@ jobs:
     name: Gate
     if: >
       ${{
-        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'pull_request' && github.event.label.name == 'ai-review-test') ||
+        github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         startsWith(github.event.comment.body, '/ai-review') &&
         contains(fromJSON('["MEMBER","OWNER"]'), github.event.comment.author_association)
@@ -39,7 +35,7 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.gate.outputs.run }}
-      comment_id: ${{ env.COMMENT_ID }}
+      comment_id: ${{ steps.event.outputs.comment_id }}
       pr_number: ${{ steps.gate.outputs.pr_number }}
       head_sha: ${{ steps.gate.outputs.head_sha }}
       base_sha: ${{ steps.gate.outputs.base_sha }}
@@ -52,16 +48,26 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --filter @l2beat/ai-review...
       - name: Build comment event
+        id: event
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
             cp "$GITHUB_EVENT_PATH" "$RUNNER_TEMP/event.json"
           else
-            gh api "repos/${{ github.repository }}/issues/comments/$COMMENT_ID" \
+            COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+              --jq '[.[] | select(.body | startswith("/ai-review"))] | last | .id // empty')
+            if [ -z "$COMMENT_ID" ]; then
+              echo "No /ai-review comment found on PR $PR_NUMBER"
+              exit 1
+            fi
+            gh api "repos/$REPO/issues/comments/$COMMENT_ID" \
               | jq '{action: "created", comment: ., issue: {number: (.issue_url | split("/") | last | tonumber), pull_request: {url: .issue_url}}}' \
               > "$RUNNER_TEMP/event.json"
           fi
+          echo "comment_id=$(jq .comment.id "$RUNNER_TEMP/event.json")" >> "$GITHUB_OUTPUT"
       - name: Fetch pull request
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ai-review/.mocharc.cjs
+++ b/packages/ai-review/.mocharc.cjs
@@ -1,0 +1,7 @@
+process.env.NODE_ENV = 'test'
+module.exports = {
+  spec: '{src,test}/**/*.test.ts',
+  'node-option': ['import=tsx'],
+  watchExtensions: ['js', 'ts'],
+  extension: ['js', 'ts'],
+}

--- a/packages/ai-review/package.json
+++ b/packages/ai-review/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@l2beat/ai-review",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "pnpm run clean && tsc -p tsconfig.build.json",
+    "clean": "rm -rf build *.tsbuildinfo",
+    "format:fix": "biome format --write .",
+    "format": "biome format .",
+    "lint:fix": "biome check --formatter-enabled=false --write .",
+    "lint": "biome check --formatter-enabled=false .",
+    "test": "mocha",
+    "typecheck": "tsc --noEmit",
+    "gate": "tsx src/cli/gate.ts",
+    "review": "tsx src/cli/review.ts",
+    "post": "tsx src/cli/post.ts"
+  },
+  "dependencies": {
+    "@l2beat/validate": "workspace:*"
+  },
+  "devDependencies": {
+    "@l2beat/typescript-config": "workspace:*"
+  }
+}

--- a/packages/ai-review/src/cli/gate.ts
+++ b/packages/ai-review/src/cli/gate.ts
@@ -2,7 +2,7 @@ import { evaluateTrigger } from '../gate/evaluateTrigger.js'
 import type { CommentEvent, PullRequest } from '../gate/types.js'
 import { readJson, requireEnv, setOutput } from './io.js'
 
-const event = readJson(requireEnv('GITHUB_EVENT_PATH')) as CommentEvent
+const event = readJson(requireEnv('EVENT_JSON_PATH')) as CommentEvent
 const pr = readJson(requireEnv('PR_JSON_PATH')) as PullRequest
 
 const decision = evaluateTrigger(event, pr)

--- a/packages/ai-review/src/cli/gate.ts
+++ b/packages/ai-review/src/cli/gate.ts
@@ -1,0 +1,15 @@
+import { evaluateTrigger } from '../gate/evaluateTrigger.js'
+import type { CommentEvent, PullRequest } from '../gate/types.js'
+import { readJson, requireEnv, setOutput } from './io.js'
+
+const event = readJson(requireEnv('GITHUB_EVENT_PATH')) as CommentEvent
+const pr = readJson(requireEnv('PR_JSON_PATH')) as PullRequest
+
+const decision = evaluateTrigger(event, pr)
+console.log(JSON.stringify(decision))
+setOutput('run', String(decision.run))
+if (decision.run) {
+  setOutput('pr_number', String(decision.prNumber))
+  setOutput('head_sha', decision.headSha)
+  setOutput('base_sha', decision.baseSha)
+}

--- a/packages/ai-review/src/cli/io.ts
+++ b/packages/ai-review/src/cli/io.ts
@@ -1,0 +1,21 @@
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs'
+
+export function readJson(path: string): unknown {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+export function writeText(path: string, content: string) {
+  writeFileSync(path, content)
+}
+
+export function setOutput(name: string, value: string) {
+  const file = process.env.GITHUB_OUTPUT
+  if (file) appendFileSync(file, `${name}=${value}\n`)
+  else console.log(`${name}=${value}`)
+}
+
+export function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing env ${name}`)
+  return value
+}

--- a/packages/ai-review/src/cli/post.ts
+++ b/packages/ai-review/src/cli/post.ts
@@ -1,0 +1,11 @@
+import { buildComment } from '../post/buildComment.js'
+import { ReviewOutput, RunMeta } from '../post/schema.js'
+import { readJson, requireEnv, writeText } from './io.js'
+
+const review = ReviewOutput.validate(readJson(requireEnv('REVIEW_OUTPUT_PATH')))
+const meta = RunMeta.validate({
+  run_id: requireEnv('RUN_ID'),
+  lessons_version: process.env.LESSONS_VERSION ?? 'none',
+  engine: process.env.ENGINE ?? 'stub',
+})
+writeText(requireEnv('COMMENT_PATH'), buildComment(review, meta))

--- a/packages/ai-review/src/cli/review.ts
+++ b/packages/ai-review/src/cli/review.ts
@@ -1,0 +1,10 @@
+// Stub agent stage: no model yet, emits an empty schema-valid review.
+import type { ReviewOutput } from '../post/schema.js'
+import { requireEnv, writeText } from './io.js'
+
+const review: ReviewOutput = {
+  intent: 'Stub review: no model engaged yet.',
+  findings: [],
+  context_sources: ['diff'],
+}
+writeText(requireEnv('REVIEW_OUTPUT_PATH'), JSON.stringify(review, null, 2))

--- a/packages/ai-review/src/gate/evaluateTrigger.test.ts
+++ b/packages/ai-review/src/gate/evaluateTrigger.test.ts
@@ -1,0 +1,138 @@
+import { expect } from 'earl'
+import { commentEvent, pullRequest } from '../test/fixtures/comment.js'
+import { evaluateTrigger, isCommand } from './evaluateTrigger.js'
+import type { GateSkipReason } from './types.js'
+
+describe(evaluateTrigger.name, () => {
+  it('runs for an org member on an open, non-draft, non-fork, non-bot PR', () => {
+    expect(evaluateTrigger(commentEvent(), pullRequest())).toEqual({
+      run: true,
+      prNumber: 42,
+      headSha: 'aaa111',
+      baseSha: 'bbb222',
+    })
+  })
+
+  it('accepts OWNER association', () => {
+    const event = commentEvent({ author_association: 'OWNER' })
+    expect(evaluateTrigger(event, pullRequest()).run).toEqual(true)
+  })
+
+  const skips: [string, Parameters<typeof evaluateTrigger>, GateSkipReason][] =
+    [
+      ['edited comment', [commentEvent(), pullRequest()], 'not-created'],
+      [
+        'issue comment',
+        [commentEvent({}, { pull_request: undefined }), pullRequest()],
+        'not-pull-request',
+      ],
+      [
+        'other text',
+        [commentEvent({ body: 'lgtm' }), pullRequest()],
+        'not-command',
+      ],
+      [
+        'command mid-text',
+        [commentEvent({ body: 'please /ai-review' }), pullRequest()],
+        'not-command',
+      ],
+      [
+        'bot commenter',
+        [
+          commentEvent({ user: { login: 'x[bot]', type: 'Bot' } }),
+          pullRequest(),
+        ],
+        'bot-commenter',
+      ],
+      [
+        'contributor',
+        [commentEvent({ author_association: 'CONTRIBUTOR' }), pullRequest()],
+        'not-org-member',
+      ],
+      [
+        'collaborator',
+        [commentEvent({ author_association: 'COLLABORATOR' }), pullRequest()],
+        'not-org-member',
+      ],
+      [
+        'none',
+        [commentEvent({ author_association: 'NONE' }), pullRequest()],
+        'not-org-member',
+      ],
+      ['draft', [commentEvent(), pullRequest({ draft: true })], 'draft'],
+      [
+        'fork flag',
+        [
+          commentEvent(),
+          pullRequest({
+            head: {
+              sha: 'a',
+              ref: 'f',
+              repo: { fork: true, full_name: 'l2beat/l2beat' },
+            },
+          }),
+        ],
+        'fork',
+      ],
+      [
+        'fork by repo name',
+        [
+          commentEvent(),
+          pullRequest({
+            head: {
+              sha: 'a',
+              ref: 'f',
+              repo: { fork: false, full_name: 'other/l2beat' },
+            },
+          }),
+        ],
+        'fork',
+      ],
+      [
+        'bot author',
+        [
+          commentEvent(),
+          pullRequest({ user: { login: 'dependabot[bot]', type: 'Bot' } }),
+        ],
+        'bot-author',
+      ],
+      [
+        'closed PR',
+        [commentEvent(), pullRequest({ state: 'closed' })],
+        'pr-closed',
+      ],
+      [
+        'PR number mismatch',
+        [commentEvent(), pullRequest({ number: 7 })],
+        'pr-mismatch',
+      ],
+    ]
+  skips[0][1][0].action = 'edited'
+
+  for (const [name, args, reason] of skips) {
+    it(`skips: ${name}`, () => {
+      expect(evaluateTrigger(...args)).toEqual({ run: false, reason })
+    })
+  }
+
+  it('membership is checked before PR properties', () => {
+    const event = commentEvent({ author_association: 'NONE' })
+    const result = evaluateTrigger(event, pullRequest({ draft: true }))
+    expect(result).toEqual({ run: false, reason: 'not-org-member' })
+  })
+})
+
+describe(isCommand.name, () => {
+  it('matches the bare command and command with arguments', () => {
+    expect(isCommand('/ai-review')).toEqual(true)
+    expect(isCommand('  /ai-review  \n')).toEqual(true)
+    expect(isCommand('/ai-review focus on tests')).toEqual(true)
+    expect(isCommand('/ai-review\nmore context')).toEqual(true)
+  })
+
+  it('rejects prefixes and embedded mentions', () => {
+    expect(isCommand('/ai-reviewer')).toEqual(false)
+    expect(isCommand('run /ai-review')).toEqual(false)
+    expect(isCommand('')).toEqual(false)
+  })
+})

--- a/packages/ai-review/src/gate/evaluateTrigger.ts
+++ b/packages/ai-review/src/gate/evaluateTrigger.ts
@@ -1,0 +1,56 @@
+import type {
+  CommentEvent,
+  GateDecision,
+  GateSkipReason,
+  PullRequest,
+} from './types.js'
+
+export const COMMAND = '/ai-review'
+
+// author_association is computed by GitHub and covers private org membership,
+// unlike GET /orgs/{org}/members which GITHUB_TOKEN cannot query.
+const ORG_ASSOCIATIONS = new Set(['MEMBER', 'OWNER'])
+
+export function isCommand(body: string): boolean {
+  const firstLine = body.trim().split('\n')[0]?.trim() ?? ''
+  return firstLine === COMMAND || firstLine.startsWith(`${COMMAND} `)
+}
+
+export function evaluateComment(
+  event: CommentEvent,
+): { ok: true; prNumber: number } | { ok: false; reason: GateSkipReason } {
+  if (event.action !== 'created') return skip('not-created')
+  if (!event.issue.pull_request) return skip('not-pull-request')
+  if (!isCommand(event.comment.body)) return skip('not-command')
+  if (event.comment.user.type === 'Bot') return skip('bot-commenter')
+  if (!ORG_ASSOCIATIONS.has(event.comment.author_association)) {
+    return skip('not-org-member')
+  }
+  return { ok: true, prNumber: event.issue.number }
+}
+
+export function evaluateTrigger(
+  event: CommentEvent,
+  pr: PullRequest,
+): GateDecision {
+  const comment = evaluateComment(event)
+  if (!comment.ok) return { run: false, reason: comment.reason }
+  if (pr.number !== comment.prNumber)
+    return { run: false, reason: 'pr-mismatch' }
+  if (pr.state !== 'open') return { run: false, reason: 'pr-closed' }
+  if (pr.draft) return { run: false, reason: 'draft' }
+  if (pr.head.repo.fork || pr.head.repo.full_name !== pr.base.repo.full_name) {
+    return { run: false, reason: 'fork' }
+  }
+  if (pr.user.type === 'Bot') return { run: false, reason: 'bot-author' }
+  return {
+    run: true,
+    prNumber: pr.number,
+    headSha: pr.head.sha,
+    baseSha: pr.base.sha,
+  }
+}
+
+function skip(reason: GateSkipReason) {
+  return { ok: false as const, reason }
+}

--- a/packages/ai-review/src/gate/types.ts
+++ b/packages/ai-review/src/gate/types.ts
@@ -1,0 +1,37 @@
+export interface CommentEvent {
+  action: string
+  comment: {
+    body: string
+    user: { login: string; type: string }
+    author_association: string
+  }
+  issue: {
+    number: number
+    pull_request?: { url: string }
+  }
+}
+
+export interface PullRequest {
+  number: number
+  draft: boolean
+  state: string
+  user: { login: string; type: string }
+  head: { sha: string; ref: string; repo: { fork: boolean; full_name: string } }
+  base: { sha: string; ref: string; repo: { full_name: string } }
+}
+
+export type GateDecision =
+  | { run: true; prNumber: number; headSha: string; baseSha: string }
+  | { run: false; reason: GateSkipReason }
+
+export type GateSkipReason =
+  | 'not-created'
+  | 'not-pull-request'
+  | 'not-command'
+  | 'bot-commenter'
+  | 'not-org-member'
+  | 'draft'
+  | 'fork'
+  | 'bot-author'
+  | 'pr-closed'
+  | 'pr-mismatch'

--- a/packages/ai-review/src/index.ts
+++ b/packages/ai-review/src/index.ts
@@ -1,0 +1,8 @@
+export {
+  evaluateComment,
+  evaluateTrigger,
+  isCommand,
+} from './gate/evaluateTrigger.js'
+export type * from './gate/types.js'
+export { buildComment, buildMarker } from './post/buildComment.js'
+export { Finding, ReviewOutput, RunMeta } from './post/schema.js'

--- a/packages/ai-review/src/post/buildComment.test.ts
+++ b/packages/ai-review/src/post/buildComment.test.ts
@@ -1,0 +1,86 @@
+import { expect } from 'earl'
+import { buildComment, buildMarker } from './buildComment.js'
+import { ReviewOutput, type RunMeta } from './schema.js'
+
+const meta: RunMeta = { run_id: '123', lessons_version: 'none', engine: 'stub' }
+
+describe(buildComment.name, () => {
+  it('renders the no-findings stub with a footer marker', () => {
+    const review: ReviewOutput = {
+      intent: 'Adds a gate.',
+      findings: [],
+      context_sources: ['diff', 'linear:L2B-1'],
+    }
+    const comment = buildComment(review, meta)
+    expect(comment).toInclude('Adds a gate.')
+    expect(comment).toInclude(
+      'Reviewed, consulted `diff`, `linear:L2B-1`, no findings above the bar.',
+    )
+    expect(comment.trim().endsWith(buildMarker(review, meta))).toEqual(true)
+  })
+
+  it('renders findings with location, evidence and fix', () => {
+    const review: ReviewOutput = {
+      intent: 'x',
+      findings: [
+        {
+          file: 'src/a.ts',
+          line_start: 3,
+          severity: 'major',
+          category: 'correctness',
+          claim: 'off by one',
+          evidence: 'src/a.ts:3',
+          fix_sketch: 'use <=',
+          confidence: 0.9,
+        },
+        {
+          severity: 'major',
+          category: 'intent-missing',
+          claim: 'no issue linked',
+          evidence: 'PR description',
+          fix_sketch: 'link issue',
+          confidence: 1,
+        },
+      ],
+      context_sources: [],
+    }
+    const comment = buildComment(review, meta)
+    expect(comment).toInclude(
+      '### 1. [major/correctness] off by one — `src/a.ts:3`',
+    )
+    expect(comment).toInclude('### 2. [major/intent-missing] no issue linked\n')
+    expect(comment).not.toInclude('no findings above the bar')
+  })
+})
+
+describe(buildMarker.name, () => {
+  it('carries run id, lessons version, engine and sources', () => {
+    const marker = buildMarker(
+      { intent: '', findings: [], context_sources: ['a', 'b'] },
+      meta,
+    )
+    expect(marker).toEqual(
+      '<!-- ai-review run=123 lessons=none engine=stub sources=a,b -->',
+    )
+  })
+})
+
+describe('ReviewOutput schema', () => {
+  it('rejects unknown severity', () => {
+    const result = ReviewOutput.safeValidate({
+      intent: 'x',
+      findings: [
+        {
+          severity: 'critical',
+          category: 'perf',
+          claim: '',
+          evidence: '',
+          fix_sketch: '',
+          confidence: 0,
+        },
+      ],
+      context_sources: [],
+    })
+    expect(result.success).toEqual(false)
+  })
+})

--- a/packages/ai-review/src/post/buildComment.ts
+++ b/packages/ai-review/src/post/buildComment.ts
@@ -1,0 +1,47 @@
+import type { ReviewOutput, RunMeta } from './schema.js'
+
+export const MARKER_PREFIX = '<!-- ai-review'
+
+export function buildMarker(review: ReviewOutput, meta: RunMeta): string {
+  const fields = [
+    `run=${meta.run_id}`,
+    `lessons=${meta.lessons_version}`,
+    `engine=${meta.engine}`,
+    `sources=${review.context_sources.join(',')}`,
+  ]
+  return `${MARKER_PREFIX} ${fields.join(' ')} -->`
+}
+
+export function buildComment(review: ReviewOutput, meta: RunMeta): string {
+  const sources = review.context_sources.length
+    ? review.context_sources.map((s) => `\`${s}\``).join(', ')
+    : 'none'
+  const lines = [
+    '## AI review',
+    '',
+    review.intent,
+    '',
+    review.findings.length === 0
+      ? `Reviewed, consulted ${sources}, no findings above the bar.`
+      : formatFindings(review),
+    '',
+    `<sub>run \`${meta.run_id}\` · lessons \`${meta.lessons_version}\` · engine \`${meta.engine}\`</sub>`,
+    buildMarker(review, meta),
+  ]
+  return lines.join('\n')
+}
+
+function formatFindings(review: ReviewOutput): string {
+  return review.findings
+    .map((f, i) => {
+      const loc = f.file
+        ? ` — \`${f.file}${f.line_start ? `:${f.line_start}` : ''}\``
+        : ''
+      return [
+        `### ${i + 1}. [${f.severity}/${f.category}] ${f.claim}${loc}`,
+        `Evidence: ${f.evidence}`,
+        `Fix: ${f.fix_sketch}`,
+      ].join('\n')
+    })
+    .join('\n\n')
+}

--- a/packages/ai-review/src/post/schema.ts
+++ b/packages/ai-review/src/post/schema.ts
@@ -1,0 +1,36 @@
+import { v } from '@l2beat/validate'
+
+export const Finding = v.object({
+  file: v.string().optional(),
+  line_start: v.number().optional(),
+  line_end: v.number().optional(),
+  severity: v.enum(['blocker', 'major', 'minor']),
+  category: v.enum([
+    'correctness',
+    'security',
+    'perf',
+    'convention',
+    'test-gap',
+    'intent-mismatch',
+    'intent-missing',
+  ]),
+  claim: v.string(),
+  evidence: v.string(),
+  fix_sketch: v.string(),
+  confidence: v.number(),
+})
+export type Finding = v.infer<typeof Finding>
+
+export const ReviewOutput = v.object({
+  intent: v.string(),
+  findings: v.array(Finding),
+  context_sources: v.array(v.string()),
+})
+export type ReviewOutput = v.infer<typeof ReviewOutput>
+
+export const RunMeta = v.object({
+  run_id: v.string(),
+  lessons_version: v.string(),
+  engine: v.string(),
+})
+export type RunMeta = v.infer<typeof RunMeta>

--- a/packages/ai-review/src/test/fixtures/comment.ts
+++ b/packages/ai-review/src/test/fixtures/comment.ts
@@ -1,0 +1,39 @@
+import type { CommentEvent, PullRequest } from '../../gate/types.js'
+
+export function commentEvent(
+  overrides: Partial<CommentEvent['comment']> = {},
+  issue: Partial<CommentEvent['issue']> = {},
+): CommentEvent {
+  return {
+    action: 'created',
+    comment: {
+      body: '/ai-review',
+      user: { login: 'alice', type: 'User' },
+      author_association: 'MEMBER',
+      ...overrides,
+    },
+    issue: {
+      number: 42,
+      pull_request: {
+        url: 'https://api.github.com/repos/l2beat/l2beat/pulls/42',
+      },
+      ...issue,
+    },
+  }
+}
+
+export function pullRequest(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    number: 42,
+    draft: false,
+    state: 'open',
+    user: { login: 'bob', type: 'User' },
+    head: {
+      sha: 'aaa111',
+      ref: 'feature',
+      repo: { fork: false, full_name: 'l2beat/l2beat' },
+    },
+    base: { sha: 'bbb222', ref: 'main', repo: { full_name: 'l2beat/l2beat' } },
+    ...overrides,
+  }
+}

--- a/packages/ai-review/tsconfig.build.json
+++ b/packages/ai-review/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["build", "node_modules", "**/test/*", "**/*test.ts"]
+}

--- a/packages/ai-review/tsconfig.json
+++ b/packages/ai-review/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@l2beat/typescript-config/base",
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": false,
+    "verbatimModuleSyntax": true,
+    "outDir": "build",
+    "rootDir": "./src"
+  },
+  "exclude": ["build", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ importers:
         version: 8.1.5
       cmd-ts:
         specifier: ^0.13.0
-        version: 0.13.0
+        version: 0.13.0(supports-color@8.1.1)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -58,11 +58,21 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
 
+  packages/ai-review:
+    dependencies:
+      '@l2beat/validate':
+        specifier: workspace:*
+        version: link:../validate
+    devDependencies:
+      '@l2beat/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+
   packages/backend:
     dependencies:
       '@koa/router':
         specifier: ^12.0.0
-        version: 12.0.2
+        version: 12.0.2(supports-color@8.1.1)
       '@l2beat/backend-tools':
         specifier: workspace:*
         version: link:../backend-tools
@@ -110,7 +120,7 @@ importers:
         version: 7.0.0
       elastic-apm-node:
         specifier: ^4.11.2
-        version: 4.11.2
+        version: 4.11.2(supports-color@8.1.1)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -119,7 +129,7 @@ importers:
         version: 5.10.0
       koa:
         specifier: ^2.14.1
-        version: 2.16.0
+        version: 2.16.0(supports-color@8.1.1)
       koa-bodyparser:
         specifier: ^4.4.1
         version: 4.4.1
@@ -201,13 +211,13 @@ importers:
         version: 2.0.16
       cmd-ts:
         specifier: ^0.13.0
-        version: 0.13.0
+        version: 0.13.0(supports-color@8.1.1)
       dotenv:
         specifier: ^16.3.1
         version: 16.4.5
       supertest:
         specifier: ^6.2.3
-        version: 6.3.4
+        version: 6.3.4(supports-color@8.1.1)
       tsx:
         specifier: ^4.9.3
         version: 4.19.2
@@ -216,7 +226,7 @@ importers:
     dependencies:
       '@elastic/elasticsearch':
         specifier: ^8.13.1
-        version: 8.18.2
+        version: 8.18.2(supports-color@8.1.1)
       '@l2beat/shared-pure':
         specifier: workspace:*
         version: link:../shared-pure
@@ -280,7 +290,7 @@ importers:
         version: 1.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tailwindcss/vite':
         specifier: 4.1.11
-        version: 4.1.11(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))
+        version: 4.1.11(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))
       '@tanstack/match-sorter-utils':
         specifier: ^8.19.4
         version: 8.19.4
@@ -353,13 +363,13 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.1
-        version: 3.7.1(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))
+        version: 3.7.1(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
       vite:
         specifier: ^5.4.10
-        version: 5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0)
+        version: 5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0)
 
   packages/config:
     dependencies:
@@ -383,7 +393,7 @@ importers:
         version: 4.17.21
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7
+        version: 5.1.7(supports-color@8.1.1)
     devDependencies:
       '@l2beat/backend-tools':
         specifier: workspace:*
@@ -466,7 +476,7 @@ importers:
         version: 5.22.0
       prisma-kysely:
         specifier: ^1.8.0
-        version: 1.8.0(encoding@0.1.13)
+        version: 1.8.0(encoding@0.1.13)(supports-color@8.1.1)
       tsx:
         specifier: ^4.9.3
         version: 4.19.2
@@ -502,7 +512,7 @@ importers:
         version: 0.3.2
       cmd-ts:
         specifier: ^0.13.0
-        version: 0.13.0
+        version: 0.13.0(supports-color@8.1.1)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -523,7 +533,7 @@ importers:
         version: 5.0.10
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7
+        version: 5.1.7(supports-color@8.1.1)
     devDependencies:
       '@l2beat/typescript-config':
         specifier: workspace:*
@@ -638,7 +648,7 @@ importers:
         version: 1.0.0(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       compression:
         specifier: ^1.8.0
-        version: 1.8.0
+        version: 1.8.0(supports-color@8.1.1)
       connect-timeout:
         specifier: ^1.9.0
         version: 1.9.0
@@ -650,7 +660,7 @@ importers:
         version: 8.6.0(react@19.0.0)
       express:
         specifier: ^5.0.0
-        version: 5.0.1
+        version: 5.0.1(supports-color@8.1.1)
       fuzzysort:
         specifier: ^3.1.0
         version: 3.1.0
@@ -774,7 +784,7 @@ importers:
         version: 1.5.1
       '@ethereum-sourcify/compilers':
         specifier: ^1.1.1
-        version: 1.1.1
+        version: 1.1.1(debug@4.4.0(supports-color@8.1.1))
       '@ethereum-sourcify/compilers-types':
         specifier: ^1.2.0
         version: 1.2.0
@@ -810,7 +820,7 @@ importers:
         version: 4.1.2
       cmd-ts:
         specifier: ^0.13.0
-        version: 0.13.0
+        version: 0.13.0(supports-color@8.1.1)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -819,7 +829,7 @@ importers:
         version: 5.7.2
       express:
         specifier: ^4.21.1
-        version: 4.21.1
+        version: 4.21.1(supports-color@8.1.1)
       fflate:
         specifier: ^0.7.4
         version: 0.7.4
@@ -977,7 +987,7 @@ importers:
         version: 0.0.0
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.1
-        version: 3.7.1(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))
+        version: 3.7.1(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.47)
@@ -986,10 +996,10 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: ^3.4.14
-        version: 3.4.14(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@22.8.2)(typescript@7.0.2))
+        version: 3.4.14(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@7.0.2))
       vite:
         specifier: ^5.4.10
-        version: 5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0)
+        version: 5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0)
 
   packages/public-api:
     dependencies:
@@ -1010,13 +1020,13 @@ importers:
         version: link:../validate
       express:
         specifier: ^5.0.0
-        version: 5.0.1
+        version: 5.0.1(supports-color@8.1.1)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
       swagger-ui-express:
         specifier: ^5.0.1
-        version: 5.0.1(express@5.0.1)
+        version: 5.0.1(express@5.0.1(supports-color@8.1.1))
     devDependencies:
       '@l2beat/typescript-config':
         specifier: workspace:*
@@ -1047,7 +1057,7 @@ importers:
         version: link:../validate
       '@polkadot/api':
         specifier: ^12.4.2
-        version: 12.4.2
+        version: 12.4.2(supports-color@8.1.1)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -1087,7 +1097,7 @@ importers:
         version: 1.7.7
       nock:
         specifier: ^13.5.5
-        version: 13.5.5
+        version: 13.5.5(supports-color@8.1.1)
 
   packages/shared-pure:
     dependencies:
@@ -1136,7 +1146,7 @@ importers:
         version: 17.2.3
       express:
         specifier: ^5.1.0
-        version: 5.1.0
+        version: 5.1.0(supports-color@8.1.1)
       fuzzysort:
         specifier: 3.1.0
         version: 3.1.0
@@ -1200,7 +1210,7 @@ importers:
         version: 1.1.3(@types/react-dom@19.0.4(@types/react@19.0.10))(@types/react@19.0.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@tailwindcss/vite':
         specifier: 4.1.11
-        version: 4.1.11(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))
+        version: 4.1.11(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))
       '@tanstack/react-query':
         specifier: 5.100.14
         version: 5.100.14(react@19.0.0)
@@ -1264,13 +1274,13 @@ importers:
         version: 19.0.4(@types/react@19.0.10)
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.1
-        version: 3.7.1(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))
+        version: 3.7.1(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
       vite:
         specifier: ^5.4.10
-        version: 5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0)
+        version: 5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0)
 
   packages/tools:
     dependencies:
@@ -1322,7 +1332,7 @@ importers:
         version: link:../typescript-config
       '@vitejs/plugin-react-swc':
         specifier: ^3.7.1
-        version: 3.7.1(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))
+        version: 3.7.1(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))
       abitype:
         specifier: ^1.0.6
         version: 1.0.8(typescript@7.0.2)(zod@3.24.1)
@@ -1334,10 +1344,10 @@ importers:
         version: 8.4.47
       tailwindcss:
         specifier: ^3.4.14
-        version: 3.4.14(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@22.8.2)(typescript@7.0.2))
+        version: 3.4.14(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@7.0.2))
       vite:
         specifier: ^5.4.10
-        version: 5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0)
+        version: 5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0)
 
   packages/tools-api:
     dependencies:
@@ -1373,7 +1383,7 @@ importers:
         version: 2.8.5
       express:
         specifier: ^5.0.0
-        version: 5.0.1
+        version: 5.0.1(supports-color@8.1.1)
       viem:
         specifier: ^2.8.14
         version: 2.31.6(typescript@7.0.2)(zod@3.24.1)
@@ -1523,24 +1533,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.8':
     resolution: {integrity: sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.8':
     resolution: {integrity: sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.8':
     resolution: {integrity: sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.8':
     resolution: {integrity: sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==}
@@ -2373,67 +2387,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2514,24 +2540,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.0.5':
     resolution: {integrity: sha512-CozywhydLroNNz1AMKdKKVBuRc0UIBG7TlVgXXn51MdZo4sMbfApOlQFUyuAbKJbe67vd39Yib2lVVVDfLTtfw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.0.5':
     resolution: {integrity: sha512-VWfvl8toyC/5Rn1GgKfiASYgssCsxz4GtwK2cFKmmnyGfoKubFc6DfCI5MzBoe2Q2gzd2CeZDoT1BhuutSiL7A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.0.5':
     resolution: {integrity: sha512-xCD/V4Z55eFtG2SNyXgG3ciIikcxNe4FgmgcW4xTaEcLY59ZJVLxx4PLve2vDgp7xqvwDD4vvUsJuFMuQ12oGg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.0.5':
     resolution: {integrity: sha512-OmKXP/mUzY+AiDFk9PR3RoM6YfgzNYhtSbfvTUDk3PxoCLKnwTZ8xsFoWX2ph/RFC25QucTeAFepouGGsdBPAg==}
@@ -3820,24 +3850,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -3916,66 +3950,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -4077,24 +4124,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.13':
     resolution: {integrity: sha512-SmZ9m+XqCB35NddHCctvHFLqPZDAs5j8IgD36GoutufDJmeq2VNfgk5rQoqNqKmAK3Y7iFdEmI76QoHIWiCLyw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.13':
     resolution: {integrity: sha512-5rij+vB9a29aNkHq72EXI2ihDZPszJb4zlApJY4aCC/q6utgqFA6CkrfTfIb+O8hxtG3zP5KERETz8mfFK6A0A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.13':
     resolution: {integrity: sha512-OlSlaOK9JplQ5qn07WiBLibkOw7iml2++ojEXhhR3rbWrNEKCD7sd8+6wSavsInyFdw4PhLA+Hy6YyDBIE23Yw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.13':
     resolution: {integrity: sha512-zwQii5YVdsfG8Ti9gIKgBKZg8qMkRZxl+OlYWUT5D93Jl4NuNBRausP20tfEkQdAPSRrMCSUZBM6FhW7izAZRg==}
@@ -4173,24 +4224,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -4565,9 +4620,6 @@ packages:
 
   '@types/node@20.17.2':
     resolution: {integrity: sha512-OOHK4sjXqkL7yQ7VEEHcf6+0jSvKjWqwnaCtY7AKD/VLEvRHMsxxu7eI8ErnjxHS8VwmekD4PeVCpu4qZEZSxg==}
-
-  '@types/node@22.8.2':
-    resolution: {integrity: sha512-NzaRNFV+FZkvK/KLCsNdTvID0SThyrs5SHB6tsD/lajr22FGC73N2QeDPM2wHtVde8mgcXuSsHQkH5cX1pbPLw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -6575,24 +6627,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -8812,16 +8868,16 @@ snapshots:
     dependencies:
       '@elastic/ecs-helpers': 2.1.1
 
-  '@elastic/elasticsearch@8.18.2':
+  '@elastic/elasticsearch@8.18.2(supports-color@8.1.1)':
     dependencies:
-      '@elastic/transport': 8.9.6
+      '@elastic/transport': 8.9.6(supports-color@8.1.1)
       apache-arrow: 19.0.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@75lb/nature'
       - supports-color
 
-  '@elastic/transport@8.9.6':
+  '@elastic/transport@8.9.6(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       debug: 4.4.0(supports-color@8.1.1)
@@ -9144,10 +9200,10 @@ snapshots:
 
   '@ethereum-sourcify/compilers-types@1.2.0': {}
 
-  '@ethereum-sourcify/compilers@1.1.1':
+  '@ethereum-sourcify/compilers@1.1.1(debug@4.4.0(supports-color@8.1.1))':
     dependencies:
       semver: 7.7.4
-      solc: 0.8.34
+      solc: 0.8.34(debug@4.4.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - debug
 
@@ -9560,7 +9616,7 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
     optional: true
 
-  '@koa/router@12.0.2':
+  '@koa/router@12.0.2(supports-color@8.1.1)':
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       http-errors: 2.0.0
@@ -9703,10 +9759,10 @@ snapshots:
   '@polkadot-api/utils@0.1.0':
     optional: true
 
-  '@polkadot/api-augment@12.4.2':
+  '@polkadot/api-augment@12.4.2(supports-color@8.1.1)':
     dependencies:
-      '@polkadot/api-base': 12.4.2
-      '@polkadot/rpc-augment': 12.4.2
+      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
       '@polkadot/types': 12.4.2
       '@polkadot/types-augment': 12.4.2
       '@polkadot/types-codec': 12.4.2
@@ -9717,9 +9773,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-base@12.4.2':
+  '@polkadot/api-base@12.4.2(supports-color@8.1.1)':
     dependencies:
-      '@polkadot/rpc-core': 12.4.2
+      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
       '@polkadot/types': 12.4.2
       '@polkadot/util': 13.2.2
       rxjs: 7.8.1
@@ -9729,12 +9785,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-derive@12.4.2':
+  '@polkadot/api-derive@12.4.2(supports-color@8.1.1)':
     dependencies:
-      '@polkadot/api': 12.4.2
-      '@polkadot/api-augment': 12.4.2
-      '@polkadot/api-base': 12.4.2
-      '@polkadot/rpc-core': 12.4.2
+      '@polkadot/api': 12.4.2(supports-color@8.1.1)
+      '@polkadot/api-augment': 12.4.2(supports-color@8.1.1)
+      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
       '@polkadot/util': 13.2.2
@@ -9746,15 +9802,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api@12.4.2':
+  '@polkadot/api@12.4.2(supports-color@8.1.1)':
     dependencies:
-      '@polkadot/api-augment': 12.4.2
-      '@polkadot/api-base': 12.4.2
-      '@polkadot/api-derive': 12.4.2
+      '@polkadot/api-augment': 12.4.2(supports-color@8.1.1)
+      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
+      '@polkadot/api-derive': 12.4.2(supports-color@8.1.1)
       '@polkadot/keyring': 13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)
-      '@polkadot/rpc-augment': 12.4.2
-      '@polkadot/rpc-core': 12.4.2
-      '@polkadot/rpc-provider': 12.4.2
+      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-provider': 12.4.2(supports-color@8.1.1)
       '@polkadot/types': 12.4.2
       '@polkadot/types-augment': 12.4.2
       '@polkadot/types-codec': 12.4.2
@@ -9782,9 +9838,9 @@ snapshots:
       '@substrate/ss58-registry': 1.51.0
       tslib: 2.8.1
 
-  '@polkadot/rpc-augment@12.4.2':
+  '@polkadot/rpc-augment@12.4.2(supports-color@8.1.1)':
     dependencies:
-      '@polkadot/rpc-core': 12.4.2
+      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
       '@polkadot/util': 13.2.2
@@ -9794,10 +9850,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-core@12.4.2':
+  '@polkadot/rpc-core@12.4.2(supports-color@8.1.1)':
     dependencies:
-      '@polkadot/rpc-augment': 12.4.2
-      '@polkadot/rpc-provider': 12.4.2
+      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-provider': 12.4.2(supports-color@8.1.1)
       '@polkadot/types': 12.4.2
       '@polkadot/util': 13.2.2
       rxjs: 7.8.1
@@ -9807,7 +9863,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-provider@12.4.2':
+  '@polkadot/rpc-provider@12.4.2(supports-color@8.1.1)':
     dependencies:
       '@polkadot/keyring': 13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)
       '@polkadot/types': 12.4.2
@@ -9819,7 +9875,7 @@ snapshots:
       '@polkadot/x-ws': 13.2.2
       eventemitter3: 5.0.1
       mock-socket: 9.3.1
-      nock: 13.5.5
+      nock: 13.5.5(supports-color@8.1.1)
       tslib: 2.8.1
     optionalDependencies:
       '@substrate/connect': 0.8.11
@@ -9984,10 +10040,10 @@ snapshots:
 
   '@prisma/debug@5.22.0': {}
 
-  '@prisma/debug@5.3.1':
+  '@prisma/debug@5.3.1(supports-color@8.1.1)':
     dependencies:
       '@types/debug': 4.1.8
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10009,16 +10065,16 @@ snapshots:
       '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
       '@prisma/get-platform': 5.22.0
 
-  '@prisma/fetch-engine@5.3.1(encoding@0.1.13)':
+  '@prisma/fetch-engine@5.3.1(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
-      '@prisma/debug': 5.3.1
-      '@prisma/get-platform': 5.3.1
+      '@prisma/debug': 5.3.1(supports-color@8.1.1)
+      '@prisma/get-platform': 5.3.1(supports-color@8.1.1)
       execa: 5.1.1
       find-cache-dir: 3.3.2
       fs-extra: 11.1.1
       hasha: 5.2.2
-      http-proxy-agent: 7.0.0
-      https-proxy-agent: 7.0.2
+      http-proxy-agent: 7.0.0(supports-color@8.1.1)
+      https-proxy-agent: 7.0.2(supports-color@8.1.1)
       kleur: 4.1.5
       node-fetch: 2.7.0(encoding@0.1.13)
       p-filter: 2.1.0
@@ -10032,9 +10088,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@prisma/generator-helper@5.3.1':
+  '@prisma/generator-helper@5.3.1(supports-color@8.1.1)':
     dependencies:
-      '@prisma/debug': 5.3.1
+      '@prisma/debug': 5.3.1(supports-color@8.1.1)
       '@types/cross-spawn': 6.0.2
       cross-spawn: 7.0.3
       kleur: 4.1.5
@@ -10045,9 +10101,9 @@ snapshots:
     dependencies:
       '@prisma/debug': 5.22.0
 
-  '@prisma/get-platform@5.3.1':
+  '@prisma/get-platform@5.3.1(supports-color@8.1.1)':
     dependencies:
-      '@prisma/debug': 5.3.1
+      '@prisma/debug': 5.3.1(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       fs-jetpack: 5.1.0
@@ -10060,15 +10116,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@prisma/internals@5.3.1(encoding@0.1.13)':
+  '@prisma/internals@5.3.1(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@antfu/ni': 0.21.8
       '@opentelemetry/api': 1.4.1
-      '@prisma/debug': 5.3.1
+      '@prisma/debug': 5.3.1(supports-color@8.1.1)
       '@prisma/engines': 5.3.1
-      '@prisma/fetch-engine': 5.3.1(encoding@0.1.13)
-      '@prisma/generator-helper': 5.3.1
-      '@prisma/get-platform': 5.3.1
+      '@prisma/fetch-engine': 5.3.1(encoding@0.1.13)(supports-color@8.1.1)
+      '@prisma/generator-helper': 5.3.1(supports-color@8.1.1)
+      '@prisma/get-platform': 5.3.1(supports-color@8.1.1)
       '@prisma/prisma-schema-wasm': 5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59
       archiver: 5.3.2
       arg: 5.0.2
@@ -11390,12 +11446,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.11
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.11
 
-  '@tailwindcss/vite@4.1.11(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))':
+  '@tailwindcss/vite@4.1.11(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))':
     dependencies:
       '@tailwindcss/node': 4.1.11
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
-      vite: 5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0)
+      vite: 5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0)
 
   '@tailwindcss/vite@4.1.11(vite@7.3.1(@types/node@20.17.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.36.0)(tsx@4.19.2)(yaml@2.6.0))':
     dependencies:
@@ -11771,11 +11827,6 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.8.2':
-    dependencies:
-      undici-types: 6.19.8
-    optional: true
-
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/pg@8.6.5':
@@ -11918,10 +11969,10 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vitejs/plugin-react-swc@3.7.1(vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0))':
+  '@vitejs/plugin-react-swc@3.7.1(vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0))':
     dependencies:
       '@swc/core': 1.15.13
-      vite: 5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0)
+      vite: 5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -11979,7 +12030,7 @@ snapshots:
 
   after-all-results@2.0.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -12172,11 +12223,11 @@ snapshots:
 
   bn.js@5.2.1: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.3(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.0
@@ -12189,7 +12240,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.1.0:
+  body-parser@2.1.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -12203,7 +12254,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.2.0:
+  body-parser@2.2.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -12453,7 +12504,7 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
-  cmd-ts@0.13.0:
+  cmd-ts@0.13.0(supports-color@8.1.1):
     dependencies:
       chalk: 4.1.2
       debug: 4.4.0(supports-color@8.1.1)
@@ -12555,11 +12606,11 @@ snapshots:
     dependencies:
       mime-db: 1.53.0
 
-  compression@1.8.0:
+  compression@1.8.0(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       negotiator: 0.6.4
       on-headers: 1.0.2
       safe-buffer: 5.2.1
@@ -12827,17 +12878,23 @@ snapshots:
 
   debounce@2.1.0: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.3.4:
+  debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.3.6:
+  debug@4.3.6(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
+      supports-color: 8.1.1
 
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
@@ -12958,7 +13015,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  elastic-apm-node@4.11.2:
+  elastic-apm-node@4.11.2(supports-color@8.1.1):
     dependencies:
       '@elastic/ecs-pino-format': 1.5.0
       '@opentelemetry/api': 1.9.0
@@ -12990,7 +13047,7 @@ snapshots:
       pino: 8.21.0
       readable-stream: 3.6.2
       relative-microtime: 2.0.0
-      require-in-the-middle: 7.5.2
+      require-in-the-middle: 7.5.2(supports-color@8.1.1)
       semver: 7.7.1
       shallow-clone-shim: 2.0.0
       source-map: 0.8.0-beta.0
@@ -13267,21 +13324,21 @@ snapshots:
 
   expand-template@2.0.3: {}
 
-  express@4.21.1:
+  express@4.21.1(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.3(supports-color@8.1.1)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.0.6
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1
+      finalhandler: 1.3.1(supports-color@8.1.1)
       fresh: 0.5.2
       http-errors: 2.0.0
       merge-descriptors: 1.0.3
@@ -13293,8 +13350,8 @@ snapshots:
       qs: 6.13.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
+      send: 0.19.0(supports-color@8.1.1)
+      serve-static: 1.16.2(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -13303,20 +13360,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.0.1:
+  express@5.0.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.1.0
+      body-parser: 2.1.0(supports-color@8.1.1)
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.2.2
-      debug: 4.3.6
+      debug: 4.3.6(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.0
+      finalhandler: 2.1.0(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.0
       merge-descriptors: 2.0.0
@@ -13330,8 +13387,8 @@ snapshots:
       range-parser: 1.2.1
       router: 2.1.0
       safe-buffer: 5.2.1
-      send: 1.1.0
-      serve-static: 2.1.0
+      send: 1.1.0(supports-color@8.1.1)
+      serve-static: 2.1.0(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 2.0.0
@@ -13340,10 +13397,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.1.0:
+  express@5.1.0(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.0
+      body-parser: 2.2.0(supports-color@8.1.1)
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.1
@@ -13352,7 +13409,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.0
+      finalhandler: 2.1.0(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.0
       merge-descriptors: 2.0.0
@@ -13363,9 +13420,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.14.0
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.0
-      serve-static: 2.2.0
+      router: 2.2.0(supports-color@8.1.1)
+      send: 1.2.0(supports-color@8.1.1)
+      serve-static: 2.2.0(supports-color@8.1.1)
       statuses: 2.0.1
       type-is: 2.0.1
       vary: 1.1.2
@@ -13417,9 +13474,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.1:
+  finalhandler@1.3.1(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -13429,7 +13486,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.0:
+  finalhandler@2.1.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -13492,7 +13549,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.0(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.0(supports-color@8.1.1)
 
   foreground-child@3.3.0:
     dependencies:
@@ -13763,31 +13822,31 @@ snapshots:
     dependencies:
       next-line: 1.1.0
 
-  http-proxy-agent@4.0.1:
+  http-proxy-agent@4.0.1(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 1.1.2
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  http-proxy-agent@7.0.0:
+  http-proxy-agent@7.0.0(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  https-proxy-agent@7.0.2:
+  https-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.0(supports-color@8.1.1)
@@ -14029,7 +14088,7 @@ snapshots:
 
   koa-is-json@1.0.0: {}
 
-  koa@2.16.0:
+  koa@2.16.0(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       cache-content-type: 1.0.1
@@ -14187,13 +14246,13 @@ snapshots:
   make-error@1.3.6:
     optional: true
 
-  make-fetch-happen@9.1.0:
+  make-fetch-happen@9.1.0(supports-color@8.1.1):
     dependencies:
       agentkeepalive: 4.6.0
       cacache: 15.3.0
       http-cache-semantics: 4.1.1
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 4.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       is-lambda: 1.0.1
       lru-cache: 6.0.0
       minipass: 3.3.6
@@ -14203,7 +14262,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1
+      socks-proxy-agent: 6.2.1(supports-color@8.1.1)
       ssri: 8.0.1
     transitivePeerDependencies:
       - bluebird
@@ -14454,7 +14513,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nock@13.5.5:
+  nock@13.5.5(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
@@ -14495,12 +14554,12 @@ snapshots:
       detect-libc: 2.0.4
     optional: true
 
-  node-gyp@8.4.1:
+  node-gyp@8.4.1(supports-color@8.1.1):
     dependencies:
       env-paths: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0
+      make-fetch-happen: 9.1.0(supports-color@8.1.1)
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
@@ -14821,13 +14880,13 @@ snapshots:
       postcss: 8.4.47
       ts-node: 10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@5.6.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@22.8.2)(typescript@7.0.2)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@7.0.2)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.6.0
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.15.13)(@types/node@22.8.2)(typescript@7.0.2)
+      ts-node: 10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@7.0.2)
 
   postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.47)(tsx@4.19.2)(yaml@2.6.0):
     dependencies:
@@ -14893,11 +14952,11 @@ snapshots:
       tar-fs: 2.1.2
       tunnel-agent: 0.6.0
 
-  prisma-kysely@1.8.0(encoding@0.1.13):
+  prisma-kysely@1.8.0(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       '@mrleebo/prisma-ast': 0.7.0
-      '@prisma/generator-helper': 5.3.1
-      '@prisma/internals': 5.3.1(encoding@0.1.13)
+      '@prisma/generator-helper': 5.3.1(supports-color@8.1.1)
+      '@prisma/internals': 5.3.1(encoding@0.1.13)(supports-color@8.1.1)
       typescript: 5.9.3
       zod: 3.23.8
     transitivePeerDependencies:
@@ -15219,7 +15278,7 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-in-the-middle@7.5.2:
+  require-in-the-middle@7.5.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       module-details-from-path: 1.0.3
@@ -15297,7 +15356,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 8.2.0
 
-  router@2.2.0:
+  router@2.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       depd: 2.0.0
@@ -15361,9 +15420,9 @@ snapshots:
 
   semver@7.7.4: {}
 
-  send@0.19.0:
+  send@0.19.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -15379,7 +15438,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.1.0:
+  send@1.1.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       destroy: 1.2.0
@@ -15396,7 +15455,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.0:
+  send@1.2.0(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
       encodeurl: 2.0.0
@@ -15416,30 +15475,30 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serve-static@1.16.2:
+  serve-static@1.16.2(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.19.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.1.0:
+  serve-static@2.1.0(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.0
+      send: 1.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.0:
+  serve-static@2.2.0(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.0
+      send: 1.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15568,9 +15627,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  socks-proxy-agent@6.2.1:
+  socks-proxy-agent@6.2.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.0(supports-color@8.1.1)
       socks: 2.8.4
     transitivePeerDependencies:
@@ -15583,11 +15642,11 @@ snapshots:
       smart-buffer: 4.2.0
     optional: true
 
-  solc@0.8.34:
+  solc@0.8.34(debug@4.4.0(supports-color@8.1.1)):
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.0(supports-color@8.1.1))
       js-sha3: 0.8.0
       memorystream: 0.3.1
       semver: 5.7.2
@@ -15642,14 +15701,14 @@ snapshots:
 
   sql-summary@1.0.1: {}
 
-  sqlite3@5.1.7:
+  sqlite3@5.1.7(supports-color@8.1.1):
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
       tar: 6.2.1
     optionalDependencies:
-      node-gyp: 8.4.1
+      node-gyp: 8.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -15734,7 +15793,7 @@ snapshots:
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
 
-  superagent@8.1.2:
+  superagent@8.1.2(supports-color@8.1.1):
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
@@ -15749,10 +15808,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  supertest@6.3.4:
+  supertest@6.3.4(supports-color@8.1.1):
     dependencies:
       methods: 1.1.2
-      superagent: 8.1.2
+      superagent: 8.1.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15775,9 +15834,9 @@ snapshots:
     dependencies:
       '@scarf/scarf': 1.4.0
 
-  swagger-ui-express@5.0.1(express@5.0.1):
+  swagger-ui-express@5.0.1(express@5.0.1(supports-color@8.1.1)):
     dependencies:
-      express: 5.0.1
+      express: 5.0.1(supports-color@8.1.1)
       swagger-ui-dist: 5.29.1
 
   tabbable@6.2.0: {}
@@ -15826,7 +15885,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@22.8.2)(typescript@7.0.2)):
+  tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@7.0.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -15845,7 +15904,7 @@ snapshots:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@22.8.2)(typescript@7.0.2))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@7.0.2))
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -15984,14 +16043,14 @@ snapshots:
       '@swc/core': 1.15.13
     optional: true
 
-  ts-node@10.9.2(@swc/core@1.15.13)(@types/node@22.8.2)(typescript@7.0.2):
+  ts-node@10.9.2(@swc/core@1.15.13)(@types/node@20.17.2)(typescript@7.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.8.2
+      '@types/node': 20.17.2
       acorn: 8.16.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -16217,13 +16276,13 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@5.4.10(@types/node@22.8.2)(lightningcss@1.30.1)(terser@5.36.0):
+  vite@5.4.10(@types/node@20.17.2)(lightningcss@1.30.1)(terser@5.36.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.59.0
     optionalDependencies:
-      '@types/node': 22.8.2
+      '@types/node': 20.17.2
       fsevents: 2.3.3
       lightningcss: 1.30.1
       terser: 5.36.0


### PR DESCRIPTION
## Summary
L2B-14796.

- `.github/workflows/ai-review.yml`: `issue_comment` trigger for `/ai-review` from org members only (`author_association` MEMBER/OWNER), concurrency per PR with cancel-in-progress
- Privilege split across jobs: `gate` and `review` hold read-only tokens, only `post` has `pull-requests: write`
- 👀 reaction on the trigger comment while running, replaced by 👍 when posted
- Dev replay: label `ai-review-test` re-runs the latest `/ai-review` comment using the branch's workflow and code (`issue_comment` always runs main's YAML)
- `@l2beat/ai-review` package: pure, unit-tested gate (`evaluateTrigger`: not-created / not-PR / not-command / bot / non-member / draft / fork / bot-author / closed), stub review stage, comment mapping with footer marker `<!-- ai-review run=… lessons=… engine=… sources=… -->`

## Testing
- `pnpm --filter @l2beat/ai-review test`, typecheck, lint
- Branch e2e via the `ai-review-test` label: stub comment posted, reaction cycle verified

Codex engine and real findings follow in the stacked PR.