### PR TITLE
Store liveness per grouping key ('none' sentinel in the primary key)

### DIFF
--- a/packages/database/prisma/migrations/20260827130001_liveness_grouping_key_sentinel/migration.sql
+++ b/packages/database/prisma/migrations/20260827130001_liveness_grouping_key_sentinel/migration.sql
@@ -1,0 +1,14 @@
+-- The old grouping index treats every non-null value as grouped, so it must
+-- be gone before ungrouped records receive the 'none' sentinel; otherwise the
+-- backfill below would violate its uniqueness. Its replacement (previous
+-- migration) excludes 'none'.
+DROP INDEX "Liveness_configurationId_groupingKey_key";
+
+-- Rewrites every previously ungrouped row (~15.6M in production).
+UPDATE "Liveness"
+SET "groupingKey" = 'none'
+WHERE "groupingKey" IS NULL;
+
+ALTER TABLE "Liveness"
+ALTER COLUMN "groupingKey" SET NOT NULL,
+ALTER COLUMN "groupingKey" SET DEFAULT 'none';

--- a/packages/database/prisma/migrations/20260827130002_create_liveness_primary_key_index/migration.sql
+++ b/packages/database/prisma/migrations/20260827130002_create_liveness_primary_key_index/migration.sql
@@ -1,0 +1,5 @@
+-- Keep this as a single statement so PostgreSQL can build the replacement
+-- primary-key index concurrently, outside an implicit multi-statement
+-- transaction.
+CREATE UNIQUE INDEX CONCURRENTLY "Liveness_new_pkey"
+ON "Liveness"("configurationId", "txHash", "groupingKey");

--- a/packages/database/prisma/migrations/20260827130003_replace_liveness_primary_key/migration.sql
+++ b/packages/database/prisma/migrations/20260827130003_replace_liveness_primary_key/migration.sql
@@ -1,0 +1,6 @@
+-- The replacement index was built concurrently; attaching it as the primary
+-- key only takes the brief lock needed to swap the constraint. One
+-- transaction can now store a record per grouping key.
+ALTER TABLE "Liveness"
+DROP CONSTRAINT "Liveness_pkey",
+ADD CONSTRAINT "Liveness_pkey" PRIMARY KEY USING INDEX "Liveness_new_pkey";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -116,10 +116,13 @@ model Liveness {
   blockNumber     Int
   txHash          String   @db.VarChar(255)
   configurationId String   @db.VarChar(12)
-  // Partial unique grouping index: migration 20260723120001.
-  groupingKey     String?  @db.VarChar(255)
+  // 'none' marks ungrouped records; the sentinel keeps the column non-null so
+  // it can be part of the primary key and one transaction can store a record
+  // per grouping key. Partial unique grouping index (excluding 'none'):
+  // migration 20260827130000.
+  groupingKey     String   @default("none") @db.VarChar(255)
 
-  @@id([configurationId, txHash])
+  @@id([configurationId, txHash, groupingKey])
   @@index([configurationId, timestamp])
 }
 

--- a/packages/database/src/repositories/LivenessRepository.test.ts
+++ b/packages/database/src/repositories/LivenessRepository.test.ts
@@ -169,6 +169,36 @@ describeDatabase(LivenessRepository.name, (db) => {
       expect(results).toEqualUnsorted([...DATA, earlier])
     })
 
+    it('stores a record per grouping key for one transaction', async () => {
+      const sharedTx = {
+        timestamp: START - 4 * UnixTime.MINUTE,
+        blockNumber: 20,
+        txHash: '0xgrouped-multicall',
+        configurationId: txIdA,
+      }
+      const grouped = [
+        { ...sharedTx, groupingKey: 'epoch-1' },
+        { ...sharedTx, groupingKey: 'epoch-2' },
+      ]
+
+      await repository.insertMany(grouped)
+
+      const results = await repository.getAll()
+      expect(results).toEqualUnsorted([...DATA, ...grouped])
+    })
+
+    it('rejects the same ungrouped transaction twice', async () => {
+      const record = {
+        timestamp: START - 4 * UnixTime.MINUTE,
+        blockNumber: 20,
+        txHash: '0xungrouped-duplicate',
+        configurationId: txIdA,
+        groupingKey: undefined,
+      }
+
+      await expect(repository.insertMany([record, record])).toBeRejected()
+    })
+
     it('big query', async () => {
       const records: LivenessRecord[] = []
       for (let i = 0; i < 15_000; i++) {


### PR DESCRIPTION
## Stack

1. #12691 — backend dedupe for multi-call transactions
2. #12695 — database transition for the `'none'` sentinel (**base of this PR**)
3. 👉 **this PR** — liveness primary key per grouping key

## Why

A wrapper transaction can prove two Aztec epochs at once (see #12691). Liveness must keep **both**: deduping to one record per transaction would silently lose an epoch, and if that epoch were later re-submitted by another transaction, it would be wrongly counted as a brand-new liveness event at the later timestamp. The database model must therefore be able to hold several grouped records for one transaction.

## Changes

- `Liveness.groupingKey` becomes `NOT NULL DEFAULT 'none'` (`'none'` = ungrouped record).
- Primary key becomes `(configurationId, txHash, groupingKey)` — one row per epoch per transaction, while ungrouped records keep their one-row-per-transaction identity via the sentinel.
- The partial grouping index from #12695 still enforces one earliest transaction per epoch *across* transactions — the two constraints guard different axes.
- Regression tests: one transaction stores a record per grouping key; the same ungrouped transaction twice is still rejected (inserts stay strict, no `ON CONFLICT DO NOTHING`).

## Migrations (order matters)

1. *(in #12695)* build the replacement grouping index excluding `'none'`, concurrently.
2. Drop the old `IS NOT NULL` grouping index **before** the backfill — otherwise ~15.6M `'none'` rows would enter it and violate uniqueness — then backfill `NULL → 'none'` and set `NOT NULL DEFAULT 'none'`.
3. Build the replacement primary-key index concurrently (single-statement migration, same pattern as the July grouping indexes).
4. Swap the primary key onto the pre-built index (brief lock).

## Deploy notes

- **Merge only after #12695 is deployed.** Its code omits/maps the sentinel; older code would violate `NOT NULL` and lose its `ON CONFLICT` arbiter.
- The backfill rewrites ~15.6M rows (minutes in production): Liveness reads/writes queue behind the lock, nothing errors. Expect table bloat until autovacuum catches up.
- Verified locally: full db suite on a freshly migrated database, plus a simulated production upgrade (pre-existing NULL + grouped rows → backfill → multi-epoch insert OK, duplicate ungrouped insert rejected).

Base is `liveness-grouping-transition`; retarget to `main` once #12695 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
