### PR TITLE
Add block observers to block sync

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -48,6 +48,7 @@ export class Application {
       providers,
       db,
       blockProcessors: [],
+      blockObservers: [],
     }
 
     // Modules with TRPC

--- a/packages/backend/src/modules/block-sync/BlockIndexer.test.ts
+++ b/packages/backend/src/modules/block-sync/BlockIndexer.test.ts
@@ -106,6 +106,46 @@ describe(BlockIndexer.name, () => {
       expect(processBlock).toHaveBeenCalledWith(block2, [log2])
     })
 
+    it('passes consistent blocks to observers and survives their failures', async () => {
+      const block1 = makeBlock(10, 1_000)
+      const block2 = makeBlock(11, 2_000)
+      const observe = mockFn()
+        .rejectsWithOnce(new Error('observer error'))
+        .resolvesTo(undefined)
+      const processBlock = mockFn().resolvesTo(undefined)
+
+      const indexer = createIndexer({
+        blockProvider: mockObject<BlockProvider>({
+          getBlockWithTransactions: mockFn()
+            .resolvesToOnce(block1)
+            .resolvesToOnce(block2),
+        }),
+        logsProvider: mockObject<LogsProvider>({
+          getLogs: mockFn().resolvesTo([
+            makeLog(block1, 1),
+            makeLog(block2, 2),
+          ]),
+        }),
+        blockProcessors: [
+          mockObject<BlockProcessor>({ chain: 'ethereum', processBlock }),
+        ],
+        blockObservers: [
+          mockObject<BlockProcessor>({
+            chain: 'ethereum',
+            processBlock: observe,
+          }),
+        ],
+      })
+
+      const result = await indexer.update(10, 11)
+
+      expect(result).toEqual(11)
+      expect(observe).toHaveBeenCalledTimes(2)
+      expect(observe).toHaveBeenNthCalledWith(1, block1, [makeLog(block1, 1)])
+      expect(observe).toHaveBeenNthCalledWith(2, block2, [makeLog(block2, 2)])
+      expect(processBlock).toHaveBeenCalledTimes(2)
+    })
+
     it('throws without processing when first block exceeds configured timestamp', async () => {
       const block = makeBlock(10, 3_000)
       const log = makeLog(block, 1)
@@ -145,6 +185,7 @@ function createIndexer(overrides: Partial<BlockIndexerDeps> = {}) {
       getLogs: mockFn().resolvesTo([]),
     }),
     blockProcessors: [],
+    blockObservers: [],
     stopBlockIndexerAtTimestampMs: undefined,
     batchSize: 50,
     minHeight: 1,

--- a/packages/backend/src/modules/block-sync/BlockIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockIndexer.ts
@@ -15,6 +15,8 @@ export interface BlockIndexerDeps
   blockProvider: BlockProvider
   logsProvider: LogsProvider
   blockProcessors: BlockProcessor[]
+  /** Cheap listeners that only get the block; failures are logged, nothing else */
+  blockObservers: BlockProcessor[]
   stopBlockIndexerAtTimestampMs?: number
   /** The number of blocks/days to process at once. In case of error this is the maximum amount of blocks/days we will need to refetch */
   batchSize: number
@@ -119,6 +121,17 @@ export class BlockIndexer extends ManagedChildIndexer {
           )
         }
         break
+      }
+
+      for (const observer of this.$.blockObservers) {
+        try {
+          await observer.processBlock(block, logs)
+        } catch (error) {
+          this.logger.error('Observer failed', {
+            blockNumber: block.number,
+            error,
+          })
+        }
       }
 
       for (const processor of this.$.blockProcessors) {

--- a/packages/backend/src/modules/block-sync/BlockSyncModule.ts
+++ b/packages/backend/src/modules/block-sync/BlockSyncModule.ts
@@ -12,6 +12,7 @@ export function createBlockSyncModule({
   db,
   providers,
   blockProcessors,
+  blockObservers,
 }: ModuleDependencies): ApplicationModule | undefined {
   if (blockProcessors.length === 0) {
     // This module is special in that it is only created if other modules
@@ -53,6 +54,7 @@ export function createBlockSyncModule({
         minHeight: 1,
         parents: [blockNumberIndexer],
         blockProcessors: blockProcessors.filter((x) => x.chain === chain),
+        blockObservers: blockObservers.filter((x) => x.chain === chain),
         source: chain,
         blockProvider: providers.block.getBlockProvider(chain),
         logsProvider: providers.logs.getLogsProvider(chain),

--- a/packages/backend/src/modules/types.ts
+++ b/packages/backend/src/modules/types.ts
@@ -28,6 +28,8 @@ export interface ModuleDependencies {
   providers: Providers
   db: Database
   blockProcessors: BlockProcessor[]
+  /** Receive blocks of chains synced for blockProcessors without causing any chain to be synced */
+  blockObservers: BlockProcessor[]
 }
 
 export interface BlockProcessor {


### PR DESCRIPTION
## Summary
- `ModuleDependencies.blockObservers`: `BlockProcessor`-shaped listeners that receive the consistent blocks of the chains block sync already fetches for its processors. They never cause a chain to be synced (chains still come from `blockProcessors` only) and run in a silent loop: no per-block "Processor finished" log line, failures are logged and skipped.
- Nothing registers an observer yet; the activity module will, to stop re-downloading blocks that block sync already has. Independent of the `getBlockHeader` stack.

## Testing
- `BlockIndexer` test: observers get the consistent blocks with their logs, an observer error does not stop processing
- `packages/backend`: typecheck, lint, tests (1350 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
