### PR TITLE
Bound Relay updates by time window instead of row count

### DIFF
--- a/packages/backend/src/config/Config.ts
+++ b/packages/backend/src/config/Config.ts
@@ -272,6 +272,11 @@ export interface InteropFeatureConfig {
     chains: { id: number; name: string }[]
     configIntervalMs: number
   }
+  relay: {
+    batchSize: number
+    maxRequestsPerUpdate: number
+    safeTimeOffset: number
+  }
   inMemoryEventCap: number
   oneSidedChains: string[]
 }

--- a/packages/backend/src/config/features/interop.ts
+++ b/packages/backend/src/config/features/interop.ts
@@ -98,6 +98,14 @@ export async function getInteropFeatureConfig(
         12 * 60 * 60 * 1000, // 12 hours
       ),
     },
+    relay: {
+      batchSize: env.integer('INTEROP_RELAY_BATCH_SIZE', 60),
+      maxRequestsPerUpdate: env.integer(
+        'INTEROP_RELAY_MAX_REQUESTS_PER_UPDATE',
+        10_000,
+      ),
+      safeTimeOffset: env.integer('INTEROP_RELAY_SAFE_TIME_OFFSET', 10),
+    },
     inMemoryEventCap: env.integer('INTEROP_EVENT_CAP', 500_000),
     oneSidedChains: [
       ...INTEROP_ONE_SIDED_CHAINS.filter((chain) =>

--- a/packages/backend/src/modules/interop/engine/InteropModule.ts
+++ b/packages/backend/src/modules/interop/engine/InteropModule.ts
@@ -217,11 +217,15 @@ export function createInteropModule({
   )
 
   const relayApiClient = new RelayApiClient(new HttpClient(), logger)
-  const relayRootIndexer = new RelayRootIndexer(logger)
+  const relayRootIndexer = new RelayRootIndexer(
+    logger,
+    config.interop.relay.safeTimeOffset,
+  )
   const relayIndexer = new RelayIndexer(
     config.interop.config.chains,
     configStore,
     config.interop.capture.chains.map((c) => c.id),
+    config.interop.relay,
     relayApiClient,
     db,
     eventStore,

--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.test.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.test.ts
@@ -1,0 +1,109 @@
+import { Logger } from '@l2beat/backend-tools'
+import type { Database } from '@l2beat/database'
+import { expect, mockFn, mockObject } from 'earl'
+import type { IndexerService } from '../../../../tools/uif/IndexerService'
+import { _TEST_ONLY_resetUniqueIds } from '../../../../tools/uif/ids'
+import type { InteropEventStore } from '../../engine/capture/InteropEventStore'
+import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
+import type { GetRequestsResponse, RelayApiClient } from './RelayApiClient'
+import { BATCH_SIZE, RelayIndexer, RelayRootIndexer } from './relay.indexer'
+
+const FROM = 1787583059
+
+describe(RelayIndexer.name, () => {
+  beforeEach(() => {
+    _TEST_ONLY_resetUniqueIds()
+  })
+
+  describe(RelayIndexer.prototype.update.name, () => {
+    it('fetches one batch window and advances by it', async () => {
+      const relayApiClient = clientReturning({ requests: [] })
+      const indexer = createIndexer(relayApiClient)
+
+      const syncedTo = await indexer.update(FROM, FROM + 10_000)
+
+      expect(relayApiClient.getAllRequests).toHaveBeenCalledWith({
+        startTimestamp: FROM,
+        endTimestamp: FROM + BATCH_SIZE + 1,
+        limit: 10_000,
+      })
+      expect(syncedTo).toEqual(FROM + BATCH_SIZE)
+    })
+
+    it('clamps the window to the target height', async () => {
+      const relayApiClient = clientReturning({ requests: [] })
+      const indexer = createIndexer(relayApiClient)
+
+      const syncedTo = await indexer.update(FROM, FROM + 5)
+
+      expect(relayApiClient.getAllRequests).toHaveBeenCalledWith({
+        startTimestamp: FROM,
+        endTimestamp: FROM + 6,
+        limit: 10_000,
+      })
+      expect(syncedTo).toEqual(FROM + 5)
+    })
+
+    it('advances through a second holding more entries than one page', async () => {
+      const relayApiClient = clientReturning({
+        requests: manyInSameSecond(619, '2026-08-24T14:50:59'),
+      })
+      const indexer = createIndexer(relayApiClient)
+
+      const syncedTo = await indexer.update(FROM, FROM + 10_000)
+
+      expect(syncedTo).toEqual(FROM + BATCH_SIZE)
+    })
+
+    it('advances when the window holds no entries at all', async () => {
+      const relayApiClient = clientReturning({ requests: [] })
+      const indexer = createIndexer(relayApiClient)
+
+      const syncedTo = await indexer.update(FROM, FROM + 10_000)
+
+      expect(syncedTo).toEqual(FROM + BATCH_SIZE)
+    })
+
+    it('throws when the window was not fully fetched', async () => {
+      const relayApiClient = clientReturning({
+        requests: manyInSameSecond(3, '2026-08-24T14:50:59'),
+        continuation: 'cursor-1',
+      })
+      const indexer = createIndexer(relayApiClient)
+
+      await expect(indexer.update(FROM, FROM + 10_000)).toBeRejectedWith(
+        'was not fully fetched',
+      )
+    })
+  })
+})
+
+function clientReturning(response: GetRequestsResponse) {
+  return mockObject<RelayApiClient>({
+    getAllRequests: mockFn().resolvesTo(response),
+  })
+}
+
+function manyInSameSecond(count: number, second: string) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `0x${i}`,
+    status: 'success',
+    data: {},
+    createdAt: `${second}.000Z`,
+    updatedAt: `${second}.${String(i % 1000).padStart(3, '0')}Z`,
+  }))
+}
+
+function createIndexer(relayApiClient: RelayApiClient) {
+  return new RelayIndexer(
+    [],
+    mockObject<InteropConfigStore>({ get: mockFn().returns(undefined) }),
+    ['ethereum'],
+    relayApiClient,
+    mockObject<Database>(),
+    mockObject<InteropEventStore>(),
+    new RelayRootIndexer(Logger.SILENT),
+    mockObject<IndexerService>(),
+    Logger.SILENT,
+  )
+}

--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.test.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.test.ts
@@ -1,14 +1,28 @@
 import { Logger } from '@l2beat/backend-tools'
 import type { Database } from '@l2beat/database'
+import { UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
 import type { IndexerService } from '../../../../tools/uif/IndexerService'
 import { _TEST_ONLY_resetUniqueIds } from '../../../../tools/uif/ids'
 import type { InteropEventStore } from '../../engine/capture/InteropEventStore'
 import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
 import type { GetRequestsResponse, RelayApiClient } from './RelayApiClient'
-import { BATCH_SIZE, RelayIndexer, RelayRootIndexer } from './relay.indexer'
+import {
+  BATCH_SIZE,
+  RelayIndexer,
+  RelayRootIndexer,
+  SAFE_TIME_OFFSET,
+} from './relay.indexer'
 
 const FROM = 1787583059
+
+describe(RelayRootIndexer.name, () => {
+  it('never targets a second that has not fully elapsed', async () => {
+    const target = await new RelayRootIndexer(Logger.SILENT).tick()
+
+    expect(UnixTime.now() - target).toBeGreaterThanOrEqual(SAFE_TIME_OFFSET)
+  })
+})
 
 describe(RelayIndexer.name, () => {
   beforeEach(() => {

--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.test.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.test.ts
@@ -7,18 +7,19 @@ import { _TEST_ONLY_resetUniqueIds } from '../../../../tools/uif/ids'
 import type { InteropEventStore } from '../../engine/capture/InteropEventStore'
 import type { InteropConfigStore } from '../../engine/config/InteropConfigStore'
 import type { GetRequestsResponse, RelayApiClient } from './RelayApiClient'
-import {
-  BATCH_SIZE,
-  RelayIndexer,
-  RelayRootIndexer,
-  SAFE_TIME_OFFSET,
-} from './relay.indexer'
+import { RelayIndexer, RelayRootIndexer } from './relay.indexer'
 
 const FROM = 1787583059
+const BATCH_SIZE = 60
+const MAX_REQUESTS_PER_UPDATE = 10_000
+const SAFE_TIME_OFFSET = 10
 
 describe(RelayRootIndexer.name, () => {
   it('never targets a second that has not fully elapsed', async () => {
-    const target = await new RelayRootIndexer(Logger.SILENT).tick()
+    const target = await new RelayRootIndexer(
+      Logger.SILENT,
+      SAFE_TIME_OFFSET,
+    ).tick()
 
     expect(UnixTime.now() - target).toBeGreaterThanOrEqual(SAFE_TIME_OFFSET)
   })
@@ -86,8 +87,20 @@ describe(RelayIndexer.name, () => {
       const indexer = createIndexer(relayApiClient)
 
       await expect(indexer.update(FROM, FROM + 10_000)).toBeRejectedWith(
-        'was not fully fetched',
+        'incomplete after 3 requests',
       )
+    })
+
+    it('treats an empty continuation as a fully fetched window', async () => {
+      const relayApiClient = clientReturning({
+        requests: manyInSameSecond(3, '2026-08-24T14:50:59'),
+        continuation: '',
+      })
+      const indexer = createIndexer(relayApiClient)
+
+      const syncedTo = await indexer.update(FROM, FROM + 10_000)
+
+      expect(syncedTo).toEqual(FROM + BATCH_SIZE)
     })
   })
 })
@@ -113,10 +126,15 @@ function createIndexer(relayApiClient: RelayApiClient) {
     [],
     mockObject<InteropConfigStore>({ get: mockFn().returns(undefined) }),
     ['ethereum'],
+    {
+      batchSize: BATCH_SIZE,
+      maxRequestsPerUpdate: MAX_REQUESTS_PER_UPDATE,
+      safeTimeOffset: SAFE_TIME_OFFSET,
+    },
     relayApiClient,
     mockObject<Database>(),
     mockObject<InteropEventStore>(),
-    new RelayRootIndexer(Logger.SILENT),
+    new RelayRootIndexer(Logger.SILENT, SAFE_TIME_OFFSET),
     mockObject<IndexerService>(),
     Logger.SILENT,
   )

--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
@@ -13,9 +13,20 @@ import { buildRelayBootstrapChainNamesById, RelayConfig } from './relay.config'
 type RelayMetadata = GetRequestsResponse['requests'][number]['data']['metadata']
 type RelayCurrency = NonNullable<RelayMetadata>['currencyIn']
 
-export const SAFE_TIME_OFFSET = 10
+export interface RelayIndexerConfig {
+  batchSize: number
+  maxRequestsPerUpdate: number
+  safeTimeOffset: number
+}
 
 export class RelayRootIndexer extends RootIndexer {
+  constructor(
+    logger: Logger,
+    private readonly safeTimeOffset: number,
+  ) {
+    super(logger)
+  }
+
   override initialize() {
     setInterval(() => this.requestTick(), 1_000)
     this.requestTick()
@@ -23,7 +34,7 @@ export class RelayRootIndexer extends RootIndexer {
   }
 
   tick(): Promise<number> {
-    return Promise.resolve(UnixTime.now() - SAFE_TIME_OFFSET)
+    return Promise.resolve(UnixTime.now() - this.safeTimeOffset)
   }
 }
 
@@ -51,9 +62,6 @@ export const TokenReceived = createInteropEventType<TokenReceivedArgs>(
   { direction: 'incoming' },
 )
 
-export const BATCH_SIZE = 60
-export const MAX_REQUESTS_PER_UPDATE = 10_000
-
 export class RelayIndexer extends ManagedChildIndexer {
   private sentIds = new Set<string>()
   private receivedIds = new Set<string>()
@@ -63,6 +71,7 @@ export class RelayIndexer extends ManagedChildIndexer {
     chains: { id: number; name: string }[],
     private configs: InteropConfigStore,
     private trackedChains: string[],
+    private readonly relayConfig: RelayIndexerConfig,
     private relayApiClient: RelayApiClient,
     private db: Database,
     private interopEventStore: InteropEventStore,
@@ -116,17 +125,18 @@ export class RelayIndexer extends ManagedChildIndexer {
       return to
     }
 
-    const syncedTo = from + BATCH_SIZE < to ? from + BATCH_SIZE : to
+    const batchSize = this.relayConfig.batchSize
+    const syncedTo = from + batchSize < to ? from + batchSize : to
 
     const res = await this.relayApiClient.getAllRequests({
       startTimestamp: from,
       endTimestamp: syncedTo + 1,
-      limit: MAX_REQUESTS_PER_UPDATE,
+      limit: this.relayConfig.maxRequestsPerUpdate,
     })
 
-    if (res.continuation !== undefined) {
+    if (res.continuation) {
       throw new Error(
-        `Window ${from}-${syncedTo} was not fully fetched after ${res.requests.length} requests`,
+        `Window ${from}-${syncedTo} incomplete after ${res.requests.length} requests. Check the client warning for the reason and lower INTEROP_RELAY_BATCH_SIZE if the window is too dense`,
       )
     }
 

--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
@@ -49,6 +49,9 @@ export const TokenReceived = createInteropEventType<TokenReceivedArgs>(
   { direction: 'incoming' },
 )
 
+export const BATCH_SIZE = 60
+export const MAX_REQUESTS_PER_UPDATE = 10_000
+
 export class RelayIndexer extends ManagedChildIndexer {
   private sentIds = new Set<string>()
   private receivedIds = new Set<string>()
@@ -111,35 +114,26 @@ export class RelayIndexer extends ManagedChildIndexer {
       return to
     }
 
+    const syncedTo = from + BATCH_SIZE < to ? from + BATCH_SIZE : to
+
     const res = await this.relayApiClient.getAllRequests({
-      limit: 500,
       startTimestamp: from,
+      endTimestamp: syncedTo + 1,
+      limit: MAX_REQUESTS_PER_UPDATE,
     })
 
-    const successes = res.requests.filter((x) => x.status === 'success')
-    const last =
-      successes.length > 0 ? successes[successes.length - 1] : undefined
+    if (res.continuation !== undefined) {
+      throw new Error(
+        `Window ${from}-${syncedTo} was not fully fetched after ${res.requests.length} requests`,
+      )
+    }
 
-    if (!last) {
-      // TODO: allow not progressing
-      throw new Error('No entries')
-    }
-    const syncedTo = Math.min(
-      to,
-      UnixTime.fromDate(new Date(last.updatedAt)) - 1,
-    )
-    if (syncedTo < from) {
-      // TODO: allow not progressing
-      throw new Error('No entries')
-    }
+    const successes = res.requests.filter((x) => x.status === 'success')
 
     const events: InteropEvent[] = []
 
     for (const item of successes) {
       const updateTime = UnixTime.fromDate(new Date(item.updatedAt))
-      if (updateTime > syncedTo) {
-        continue
-      }
       const createTime = UnixTime.fromDate(new Date(item.createdAt))
 
       const srcTx = item.data.inTxs?.[0]

--- a/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
+++ b/packages/backend/src/modules/interop/plugins/relay/relay.indexer.ts
@@ -13,6 +13,8 @@ import { buildRelayBootstrapChainNamesById, RelayConfig } from './relay.config'
 type RelayMetadata = GetRequestsResponse['requests'][number]['data']['metadata']
 type RelayCurrency = NonNullable<RelayMetadata>['currencyIn']
 
+export const SAFE_TIME_OFFSET = 10
+
 export class RelayRootIndexer extends RootIndexer {
   override initialize() {
     setInterval(() => this.requestTick(), 1_000)
@@ -21,7 +23,7 @@ export class RelayRootIndexer extends RootIndexer {
   }
 
   tick(): Promise<number> {
-    return Promise.resolve(UnixTime.now())
+    return Promise.resolve(UnixTime.now() - SAFE_TIME_OFFSET)
   }
 }
 


### PR DESCRIPTION
The watermark was inferred from the last fetched row, so progress depended on data density. A burst of 619 requests sharing updatedAt second 1787583059 overran the 500 row budget, every fetched row floored to that same second, syncedTo computed to from - 1, and the indexer threw "No entries" on every attempt for four days while 619 real transfers sat in the window.

Bounding by time instead makes syncedTo known before the fetch, so progress no longer depends on how many rows a second holds, and an empty window advances normally. This matches BlockActivityIndexer and BlobIndexer. endTimestamp is exclusive, hence syncedTo + 1. A window that does not fit in one update throws rather than advancing, since committing a partial window would skip entries.