### PR TITLE
Add ActivityBlockCache

### DIFF
--- a/packages/backend/src/providers/ActivityBlockCache.test.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.test.ts
@@ -1,0 +1,42 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { ActivityBlockCache } from './ActivityBlockCache'
+
+describe(ActivityBlockCache.name, () => {
+  it('returns stored blocks and undefined for unknown ones', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(10, 5))
+
+    expect(cache.get(10)).toEqual(block(10, 5))
+    expect(cache.get(11)).toEqual(undefined)
+  })
+
+  it('keeps a null uops count', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(10, null))
+
+    expect(cache.get(10)).toEqual(block(10, null))
+  })
+
+  it('evicts the older block sharing a slot', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(1, 1))
+    cache.set(block(5, 2))
+
+    expect(cache.get(1)).toEqual(undefined)
+    expect(cache.get(5)).toEqual(block(5, 2))
+  })
+
+  it('is empty before anything is stored', () => {
+    expect(new ActivityBlockCache(4).get(0)).toEqual(undefined)
+  })
+})
+
+function block(number: number, uopsCount: number | null) {
+  return {
+    number,
+    timestamp: UnixTime(1_700_000_000 + number),
+    txsCount: number * 2,
+    uopsCount,
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockCache.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.ts
@@ -1,0 +1,50 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { ActivityBlock } from '../modules/activity/services/txs/types'
+
+const DEFAULT_CAPACITY = 100_000
+
+interface Slots {
+  numbers: Float64Array
+  timestamps: Float64Array
+  txsCounts: Int32Array
+  uopsCounts: Int32Array
+}
+
+/**
+ * Summaries of the newest blocks of a chain, stored in typed arrays so that
+ * the default capacity costs ~2.4 MB. A block lives in the slot
+ * `number % capacity`; a newer block landing in the same slot evicts it.
+ */
+export class ActivityBlockCache {
+  private slots: Slots | undefined
+
+  constructor(private readonly capacity = DEFAULT_CAPACITY) {}
+
+  set(block: ActivityBlock) {
+    this.slots ??= {
+      numbers: new Float64Array(this.capacity).fill(-1),
+      timestamps: new Float64Array(this.capacity),
+      txsCounts: new Int32Array(this.capacity),
+      uopsCounts: new Int32Array(this.capacity),
+    }
+
+    const slot = block.number % this.capacity
+    this.slots.numbers[slot] = block.number
+    this.slots.timestamps[slot] = block.timestamp
+    this.slots.txsCounts[slot] = block.txsCount
+    this.slots.uopsCounts[slot] = block.uopsCount ?? -1
+  }
+
+  get(number: number): ActivityBlock | undefined {
+    const slot = number % this.capacity
+    if (!this.slots || this.slots.numbers[slot] !== number) return undefined
+
+    const uopsCount = this.slots.uopsCounts[slot]
+    return {
+      number,
+      timestamp: UnixTime(this.slots.timestamps[slot]),
+      txsCount: this.slots.txsCounts[slot],
+      uopsCount: uopsCount === -1 ? null : uopsCount,
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Per-chain ring of activity summaries (`number`, `timestamp`, `txsCount`, `uopsCount`) keyed by `number % capacity`, kept in typed arrays: 100k slots ≈ 2.4 MB, allocated lazily on the first write.
- Not used yet; the next PR fills it from block sync and reads it before the RPC. Stacked on #12679.

## Testing
- Unit tests: roundtrip, null uops count, slot eviction, empty cache (1354 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
