### PR TITLE
Add getBlockHeader to block clients and BlockProvider

### DIFF
--- a/packages/backend/src/modules/interop/examples/snapshot/replay.ts
+++ b/packages/backend/src/modules/interop/examples/snapshot/replay.ts
@@ -70,6 +70,10 @@ export class RpcReplay implements Omit<RpcClientCompat, 'ethRpcClient'> {
     throw new ReplayError(key)
   }
 
+  getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock> {
+    return this.getBlock(blockNumber, false)
+  }
+
   getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const key = this.buildSnapshotKey([
       'blockParentBeaconRoot',

--- a/packages/shared/src/clients/fuel/FuelClient.test.ts
+++ b/packages/shared/src/clients/fuel/FuelClient.test.ts
@@ -39,6 +39,44 @@ describe(FuelClient.name, () => {
     })
   })
 
+  describe(FuelClient.prototype.getBlockHeader.name, () => {
+    const time = '4611686020155261080'
+
+    it('fetches a header by block number without tx bodies', async () => {
+      const http = mockObject<HttpClient>({
+        fetch: async () => ({
+          data: { block: { id: '0xabc', height: '100', header: { time } } },
+        }),
+      })
+      const client = mockClient({ http })
+
+      expect(await client.getBlockHeader(100)).toEqual({
+        hash: '0xabc',
+        number: 100,
+        timestamp: tai64ToUnix(time),
+      })
+    })
+
+    it('fetches the latest header', async () => {
+      const http = mockObject<HttpClient>({
+        fetch: async () => ({
+          data: {
+            blocks: {
+              nodes: [{ id: '0xdef', height: '200', header: { time } }],
+            },
+          },
+        }),
+      })
+      const client = mockClient({ http })
+
+      expect(await client.getBlockHeader('latest')).toEqual({
+        hash: '0xdef',
+        number: 200,
+        timestamp: tai64ToUnix(time),
+      })
+    })
+  })
+
   describe(FuelClient.prototype.getLatestBlockNumber.name, () => {
     it('returns number of the block', async () => {
       const http = mockObject<HttpClient>({

--- a/packages/shared/src/clients/fuel/FuelClient.ts
+++ b/packages/shared/src/clients/fuel/FuelClient.ts
@@ -1,10 +1,13 @@
 import type { Block, json } from '@l2beat/shared-pure'
 import { ClientCore, type ClientCoreDependencies } from '../ClientCore'
-import type { BlockClient } from '../types'
+import type { BlockClient, BlockHeader } from '../types'
 import { tai64ToUnix } from './tai64ToUnix'
 import {
+  type FuelBlockHeader,
+  FuelBlockHeaderResponse,
   FuelBlockResponse,
   FuelError,
+  FuelLatestBlockHeaderResponse,
   FuelLatestBlockNumberResponse,
 } from './types'
 
@@ -39,6 +42,57 @@ export class FuelClient extends ClientCore implements BlockClient {
     }
 
     return Number(latestBlockNumberResponse.data.data.blocks.nodes[0].height)
+  }
+
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<BlockHeader> {
+    const header =
+      blockNumber === 'latest'
+        ? await this.queryLatestHeader()
+        : await this.queryHeader(blockNumber)
+
+    return {
+      hash: header.id,
+      number: Number(header.height),
+      timestamp: tai64ToUnix(header.header.time),
+    }
+  }
+
+  private async queryHeader(blockNumber: number): Promise<FuelBlockHeader> {
+    const query = `query Block($height: U32) {
+        block(height: $height) {
+            id
+            height
+            header {
+                time
+            }
+        }
+      }`
+    const response = await this.query(query, { height: blockNumber.toString() })
+    const parsed = FuelBlockHeaderResponse.safeParse(response)
+    if (!parsed.success) {
+      throw new Error(`Block ${blockNumber}: Error during parsing`)
+    }
+    return parsed.data.data.block
+  }
+
+  private async queryLatestHeader(): Promise<FuelBlockHeader> {
+    const query = `query LatestBlocks {
+        blocks(last: 1) {
+          nodes {
+            id
+            height
+            header {
+                time
+            }
+          }
+        }
+      }`
+    const response = await this.query(query)
+    const parsed = FuelLatestBlockHeaderResponse.safeParse(response)
+    if (!parsed.success || parsed.data.data.blocks.nodes.length === 0) {
+      throw new Error('Latest block header: Error during parsing')
+    }
+    return parsed.data.data.blocks.nodes[0]
   }
 
   async getBlockWithTransactions(blockNumber: number): Promise<Block> {

--- a/packages/shared/src/clients/fuel/types.ts
+++ b/packages/shared/src/clients/fuel/types.ts
@@ -15,6 +15,33 @@ export const FuelLatestBlockNumberResponse = v.object({
   }),
 })
 
+export type FuelBlockHeader = v.infer<typeof FuelBlockHeader>
+export const FuelBlockHeader = v.object({
+  id: v.string(),
+  height: v.string(),
+  header: v.object({
+    time: v.string(),
+  }),
+})
+
+export type FuelBlockHeaderResponse = v.infer<typeof FuelBlockHeaderResponse>
+export const FuelBlockHeaderResponse = v.object({
+  data: v.object({
+    block: FuelBlockHeader,
+  }),
+})
+
+export type FuelLatestBlockHeaderResponse = v.infer<
+  typeof FuelLatestBlockHeaderResponse
+>
+export const FuelLatestBlockHeaderResponse = v.object({
+  data: v.object({
+    blocks: v.object({
+      nodes: v.array(FuelBlockHeader),
+    }),
+  }),
+})
+
 export type FuelBlockResponse = v.infer<typeof FuelBlockResponse>
 export const FuelBlockResponse = v.object({
   data: v.object({

--- a/packages/shared/src/clients/rpc-celestia/CelestiaRpcClient.test.ts
+++ b/packages/shared/src/clients/rpc-celestia/CelestiaRpcClient.test.ts
@@ -32,6 +32,24 @@ describe(CelestiaRpcClient.name, () => {
     })
   })
 
+  describe(CelestiaRpcClient.prototype.getBlockHeader.name, () => {
+    it('returns the header for a block number', async () => {
+      const time = '2024-02-07T10:00:00Z'
+      const http = mockObject<HttpClient>({
+        fetch: async () => ({
+          result: { block: { header: { time, height: '12345' } } },
+        }),
+      })
+      const rpc = mockClient({ http })
+
+      expect(await rpc.getBlockHeader(12345)).toEqual({
+        number: 12345,
+        hash: 'UNSUPPORTED',
+        timestamp: UnixTime.fromDate(new Date(time)),
+      })
+    })
+  })
+
   describe(CelestiaRpcClient.prototype.getBlockWithTransactions.name, () => {
     it('returns block with transactions for a specific block number', async () => {
       const mockBlockHeight = '12345'

--- a/packages/shared/src/clients/rpc-celestia/CelestiaRpcClient.ts
+++ b/packages/shared/src/clients/rpc-celestia/CelestiaRpcClient.ts
@@ -1,5 +1,6 @@
 import { type Block, type json, UnixTime } from '@l2beat/shared-pure'
 import { ClientCore, type ClientCoreDependencies } from '../ClientCore'
+import type { BlockHeader } from '../types'
 import {
   type CelestiaBlock,
   CelestiaBlockResponse,
@@ -37,6 +38,16 @@ export class CelestiaRpcClient extends ClientCore {
       logsBloom: 'UNSUPPORTED',
       timestamp: UnixTime.fromDate(new Date(block.block.header.time)),
       transactions: [], // UNSUPPORTED
+    }
+  }
+
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<BlockHeader> {
+    const height = blockNumber === 'latest' ? undefined : blockNumber
+    const block = await this.getBlock(height)
+    return {
+      number: block.block.header.height,
+      hash: 'UNSUPPORTED',
+      timestamp: UnixTime.fromDate(new Date(block.block.header.time)),
     }
   }
 

--- a/packages/shared/src/clients/rpc-polkadot/PolkadotRpcClient.test.ts
+++ b/packages/shared/src/clients/rpc-polkadot/PolkadotRpcClient.test.ts
@@ -24,6 +24,26 @@ describe(PolkadotRpcClient.name, () => {
     })
   })
 
+  describe(PolkadotRpcClient.prototype.getBlockHeader.name, () => {
+    it('returns the header for a block number', async () => {
+      const mockBlockNumber = '0x12345'
+      const http = mockObject<HttpClient>({
+        fetch: mockFn()
+          .resolvesToOnce({ result: '0x00001' })
+          .resolvesToOnce(
+            mockBlockResponse({ header: { number: mockBlockNumber } }),
+          ),
+      })
+      const rpc = mockClient({ http, generateId: () => 'unique-id' })
+
+      expect(await rpc.getBlockHeader(+mockBlockNumber)).toEqual({
+        number: +mockBlockNumber,
+        hash: 'UNSUPPORTED',
+        timestamp: PolkadotRpcClient.calculateAvailTimestamp(+mockBlockNumber),
+      })
+    })
+  })
+
   describe(PolkadotRpcClient.prototype.getBlockWithTransactions.name, () => {
     it('returns block with transactions for a specific block number', async () => {
       const mockBlockNumber = '0x12345'

--- a/packages/shared/src/clients/rpc-polkadot/PolkadotRpcClient.ts
+++ b/packages/shared/src/clients/rpc-polkadot/PolkadotRpcClient.ts
@@ -1,6 +1,7 @@
 import type { Block, json } from '@l2beat/shared-pure'
 import { generateId } from '../../tools/generateId'
 import { ClientCore, type ClientCoreDependencies } from '../ClientCore'
+import type { BlockHeader } from '../types'
 import {
   type PolkadotBlock,
   PolkadotErrorResponse,
@@ -39,6 +40,17 @@ export class PolkadotRpcClient extends ClientCore {
       logsBloom: 'UNSUPPORTED',
       timestamp: PolkadotRpcClient.calculateAvailTimestamp(bn),
       transactions: [], // UNSUPPORTED
+    }
+  }
+
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<BlockHeader> {
+    const height = blockNumber === 'latest' ? undefined : blockNumber
+    const block = await this.getBlock(height)
+    const bn = Number(block.header.number)
+    return {
+      number: bn,
+      hash: 'UNSUPPORTED',
+      timestamp: PolkadotRpcClient.calculateAvailTimestamp(bn),
     }
   }
 

--- a/packages/shared/src/clients/rpc/RpcClient.test.ts
+++ b/packages/shared/src/clients/rpc/RpcClient.test.ts
@@ -83,6 +83,34 @@ describe(RpcClient.name, () => {
     })
   })
 
+  describe(RpcClient.prototype.getBlockHeader.name, () => {
+    it('fetches block without tx bodies', async () => {
+      const http = mockObject<HttpClient>({
+        fetch: async () => mockResponse(100),
+      })
+      const rpc = mockClient({ http, generateId: () => 'unique-id' })
+
+      const result = await rpc.getBlockHeader(100)
+
+      expect(result).toEqual({
+        timestamp: 100,
+        hash: '0xabcdef',
+        logsBloom: `0x${'0'.repeat(512)}`,
+        number: 100,
+        parentBeaconBlockRoot: '0x123',
+      })
+
+      expect(http.fetch.calls[0].args[1]?.body).toEqual(
+        JSON.stringify({
+          method: 'eth_getBlockByNumber',
+          params: ['0x64', false],
+          id: 'unique-id',
+          jsonrpc: '2.0',
+        }),
+      )
+    })
+  })
+
   describe(RpcClient.prototype.getTransaction.name, () => {
     it('fetches tx from rpc and parses response', async () => {
       const http = mockObject<HttpClient>({

--- a/packages/shared/src/clients/rpc/RpcClient.ts
+++ b/packages/shared/src/clients/rpc/RpcClient.ts
@@ -76,6 +76,10 @@ export class RpcClient extends ClientCore implements IRpcClient {
     return await this.getBlock(blockNumber, true)
   }
 
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock> {
+    return await this.getBlock(blockNumber, false)
+  }
+
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const block = await this.getBlock(blockNumber, false)
 

--- a/packages/shared/src/clients/starknet/StarknetClient.test.ts
+++ b/packages/shared/src/clients/starknet/StarknetClient.test.ts
@@ -55,18 +55,41 @@ describe(StarknetClient.name, () => {
     })
   })
 
+  describe(StarknetClient.prototype.getBlockHeader.name, () => {
+    it('fetches a block header via getBlockWithTxHashes', async () => {
+      const timestamp = UnixTime.now()
+      const http = mockObject<HttpClient>({
+        fetch: async () => ({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            block_number: 100,
+            block_hash: '0xabcdef',
+            timestamp,
+            transactions: [],
+          },
+        }),
+      })
+      const client = mockClient({ http })
+
+      const result = await client.getBlockHeader(100)
+
+      expect(result).toEqual({ number: 100, hash: '0xabcdef', timestamp })
+    })
+  })
+
   describe(StarknetClient.prototype.getBlockTimestamps.name, () => {
     it('returns timestamps keyed by block number', async () => {
       const client = mockClient({})
-      const getBlockWithTransactions = mockFn()
+      const getBlockHeader = mockFn()
         .returnsOnce({ number: 100, timestamp: 1_000 })
         .returnsOnce({ number: 200, timestamp: 2_000 })
-      client.getBlockWithTransactions = getBlockWithTransactions
+      client.getBlockHeader = getBlockHeader
 
       const result = await client.getBlockTimestamps([100, 200])
 
-      expect(getBlockWithTransactions).toHaveBeenNthCalledWith(1, 100)
-      expect(getBlockWithTransactions).toHaveBeenNthCalledWith(2, 200)
+      expect(getBlockHeader).toHaveBeenNthCalledWith(1, 100)
+      expect(getBlockHeader).toHaveBeenNthCalledWith(2, 200)
       expect(result).toEqual(
         new Map([
           [100, 1_000],
@@ -235,6 +258,7 @@ const mockStarknetGetBlockResponse = (
   id: 1,
   result: {
     block_number: blockNumber,
+    block_hash: '0xblockhash',
     timestamp: UnixTime.now(),
     transactions: [],
   },

--- a/packages/shared/src/clients/starknet/StarknetClient.ts
+++ b/packages/shared/src/clients/starknet/StarknetClient.ts
@@ -1,7 +1,7 @@
 import type { Block, json } from '@l2beat/shared-pure'
 import { generateIntId } from '../../tools/generateId'
 import { ClientCore, type ClientCoreDependencies } from '../ClientCore'
-import type { BlockClient } from '../types'
+import type { BlockClient, BlockHeader } from '../types'
 import {
   type StarknetCallParameters,
   StarknetCallResponse,
@@ -38,6 +38,25 @@ export class StarknetClient extends ClientCore implements BlockClient {
     }
 
     return Number(latestBlockNumberResponse.data.result.block_number)
+  }
+
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<BlockHeader> {
+    const params = [
+      blockNumber === 'latest' ? 'latest' : { block_number: blockNumber },
+    ]
+
+    const response = await this.query('starknet_getBlockWithTxHashes', params)
+
+    const parsed = StarknetGetBlockResponse.safeParse(response)
+    if (!parsed.success) {
+      throw new Error(`Block ${blockNumber}: Error during parsing`)
+    }
+
+    return {
+      number: parsed.data.result.block_number,
+      hash: parsed.data.result.block_hash,
+      timestamp: parsed.data.result.timestamp,
+    }
   }
 
   async getBlockWithTransactions(blockNumber: number): Promise<Block> {
@@ -80,12 +99,10 @@ export class StarknetClient extends ClientCore implements BlockClient {
   async getBlockTimestamps(
     blockNumbers: number[],
   ): Promise<Map<number, number>> {
-    const blocks = await Promise.all(
-      blockNumbers.map((blockNumber) =>
-        this.getBlockWithTransactions(blockNumber),
-      ),
+    const headers = await Promise.all(
+      blockNumbers.map((blockNumber) => this.getBlockHeader(blockNumber)),
     )
-    return new Map(blocks.map((block) => [block.number, block.timestamp]))
+    return new Map(headers.map((header) => [header.number, header.timestamp]))
   }
 
   async call(

--- a/packages/shared/src/clients/starknet/types.ts
+++ b/packages/shared/src/clients/starknet/types.ts
@@ -38,6 +38,7 @@ export const StarknetGetBlockResponse = v.object({
   id: v.number().check(Number.isInteger),
   result: v.object({
     block_number: v.number().check(Number.isInteger),
+    block_hash: v.string(),
     timestamp: v.number().check(Number.isInteger),
     transactions: v.array(v.string()),
   }),

--- a/packages/shared/src/clients/types.ts
+++ b/packages/shared/src/clients/types.ts
@@ -1,9 +1,17 @@
 import type { Block, Log, UnixTime } from '@l2beat/shared-pure'
 import type { SvmBlock } from './rpc-svm/types'
 
+export interface BlockHeader {
+  number: number
+  hash: string
+  timestamp: number
+}
+
 export interface BlockClient {
   getLatestBlockNumber(): Promise<number>
   getBlockWithTransactions(blockNumber: number | 'latest'): Promise<Block>
+  /** Fetch a block without transaction bodies. */
+  getBlockHeader(blockNumber: number | 'latest'): Promise<BlockHeader>
   /** Optional capability: batch-fetch block timestamps. Implementations are
    *  expected to chunk requests internally. */
   getBlockTimestamps?(blockNumbers: number[]): Promise<Map<number, number>>

--- a/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
+++ b/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
@@ -49,6 +49,7 @@ export interface IRpcClient extends BlockClient, LogsClient {
   getBlockWithTransactions(
     blockNumber: number | 'latest',
   ): Promise<EVMBlockWithTransactions>
+  getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock>
   getBlockParentBeaconRoot(blockNumber: number): Promise<string>
   getBlock(blockNumber: 'latest' | number, includeTxs: false): Promise<EVMBlock>
   getBlock(
@@ -129,6 +130,10 @@ export class RpcClientCompat implements IRpcClient {
     blockNumber: number | 'latest',
   ): Promise<EVMBlockWithTransactions> {
     return await this.getBlock(blockNumber, true)
+  }
+
+  async getBlockHeader(blockNumber: number | 'latest'): Promise<EVMBlock> {
+    return await this.getBlock(blockNumber, false)
   }
 
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -62,6 +62,29 @@ describe(BlockProvider.name, () => {
     })
   })
 
+  describe(BlockProvider.prototype.getBlockHeader.name, () => {
+    it('returns header from client', async () => {
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => header(x === 'latest' ? 1000 : x),
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      expect(await provider.getBlockHeader(5)).toEqual(header(5))
+      expect(await provider.getBlockHeader('latest')).toEqual(header(1000))
+    })
+
+    it('rejects a header of a different block', async () => {
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async () => header(7),
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      await expect(provider.getBlockHeader(5)).toBeRejectedWith(
+        'expected block number 5, got 7',
+      )
+    })
+  })
+
   describe(BlockProvider.prototype.getBlockNumberAtOrBefore.name, () => {
     it('finds the closest block number to given timestamp', async () => {
       const client = mockObject<BlockClient>({
@@ -148,6 +171,14 @@ function block(x: number) {
     transactions: [],
     hash: '0x' + x.toString(),
     logsBloom: `0x${'0'.repeat(512)}`,
+    timestamp: x * 100,
+  }
+}
+
+function header(x: number) {
+  return {
+    number: x,
+    hash: '0x' + x.toString(),
     timestamp: x * 100,
   }
 }

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -11,75 +11,63 @@ export class BlockProvider {
   }
 
   async getLatestBlockNumber(): Promise<number> {
-    for (const [index, client] of this.clients.entries()) {
-      try {
-        return await client.getLatestBlockNumber()
-      } catch (error) {
-        if (index === this.clients.length - 1) throw error
-      }
-    }
-
-    throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+    return await this.tryClients((client) => client.getLatestBlockNumber())
   }
 
   async getBlockWithTransactions(x: number | 'latest'): Promise<Block> {
-    for (const [index, client] of this.clients.entries()) {
-      try {
-        const block = await client.getBlockWithTransactions(x)
-        if (typeof x === 'number') {
-          assert(
-            block.number === x,
-            `Invalid response: expected block number ${x}, got ${block.number}`,
-          )
-        }
-        return block
-      } catch (error) {
-        if (index === this.clients.length - 1) throw error
+    return await this.tryClients(async (client) => {
+      const block = await client.getBlockWithTransactions(x)
+      if (typeof x === 'number') {
+        assert(
+          block.number === x,
+          `Invalid response: expected block number ${x}, got ${block.number}`,
+        )
       }
-    }
-
-    throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+      return block
+    })
   }
 
   async getBlockTimestamps(
     blockNumbers: number[],
   ): Promise<Map<number, UnixTime>> {
-    for (const [index, client] of this.clients.entries()) {
-      try {
-        assert(
-          client.getBlockTimestamps,
-          'Client does not support batch fetching of block timestamps',
-        )
-        const out = new Map<number, UnixTime>()
-        const timestamps = await client.getBlockTimestamps(blockNumbers)
-        for (const [n, ts] of timestamps) {
-          out.set(n, UnixTime(ts))
-        }
-        assert(out.size === blockNumbers.length, 'Missing block timestamps')
-        return out
-      } catch (error) {
-        if (index === this.clients.length - 1) throw error
+    return await this.tryClients(async (client) => {
+      assert(
+        client.getBlockTimestamps,
+        'Client does not support batch fetching of block timestamps',
+      )
+      const out = new Map<number, UnixTime>()
+      const timestamps = await client.getBlockTimestamps(blockNumbers)
+      for (const [n, ts] of timestamps) {
+        out.set(n, UnixTime(ts))
       }
-    }
-
-    throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+      assert(out.size === blockNumbers.length, 'Missing block timestamps')
+      return out
+    })
   }
 
   async getBlockNumberAtOrBefore(
     timestamp: UnixTime,
     start = 1,
   ): Promise<number> {
+    return await this.tryClients(async (client) => {
+      const end = await client.getLatestBlockNumber()
+      const effectiveStart = start >= end ? 1 : start
+
+      return await getBlockNumberAtOrBefore(
+        timestamp,
+        effectiveStart,
+        end,
+        (number: number) => client.getBlockWithTransactions(number),
+      )
+    })
+  }
+
+  private async tryClients<T>(
+    callback: (client: BlockClient) => Promise<T>,
+  ): Promise<T> {
     for (const [index, client] of this.clients.entries()) {
       try {
-        const end = await client.getLatestBlockNumber()
-        const effectiveStart = start >= end ? 1 : start
-
-        return await getBlockNumberAtOrBefore(
-          timestamp,
-          effectiveStart,
-          end,
-          (number: number) => client.getBlockWithTransactions(number),
-        )
+        return await callback(client)
       } catch (error) {
         if (index === this.clients.length - 1) throw error
       }

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -1,5 +1,5 @@
 import { assert, type Block, UnixTime } from '@l2beat/shared-pure'
-import type { BlockClient } from '../../clients'
+import type { BlockClient, BlockHeader } from '../../clients'
 import { getBlockNumberAtOrBefore } from '../../tools/getBlockNumberAtOrBefore'
 
 export class BlockProvider {
@@ -17,13 +17,16 @@ export class BlockProvider {
   async getBlockWithTransactions(x: number | 'latest'): Promise<Block> {
     return await this.tryClients(async (client) => {
       const block = await client.getBlockWithTransactions(x)
-      if (typeof x === 'number') {
-        assert(
-          block.number === x,
-          `Invalid response: expected block number ${x}, got ${block.number}`,
-        )
-      }
+      assertBlockNumber(block, x)
       return block
+    })
+  }
+
+  async getBlockHeader(x: number | 'latest'): Promise<BlockHeader> {
+    return await this.tryClients(async (client) => {
+      const header = await client.getBlockHeader(x)
+      assertBlockNumber(header, x)
+      return header
     })
   }
 
@@ -74,5 +77,14 @@ export class BlockProvider {
     }
 
     throw new Error(`Missing ${this.chain.toUpperCase()}_RPC_URL`)
+  }
+}
+
+function assertBlockNumber(block: { number: number }, x: number | 'latest') {
+  if (typeof x === 'number') {
+    assert(
+      block.number === x,
+      `Invalid response: expected block number ${x}, got ${block.number}`,
+    )
   }
 }


### PR DESCRIPTION
## Summary
- `BlockClient` now **requires** `getBlockHeader(number | 'latest')` — a block without transaction bodies (number, hash, timestamp) — so callers that only need those don't download full blocks. Implemented for every remaining block client:
  - `RpcClient` / `RpcClientCompat`: `eth_getBlockByNumber(n, false)`
  - `FuelClient`: the block GraphQL query without `transactionIds`
  - `StarknetClient`: `starknet_getBlockWithTxHashes` (also now backs `getBlockTimestamps`, which previously pulled full `getBlockWithTxs` blocks); adds `block_hash` to the block schema
  - `CelestiaRpcClient`, `PolkadotRpcClient`: the header of their existing block query
- `BlockProvider.getBlockHeader` with the usual client fallback; since the capability is required there is no full-block fallback path.
- The first commit extracts the try-the-next-client loop that every `BlockProvider` method repeated into one `withClient` helper.
- **Based on #12683** (delete archived Loopring/DeGate/zkSync Lite clients) so the required method never has to be implemented on clients that are being removed. Merge #12683 first.
- Additive to callers (no behavior change). Prerequisite of #12676 (tip poll) and #12677 (timestamp search), which are independent of each other. #12681 doesn't need it.

## Testing
- `packages/shared`: typecheck, lint, tests (405 passing; new getBlockHeader tests for RPC, Fuel, Starknet, Celestia, Polkadot)
- `packages/config`, `packages/backend`: typecheck, tests (1349 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
