### PR TITLE
Reuse block sync blocks for activity counting

### DIFF
--- a/packages/backend/src/Application.ts
+++ b/packages/backend/src/Application.ts
@@ -48,6 +48,7 @@ export class Application {
       providers,
       db,
       blockProcessors: [],
+      blockObservers: [],
     }
 
     // Modules with TRPC

--- a/packages/backend/src/modules/activity/ActivityModule.ts
+++ b/packages/backend/src/modules/activity/ActivityModule.ts
@@ -18,6 +18,7 @@ export function initActivityModule({
   db: database,
   clock,
   providers,
+  blockObservers,
 }: ModuleDependencies): ApplicationModule | undefined {
   if (!config.activity) {
     logger.info('Activity module disabled')
@@ -58,6 +59,12 @@ export function initActivityModule({
         )
 
         const provider = providers.activityBlock.getProvider(project.chainName)
+        if (
+          provider.blockObserver &&
+          !blockObservers.includes(provider.blockObserver)
+        ) {
+          blockObservers.push(provider.blockObserver)
+        }
         const txsCountService = new BlockTxsCountService(
           {
             provider,

--- a/packages/backend/src/modules/activity/services/txs/types.ts
+++ b/packages/backend/src/modules/activity/services/txs/types.ts
@@ -1,4 +1,5 @@
 import type { UnixTime } from '@l2beat/shared-pure'
+import type { BlockProcessor } from '../../../types'
 
 export interface ActivityBlock {
   number: number
@@ -11,4 +12,6 @@ export interface ActivityBlockProvider {
   chain: string
   /** Returns blocks in ascending block-number order. */
   getBlocks(from: number, to: number): Promise<ActivityBlock[]>
+  /** Lets the provider reuse blocks that block sync fetches anyway. */
+  blockObserver?: BlockProcessor
 }

--- a/packages/backend/src/modules/block-sync/BlockIndexer.test.ts
+++ b/packages/backend/src/modules/block-sync/BlockIndexer.test.ts
@@ -106,6 +106,46 @@ describe(BlockIndexer.name, () => {
       expect(processBlock).toHaveBeenCalledWith(block2, [log2])
     })
 
+    it('passes consistent blocks to observers and survives their failures', async () => {
+      const block1 = makeBlock(10, 1_000)
+      const block2 = makeBlock(11, 2_000)
+      const observe = mockFn()
+        .rejectsWithOnce(new Error('observer error'))
+        .resolvesTo(undefined)
+      const processBlock = mockFn().resolvesTo(undefined)
+
+      const indexer = createIndexer({
+        blockProvider: mockObject<BlockProvider>({
+          getBlockWithTransactions: mockFn()
+            .resolvesToOnce(block1)
+            .resolvesToOnce(block2),
+        }),
+        logsProvider: mockObject<LogsProvider>({
+          getLogs: mockFn().resolvesTo([
+            makeLog(block1, 1),
+            makeLog(block2, 2),
+          ]),
+        }),
+        blockProcessors: [
+          mockObject<BlockProcessor>({ chain: 'ethereum', processBlock }),
+        ],
+        blockObservers: [
+          mockObject<BlockProcessor>({
+            chain: 'ethereum',
+            processBlock: observe,
+          }),
+        ],
+      })
+
+      const result = await indexer.update(10, 11)
+
+      expect(result).toEqual(11)
+      expect(observe).toHaveBeenCalledTimes(2)
+      expect(observe).toHaveBeenNthCalledWith(1, block1, [makeLog(block1, 1)])
+      expect(observe).toHaveBeenNthCalledWith(2, block2, [makeLog(block2, 2)])
+      expect(processBlock).toHaveBeenCalledTimes(2)
+    })
+
     it('throws without processing when first block exceeds configured timestamp', async () => {
       const block = makeBlock(10, 3_000)
       const log = makeLog(block, 1)
@@ -145,6 +185,7 @@ function createIndexer(overrides: Partial<BlockIndexerDeps> = {}) {
       getLogs: mockFn().resolvesTo([]),
     }),
     blockProcessors: [],
+    blockObservers: [],
     stopBlockIndexerAtTimestampMs: undefined,
     batchSize: 50,
     minHeight: 1,

--- a/packages/backend/src/modules/block-sync/BlockIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockIndexer.ts
@@ -15,6 +15,8 @@ export interface BlockIndexerDeps
   blockProvider: BlockProvider
   logsProvider: LogsProvider
   blockProcessors: BlockProcessor[]
+  /** Cheap listeners that only get the block; failures are logged, nothing else */
+  blockObservers: BlockProcessor[]
   stopBlockIndexerAtTimestampMs?: number
   /** The number of blocks/days to process at once. In case of error this is the maximum amount of blocks/days we will need to refetch */
   batchSize: number
@@ -119,6 +121,17 @@ export class BlockIndexer extends ManagedChildIndexer {
           )
         }
         break
+      }
+
+      for (const observer of this.$.blockObservers) {
+        try {
+          await observer.processBlock(block, logs)
+        } catch (error) {
+          this.logger.error('Observer failed', {
+            blockNumber: block.number,
+            error,
+          })
+        }
       }
 
       for (const processor of this.$.blockProcessors) {

--- a/packages/backend/src/modules/block-sync/BlockSyncModule.ts
+++ b/packages/backend/src/modules/block-sync/BlockSyncModule.ts
@@ -12,6 +12,7 @@ export function createBlockSyncModule({
   db,
   providers,
   blockProcessors,
+  blockObservers,
 }: ModuleDependencies): ApplicationModule | undefined {
   if (blockProcessors.length === 0) {
     // This module is special in that it is only created if other modules
@@ -53,6 +54,7 @@ export function createBlockSyncModule({
         minHeight: 1,
         parents: [blockNumberIndexer],
         blockProcessors: blockProcessors.filter((x) => x.chain === chain),
+        blockObservers: blockObservers.filter((x) => x.chain === chain),
         source: chain,
         blockProvider: providers.block.getBlockProvider(chain),
         logsProvider: providers.logs.getLogsProvider(chain),

--- a/packages/backend/src/modules/types.ts
+++ b/packages/backend/src/modules/types.ts
@@ -28,6 +28,8 @@ export interface ModuleDependencies {
   providers: Providers
   db: Database
   blockProcessors: BlockProcessor[]
+  /** Receive blocks of chains synced for blockProcessors without causing any chain to be synced */
+  blockObservers: BlockProcessor[]
 }
 
 export interface BlockProcessor {

--- a/packages/backend/src/providers/ActivityBlockCache.test.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.test.ts
@@ -1,0 +1,42 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { ActivityBlockCache } from './ActivityBlockCache'
+
+describe(ActivityBlockCache.name, () => {
+  it('returns stored blocks and undefined for unknown ones', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(10, 5))
+
+    expect(cache.get(10)).toEqual(block(10, 5))
+    expect(cache.get(11)).toEqual(undefined)
+  })
+
+  it('keeps a null uops count', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(10, null))
+
+    expect(cache.get(10)).toEqual(block(10, null))
+  })
+
+  it('evicts the older block sharing a slot', () => {
+    const cache = new ActivityBlockCache(4)
+    cache.set(block(1, 1))
+    cache.set(block(5, 2))
+
+    expect(cache.get(1)).toEqual(undefined)
+    expect(cache.get(5)).toEqual(block(5, 2))
+  })
+
+  it('is empty before anything is stored', () => {
+    expect(new ActivityBlockCache(4).get(0)).toEqual(undefined)
+  })
+})
+
+function block(number: number, uopsCount: number | null) {
+  return {
+    number,
+    timestamp: UnixTime(1_700_000_000 + number),
+    txsCount: number * 2,
+    uopsCount,
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockCache.ts
+++ b/packages/backend/src/providers/ActivityBlockCache.ts
@@ -1,0 +1,50 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { ActivityBlock } from '../modules/activity/services/txs/types'
+
+const DEFAULT_CAPACITY = 100_000
+
+interface Slots {
+  numbers: Float64Array
+  timestamps: Float64Array
+  txsCounts: Int32Array
+  uopsCounts: Int32Array
+}
+
+/**
+ * Summaries of the newest blocks of a chain, stored in typed arrays so that
+ * the default capacity costs ~2.4 MB. A block lives in the slot
+ * `number % capacity`; a newer block landing in the same slot evicts it.
+ */
+export class ActivityBlockCache {
+  private slots: Slots | undefined
+
+  constructor(private readonly capacity = DEFAULT_CAPACITY) {}
+
+  set(block: ActivityBlock) {
+    this.slots ??= {
+      numbers: new Float64Array(this.capacity).fill(-1),
+      timestamps: new Float64Array(this.capacity),
+      txsCounts: new Int32Array(this.capacity),
+      uopsCounts: new Int32Array(this.capacity),
+    }
+
+    const slot = block.number % this.capacity
+    this.slots.numbers[slot] = block.number
+    this.slots.timestamps[slot] = block.timestamp
+    this.slots.txsCounts[slot] = block.txsCount
+    this.slots.uopsCounts[slot] = block.uopsCount ?? -1
+  }
+
+  get(number: number): ActivityBlock | undefined {
+    const slot = number % this.capacity
+    if (!this.slots || this.slots.numbers[slot] !== number) return undefined
+
+    const uopsCount = this.slots.uopsCounts[slot]
+    return {
+      number,
+      timestamp: UnixTime(this.slots.timestamps[slot]),
+      txsCount: this.slots.txsCounts[slot],
+      uopsCount: uopsCount === -1 ? null : uopsCount,
+    }
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockProviders.test.ts
+++ b/packages/backend/src/providers/ActivityBlockProviders.test.ts
@@ -1,5 +1,5 @@
 import type { AztecBlockProvider, BlockProvider } from '@l2beat/shared'
-import { UnixTime } from '@l2beat/shared-pure'
+import { type Block, UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
 import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
 import {
@@ -66,6 +66,40 @@ describe(StandardActivityBlockProvider.name, () => {
       },
     ])
   })
+
+  it('serves blocks seen by the block observer without fetching them', async () => {
+    const blockProvider = mockObject<BlockProvider>({
+      chain: 'ethereum',
+      getBlockWithTransactions: mockFn().resolvesToOnce(block(11, 1)),
+    })
+    const uopsAnalyzer = mockObject<UopsAnalyzer>({
+      calculateUops: (block: Block) => block.transactions.length * 2,
+    })
+    const provider = new StandardActivityBlockProvider(
+      blockProvider,
+      uopsAnalyzer,
+    )
+
+    await provider.blockObserver.processBlock(block(10, 3), [])
+    const result = await provider.getBlocks(10, 11)
+
+    expect(provider.blockObserver.chain).toEqual('ethereum')
+    expect(blockProvider.getBlockWithTransactions).toHaveBeenOnlyCalledWith(11)
+    expect(result).toEqual([
+      {
+        number: 10,
+        timestamp: UnixTime(1_700_000_010),
+        txsCount: 3,
+        uopsCount: 6,
+      },
+      {
+        number: 11,
+        timestamp: UnixTime(1_700_000_011),
+        txsCount: 1,
+        uopsCount: 2,
+      },
+    ])
+  })
 })
 
 describe(AztecActivityBlockProvider.name, () => {
@@ -98,3 +132,13 @@ describe(AztecActivityBlockProvider.name, () => {
     ])
   })
 })
+
+function block(number: number, txsCount: number): Block {
+  return {
+    number,
+    hash: `0x${number}`,
+    logsBloom: '0x',
+    timestamp: UnixTime(1_700_000_000 + number),
+    transactions: Array.from({ length: txsCount }, () => ({})),
+  }
+}

--- a/packages/backend/src/providers/ActivityBlockProviders.ts
+++ b/packages/backend/src/providers/ActivityBlockProviders.ts
@@ -1,11 +1,13 @@
 import type { AztecBlockProvider, BlockProvider } from '@l2beat/shared'
-import { assert } from '@l2beat/shared-pure'
+import { assert, type Block } from '@l2beat/shared-pure'
 import range from 'lodash/range'
 import type {
   ActivityBlock,
   ActivityBlockProvider,
 } from '../modules/activity/services/txs/types'
 import type { UopsAnalyzer } from '../modules/activity/services/uops/types'
+import type { BlockProcessor } from '../modules/types'
+import { ActivityBlockCache } from './ActivityBlockCache'
 import type { AztecBlockProviders } from './AztecBlockProviders'
 import type { BlockProviders } from './BlockProviders'
 import type { UopsAnalyzers } from './UopsAnalyzers'
@@ -47,10 +49,22 @@ export class ActivityBlockProviders {
 }
 
 export class StandardActivityBlockProvider implements ActivityBlockProvider {
+  private readonly cache = new ActivityBlockCache()
+  /** Blocks that block sync already fetched are summarized here instead of being fetched again */
+  readonly blockObserver: BlockProcessor
+
   constructor(
     private readonly provider: BlockProvider,
     private readonly uopsAnalyzer: UopsAnalyzer | undefined,
-  ) {}
+  ) {
+    this.blockObserver = {
+      chain: provider.chain,
+      processBlock: (block) => {
+        this.cache.set(this.toActivityBlock(block))
+        return Promise.resolve()
+      },
+    }
+  }
 
   get chain(): string {
     return this.provider.chain
@@ -58,16 +72,23 @@ export class StandardActivityBlockProvider implements ActivityBlockProvider {
 
   async getBlocks(from: number, to: number): Promise<ActivityBlock[]> {
     return await Promise.all(
-      range(from, to + 1).map(async (number) => {
-        const block = await this.provider.getBlockWithTransactions(number)
-        return {
-          number: block.number,
-          timestamp: block.timestamp,
-          txsCount: block.transactions.length,
-          uopsCount: this.uopsAnalyzer?.calculateUops(block) ?? null,
-        }
-      }),
+      range(from, to + 1).map(
+        async (number) =>
+          this.cache.get(number) ??
+          this.toActivityBlock(
+            await this.provider.getBlockWithTransactions(number),
+          ),
+      ),
     )
+  }
+
+  private toActivityBlock(block: Block): ActivityBlock {
+    return {
+      number: block.number,
+      timestamp: block.timestamp,
+      txsCount: block.transactions.length,
+      uopsCount: this.uopsAnalyzer?.calculateUops(block) ?? null,
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- `activity.count` is 56% of backend `eth_getBlockByNumber` usage (4.8M/day). 15 chains (robinhood, arbitrum, abstract, katana, unichain, celo, ink, megaeth, polygonpos, optimism, worldchain, base, gnosis, zksync2, ethereum) run both block sync and block-mode activity, so ~2M blocks/day were downloaded twice.
- Three commits: `ModuleDependencies.blockObservers` (listeners that get the consistent blocks of chains block sync already fetches, never cause a chain to be synced, run in a silent loop with no per-block log line, failures logged and skipped); `ActivityBlockCache` (per-chain ring of `number, timestamp, txsCount, uopsCount` in typed arrays, 100k slots ≈ 2.4 MB, allocated lazily); `StandardActivityBlockProvider` exposes a `blockObserver` that the activity module registers for every chain with block-mode activity, and `getBlocks` reads the cache before fetching.
- Block sync runs ~5 min behind the tip and activity up to an hour, so in steady state activity finds its blocks cached; right after a restart the pre-restart backlog still hits the RPC. Activity on these chains now inherits block sync's 5-minute-deep chain view instead of its own hour-old fetch.
- Expected: −2M calls/day. Standalone: independent of the `getBlockHeader` PRs.

## Testing
- `BlockIndexer` test: observers get the consistent blocks with their logs, an observer error does not stop processing
- `ActivityBlockCache` tests: roundtrip, null uops count, slot eviction, empty cache
- Provider test: a block seen by the observer is served without a fetch, a miss is fetched, uops are computed the same way
- `packages/backend`: typecheck, lint, tests (1355 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
