### PR TITLE
Seed BlockProvider timestamp search with the previous result

### DIFF
--- a/packages/backend/src/modules/block-sync/BlockNumberIndexer.test.ts
+++ b/packages/backend/src/modules/block-sync/BlockNumberIndexer.test.ts
@@ -1,0 +1,127 @@
+import { Logger } from '@l2beat/backend-tools'
+import type { BlockHeader, BlockProvider } from '@l2beat/shared'
+import { UnixTime } from '@l2beat/shared-pure'
+import { type InstalledClock, install } from '@sinonjs/fake-timers'
+import { expect, mockObject } from 'earl'
+import { BlockNumberIndexer } from './BlockNumberIndexer'
+
+const START = UnixTime(1_700_000_000)
+const BLOCK_TIME = 10
+const DELAY = 300
+const INTERVAL_MS = 10_000
+
+describe(BlockNumberIndexer.name, () => {
+  let time: InstalledClock
+
+  beforeEach(() => {
+    time = install({ now: START * 1000 })
+  })
+
+  afterEach(() => {
+    time.uninstall()
+  })
+
+  it('finds the block at the delayed timestamp using only headers', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+
+    const result = await indexer.tick()
+
+    // block 970 is exactly DELAY seconds old
+    expect(result).toEqual(970)
+    expect(chain.requested).toInclude('latest')
+    expect(chain.requested.length).toBeLessThanOrEqual(12)
+  })
+
+  it('returns the latest block when it is already old enough', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain, 0)
+
+    const result = await indexer.tick()
+
+    expect(result).toEqual(1000)
+    expect(chain.requested).toEqual(['latest'])
+  })
+
+  it('advances with a single call per tick once polled headers are old enough', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    let previous = indexer.blockHeight
+    let lastTickCalls = 0
+    for (let i = 1; i <= DELAY / (INTERVAL_MS / 1000) + 1; i++) {
+      time.tick(INTERVAL_MS)
+      chain.latest = 1000 + i
+      chain.requested.length = 0
+      const result = await indexer.tick()
+      expect(result).toBeGreaterThanOrEqual(previous)
+      previous = result
+      lastTickCalls = chain.requested.length
+    }
+
+    // block 1001 became DELAY seconds old on the last tick and was polled on the first
+    expect(previous).toEqual(1001)
+    expect(lastTickCalls).toEqual(1)
+  })
+
+  it('searches for the exact block when polls were missed', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    time.tick(600_000)
+    chain.latest = 1060
+    const result = await indexer.tick()
+
+    expect(result).toEqual(1030)
+  })
+
+  it('never lowers the height when the node reports a stale tip', async () => {
+    const chain = fakeChain(1000)
+    const indexer = createIndexer(chain)
+    await indexer.tick()
+
+    chain.latest = 990
+    const result = await indexer.tick()
+
+    expect(result).toEqual(970)
+  })
+})
+
+function createIndexer(chain: FakeChain, delay = DELAY) {
+  const blockProvider = mockObject<BlockProvider>({
+    chain: 'ethereum',
+    getBlockHeader: async (x) => chain.header(x),
+  })
+  return new BlockNumberIndexer(
+    blockProvider,
+    'ethereum',
+    Logger.SILENT,
+    delay,
+    INTERVAL_MS,
+  )
+}
+
+interface FakeChain {
+  latest: number
+  requested: (number | 'latest')[]
+  header(x: number | 'latest'): BlockHeader
+}
+
+// Block 1000 is mined at START and every BLOCK_TIME seconds another one
+function fakeChain(latest: number): FakeChain {
+  return {
+    latest,
+    requested: [],
+    header(x) {
+      this.requested.push(x)
+      const number = x === 'latest' ? this.latest : x
+      return {
+        number,
+        hash: `0x${number}`,
+        timestamp: START + (number - 1000) * BLOCK_TIME,
+      }
+    },
+  }
+}

--- a/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockNumberIndexer.ts
@@ -1,11 +1,18 @@
 import type { Logger } from '@l2beat/backend-tools'
-import type { BlockProvider } from '@l2beat/shared'
+import {
+  type BlockHeader,
+  type BlockProvider,
+  getBlockNumberAtOrBefore,
+} from '@l2beat/shared'
 import { UnixTime } from '@l2beat/shared-pure'
 import { Indexer, RootIndexer } from '@l2beat/uif'
 import { withBlockSyncRpcMetricsContext } from './blockSyncRpcMetrics'
 
 export class BlockNumberIndexer extends RootIndexer {
   blockHeight = -1
+  // Each tick fetches only the latest header. Headers seen on earlier ticks
+  // are what tells us which block is already old enough, without more calls
+  private readonly headers = new Map<number, BlockHeader>()
 
   constructor(
     private readonly blockProvider: BlockProvider,
@@ -33,16 +40,57 @@ export class BlockNumberIndexer extends RootIndexer {
       },
       async () => {
         const timestamp = UnixTime.now() - this.delayFromTipInSeconds
-        const blockNumber = await this.blockProvider.getBlockNumberAtOrBefore(
-          timestamp,
-          Math.max(this.blockHeight, 1),
-        )
+        const blockNumber = await this.findBlockNumberAtOrBefore(timestamp)
         if (blockNumber > this.blockHeight) {
           this.blockHeight = blockNumber
           this.logger.info('Advanced block number', { blockNumber })
         }
+        for (const number of this.headers.keys()) {
+          if (number < this.blockHeight) this.headers.delete(number)
+        }
         return this.blockHeight
       },
     )
+  }
+
+  private async findBlockNumberAtOrBefore(
+    timestamp: UnixTime,
+  ): Promise<number> {
+    const latest = await this.getHeader('latest')
+    if (latest.timestamp <= timestamp) return latest.number
+
+    let before: BlockHeader | undefined
+    let after = latest
+    for (const header of this.headers.values()) {
+      if (header.timestamp <= timestamp) {
+        if (!before || header.number > before.number) before = header
+      } else if (header.number < after.number) {
+        after = header
+      }
+    }
+
+    if (!before) return await this.search(timestamp, 1, after.number)
+    // Consecutive polls bracket the timestamp within one interval, so the
+    // newest block known to be old enough is close enough. A wider gap means
+    // polls were missed and the exact block is worth a few calls
+    const maxGap = (2 * this.checkIntervalMs) / 1000
+    if (after.timestamp - before.timestamp > maxGap) {
+      return await this.search(timestamp, before.number, after.number)
+    }
+    return before.number
+  }
+
+  private search(timestamp: UnixTime, from: number, to: number) {
+    return getBlockNumberAtOrBefore(timestamp, from, to, (number) =>
+      this.getHeader(number),
+    )
+  }
+
+  private async getHeader(x: number | 'latest'): Promise<BlockHeader> {
+    const known = x !== 'latest' ? this.headers.get(x) : undefined
+    if (known) return known
+    const header = await this.blockProvider.getBlockHeader(x)
+    this.headers.set(header.number, header)
+    return header
   }
 }

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -100,11 +100,41 @@ describe(BlockProvider.name, () => {
 
   describe(BlockProvider.prototype.getBlockNumberAtOrBefore.name, () => {
     it('finds the closest block number to given timestamp', async () => {
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(800 * 100),
+      )
+
+      expect(blockNumber).toEqual(800)
+      expect(getBlockHeader).toHaveBeenCalledWith('latest')
+    })
+
+    it('returns the latest block when timestamp is not earlier', async () => {
+      const getBlockHeader = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const client = mockObject<BlockClient>({ getBlockHeader })
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(1000 * 100 + 5),
+      )
+
+      expect(blockNumber).toEqual(1000)
+      expect(getBlockHeader).toHaveBeenOnlyCalledWith('latest')
+    })
+
+    it('uses full blocks for clients without header support', async () => {
       const client = mockObject<BlockClient>({
+        getBlockHeader: undefined,
         getLatestBlockNumber: async () => 1000,
         getBlockWithTransactions: async (n: number) => block(n),
       })
-
       const provider = new BlockProvider('chain', [client])
 
       const blockNumber = await provider.getBlockNumberAtOrBefore(
@@ -116,64 +146,42 @@ describe(BlockProvider.name, () => {
     })
 
     it('calls other client when there are errors', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 1000,
-        getBlockWithTransactions: mockFn().rejectsWith(new Error('error')),
-      })
-
-      const client2 = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 1000,
-        getBlockWithTransactions: async (n: number) => block(n),
-      })
-
-      const provider = new BlockProvider('chain', [client, client2])
+      const failing = mockFn().rejectsWith(new Error('error'))
+      const working = mockFn(async (x: number | 'latest') =>
+        header(x === 'latest' ? 1000 : x),
+      )
+      const provider = new BlockProvider('chain', [
+        mockObject<BlockClient>({ getBlockHeader: failing }),
+        mockObject<BlockClient>({ getBlockHeader: working }),
+      ])
 
       const blockNumber = await provider.getBlockNumberAtOrBefore(
         UnixTime(800 * 100),
       )
 
       expect(blockNumber).toEqual(800)
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client2.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-    })
-
-    it('falls back to 0 when start is above client latest', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: async () => 500,
-        getBlockWithTransactions: async (n: number) => block(n),
-      })
-
-      const provider = new BlockProvider('chain', [client])
-
-      const blockNumber = await provider.getBlockNumberAtOrBefore(
-        UnixTime(300 * 100),
-        800,
-      )
-
-      expect(blockNumber).toEqual(300)
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+      expect(failing).toHaveBeenCalledTimes(1)
+      expect(working).toHaveBeenCalledWith('latest')
     })
 
     it('throws error when run out of fallbacks', async () => {
-      const client = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('1')),
-      })
-      const client2 = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('2')),
-      })
-      const client3 = mockObject<BlockClient>({
-        getLatestBlockNumber: mockFn().rejectsWith(new Error('3')),
-      })
-
-      const provider = new BlockProvider('chain', [client, client2, client3])
+      const failing = [1, 2, 3].map((i) =>
+        mockFn().rejectsWith(new Error(i.toString())),
+      )
+      const provider = new BlockProvider(
+        'chain',
+        failing.map((getBlockHeader) =>
+          mockObject<BlockClient>({ getBlockHeader }),
+        ),
+      )
 
       await expect(
         async () => await provider.getBlockNumberAtOrBefore(UnixTime(800)),
       ).toBeRejectedWith('3')
 
-      expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client2.getLatestBlockNumber).toHaveBeenCalledTimes(1)
-      expect(client3.getLatestBlockNumber).toHaveBeenCalledTimes(1)
+      for (const getBlockHeader of failing) {
+        expect(getBlockHeader).toHaveBeenCalledTimes(1)
+      }
     })
   })
 })

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -129,6 +129,50 @@ describe(BlockProvider.name, () => {
       expect(getBlockHeader).toHaveBeenOnlyCalledWith('latest')
     })
 
+    it('starts the next search from the previous result', async () => {
+      const requested: (number | 'latest')[] = []
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => {
+          requested.push(x)
+          return header(x === 'latest' ? 1000 : x)
+        },
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      await provider.getBlockNumberAtOrBefore(UnixTime(500 * 100))
+      expect(requested).toInclude(1)
+
+      requested.length = 0
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(600 * 100),
+      )
+
+      expect(blockNumber).toEqual(600)
+      const numbers = requested.filter((x) => typeof x === 'number')
+      expect(Math.min(...numbers)).toBeGreaterThanOrEqual(500)
+    })
+
+    it('does not reuse the previous result for an earlier timestamp', async () => {
+      const requested: (number | 'latest')[] = []
+      const client = mockObject<BlockClient>({
+        getBlockHeader: async (x) => {
+          requested.push(x)
+          return header(x === 'latest' ? 1000 : x)
+        },
+      })
+      const provider = new BlockProvider('chain', [client])
+
+      await provider.getBlockNumberAtOrBefore(UnixTime(600 * 100))
+
+      requested.length = 0
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(300 * 100),
+      )
+
+      expect(blockNumber).toEqual(300)
+      expect(requested).toInclude(1)
+    })
+
     it('uses full blocks for clients without header support', async () => {
       const client = mockObject<BlockClient>({
         getBlockHeader: undefined,

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -3,6 +3,10 @@ import type { BlockClient, BlockHeader } from '../../clients'
 import { getBlockNumberAtOrBefore } from '../../tools/getBlockNumberAtOrBefore'
 
 export class BlockProvider {
+  // Consumers ask for hourly, increasing timestamps, so the previous answer is
+  // a much better lower bound for the next search than block 1
+  private lastFound: BlockHeader | undefined
+
   constructor(
     readonly chain: string,
     private readonly clients: BlockClient[],
@@ -58,12 +62,21 @@ export class BlockProvider {
       const latest = await getHeader('latest')
       if (timestamp >= latest.timestamp) return latest.number
 
-      return await getBlockNumberAtOrBefore(
+      let start = 1
+      const seed = this.lastFound
+      if (seed && seed.timestamp <= timestamp && seed.number < latest.number) {
+        known.set(seed.number, seed)
+        start = seed.number
+      }
+
+      const found = await getBlockNumberAtOrBefore(
         timestamp,
-        1,
+        start,
         latest.number,
         getHeader,
       )
+      this.lastFound = known.get(found)
+      return found
     })
   }
 

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -44,19 +44,25 @@ export class BlockProvider {
     })
   }
 
-  async getBlockNumberAtOrBefore(
-    timestamp: UnixTime,
-    start = 1,
-  ): Promise<number> {
+  async getBlockNumberAtOrBefore(timestamp: UnixTime): Promise<number> {
     return await this.withClient(async (client) => {
-      const end = await client.getLatestBlockNumber()
-      const effectiveStart = start >= end ? 1 : start
+      const known = new Map<number, BlockHeader>()
+      const getHeader = async (x: number | 'latest') => {
+        const cached = x !== 'latest' ? known.get(x) : undefined
+        if (cached) return cached
+        const header = await getBlockHeader(client, x)
+        known.set(header.number, header)
+        return header
+      }
+
+      const latest = await getHeader('latest')
+      if (timestamp >= latest.timestamp) return latest.number
 
       return await getBlockNumberAtOrBefore(
         timestamp,
-        effectiveStart,
-        end,
-        (number: number) => client.getBlockWithTransactions(number),
+        1,
+        latest.number,
+        getHeader,
       )
     })
   }


### PR DESCRIPTION
## Summary
- Consumers ask for increasing hourly timestamps, but every search started from block 1, where interpolation is poor (early block times are irregular): ~8–12 probes per hourly tick per chain.
- The provider remembers the last found header and uses it as the lower bound whenever it is not after the requested timestamp; interpolating between an hour-old block and `latest` converges in ~2–3 probes. Stacked on #12677.

## Testing
- Two new tests: the seed is used for a later timestamp and ignored for an earlier one (417 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
