### PR TITLE
Repair invalid Coingecko circulating supply values, unskip Venice and Marlin

### DIFF
--- a/packages/backend/src/config/features/tvs.ts
+++ b/packages/backend/src/config/features/tvs.ts
@@ -32,12 +32,7 @@ export async function getTvsConfig(
 
   let projects = enabledProjects.map((p) => ({
     projectId: p.id,
-    // Temporary filter for Marlin and Venice tokens
-    // Coingecko started returning wrong response just for these tokens
-    // which results in halting all TVS sync. We should investigate this issue and remove this filter once it's fixed.
-    tokens: p.tvsConfig.filter(
-      (t) => t.priceId !== 'marlin' && t.priceId !== 'venice-token',
-    ),
+    tokens: p.tvsConfig,
   }))
 
   // sinceTimestamp override for local development

--- a/packages/backend/src/modules/tvs/indexers/CirculatingSupplyAmountIndexer.test.ts
+++ b/packages/backend/src/modules/tvs/indexers/CirculatingSupplyAmountIndexer.test.ts
@@ -185,6 +185,62 @@ describe(CirculatingSupplyAmountIndexer.name, () => {
       expect(safeHeight).toEqual(to)
     })
 
+    it('drops invalid supply values and saves the rest', async () => {
+      const from = 100
+      const to = 300
+      const adjustedTo = 250
+
+      const circulatingSupplyProvider = mockObject<CirculatingSupplyProvider>({
+        getAdjustedTo: mockFn().returnsOnce(adjustedTo),
+        getCirculatingSupplies: mockFn().returnsOnce([
+          { timestamp: UnixTime(150), value: 120000000 },
+          { timestamp: UnixTime(200), value: Number.NaN },
+        ]),
+      })
+
+      const syncOptimizer = mockObject<SyncOptimizer>({
+        getTimestampsToSync: mockFn().returnsOnce([
+          UnixTime(150),
+          UnixTime(200),
+        ]),
+        shouldTimestampBeSynced: mockFn().returns(true),
+      })
+
+      const tvsAmountRepository = mockObject<Database['tvsAmount']>({
+        upsertMany: mockFn().returnsOnce(undefined),
+      })
+
+      const indexer = new CirculatingSupplyAmountIndexer(
+        {
+          configurations: [config('config-1', 'ethereum', 18)],
+          circulatingSupplyProvider,
+          db: mockDatabase({ tvsAmount: tvsAmountRepository }),
+          syncOptimizer,
+          parents: [],
+          indexerService: mockObject<IndexerService>({}),
+        },
+        Logger.SILENT,
+      )
+
+      const updateFn = await indexer.multiUpdate(from, to, [
+        config('config-1', 'ethereum', 18),
+      ])
+      const safeHeight = await updateFn()
+
+      const expectedRecords: TvsAmountRecord[] = [
+        {
+          configurationId: 'config-1',
+          timestamp: UnixTime(150),
+          amount: BigInt(120000000 * 10 ** 18),
+        },
+      ]
+
+      expect(tvsAmountRepository.upsertMany).toHaveBeenOnlyCalledWith(
+        expectedRecords,
+      )
+      expect(safeHeight).toEqual(adjustedTo)
+    })
+
     it('handles insufficient data errors', async () => {
       const from = 100
       const to = 300

--- a/packages/backend/src/modules/tvs/indexers/CirculatingSupplyAmountIndexer.ts
+++ b/packages/backend/src/modules/tvs/indexers/CirculatingSupplyAmountIndexer.ts
@@ -76,7 +76,8 @@ export class CirculatingSupplyAmountIndexer extends ManagedMultiIndexer<Circulat
               (p) => Number.isFinite(p.value) && p.value >= 0,
             )
             if (validSupplies.length !== supplies.length) {
-              this.logger.error(
+              // Use critical level to trigger maintenance alert
+              this.logger.critical(
                 `Dropped invalid circulating supply values for ${configuration.properties.apiId}`,
                 {
                   priceId: configuration.properties.apiId,

--- a/packages/backend/src/modules/tvs/indexers/CirculatingSupplyAmountIndexer.ts
+++ b/packages/backend/src/modules/tvs/indexers/CirculatingSupplyAmountIndexer.ts
@@ -69,7 +69,23 @@ export class CirculatingSupplyAmountIndexer extends ManagedMultiIndexer<Circulat
                 CoingeckoId(configuration.properties.apiId),
                 { from: from, to: adjustedTo },
               )
-            const supplyRecords: TvsAmountRecord[] = supplies.map((p) => ({
+
+            // defense in depth: a non-finite value would crash the BigInt
+            // conversion below and halt the whole indexer
+            const validSupplies = supplies.filter(
+              (p) => Number.isFinite(p.value) && p.value >= 0,
+            )
+            if (validSupplies.length !== supplies.length) {
+              this.logger.error(
+                `Dropped invalid circulating supply values for ${configuration.properties.apiId}`,
+                {
+                  priceId: configuration.properties.apiId,
+                  dropped: supplies.length - validSupplies.length,
+                },
+              )
+            }
+
+            const supplyRecords: TvsAmountRecord[] = validSupplies.map((p) => ({
               configurationId: configuration.id,
               timestamp: p.timestamp,
               amount: BigInt(p.value * 10 ** configuration.properties.decimals),

--- a/packages/shared/src/services/coingecko/CoingeckoQueryService.test.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoQueryService.test.ts
@@ -6,6 +6,7 @@ import {
   CoingeckoQueryService,
   generateRangesToCallHourly,
   MAX_DAYS_FOR_HOURLY_PRECISION,
+  MAX_REPAIRED_SUPPLY_GAP_HOURS,
   pickClosestValues,
 } from './CoingeckoQueryService'
 
@@ -290,6 +291,119 @@ describe(CoingeckoQueryService.name, () => {
         { timestamp: START + 1 * UnixTime.HOUR, value: 2126600 },
         { timestamp: START + 2 * UnixTime.HOUR, value: 2871100 },
       ])
+    })
+
+    it('repairs a poisoned market cap from the previous hour', async () => {
+      const START = UnixTime.fromDate(new Date('2026-08-16T15:00:00Z'))
+
+      const coingeckoClient = supplyClient(
+        START,
+        [10, 10, 10],
+        [1_000_000, -1, 3_000_000],
+      )
+      const coingeckoQueryService = new CoingeckoQueryService(coingeckoClient)
+      const supplies = await coingeckoQueryService.getCirculatingSupplies(
+        CoingeckoId('venice-token'),
+        { from: START, to: START + 2 * UnixTime.HOUR },
+      )
+      expect(supplies).toEqual([
+        { timestamp: START, value: 100000 },
+        { timestamp: START + 1 * UnixTime.HOUR, value: 100000 },
+        { timestamp: START + 2 * UnixTime.HOUR, value: 300000 },
+      ])
+    })
+
+    it('repairs leading poisoned values from the next valid hour', async () => {
+      const START = UnixTime.fromDate(new Date('2026-08-16T15:00:00Z'))
+
+      const coingeckoClient = supplyClient(
+        START,
+        [0, 10, 10],
+        [2_000_000, -1, 2_000_000],
+      )
+      const coingeckoQueryService = new CoingeckoQueryService(coingeckoClient)
+      const supplies = await coingeckoQueryService.getCirculatingSupplies(
+        CoingeckoId('venice-token'),
+        { from: START, to: START + 2 * UnixTime.HOUR },
+      )
+      expect(supplies).toEqual([
+        { timestamp: START, value: 200000 },
+        { timestamp: START + 1 * UnixTime.HOUR, value: 200000 },
+        { timestamp: START + 2 * UnixTime.HOUR, value: 200000 },
+      ])
+    })
+
+    it('keeps zero supply when market cap is zero', async () => {
+      const START = UnixTime.fromDate(new Date('2026-08-16T15:00:00Z'))
+
+      const coingeckoClient = supplyClient(START, [10, 10], [0, 1_000_000])
+      const coingeckoQueryService = new CoingeckoQueryService(coingeckoClient)
+      const supplies = await coingeckoQueryService.getCirculatingSupplies(
+        CoingeckoId('venice-token'),
+        { from: START, to: START + 1 * UnixTime.HOUR },
+      )
+      expect(supplies).toEqual([
+        { timestamp: START, value: 0 },
+        { timestamp: START + 1 * UnixTime.HOUR, value: 100000 },
+      ])
+    })
+
+    it('repairs a gap of exactly the repairable length', async () => {
+      const START = UnixTime.fromDate(new Date('2026-08-16T15:00:00Z'))
+      const hours = MAX_REPAIRED_SUPPLY_GAP_HOURS + 2
+
+      const marketCaps = new Array(hours).fill(-1)
+      marketCaps[0] = 1_000_000
+      marketCaps[hours - 1] = 3_000_000
+
+      const coingeckoClient = supplyClient(
+        START,
+        new Array(hours).fill(10),
+        marketCaps,
+      )
+      const coingeckoQueryService = new CoingeckoQueryService(coingeckoClient)
+      const supplies = await coingeckoQueryService.getCirculatingSupplies(
+        CoingeckoId('venice-token'),
+        { from: START, to: START + (hours - 1) * UnixTime.HOUR },
+      )
+      expect(supplies[1].value).toEqual(100000)
+      expect(supplies[hours - 2].value).toEqual(100000)
+      expect(supplies[hours - 1].value).toEqual(300000)
+    })
+
+    it('throws when the corrupt stretch is longer than the repairable gap', async () => {
+      const START = UnixTime.fromDate(new Date('2026-08-16T15:00:00Z'))
+      const hours = MAX_REPAIRED_SUPPLY_GAP_HOURS + 3
+
+      const marketCaps = new Array(hours).fill(-1)
+      marketCaps[0] = 1_000_000
+      marketCaps[hours - 1] = 3_000_000
+
+      const coingeckoClient = supplyClient(
+        START,
+        new Array(hours).fill(10),
+        marketCaps,
+      )
+      const coingeckoQueryService = new CoingeckoQueryService(coingeckoClient)
+      await expect(async () => {
+        await coingeckoQueryService.getCirculatingSupplies(
+          CoingeckoId('venice-token'),
+          { from: START, to: START + (hours - 1) * UnixTime.HOUR },
+        )
+      }).toBeRejectedWith('Insufficient data in response for venice-token')
+    })
+
+    it('throws when all values are invalid', async () => {
+      const START = UnixTime.fromDate(new Date('2026-08-16T15:00:00Z'))
+
+      const coingeckoClient = supplyClient(START, [10, 10, 10], [-1, -1, -1])
+      const coingeckoQueryService = new CoingeckoQueryService(coingeckoClient)
+      await expect(async () => {
+        await coingeckoQueryService.getCirculatingSupplies(
+          CoingeckoId('venice-token'),
+          { from: START, to: START + 2 * UnixTime.HOUR },
+        )
+      }).toBeRejectedWith('Insufficient data in response for venice-token')
     })
   })
 
@@ -576,6 +690,20 @@ describe(approximateCirculatingSupply.name, () => {
       ).toEqual(testCase.expected)
     })
   }
+
+  it('returns NaN for a negative market cap', () => {
+    expect(Number.isNaN(approximateCirculatingSupply(-1, 11.9))).toEqual(true)
+  })
+
+  it('returns NaN for a zero price and positive market cap', () => {
+    expect(Number.isNaN(approximateCirculatingSupply(1_000_000, 0))).toEqual(
+      true,
+    )
+  })
+
+  it('returns 0 for a zero market cap and positive price', () => {
+    expect(approximateCirculatingSupply(0, 10)).toEqual(0)
+  })
 })
 
 function mock(date?: Date, value?: number) {
@@ -583,4 +711,19 @@ function mock(date?: Date, value?: number) {
     date: date ?? new Date(),
     value: value ?? 1234567,
   }
+}
+
+function supplyClient(start: UnixTime, prices: number[], marketCaps: number[]) {
+  return mockObject<CoingeckoClient>({
+    getCoinMarketChartRange: mockFn().returns({
+      prices: prices.map((value, i) => ({
+        date: UnixTime.toDate(start + i * UnixTime.HOUR),
+        value,
+      })),
+      marketCaps: marketCaps.map((value, i) => ({
+        date: UnixTime.toDate(start + i * UnixTime.HOUR),
+        value,
+      })),
+    }),
+  })
 }

--- a/packages/shared/src/services/coingecko/CoingeckoQueryService.ts
+++ b/packages/shared/src/services/coingecko/CoingeckoQueryService.ts
@@ -14,6 +14,7 @@ import type {
 
 export const MAX_DAYS_FOR_HOURLY_PRECISION = 80
 export const COINGECKO_INTERPOLATION_WINDOW_DAYS = 14
+export const MAX_REPAIRED_SUPPLY_GAP_HOURS = 24
 
 export interface QueryResultPoint {
   value: number
@@ -52,7 +53,7 @@ export class CoingeckoQueryService {
       coingeckoId,
       range,
     )
-    return zip(queryResult.prices, queryResult.marketCaps).map(
+    const supplies = zip(queryResult.prices, queryResult.marketCaps).map(
       ([price, marketCap]) => {
         assert(price && marketCap && price.timestamp === marketCap.timestamp)
 
@@ -63,6 +64,86 @@ export class CoingeckoQueryService {
         }
       },
     )
+    return this.repairInvalidSupplies(coingeckoId, supplies)
+  }
+
+  // Coingecko occasionally poisons single points of its market cap history
+  // (e.g. venice-token had market cap -1 for one hour), which makes the
+  // calculated supply NaN. Repair short gaps from the neighboring hours,
+  // but refuse to fabricate data for longer corrupt stretches.
+  private repairInvalidSupplies(
+    coingeckoId: CoingeckoId,
+    points: QueryResultPoint[],
+  ): QueryResultPoint[] {
+    let invalidCount = 0
+    let longestGapHours = 0
+    let currentGapHours = 0
+    let firstInvalid: UnixTime | undefined
+    let lastInvalid: UnixTime | undefined
+
+    for (const point of points) {
+      if (isValidSupply(point.value)) {
+        currentGapHours = 0
+        continue
+      }
+      // points are hourly (see getHourlyTimestamps), so a run of
+      // consecutive invalid points is a gap of that many hours
+      invalidCount++
+      currentGapHours++
+      longestGapHours = Math.max(longestGapHours, currentGapHours)
+      firstInvalid ??= point.timestamp
+      lastInvalid = point.timestamp
+    }
+
+    if (invalidCount === 0) {
+      return points
+    }
+
+    const context = {
+      coingeckoId: coingeckoId.toString(),
+      invalidCount,
+      longestGapHours,
+      from: firstInvalid,
+      to: lastInvalid,
+    }
+
+    if (
+      invalidCount === points.length ||
+      longestGapHours > MAX_REPAIRED_SUPPLY_GAP_HOURS
+    ) {
+      this.logger.error(
+        'Invalid circulating supply values, gap too long to repair',
+        context,
+      )
+      // this prefix makes callers skip the configuration instead of halting
+      throw new Error(`Insufficient data in response for ${coingeckoId}`)
+    }
+
+    this.logger.error(
+      'Invalid circulating supply values, repaired from neighboring hours',
+      context,
+    )
+
+    const repaired = [...points]
+    let previousValid: number | undefined
+    for (let i = 0; i < repaired.length; i++) {
+      if (isValidSupply(repaired[i].value)) {
+        previousValid = repaired[i].value
+      } else if (previousValid !== undefined) {
+        repaired[i] = { ...repaired[i], value: previousValid }
+      }
+    }
+    // only a leading gap can still be invalid - fill it from the next valid value
+    let nextValid: number | undefined
+    for (let i = repaired.length - 1; i >= 0; i--) {
+      if (isValidSupply(repaired[i].value)) {
+        nextValid = repaired[i].value
+      } else {
+        assert(nextValid !== undefined)
+        repaired[i] = { ...repaired[i], value: nextValid }
+      }
+    }
+    return repaired
   }
 
   async queryHourlyPricesAndMarketCaps(
@@ -269,6 +350,10 @@ function combineResults(results: CoinMarketChartRangeData[]) {
   data.marketCaps.sort((a, b) => a.date.getTime() - b.date.getTime())
 
   return data
+}
+
+function isValidSupply(value: number) {
+  return Number.isFinite(value) && value >= 0
 }
 
 // This function is a neat helper to make circulating supply values more "round"


### PR DESCRIPTION
Resolves L2B-14768

## What happened

Coingecko's hourly market cap history for `venice-token` contains a single poisoned point: `market_cap = -1` at 2026-08-16 17:00 UTC (verified still served by their API today, 15 days later — the only such point in the token's entire history). `approximateCirculatingSupply` derives supply as `marketCap / price`, so the value became `NaN` via `Math.log10(negative)`, and `BigInt(NaN)` in `CirculatingSupplyAmountIndexer.multiUpdate` threw `RangeError`. Since that indexer is shared by all circulating-supply tokens and retries infinitely, the whole TVS pipeline stalled for ~12 hours (2026-08-16 19:12 → 08-17 06:13). The mitigation was to filter `venice-token` out of the TVS config entirely (#12587), like `marlin` before it (#12453/#12455).

## The fix

- **`CoingeckoQueryService.getCirculatingSupplies`** now validates every computed supply (`Number.isFinite && >= 0`) and repairs corrupt gaps of up to `MAX_REPAIRED_SUPPLY_GAP_HOURS = 24` consecutive hours from the neighboring hour (previous hour preferred, next for a leading gap). Every repair is logged at **error** level with the coingeckoId, count, gap length and timestamps, so a long stretch of bad data can't go unnoticed. Stretches longer than 24h (or a fully-invalid window) are not fabricated: an error is logged and the existing `Insufficient data in response` error is thrown, which skips only that configuration's window while the rest of TVS keeps syncing.
- **`CirculatingSupplyAmountIndexer`** additionally drops any non-finite/negative value right before the `BigInt` conversion (defense in depth), logging the `apiId` — the missing piece that made the original incident hard to diagnose.
- **Removed the temporary `venice-token` / `marlin` filter** from `config/features/tvs.ts`. Both tokens' data was wiped when they were filtered, so they resync from their `sinceTimestamp`s automatically. Base gets ~$822M of VVV back; Arbitrum and Polygon PoS get POND back.

## Why unskipping is safe

- Venice: scanned the full history (Jan 2025 → today) via the pro API at hourly granularity — exactly one invalid point, which the repair absorbs. Verified end-to-end by running the new code against the real poisoned API response: one error log, valid BigInt conversion for every hour.
- Marlin: its amount is a sum of Ethereum escrow balances — the only Coingecko dependency is the price, so its Aug 4 failure was a different (price-path) response issue that Coingecko has since fixed: full history (Dec 2020 → today) scanned type-strict, zero anomalies in both series.

## Expected after deploy

One "Invalid circulating supply values, repaired from neighboring hours" **error log for venice-token** when its resync reaches Aug 16 2026 — that's the fix working, not an incident.

## Tests

- `getCirculatingSupplies`: poisoned mid-point repairs from previous hour, leading gap (incl. zero-price NaN) repairs from next hour, zero market cap keeps supply 0, exactly-24h gap repairs, >24h gap throws insufficient-data, all-invalid throws.
- `approximateCirculatingSupply`: NaN for negative cap, NaN for zero price, 0 for zero cap.
- Indexer: non-finite value dropped and the rest of the batch saved.
- Full suites green (shared 406, backend 1369), typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)