### PR TITLE
Prepare liveness grouping for the 'none' sentinel

### DIFF
--- a/packages/database/prisma/migrations/20260827130000_create_liveness_grouping_index_excluding_none/migration.sql
+++ b/packages/database/prisma/migrations/20260827130000_create_liveness_grouping_index_excluding_none/migration.sql
@@ -1,0 +1,8 @@
+-- Keep this as a single statement so PostgreSQL can build the index
+-- concurrently, outside an implicit multi-statement transaction.
+-- Replaces the IS NOT NULL grouping index: ungrouped records are about to
+-- receive the 'none' sentinel and must stay out of the unique grouping
+-- constraint.
+CREATE UNIQUE INDEX CONCURRENTLY "Liveness_configurationId_groupingKey_idx"
+ON "Liveness"("configurationId", "groupingKey")
+WHERE "groupingKey" <> 'none';

--- a/packages/database/prisma/migrations/20260827130000_create_liveness_grouping_index_excluding_none/migration.sql
+++ b/packages/database/prisma/migrations/20260827130000_create_liveness_grouping_index_excluding_none/migration.sql
@@ -5,4 +5,4 @@
 -- constraint.
 CREATE UNIQUE INDEX CONCURRENTLY "Liveness_configurationId_groupingKey_idx"
 ON "Liveness"("configurationId", "groupingKey")
-WHERE "groupingKey" <> 'none';
+WHERE "groupingKey" != 'none';

--- a/packages/database/src/repositories/LivenessRepository.test.ts
+++ b/packages/database/src/repositories/LivenessRepository.test.ts
@@ -9,7 +9,7 @@ import {
 } from './LivenessRepository'
 
 describe(toRecord.name, () => {
-  it('maps a null grouping key to undefined', () => {
+  it('maps the ungrouped sentinel to undefined', () => {
     const timestamp = UnixTime(1)
 
     expect(
@@ -18,7 +18,7 @@ describe(toRecord.name, () => {
         blockNumber: 1,
         txHash: '0x1234',
         configurationId: 'config-id',
-        groupingKey: null,
+        groupingKey: 'none',
       }),
     ).toEqual({
       timestamp,

--- a/packages/database/src/repositories/LivenessRepository.ts
+++ b/packages/database/src/repositories/LivenessRepository.ts
@@ -6,6 +6,7 @@ import type { Liveness } from '../kysely/generated/types'
 import {
   insertGroupedKeepingEarliest,
   splitLivenessRecords,
+  UNGROUPED_GROUPING_KEY,
 } from './utils/livenessGrouping'
 
 export interface LivenessRecord {
@@ -19,15 +20,23 @@ export interface LivenessRecord {
 export function toRecord(row: Selectable<Liveness>): LivenessRecord {
   return {
     ...row,
-    groupingKey: row.groupingKey ?? undefined,
+    // NULL appears only on schemas from before the 'none' sentinel migrations.
+    groupingKey:
+      row.groupingKey === UNGROUPED_GROUPING_KEY
+        ? undefined
+        : (row.groupingKey ?? undefined),
     timestamp: UnixTime.fromDate(row.timestamp),
   }
 }
 
 export function toRow(record: LivenessRecord): Insertable<Liveness> {
+  const { groupingKey, ...rest } = record
   return {
-    ...record,
-    groupingKey: record.groupingKey ?? null,
+    ...rest,
+    // Omitted for ungrouped records so the column default decides the stored
+    // value; this keeps the code compatible with schemas before and after the
+    // 'none' sentinel migrations.
+    ...(groupingKey === undefined ? {} : { groupingKey }),
     timestamp: UnixTime.toDate(record.timestamp),
   }
 }

--- a/packages/database/src/repositories/utils/livenessGrouping.ts
+++ b/packages/database/src/repositories/utils/livenessGrouping.ts
@@ -63,7 +63,7 @@ export async function insertGroupedKeepingEarliest(
       // The conflict target must match each table's partial grouping index.
       const guarded =
         table === 'Liveness'
-          ? target.where('groupingKey', '<>', UNGROUPED_GROUPING_KEY)
+          ? target.where('groupingKey', '!=', UNGROUPED_GROUPING_KEY)
           : target.where('groupingKey', 'is not', null)
       return guarded
         .doUpdateSet((eb) => ({

--- a/packages/database/src/repositories/utils/livenessGrouping.ts
+++ b/packages/database/src/repositories/utils/livenessGrouping.ts
@@ -4,6 +4,12 @@ import type { Liveness, RealTimeLiveness } from '../../kysely/generated/types'
 
 type LivenessTable = 'Liveness' | 'RealTimeLiveness'
 
+/**
+ * Marks ungrouped Liveness rows; keeps the column non-null so it can be part
+ * of the primary key. RealTimeLiveness keeps a nullable column instead.
+ */
+export const UNGROUPED_GROUPING_KEY = 'none'
+
 interface LivenessLikeRecord {
   configurationId: string
   timestamp: number
@@ -52,17 +58,21 @@ export async function insertGroupedKeepingEarliest(
   await db
     .insertInto(table)
     .values(rows)
-    .onConflict((cb) =>
-      cb
-        .columns(['configurationId', 'groupingKey'])
-        .where('groupingKey', 'is not', null)
+    .onConflict((cb) => {
+      const target = cb.columns(['configurationId', 'groupingKey'])
+      // The conflict target must match each table's partial grouping index.
+      const guarded =
+        table === 'Liveness'
+          ? target.where('groupingKey', '<>', UNGROUPED_GROUPING_KEY)
+          : target.where('groupingKey', 'is not', null)
+      return guarded
         .doUpdateSet((eb) => ({
           timestamp: eb.ref('excluded.timestamp'),
           blockNumber: eb.ref('excluded.blockNumber'),
           txHash: eb.ref('excluded.txHash'),
         }))
-        .where(isEarlierThanStored(table)),
-    )
+        .where(isEarlierThanStored(table))
+    })
     .execute()
 }
 


### PR DESCRIPTION
## Stack

1. #12691 — backend dedupe for multi-call transactions
2. 👉 **this PR** — database transition for the `'none'` sentinel
3. #12696 — liveness primary key per grouping key (stacked on this PR)

## Why

One Ethereum transaction can now prove several Aztec epochs (see #12691 for the full story). To store one liveness record per epoch, the follow-up PR changes the `Liveness` primary key to `(configurationId, txHash, groupingKey)`, with `'none'` marking ungrouped records. This PR makes the database package work with **both** the current and the future schema, so the migration later deploys with no failure window.

## Changes

- New partial unique grouping index `(configurationId, groupingKey) WHERE groupingKey <> 'none'`, built `CONCURRENTLY`. Today it is functionally identical to the existing `IS NOT NULL` index; it is the only one that can survive the sentinel backfill.
- Ungrouped inserts **omit** `groupingKey` entirely, letting the column default decide the stored value: `NULL` on today's schema, `'none'` after the follow-up migrations.
- Reads map both `NULL` and `'none'` to `undefined` — the public `LivenessRecord` is unchanged for all consumers.
- The grouped upsert's `ON CONFLICT` target becomes `groupingKey <> 'none'`, verified against PostgreSQL to match **both** the old and the new index (`x <> 'none'` implies `x IS NOT NULL`).
- `RealTimeLiveness` deliberately keeps the nullable convention (its writer only inspects top-level calldata and cannot produce multi-epoch records), hence the per-table conflict target in `livenessGrouping.ts`.

## Deploy notes

- Stacked on #12691 (stack #12697) — merges after it.
- Must be **deployed** before the follow-up PR's migrations run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
