### PR TITLE
Search block by timestamp with cached headers; one BlockProvider per chain

### DIFF
--- a/packages/backend/src/providers/Providers.ts
+++ b/packages/backend/src/providers/Providers.ts
@@ -2,7 +2,6 @@ import type { Logger } from '@l2beat/backend-tools'
 import {
   AvailDaProvider,
   BalanceProvider,
-  BlockProvider,
   BlockTimestampProvider,
   CelestiaDaProvider,
   CirculatingSupplyProvider,
@@ -107,10 +106,9 @@ export class Providers {
 
     this.blockTimestamp = new BlockTimestampProvider({
       indexerClients: this.clients.indexer,
-      blockProviders: [
-        ...this.clients.block.map((c) => new BlockProvider(c.chain, [c])),
-        ...this.aztecBlock.getAll(),
-      ],
+      // Reuse the per-chain BlockProviders so timestamp lookups share their
+      // client fallback and header cache instead of a second set of instances
+      blockProviders: [...this.block.getAll(), ...this.aztecBlock.getAll()],
     })
 
     this.slotTimestamp = new SlotTimestampProvider({

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -99,6 +99,8 @@ describe(BlockProvider.name, () => {
 
       expect(blockNumber).toEqual(800)
       expect(getBlockHeader).toHaveBeenCalledWith('latest')
+      // the latest header is reused as the upper bound, not fetched again
+      expect(getBlockHeader.calls.map((c) => c.args[0])).not.toInclude(1000)
     })
 
     it('returns the latest block when timestamp is not earlier', async () => {
@@ -174,6 +176,37 @@ describe(BlockProvider.name, () => {
         .filter((x): x is number => typeof x === 'number')
       expect(Math.min(...numbers)).toBeGreaterThan(1)
       expect(getBlockHeader.calls.length).toBeLessThan(firstCalls)
+    })
+
+    it('does not cache headers within the reorg window of the tip', async () => {
+      // 1s blocks, latest = 100_000
+      const oneSecondBlocks = (x: number | 'latest') => {
+        const number = x === 'latest' ? 100_000 : x
+        return { number, hash: `0x${number}`, timestamp: number }
+      }
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        oneSecondBlocks(x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client])
+
+      const requested = () => getBlockHeader.calls.map((c) => c.args[0])
+
+      // ~10s behind the tip: the probe is too fresh to remember, so an
+      // identical search fetches it again
+      await provider.getBlockNumberAtOrBefore(UnixTime(99_990))
+      expect(requested()).toInclude(99_990)
+      getBlockHeader.calls.length = 0
+      await provider.getBlockNumberAtOrBefore(UnixTime(99_990))
+      expect(requested()).toInclude(99_990)
+
+      // ~14h behind the tip: probes are remembered, the repeat needs only latest
+      getBlockHeader.calls.length = 0
+      await provider.getBlockNumberAtOrBefore(UnixTime(50_000))
+      expect(requested()).toInclude(50_000)
+      getBlockHeader.calls.length = 0
+      await provider.getBlockNumberAtOrBefore(UnixTime(50_000))
+      expect(requested()).toEqual(['latest'])
     })
 
     it('handles a sequence of non-consecutive timestamps', async () => {

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -87,11 +87,10 @@ describe(BlockProvider.name, () => {
 
   describe(BlockProvider.prototype.getBlockNumberAtOrBefore.name, () => {
     it('finds the closest block number to given timestamp', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 1000,
-        getBlockWithTransactions: async (n: number) => block(n),
-      })
-
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
       const provider = new BlockProvider('chain', [client])
 
       const blockNumber = await provider.getBlockNumberAtOrBefore(
@@ -99,68 +98,151 @@ describe(BlockProvider.name, () => {
       )
 
       expect(blockNumber).toEqual(800)
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+      expect(getBlockHeader).toHaveBeenCalledWith('latest')
+    })
+
+    it('returns the latest block when timestamp is not earlier', async () => {
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(1000 * 100 + 5),
+      )
+
+      expect(blockNumber).toEqual(1000)
+      expect(getBlockHeader).toHaveBeenOnlyCalledWith('latest')
+    })
+
+    it('respects the start lower bound', async () => {
+      const requested: (number | 'latest')[] = []
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => {
+          requested.push(x)
+          return header(x === 'latest' ? 1000 : x)
+        },
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(800 * 100),
+        700,
+      )
+
+      expect(blockNumber).toEqual(800)
+      const numbers = requested.filter(
+        (x): x is number => typeof x === 'number',
+      )
+      expect(Math.min(...numbers)).toBeGreaterThanOrEqual(700)
+    })
+
+    it('ignores a start above the latest block', async () => {
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => header(x === 'latest' ? 1000 : x),
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(800 * 100),
+        1500,
+      )
+
+      expect(blockNumber).toEqual(800)
+    })
+
+    it('reuses known headers to shrink a later, nearby search', async () => {
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client])
+
+      await provider.getBlockNumberAtOrBefore(UnixTime(500 * 100))
+      const firstCalls = getBlockHeader.calls.length
+
+      getBlockHeader.calls.length = 0
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(505 * 100),
+      )
+
+      expect(blockNumber).toEqual(505)
+      // latest + a handful of probes bracketed by cached headers, never block 1
+      const numbers = getBlockHeader.calls
+        .map((c) => c.args[0])
+        .filter((x): x is number => typeof x === 'number')
+      expect(Math.min(...numbers)).toBeGreaterThan(1)
+      expect(getBlockHeader.calls.length).toBeLessThan(firstCalls)
+    })
+
+    it('handles a sequence of non-consecutive timestamps', async () => {
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => header(x === 'latest' ? 1000 : x),
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      for (const target of [800, 300, 600, 950, 100]) {
+        expect(
+          await provider.getBlockNumberAtOrBefore(UnixTime(target * 100)),
+        ).toEqual(target)
+      }
     })
 
     it('calls other client when there are errors', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 1000,
-        getBlockWithTransactions: mockFn().rejectsWith(new Error('error')),
-      })
-
-      const client2 = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 1000,
-        getBlockWithTransactions: async (n: number) => block(n),
-      })
-
-      const provider = new BlockProvider('chain', [client, client2])
+      const failing = mockFn().rejectsWith(new Error('error'))
+      const working = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const provider = new BlockProvider('chain', [
+        mockObject<BlockClient>({ getBlockHeader: failing }),
+        mockObject<BlockClient>({ getBlockHeader: working }),
+      ])
 
       const blockNumber = await provider.getBlockNumberAtOrBefore(
         UnixTime(800 * 100),
       )
 
       expect(blockNumber).toEqual(800)
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client2.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-    })
-
-    it('falls back to 0 when start is above client latest', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 500,
-        getBlockWithTransactions: async (n: number) => block(n),
-      })
-
-      const provider = new BlockProvider('chain', [client])
-
-      const blockNumber = await provider.getBlockNumberAtOrBefore(
-        UnixTime(300 * 100),
-        800,
-      )
-
-      expect(blockNumber).toEqual(300)
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+      expect(failing).toHaveBeenCalledTimes(1)
+      expect(working).toHaveBeenCalledWith('latest')
     })
 
     it('throws error when run out of fallbacks', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('1')),
-      })
-      const client2 = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('2')),
-      })
-      const client3 = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('3')),
-      })
-
-      const provider = new BlockProvider('chain', [client, client2, client3])
+      const failing = [1, 2, 3].map((i) =>
+        mockFn().rejectsWith(new Error(i.toString())),
+      )
+      const provider = new BlockProvider(
+        'chain',
+        failing.map((getBlockHeader) =>
+          mockObject<BlockClient>({ getBlockHeader }),
+        ),
+      )
 
       await expect(
         async () => await provider.getBlockNumberAtOrBefore(UnixTime(800)),
       ).toBeRejectedWith('3')
 
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client2.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client3.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+      for (const getBlockHeader of failing) {
+        expect(getBlockHeader).toHaveBeenCalledTimes(1)
+      }
+    })
+
+    it('evicts the oldest headers past the cap', async () => {
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 100_000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client], 8)
+
+      for (let i = 1; i <= 40; i++) {
+        await provider.getBlockNumberAtOrBefore(UnixTime(i * 1000 * 100))
+      }
+
+      // still correct after many evictions
+      expect(
+        await provider.getBlockNumberAtOrBefore(UnixTime(5000 * 100)),
+      ).toEqual(5000)
     })
   })
 })

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -2,6 +2,11 @@ import { assert, type Block, UnixTime } from '@l2beat/shared-pure'
 import type { BlockClient, BlockHeader } from '../../clients'
 import { getBlockNumberAtOrBefore } from '../../tools/getBlockNumberAtOrBefore'
 
+// Headers younger than this are not cached: a reorg could replace the block
+// and a stale timestamp would then mis-bracket later searches. Deeper than any
+// reorg seen on the tracked chains (Ethereum finalizes in ~13 min).
+const REORG_SAFETY_SECONDS = UnixTime.HOUR
+
 export class BlockProvider {
   // Headers resolved by earlier timestamp searches, kept so later searches can
   // seed the interpolation from the closest known block instead of block 1 —
@@ -59,17 +64,19 @@ export class BlockProvider {
     start = 1,
   ): Promise<number> {
     return await this.tryClients(async (client) => {
-      const getHeader = async (x: number | 'latest') => {
-        const cached = x !== 'latest' ? this.knownHeaders.get(x) : undefined
+      const latest = await client.getBlockHeader('latest')
+      if (timestamp >= latest.timestamp) return latest.number
+
+      const cacheable = latest.timestamp - REORG_SAFETY_SECONDS
+      const getHeader = async (number: number) => {
+        if (number === latest.number) return latest
+        const cached = this.knownHeaders.get(number)
         if (cached) return cached
-        const header = await client.getBlockHeader(x)
-        assertBlockNumber(header, x)
-        this.remember(header)
+        const header = await client.getBlockHeader(number)
+        assertBlockNumber(header, number)
+        if (header.timestamp <= cacheable) this.remember(header)
         return header
       }
-
-      const latest = await getHeader('latest')
-      if (timestamp >= latest.timestamp) return latest.number
 
       // Narrow the search to the tightest bracket of already-known headers.
       // Block timestamps increase with block number, so any known header at or

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -3,9 +3,15 @@ import type { BlockClient, BlockHeader } from '../../clients'
 import { getBlockNumberAtOrBefore } from '../../tools/getBlockNumberAtOrBefore'
 
 export class BlockProvider {
+  // Headers resolved by earlier timestamp searches, kept so later searches can
+  // seed the interpolation from the closest known block instead of block 1 —
+  // even when consumers ask for non-consecutive timestamps.
+  private readonly knownHeaders = new Map<number, BlockHeader>()
+
   constructor(
     readonly chain: string,
     private readonly clients: BlockClient[],
+    private readonly maxKnownHeaders = 1024,
   ) {
     assert(clients.length > 0, 'Clients cannot be empty')
   }
@@ -53,16 +59,44 @@ export class BlockProvider {
     start = 1,
   ): Promise<number> {
     return await this.tryClients(async (client) => {
-      const end = await client.getLatestBlockNumber()
-      const effectiveStart = start >= end ? 1 : start
+      const getHeader = async (x: number | 'latest') => {
+        const cached = x !== 'latest' ? this.knownHeaders.get(x) : undefined
+        if (cached) return cached
+        const header = await client.getBlockHeader(x)
+        assertBlockNumber(header, x)
+        this.remember(header)
+        return header
+      }
 
-      return await getBlockNumberAtOrBefore(
-        timestamp,
-        effectiveStart,
-        end,
-        (number: number) => client.getBlockWithTransactions(number),
-      )
+      const latest = await getHeader('latest')
+      if (timestamp >= latest.timestamp) return latest.number
+
+      // Narrow the search to the tightest bracket of already-known headers.
+      // Block timestamps increase with block number, so any known header at or
+      // before the target is a valid lower bound and any known header after it
+      // an upper bound.
+      let lo = start < latest.number ? start : 1
+      let hi = latest.number
+      for (const header of this.knownHeaders.values()) {
+        if (header.number <= lo || header.number >= hi) continue
+        if (header.timestamp <= timestamp) lo = header.number
+        else hi = header.number
+      }
+
+      return await getBlockNumberAtOrBefore(timestamp, lo, hi, getHeader)
     })
+  }
+
+  private remember(header: BlockHeader) {
+    this.knownHeaders.delete(header.number)
+    this.knownHeaders.set(header.number, header)
+    // Evict the least recently inserted headers, which are the lowest blocks
+    // once timestamps march forward
+    while (this.knownHeaders.size > this.maxKnownHeaders) {
+      const oldest = this.knownHeaders.keys().next().value
+      if (oldest === undefined) break
+      this.knownHeaders.delete(oldest)
+    }
   }
 
   private async tryClients<T>(


### PR DESCRIPTION
## Summary
- **Search with headers, cached (commit 1).** `BlockProvider.getBlockNumberAtOrBefore` (activity/DA/privacy hourly targets, TVS fallback, block-sync tip) fetched `eth_blockNumber` then every probe as a full block with tx bodies, always from block 1. It now starts from the `latest` header and probes headers only. Headers seen by earlier searches are kept — bounded (default 1024/chain, evict-oldest), keyed by block number — and used to bracket the next search, so even **non-consecutive** timestamps (many consumers interleaving on one chain) converge in a few probes rather than re-walking from block 1.
- **One BlockProvider per chain (commit 2).** `BlockTimestampProvider` built its own `clients.block.map(c => new BlockProvider(c.chain, [c]))` — one per client — and `.find(b => b.chain === chain)` returned only the **first**, so timestamp lookups silently never fell back to a chain's second RPC and kept a header cache separate from block-sync/activity. It now reuses the grouped per-chain `BlockProviders`, which dedupes the instances, restores client fallback, and shares the cache above.
- **Reorg safety (commit 3, from review).** Headers within an hour of `latest` are used but never cached, so a block that can still be reorged can't leave a stale timestamp in the cache. An hour is deeper than any reorg seen on the tracked chains, and an hour-old bound still converges in the same 2–3 probes.
- Needs #12675 (`getBlockHeader`); independent of #12676 and #12681.

## Testing
- `packages/shared`: typecheck, lint, tests (411 passing; search rewritten for header mocks — closest block, latest-or-later, `start` respected/ignored-above-latest, cache reuse shrinks a nearby search, non-consecutive sequence stays correct, near-tip probes are not cached while old ones are, eviction past the cap, client fallback)
- `packages/backend`: typecheck, lint, tests (1349 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
