### PR TITLE
Allow disabling individual da-beat projects via feature flags

### DIFF
--- a/packages/backend/src/config/features/dabeat.test.ts
+++ b/packages/backend/src/config/features/dabeat.test.ts
@@ -1,0 +1,56 @@
+import { Env } from '@l2beat/backend-tools'
+import type { ProjectService } from '@l2beat/config'
+import { ProjectId } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import { FeatureFlags } from '../FeatureFlags'
+import { getDaBeatConfig } from './dabeat'
+
+const env = new Env({ CELESTIA_API_URL: 'https://celestia.example.com' })
+
+const projects = [
+  {
+    id: ProjectId('avail'),
+    daLayer: {
+      economicSecurity: { token: { coingeckoId: 'avail' } },
+    },
+  },
+  {
+    id: ProjectId('celestia'),
+    daLayer: {
+      economicSecurity: { token: { coingeckoId: 'celestia' } },
+    },
+  },
+]
+
+function mockProjectService(): ProjectService {
+  return mockObject<ProjectService>({
+    getProjects: mockFn().resolvesToOnce(projects),
+  })
+}
+
+describe(getDaBeatConfig.name, () => {
+  it('includes all projects by default', async () => {
+    const config = await getDaBeatConfig(
+      mockProjectService(),
+      env,
+      new FeatureFlags('da-beat'),
+    )
+
+    expect(config.projectsForDaBeatStats).toEqual([
+      ProjectId('avail'),
+      ProjectId('celestia'),
+    ])
+    expect(config.coingeckoIds).toEqual(['avail', 'celestia'])
+  })
+
+  it('excludes a project disabled with !da-beat.<project>', async () => {
+    const config = await getDaBeatConfig(
+      mockProjectService(),
+      env,
+      new FeatureFlags('da-beat,!da-beat.avail'),
+    )
+
+    expect(config.projectsForDaBeatStats).toEqual([ProjectId('celestia')])
+    expect(config.coingeckoIds).toEqual(['celestia'])
+  })
+})

--- a/packages/backend/src/config/features/dabeat.ts
+++ b/packages/backend/src/config/features/dabeat.ts
@@ -2,14 +2,20 @@ import type { Env } from '@l2beat/backend-tools'
 import type { ProjectService } from '@l2beat/config'
 import uniq from 'lodash/uniq'
 import type { DaBeatConfig } from '../Config'
+import type { FeatureFlags } from '../FeatureFlags'
 
 export async function getDaBeatConfig(
   ps: ProjectService,
   env: Env,
+  flags: FeatureFlags,
 ): Promise<DaBeatConfig> {
-  const projects = await ps.getProjects({
+  const allProjects = await ps.getProjects({
     select: ['daLayer'],
   })
+  // Individual projects can be disabled with e.g. FEATURES=*,!da-beat.avail
+  const projects = allProjects.filter((x) =>
+    flags.isEnabled('da-beat', x.id.toString()),
+  )
 
   const coingeckoIds = projects
     .map((x) => x.daLayer.economicSecurity?.token.coingeckoId)

--- a/packages/backend/src/config/makeConfig.ts
+++ b/packages/backend/src/config/makeConfig.ts
@@ -130,7 +130,8 @@ export async function makeConfig(
     ),
     flatSourceModuleEnabled: flags.isEnabled('flatSourcesModule'),
     chains: chains.map((x) => ({ name: x.name, chainId: x.chainId })),
-    daBeat: flags.isEnabled('da-beat') && (await getDaBeatConfig(ps, env)),
+    daBeat:
+      flags.isEnabled('da-beat') && (await getDaBeatConfig(ps, env, flags)),
     ecosystems:
       flags.isEnabled('ecosystems') && (await getEcosystemsConfig(ps)),
     chainConfig: await getChainConfig(ps, env),


### PR DESCRIPTION
## Summary

Adds per-project granularity to the `da-beat` feature flag. `FEATURES=*,!da-beat.avail` now excludes a single project from da-beat processing while the rest of the module keeps running.

`getDaBeatConfig` filters projects with `flags.isEnabled('da-beat', project.id)` before deriving both `projectsForDaBeatStats` (no stats indexer is created for a disabled project) and `coingeckoIds` (its token drops out of the prices indexer). The hierarchical flag resolution (`da-beat.avail` → `da-beat.*` → `da-beat`) already existed in `FeatureFlags`.

## Motivation

During the 2026-08-31 outage the avail RPC endpoints broke externally and the only mitigation was `!da-beat`, taking down stats for every DA project. This gives a finer kill switch for a single misbehaving provider.

## Testing

- New `dabeat.test.ts`: default-on behavior and `!da-beat.<project>` exclusion (2 tests, passing)
- `pnpm typecheck`, `pnpm lint`, `pnpm format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)