### PR TITLE
Poll one header per tick in BlockNumberIndexer

### DIFF
--- a/packages/backend/src/modules/block-sync/BlockNumberIndexer.test.ts
+++ b/packages/backend/src/modules/block-sync/BlockNumberIndexer.test.ts
@@ -1,0 +1,127 @@
+import { Logger } from '@l2beat/backend-tools'
+import type { BlockHeader, BlockProvider } from '@l2beat/shared'
+import { UnixTime } from '@l2beat/shared-pure'
+import { type InstalledClock, install } from '@sinonjs/fake-timers'
+import { expect, mockObject } from 'earl'
+import { BlockNumberIndexer } from './BlockNumberIndexer'
+
+const START = UnixTime(1_700_000_000)
+const BLOCK_TIME = 10
+const DELAY = 300
+const INTERVAL_MS = 10_000
+
+describe(BlockNumberIndexer.name, () => {
+  let time: InstalledClock
+
+  beforeEach(() => {
+    time = install({ now: START * 1000 })
+  })
+
+  afterEach(() => {
+    time.uninstall()
+  })
+
+  it('finds the block at the delayed timestamp using only headers', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+
+    const result = await indexer.tick()
+
+    // block 970 is exactly DELAY seconds old
+    expect(result).toEqual(970)
+    expect(chain.requested).toInclude('latest')
+    expect(chain.requested.length).toBeLessThanOrEqual(12)
+  })
+
+  it('returns the latest block when it is already old enough', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain, 0)
+
+    const result = await indexer.tick()
+
+    expect(result).toEqual(1000)
+    expect(chain.requested).toEqual(['latest'])
+  })
+
+  it('advances with a single call per tick once polled headers are old enough', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    let previous = indexer.blockHeight
+    let lastTickCalls = 0
+    for (let i = 1; i <= DELAY / (INTERVAL_MS / 1000) + 1; i++) {
+      time.tick(INTERVAL_MS)
+      chain.latest = 1000 + i
+      chain.requested.length = 0
+      const result = await indexer.tick()
+      expect(result).toBeGreaterThanOrEqual(previous)
+      previous = result
+      lastTickCalls = chain.requested.length
+    }
+
+    // block 1001 became DELAY seconds old on the last tick and was polled on the first
+    expect(previous).toEqual(1001)
+    expect(lastTickCalls).toEqual(1)
+  })
+
+  it('searches for the exact block when polls were missed', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    time.tick(600_000)
+    chain.latest = 1060
+    const result = await indexer.tick()
+
+    expect(result).toEqual(1030)
+  })
+
+  it('never lowers the height when the node reports a stale tip', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    chain.latest = 990
+    const result = await indexer.tick()
+
+    expect(result).toEqual(970)
+  })
+})
+
+function createIndexer(chain: FakeChain, delay = DELAY) {
+  const blockProvider = mockObject<BlockProvider>({
+    chain: 'ethereum',
+    getBlockHeader: async (x) => chain.header(x),
+  })
+  return new BlockNumberIndexer(
+    blockProvider,
+    'ethereum',
+    Logger.SILENT,
+    delay,
+    INTERVAL_MS,
+  )
+}
+
+interface FakeChain {
+  latest: number
+  requested: (number | 'latest')[]
+  header(x: number | 'latest'): BlockHeader
+}
+
+// Block 1000 is mined at START and every BLOCK_TIME seconds another one
+function fakeChain(latest: number): FakeChain {
+  return {
+    latest,
+    requested: [],
+    header(x) {
+      this.requested.push(x)
+      const number = x === 'latest' ? this.latest : x
+      return {
+        number,
+        hash: `0x${number}`,
+        timestamp: START + (number - 1000) * BLOCK_TIME,
+      }
+    },
+  }
+}

--- a/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
@@ -1,11 +1,22 @@
 import type { Logger } from '@l2beat/backend-tools'
-import type { BlockProvider } from '@l2beat/shared'
+import {
+  type BlockHeader,
+  type BlockProvider,
+  getBlockNumberAtOrBefore,
+} from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import { Indexer, RootIndexer } from '@l2beat/uif'
 import { withBlockSyncRpcMetricsContext } from './blockSyncRpcMetrics'
 
 export class BlockNumberIndexer extends RootIndexer {
   blockHeight = -1
+  // Each tick fetches only the latest header. Headers seen on earlier ticks
+  // are what tells us which block is already old enough, without more calls.
+  // A reorg can leave a stale timestamp here, which is harmless: the height is
+  // only a lower bound behind a delay of minutes, a replacement block is mined
+  // within seconds of the one it replaced, entries are dropped once the height
+  // passes them, and BlockIndexer fetches every block fresh by number anyway
+  private readonly headers = new Map<number, BlockHeader>()
 
   constructor(
     private readonly blockProvider: BlockProvider,
@@ -33,16 +44,57 @@ export class BlockNumberIndexer extends RootIndexer {
       },
       async () => {
         const timestamp = UnixTime.now() - this.delayFromTipInSeconds
-        const blockNumber = await this.blockProvider.getBlockNumberAtOrBefore(
-          timestamp,
-          Math.max(this.blockHeight, 1),
-        )
+        const blockNumber = await this.findBlockNumberAtOrBefore(timestamp)
         if (blockNumber > this.blockHeight) {
           this.blockHeight = blockNumber
           this.logger.info('Advanced block number', { blockNumber })
         }
+        for (const number of this.headers.keys()) {
+          if (number < this.blockHeight) this.headers.delete(number)
+        }
         return this.blockHeight
       },
     )
+  }
+
+  private async findBlockNumberAtOrBefore(
+    timestamp: UnixTime,
+  ): Promise<number> {
+    const latest = await this.getHeader('latest')
+    if (latest.timestamp <= timestamp) return latest.number
+
+    let before: BlockHeader | undefined
+    let after = latest
+    for (const header of this.headers.values()) {
+      if (header.timestamp <= timestamp) {
+        if (!before || header.number > before.number) before = header
+      } else if (header.number < after.number) {
+        after = header
+      }
+    }
+
+    if (!before) return await this.search(timestamp, 1, after.number)
+    // Consecutive polls bracket the timestamp within one interval, so the
+    // newest block known to be old enough is close enough. A wider gap means
+    // polls were missed and the exact block is worth a few calls
+    const maxGap = (2 * this.checkIntervalMs) / 1000
+    if (after.timestamp - before.timestamp > maxGap) {
+      return await this.search(timestamp, before.number, after.number)
+    }
+    return before.number
+  }
+
+  private search(timestamp: UnixTime, from: number, to: number) {
+    return getBlockNumberAtOrBefore(timestamp, from, to, (number) =>
+      this.getHeader(number),
+    )
+  }
+
+  private async getHeader(x: number | 'latest'): Promise<BlockHeader> {
+    const known = x !== 'latest' ? this.headers.get(x) : undefined
+    if (known) return known
+    const header = await this.blockProvider.getBlockHeader(x)
+    this.headers.set(header.number, header)
+    return header
   }
 }


### PR DESCRIPTION
## Summary
- `blockSync.tip` is ~10% of backend `eth_getBlockByNumber` usage: every 10 s per chain it did `eth_blockNumber` plus ~5 full blocks with tx bodies to find the block that is `BLOCK_SYNC_DELAY_FROM_TIP_IN_SECONDS` old (600 s in prod).
- Each tick now fetches only the `latest` header. Headers seen on earlier ticks form a window; the newest one already older than the delay is the safe height (at most two poll intervals behind the exact block, always on the safe side). The exact search runs only at bootstrap or when the bracketing headers are more than two poll intervals apart (missed polls, restart).
- The height never decreases; the window is pruned below the returned height so it stays ~delay/interval entries (~60 in prod).
- Reorgs: a replaced block's cached timestamp is off by seconds, which only shortens the 10-minute margin by that much; entries are dropped once the height passes them and `BlockIndexer` fetches every block fresh by number (see comment in code).
- Needs #12675 (`getBlockHeader`); independent of #12677 and #12681.

## Before / after

**Production, last 24 h (Kibana `Rpc metrics`, `coreFeature: blockSync.tip`):** 834,826 `eth_getBlockByNumber` + 165,059 `eth_blockNumber` = **~1.0M calls/day**, i.e. ~5.9 calls per tick (1 + 4.9) across the block-sync chains.

**Simulation, 24 h of 10 s ticks, 600 s delay, process restart at hour 12** — `main`'s tick logic vs the real `BlockNumberIndexer` from this PR, on synthetic chains with realistic block times; every RPC call counted, every returned height checked against the delay:

| chain | before: calls/tick (`eth_blockNumber` + full blocks) | after: calls/tick (headers) | after: max lag vs exact block | unsafe ticks | extra calls during 10-min warm-up after restart |
|---|---|---|---|---|---|
| ethereum (12 s) | 5.39 (1 + 4.39) | 1.01 | 0 s | 0 | 52 |
| base / optimism (2 s) | 6.00 (1 + 5.00) | 1.02 | 10 s | 0 | 96 |
| polygonpos (~2 s, jitter) | 5.81 (1 + 4.81) | 1.02 | 18 s | 0 | 101 |
| bsc (0.75 s) | 6.67 (1 + 5.67) | 1.02 | 15 s | 0 | 101 |
| arbitrum (~0.25 s, bursty) | 8.11 (1 + 7.11) | 1.03 | 16 s | 0 | 153 |
| robinhood (10 blocks/s) | 6.00 (1 + 5.00) | 1.04 | 14 s | 0 | 177 |
| 2 s chain with a 20-min stall | 6.02 (1 + 5.02) | 1.02 | 10 s | 0 | 96 |
| **average** | **6.28** | **1.03** | | | |

The simulated "before" (6.28/tick) matches production (5.9/tick), so the projection is **~1.0M → ~175k calls/day (−84%)**, with the remaining calls being ~1 KB headers instead of full blocks. The safe height never violated the delay in any tick; it trails the exact block by at most two poll intervals. A restart costs ~50–180 extra header calls per chain while the window refills.

## Testing
- New `BlockNumberIndexer.test.ts` (fake timers): bootstrap finds the exact block with headers only, one call per tick after warm-up, exact search after a 10-minute gap, a stale tip never lowers the height
- `packages/backend`: typecheck, lint, tests (1354 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
