### PR TITLE
Read Avail staking storage over raw JSON-RPC, drop @polkadot/api

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -43,7 +43,6 @@
     "@l2beat/backend-tools": "workspace:*",
     "@l2beat/shared-pure": "workspace:*",
     "@l2beat/validate": "workspace:*",
-    "@polkadot/api": "^12.4.2",
     "ethers": "^5.7.2",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",

--- a/packages/shared/src/clients/rpc-polkadot/PolkadotRpcClient.ts
+++ b/packages/shared/src/clients/rpc-polkadot/PolkadotRpcClient.ts
@@ -1,12 +1,23 @@
 import type { Block, json } from '@l2beat/shared-pure'
-import type { ApiPromise } from '@polkadot/api'
 import { generateId } from '../../tools/generateId'
 import { ClientCore, type ClientCoreDependencies } from '../ClientCore'
+import {
+  bytesToHex,
+  decodeCompact,
+  decodeU32Le,
+  encodeU32Le,
+  hexToBytes,
+  twox64Concat,
+  twox128,
+} from './substrate'
 import {
   type PolkadotBlock,
   PolkadotErrorResponse,
   PolkadotGetBlockHashResponse,
   PolkadotGetBlockResponse,
+  PolkadotGetKeysPagedResponse,
+  PolkadotGetStorageResponse,
+  PolkadotQueryStorageAtResponse,
 } from './types'
 
 interface Dependencies extends ClientCoreDependencies {
@@ -15,6 +26,15 @@ interface Dependencies extends ClientCoreDependencies {
 }
 
 const TIMESTAMP_SHIFT = 4300
+
+// Storage key prefixes are twox128 hashes of pallet and item names.
+const STAKING = twox128(new TextEncoder().encode('Staking'))
+const CURRENT_ERA = twox128(new TextEncoder().encode('CurrentEra'))
+const ERAS_STAKERS_OVERVIEW = twox128(
+  new TextEncoder().encode('ErasStakersOverview'),
+)
+
+const KEYS_PAGE_SIZE = 1000
 
 export class PolkadotRpcClient extends ClientCore {
   constructor(private readonly $: Dependencies) {
@@ -76,7 +96,7 @@ export class PolkadotRpcClient extends ClientCore {
 
   async query(
     method: string,
-    params: (string | number | boolean | Record<string, string>)[],
+    params: (string | number | boolean | string[] | Record<string, string>)[],
   ) {
     return await this.fetch(this.$.url, {
       method: 'POST',
@@ -109,61 +129,77 @@ export class PolkadotRpcClient extends ClientCore {
   }
 
   /**
-   * Validator stake overview for the chain's current staking era.
-   * Storage reads go through @polkadot/api over HTTP - plain
-   * request/response, no sockets or background timers.
+   * Validator stake overview for the chain's current staking era, read
+   * straight from Substrate storage over JSON-RPC (see substrate.ts for the
+   * key hashing and SCALE decoding this requires).
    */
   async getStakingEraOverview(): Promise<Record<string, Exposure>> {
-    const api = await this.createApi()
-    try {
-      const currentEra = await api.query.staking.currentEra()
-      const overview = (await api.query.staking.erasStakersOverview.entries(
-        currentEra.toHuman() as string,
-      )) as unknown as [ValidatorKeysCodec, ValidatorValueCodec][]
+    const era = await this.getCurrentEra()
 
-      const validatorsOverview = overview.reduce(
-        (
-          acc: Record<string, Exposure>,
-          [validatorKeys, value]: [ValidatorKeysCodec, ValidatorValueCodec],
-        ) => {
-          const [, validator] = validatorKeys.toHuman()
-          const { own, total } = value.toPrimitive()
+    // Staking.ErasStakersOverview is a (Twox64Concat era, Twox64Concat
+    // account) double map, so all entries of one era share this prefix.
+    const prefix = bytesToHex(
+      concatBytes(
+        STAKING,
+        ERAS_STAKERS_OVERVIEW,
+        twox64Concat(encodeU32Le(era)),
+      ),
+    )
+    const keys = await this.getStorageKeys(prefix)
 
-          acc[validator] = {
-            own: BigInt(own),
-            total: BigInt(total),
-          }
+    const overview: Record<string, Exposure> = {}
+    for (const [key, value] of await this.queryStorageAt(keys)) {
+      if (value === null) continue
+      // The key ends with twox64Concat(AccountId32): 8 hash bytes + the
+      // 32-byte account id, reported as hex (the id is only used as a
+      // unique label for counting).
+      const validator = `0x${key.slice(-64)}`
+      // Value is a SCALE PagedExposureMetadata:
+      // compact total, compact own, u32 nominatorCount, u32 pageCount.
+      const bytes = hexToBytes(value)
+      const total = decodeCompact(bytes, 0)
+      const own = decodeCompact(bytes, total.offset)
+      overview[validator] = { own: own.value, total: total.value }
+    }
+    return overview
+  }
 
-          return acc
-        },
-        {},
-      )
+  private async getCurrentEra(): Promise<number> {
+    const key = bytesToHex(concatBytes(STAKING, CURRENT_ERA))
+    const response = PolkadotGetStorageResponse.parse(
+      await this.query('state_getStorage', [key]),
+    )
+    if (response.result === null) {
+      throw new Error('Staking.CurrentEra is not set')
+    }
+    return decodeU32Le(hexToBytes(response.result), 0)
+  }
 
-      return validatorsOverview
-    } finally {
-      await api.disconnect().catch(() => {})
+  private async getStorageKeys(prefix: string): Promise<string[]> {
+    const keys: string[] = []
+    let startKey: string | undefined
+    while (true) {
+      const page = PolkadotGetKeysPagedResponse.parse(
+        await this.query('state_getKeysPaged', [
+          prefix,
+          KEYS_PAGE_SIZE,
+          ...(startKey ? [startKey] : []),
+        ]),
+      ).result
+      keys.push(...page)
+      if (page.length < KEYS_PAGE_SIZE) return keys
+      startKey = page[page.length - 1]
     }
   }
 
-  // ApiPromise.isReadyOrError is not a socket handshake - it downloads the
-  // chain's runtime metadata and builds the type registry. Done per call so
-  // the metadata never goes stale across runtime upgrades. @polkadot/api is
-  // imported lazily because loading it costs ~700ms and ~80MB RSS.
-  private async createApi(): Promise<ApiPromise> {
-    const { ApiPromise, HttpProvider } = await import('@polkadot/api')
-    const api = new ApiPromise({
-      provider: new HttpProvider(this.$.url),
-      noInitWarn: true,
-      throwOnConnect: true,
-    })
-    api.on('error', () => {})
-    try {
-      await api.isReadyOrError
-    } catch (error) {
-      await api.disconnect().catch(() => {})
-      throw error
-    }
-    return api
+  private async queryStorageAt(
+    keys: string[],
+  ): Promise<[string, string | null][]> {
+    if (keys.length === 0) return []
+    const response = PolkadotQueryStorageAtResponse.parse(
+      await this.query('state_queryStorageAt', [keys]),
+    )
+    return response.result.flatMap((changeSet) => changeSet.changes)
   }
 
   get chain() {
@@ -187,13 +223,15 @@ export class PolkadotRpcClient extends ClientCore {
     return timestamp
   }
 }
-type Codec<T> = {
-  toHuman: () => T
-  toPrimitive: () => T
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(parts.reduce((sum, p) => sum + p.length, 0))
+  let offset = 0
+  for (const part of parts) {
+    result.set(part, offset)
+    offset += part.length
+  }
+  return result
 }
-
-type ValidatorKeysCodec = Codec<[string, string]>
-type ValidatorValueCodec = Codec<{ own: string; total: string }>
 
 type Exposure = {
   own: bigint

--- a/packages/shared/src/clients/rpc-polkadot/substrate.test.ts
+++ b/packages/shared/src/clients/rpc-polkadot/substrate.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'earl'
+import {
+  bytesToHex,
+  decodeCompact,
+  decodeU32Le,
+  encodeU32Le,
+  hexToBytes,
+  twox64Concat,
+  twox128,
+} from './substrate'
+
+// Expected values verified against @polkadot/util-crypto's xxhashAsHex.
+describe('substrate', () => {
+  describe(twox128.name, () => {
+    const cases = [
+      ['Staking', '0x5f3e4907f716ac89b6347d15ececedca'],
+      ['CurrentEra', '0x0b6a45321efae92aea15e0740ec7afe7'],
+      ['ErasStakersOverview', '0x7493ea190d0af47acc70e25428f8b1a3'],
+      ['', '0x99e9d85137db46ef4bbea33613baafd5'],
+    ] as const
+
+    for (const [input, expected] of cases) {
+      it(`hashes ${JSON.stringify(input)}`, () => {
+        expect(bytesToHex(twox128(new TextEncoder().encode(input)))).toEqual(
+          expected,
+        )
+      })
+    }
+  })
+
+  describe(twox64Concat.name, () => {
+    it('hashes an encoded era and appends the input', () => {
+      const era = encodeU32Le(790)
+      const result = bytesToHex(twox64Concat(era))
+      expect(result).toEqual('0x2f9e04a205412d2e16030000')
+      expect(result.endsWith('16030000')).toEqual(true) // 790 as u32 LE
+    })
+  })
+
+  describe(decodeCompact.name, () => {
+    const cases = [
+      ['0x00', 0n, 1],
+      ['0x04', 1n, 1],
+      ['0xa8', 42n, 1],
+      ['0x1501', 69n, 2],
+      ['0x02000100', 16384n, 4],
+      ['0x0370605040', 0x40506070n, 5],
+      ['0x0b00407a10f35a', 100_000_000_000_000n, 7],
+    ] as const
+
+    for (const [hex, value, offset] of cases) {
+      it(`decodes ${hex}`, () => {
+        expect(decodeCompact(hexToBytes(hex), 0)).toEqual({ value, offset })
+      })
+    }
+
+    it('decodes a SCALE PagedExposureMetadata value', () => {
+      // compact total, compact own, u32 nominatorCount, u32 pageCount
+      const bytes = hexToBytes('0x02000100a80500000001000000')
+      const total = decodeCompact(bytes, 0)
+      const own = decodeCompact(bytes, total.offset)
+      expect(total.value).toEqual(16384n)
+      expect(own.value).toEqual(42n)
+      expect(decodeU32Le(bytes, own.offset)).toEqual(5)
+    })
+  })
+})

--- a/packages/shared/src/clients/rpc-polkadot/substrate.ts
+++ b/packages/shared/src/clients/rpc-polkadot/substrate.ts
@@ -1,0 +1,164 @@
+/**
+ * Minimal Substrate storage primitives: twox ("xxhash64") storage-key hashing
+ * and SCALE compact decoding. Storage keys are built as
+ * twox128(pallet) ++ twox128(item) ++ hasher(encoded map key) and values come
+ * back SCALE-encoded, which is why plain JSON-RPC alone is not enough.
+ */
+
+const P1 = 0x9e3779b185ebca87n
+const P2 = 0xc2b2ae3d27d4eb4fn
+const P3 = 0x165667b19e3779f9n
+const P4 = 0x85ebca77c2b2ae63n
+const P5 = 0x27d4eb2f165667c5n
+const MASK = (1n << 64n) - 1n
+
+function rotl(value: bigint, bits: bigint): bigint {
+  return ((value << bits) | (value >> (64n - bits))) & MASK
+}
+
+function round(acc: bigint, input: bigint): bigint {
+  return (rotl((acc + input * P2) & MASK, 31n) * P1) & MASK
+}
+
+function mergeRound(acc: bigint, value: bigint): bigint {
+  return ((acc ^ round(0n, value)) * P1 + P4) & MASK
+}
+
+function readU64(data: Uint8Array, offset: number): bigint {
+  let value = 0n
+  for (let i = 7; i >= 0; i--) {
+    value = (value << 8n) | BigInt(data[offset + i])
+  }
+  return value
+}
+
+function readU32(data: Uint8Array, offset: number): bigint {
+  let value = 0n
+  for (let i = 3; i >= 0; i--) {
+    value = (value << 8n) | BigInt(data[offset + i])
+  }
+  return value
+}
+
+export function xxhash64(data: Uint8Array, seed: bigint): bigint {
+  const len = data.length
+  let h: bigint
+  let i = 0
+
+  if (len >= 32) {
+    let v1 = (seed + P1 + P2) & MASK
+    let v2 = (seed + P2) & MASK
+    let v3 = seed & MASK
+    let v4 = (seed - P1) & MASK
+    for (; i + 32 <= len; i += 32) {
+      v1 = round(v1, readU64(data, i))
+      v2 = round(v2, readU64(data, i + 8))
+      v3 = round(v3, readU64(data, i + 16))
+      v4 = round(v4, readU64(data, i + 24))
+    }
+    h = (rotl(v1, 1n) + rotl(v2, 7n) + rotl(v3, 12n) + rotl(v4, 18n)) & MASK
+    h = mergeRound(h, v1)
+    h = mergeRound(h, v2)
+    h = mergeRound(h, v3)
+    h = mergeRound(h, v4)
+  } else {
+    h = (seed + P5) & MASK
+  }
+
+  h = (h + BigInt(len)) & MASK
+  for (; i + 8 <= len; i += 8) {
+    h = (rotl(h ^ round(0n, readU64(data, i)), 27n) * P1 + P4) & MASK
+  }
+  if (i + 4 <= len) {
+    h = (rotl(h ^ ((readU32(data, i) * P1) & MASK), 23n) * P2 + P3) & MASK
+    i += 4
+  }
+  for (; i < len; i++) {
+    h = (rotl(h ^ ((BigInt(data[i]) * P5) & MASK), 11n) * P1) & MASK
+  }
+
+  h ^= h >> 33n
+  h = (h * P2) & MASK
+  h ^= h >> 29n
+  h = (h * P3) & MASK
+  h ^= h >> 32n
+  return h
+}
+
+function u64ToLeBytes(value: bigint): Uint8Array {
+  const bytes = new Uint8Array(8)
+  for (let i = 0; i < 8; i++) {
+    bytes[i] = Number((value >> BigInt(i * 8)) & 0xffn)
+  }
+  return bytes
+}
+
+/** Substrate's Twox128 hasher: two seeded xxhash64 runs, little-endian. */
+export function twox128(data: Uint8Array): Uint8Array {
+  const result = new Uint8Array(16)
+  result.set(u64ToLeBytes(xxhash64(data, 0n)), 0)
+  result.set(u64ToLeBytes(xxhash64(data, 1n)), 8)
+  return result
+}
+
+/** Substrate's Twox64Concat hasher: xxhash64 of the key followed by the key. */
+export function twox64Concat(data: Uint8Array): Uint8Array {
+  const result = new Uint8Array(8 + data.length)
+  result.set(u64ToLeBytes(xxhash64(data, 0n)), 0)
+  result.set(data, 8)
+  return result
+}
+
+/**
+ * Decodes a SCALE compact-encoded integer.
+ * Returns the value and the offset just past it.
+ */
+export function decodeCompact(
+  data: Uint8Array,
+  offset: number,
+): { value: bigint; offset: number } {
+  const first = data[offset]
+  const mode = first & 0b11
+  if (mode === 0b00) {
+    return { value: BigInt(first >> 2), offset: offset + 1 }
+  }
+  if (mode === 0b01) {
+    const raw = first | (data[offset + 1] << 8)
+    return { value: BigInt(raw >> 2), offset: offset + 2 }
+  }
+  if (mode === 0b10) {
+    const raw = readU32(data, offset)
+    return { value: raw >> 2n, offset: offset + 4 }
+  }
+  const byteLength = (first >> 2) + 4
+  let value = 0n
+  for (let i = byteLength - 1; i >= 0; i--) {
+    value = (value << 8n) | BigInt(data[offset + 1 + i])
+  }
+  return { value, offset: offset + 1 + byteLength }
+}
+
+export function decodeU32Le(data: Uint8Array, offset: number): number {
+  return Number(readU32(data, offset))
+}
+
+export function encodeU32Le(value: number): Uint8Array {
+  const bytes = new Uint8Array(4)
+  for (let i = 0; i < 4; i++) {
+    bytes[i] = (value >>> (i * 8)) & 0xff
+  }
+  return bytes
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const stripped = hex.startsWith('0x') ? hex.slice(2) : hex
+  const bytes = new Uint8Array(stripped.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(stripped.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  return `0x${Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')}`
+}

--- a/packages/shared/src/clients/rpc-polkadot/types.ts
+++ b/packages/shared/src/clients/rpc-polkadot/types.ts
@@ -40,6 +40,22 @@ export const PolkadotGetBlockResponse = v.object({
   }),
 })
 
+export const PolkadotGetStorageResponse = v.object({
+  result: v.union([v.string(), v.null()]),
+})
+
+export const PolkadotGetKeysPagedResponse = v.object({
+  result: v.array(v.string()),
+})
+
+export const PolkadotQueryStorageAtResponse = v.object({
+  result: v.array(
+    v.object({
+      changes: v.array(v.tuple([v.string(), v.union([v.string(), v.null()])])),
+    }),
+  ),
+})
+
 export const PolkadotErrorResponse = v.object({
   error: v.object({
     code: v.number(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1061,9 +1061,6 @@ importers:
       '@l2beat/validate':
         specifier: workspace:*
         version: link:../validate
-      '@polkadot/api':
-        specifier: ^12.4.2
-        version: 12.4.2(supports-color@8.1.1)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -2758,173 +2755,6 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
-  '@polkadot-api/json-rpc-provider-proxy@0.1.0':
-    resolution: {integrity: sha512-8GSFE5+EF73MCuLQm8tjrbCqlgclcHBSRaswvXziJ0ZW7iw3UEMsKkkKvELayWyBuOPa2T5i1nj6gFOeIsqvrg==}
-
-  '@polkadot-api/json-rpc-provider@0.0.1':
-    resolution: {integrity: sha512-/SMC/l7foRjpykLTUTacIH05H3mr9ip8b5xxfwXlVezXrNVLp3Cv0GX6uItkKd+ZjzVPf3PFrDF2B2/HLSNESA==}
-
-  '@polkadot-api/metadata-builders@0.3.2':
-    resolution: {integrity: sha512-TKpfoT6vTb+513KDzMBTfCb/ORdgRnsS3TDFpOhAhZ08ikvK+hjHMt5plPiAX/OWkm1Wc9I3+K6W0hX5Ab7MVg==}
-
-  '@polkadot-api/observable-client@0.3.2':
-    resolution: {integrity: sha512-HGgqWgEutVyOBXoGOPp4+IAq6CNdK/3MfQJmhCJb8YaJiaK4W6aRGrdQuQSTPHfERHCARt9BrOmEvTXAT257Ug==}
-    peerDependencies:
-      '@polkadot-api/substrate-client': 0.1.4
-      rxjs: '>=7.8.0'
-
-  '@polkadot-api/substrate-bindings@0.6.0':
-    resolution: {integrity: sha512-lGuhE74NA1/PqdN7fKFdE5C1gNYX357j1tWzdlPXI0kQ7h3kN0zfxNOpPUN7dIrPcOFZ6C0tRRVrBylXkI6xPw==}
-
-  '@polkadot-api/substrate-client@0.1.4':
-    resolution: {integrity: sha512-MljrPobN0ZWTpn++da9vOvt+Ex+NlqTlr/XT7zi9sqPtDJiQcYl+d29hFAgpaeTqbeQKZwz3WDE9xcEfLE8c5A==}
-
-  '@polkadot-api/utils@0.1.0':
-    resolution: {integrity: sha512-MXzWZeuGxKizPx2Xf/47wx9sr/uxKw39bVJUptTJdsaQn/TGq+z310mHzf1RCGvC1diHM8f593KrnDgc9oNbJA==}
-
-  '@polkadot/api-augment@12.4.2':
-    resolution: {integrity: sha512-BkG2tQpUUO0iUm65nSqP8hwHkNfN8jQw8apqflJNt9H8EkEL6v7sqwbLvGqtlxM9wzdxbg7lrWp3oHg4rOP31g==}
-    engines: {node: '>=18'}
-
-  '@polkadot/api-base@12.4.2':
-    resolution: {integrity: sha512-XYI7Po8i6C4lYZah7Xo0v7zOAawBUfkmtx0YxsLY/665Sup8oqzEj666xtV9qjBzR9coNhQonIFOn+9fh27Ncw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/api-derive@12.4.2':
-    resolution: {integrity: sha512-R0AMANEnqs5AiTaiQX2FXCxUlOibeDSgqlkyG1/0KDsdr6PO/l3dJOgEO+grgAwh4hdqzk4I9uQpdKxG83f2Gw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/api@12.4.2':
-    resolution: {integrity: sha512-e1KS048471iBWZU10TJNEYOZqLO+8h8ajmVqpaIBOVkamN7tmacBxmHgq0+IA8VrGxjxtYNa1xF5Sqrg76uBEg==}
-    engines: {node: '>=18'}
-
-  '@polkadot/keyring@13.2.2':
-    resolution: {integrity: sha512-h4bPU92CALAAC+QOp6+zttuhI5H0GKOUzj1qwnmoPVoWxh21FoekLAXO1YJlsKxciTDdK5OhjdNPOIqcF0GCXA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/util-crypto': 13.2.2
-
-  '@polkadot/networks@13.2.2':
-    resolution: {integrity: sha512-di3dLB9BcLQ9ARcDe/nizl7jZZnQbQlxB8kXtAXqTIVFtshtKT+zYcji6dTX7xX9/O9tZB7qnrvuIuI0MkwJ5A==}
-    engines: {node: '>=18'}
-
-  '@polkadot/rpc-augment@12.4.2':
-    resolution: {integrity: sha512-IEco5pnso+fYkZNMlMAN5i4XAxdXPv0PZ0HNuWlCwF/MmRvWl8pq5JFtY1FiByHEbeuHwMIUhHM5SDKQ85q9Hg==}
-    engines: {node: '>=18'}
-
-  '@polkadot/rpc-core@12.4.2':
-    resolution: {integrity: sha512-yaveqxNcmyluyNgsBT5tpnCa/md0CGbOtRK7K82LWsz7gsbh0x80GBbJrQGxsUybg1gPeZbO1q9IigwA6fY8ag==}
-    engines: {node: '>=18'}
-
-  '@polkadot/rpc-provider@12.4.2':
-    resolution: {integrity: sha512-cAhfN937INyxwW1AdjABySdCKhC7QCIONRDHDea1aLpiuxq/w+QwjxauR9fCNGh3lTaAwwnmZ5WfFU2PtkDMGQ==}
-    engines: {node: '>=18'}
-
-  '@polkadot/types-augment@12.4.2':
-    resolution: {integrity: sha512-3fDCOy2BEMuAtMYl4crKg76bv/0pDNEuzpAzV4EBUMIlJwypmjy5sg3gUPCMcA+ckX3xb8DhkWU4ceUdS7T2KQ==}
-    engines: {node: '>=18'}
-
-  '@polkadot/types-codec@12.4.2':
-    resolution: {integrity: sha512-DiPGRFWtVMepD9i05eC3orSbGtpN7un/pXOrXu0oriU+oxLkpvZH68ZsPNtJhKdQy03cAYtvB8elJOFJZYqoqQ==}
-    engines: {node: '>=18'}
-
-  '@polkadot/types-create@12.4.2':
-    resolution: {integrity: sha512-nOpeAKZLdSqNMfzS3waQXgyPPaNt8rUHEmR5+WNv6c/Ke/vyf710wjxiTewfp0wpBgtdrimlgG4DLX1J9Ms1LA==}
-    engines: {node: '>=18'}
-
-  '@polkadot/types-known@12.4.2':
-    resolution: {integrity: sha512-bvhO4KQu/dgPmdwQXsweSMRiRisJ7Bp38lZVEIFykfd2qYyRW3OQEbIPKYpx9raD+fDATU0bTiKQnELrSGhYXw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/types-support@12.4.2':
-    resolution: {integrity: sha512-bz6JSt23UEZ2eXgN4ust6z5QF9pO5uNH7UzCP+8I/Nm85ZipeBYj2Wu6pLlE3Hw30hWZpuPxMDOKoEhN5bhLgw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/types@12.4.2':
-    resolution: {integrity: sha512-ivYtt7hYcRvo69ULb1BJA9BE1uefijXcaR089Dzosr9+sMzvsB1yslNQReOq+Wzq6h6AQj4qex6qVqjWZE6Z4A==}
-    engines: {node: '>=18'}
-
-  '@polkadot/util-crypto@13.2.2':
-    resolution: {integrity: sha512-C4vl07XC43vE6egd9LmSe0uOc7hAvBq6CIoILk5ZB95ABNBQSHOrS1pHugW4rJgVUiZgv8sdl+twmgisuSsSfg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': 13.2.2
-
-  '@polkadot/util@13.2.2':
-    resolution: {integrity: sha512-zhsGtR0J2a0ODesJNbCYqEXOL2rhPrmv1F6OB2JMdho7iOrkONck3PZaoT/Y0JF7IlHjGV8K6yrw7k9KUtFrEA==}
-    engines: {node: '>=18'}
-
-  '@polkadot/wasm-bridge@7.4.1':
-    resolution: {integrity: sha512-tdkJaV453tezBxhF39r4oeG0A39sPKGDJmN81LYLf+Fihb7astzwju+u75BRmDrHZjZIv00un3razJEWCxze6g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': '*'
-      '@polkadot/x-randomvalues': '*'
-
-  '@polkadot/wasm-crypto-asmjs@7.4.1':
-    resolution: {integrity: sha512-pwU8QXhUW7IberyHJIQr37IhbB6DPkCG5FhozCiNTq4vFBsFPjm9q8aZh7oX1QHQaiAZa2m2/VjIVE+FHGbvHQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': '*'
-
-  '@polkadot/wasm-crypto-init@7.4.1':
-    resolution: {integrity: sha512-AVka33+f7MvXEEIGq5U0dhaA2SaXMXnxVCQyhJTaCnJ5bRDj0Xlm3ijwDEQUiaDql7EikbkkRtmlvs95eSUWYQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': '*'
-      '@polkadot/x-randomvalues': '*'
-
-  '@polkadot/wasm-crypto-wasm@7.4.1':
-    resolution: {integrity: sha512-PE1OAoupFR0ZOV2O8tr7D1FEUAwaggzxtfs3Aa5gr+yxlSOaWUKeqsOYe1KdrcjmZVV3iINEAXxgrbzCmiuONg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': '*'
-
-  '@polkadot/wasm-crypto@7.4.1':
-    resolution: {integrity: sha512-kHN/kF7hYxm1y0WeFLWeWir6oTzvcFmR4N8fJJokR+ajYbdmrafPN+6iLgQVbhZnDdxyv9jWDuRRsDnBx8tPMQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': '*'
-      '@polkadot/x-randomvalues': '*'
-
-  '@polkadot/wasm-util@7.4.1':
-    resolution: {integrity: sha512-RAcxNFf3zzpkr+LX/ItAsvj+QyM56TomJ0xjUMo4wKkHjwsxkz4dWJtx5knIgQz/OthqSDMR59VNEycQeNuXzA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': '*'
-
-  '@polkadot/x-bigint@13.2.2':
-    resolution: {integrity: sha512-9ENDfG2wYqABWhQYYrbjJK0aPBvCqVPiFhBiKgIg6OTSJKJToa4Di9R8NxelF8eJTtz7DIvgf6gZY/jnKfbtWw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/x-fetch@13.2.2':
-    resolution: {integrity: sha512-aDhd2kdx3JWvZSU4Ge966C0111CH8pCsDX7+9IsMGaZhjLF1NEo2xDjs+EwfUbSvNk68A4UVeJsXjG+IVor/ug==}
-    engines: {node: '>=18'}
-
-  '@polkadot/x-global@13.2.2':
-    resolution: {integrity: sha512-a+iKD7JXxDRtYVo0bp1+HHlaem6MkUHU2yE0cx2e97p9x+IKyNEY58D0L5P66kszLvhFw+t3Jq+qHIj0+2YxkQ==}
-    engines: {node: '>=18'}
-
-  '@polkadot/x-randomvalues@13.2.2':
-    resolution: {integrity: sha512-1UNImkS5PAaGHeIl2DlMjgt2iN7nlclzwrYhmxd0e9Z11RQqavGqi1a02HGREgnUu+wJ7eHmPMVe6K96+cL+aQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/wasm-util': '*'
-
-  '@polkadot/x-textdecoder@13.2.2':
-    resolution: {integrity: sha512-elpIrgdq22yyvt4fzxwb2IRJEpswPVwizzauRipVy3uUmI/lC2f7D7u9jrC554Xy8UrrAPExX1sWJCxZA8DZ/g==}
-    engines: {node: '>=18'}
-
-  '@polkadot/x-textencoder@13.2.2':
-    resolution: {integrity: sha512-nxlNvK5h0KPCaAE/cx92e8JCPAlmFGbuXC9l03C1Ei1wAnOcWuJWRIk2qOkCEYkpT+G0jITPN4dgk634+pBQSw==}
-    engines: {node: '>=18'}
-
-  '@polkadot/x-ws@13.2.2':
-    resolution: {integrity: sha512-WEygcHPB55cKLiNoejJ0Lq3Z1fb4hUO3FmYTXdpHgk0xIOfYDrr7rTlI2cZ4Nb32MofeehN/ZStmEW5Edib6TQ==}
-    engines: {node: '>=18'}
-
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
@@ -4201,24 +4031,6 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
-  '@substrate/connect-extension-protocol@2.2.0':
-    resolution: {integrity: sha512-8b5bN/jo6qD4vcnoWr3T+Nn2u1XLRkJTsEt8b9iGvPPZ1cFcPCVQVpn3lP3U3WqbuSLiVkh0CjX5TW+aCUAi3g==}
-
-  '@substrate/connect-known-chains@1.6.0':
-    resolution: {integrity: sha512-ImPIaaQjSs07qI+gfP6sV/HnupexqgPnyicsPax3Pc6mqDp2HUNMDVdaoWjR84yPbgN8+un/P4KOEb5g4wqHSg==}
-
-  '@substrate/connect@0.8.11':
-    resolution: {integrity: sha512-ofLs1PAO9AtDdPbdyTYj217Pe+lBfTLltdHDs3ds8no0BseoLeAGxpz1mHfi7zB4IxI3YyAiLjH6U8cw4pj4Nw==}
-    deprecated: versions below 1.x are no longer maintained
-
-  '@substrate/light-client-extension-helpers@1.0.0':
-    resolution: {integrity: sha512-TdKlni1mBBZptOaeVrKnusMg/UBpWUORNDv5fdCaJklP4RJiFOzBCrzC+CyVI5kQzsXBisZ+2pXm+rIjS38kHg==}
-    peerDependencies:
-      smoldot: 2.x
-
-  '@substrate/ss58-registry@1.51.0':
-    resolution: {integrity: sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==}
-
   '@swc/core-darwin-arm64@1.15.13':
     resolution: {integrity: sha512-ztXusRuC5NV2w+a6pDhX13CGioMLq8CjX5P4XgVJ21ocqz9t19288Do0y8LklplDtwcEhYGTNdMbkmUT7+lDTg==}
     engines: {node: '>=10'}
@@ -4516,9 +4328,6 @@ packages:
 
   '@types/basic-auth@1.1.8':
     resolution: {integrity: sha512-dKcUeixGuZn8pBjcUrf1N7x5K6lWuKuwHHitM2IZ4vwZUDWEhhNtwCWiba8jTA9zn0GQQ+fTFkWpKx8pOU/enw==}
-
-  '@types/bn.js@5.1.6':
-    resolution: {integrity: sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==}
 
   '@types/body-parser@1.19.5':
     resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
@@ -5789,10 +5598,6 @@ packages:
     resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
     engines: {node: '>=12'}
 
-  data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-
   datastore-core@10.0.4:
     resolution: {integrity: sha512-IctgCO0GA7GHG7aRm3JRruibCsfvN4EXNnNIlLCZMKIv0TPkdAL5UFV3/xTYFYrrZ1jRNrXZNZRvfcVf/R+rAw==}
 
@@ -6194,10 +5999,6 @@ packages:
       picomatch:
         optional: true
 
-  fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
@@ -6277,10 +6078,6 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
-
-  formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
 
   formidable@2.1.2:
     resolution: {integrity: sha512-CM3GuJ57US06mlpQ47YcunuUZ9jpm8Vx+P2CGt2j7HpgkKZO/DJYQ0Bobim8G6PFQmK5lOqOOdUXboU+h73A4g==}
@@ -7293,10 +7090,6 @@ packages:
     resolution: {integrity: sha512-3ROPnEMgBOkusBMYQUW2rnT3wZwsgfOKzJDLvx/TZ7FL1WmWvwSwn3j4aDR5fLDGtgcc1WF0Z1y0di7c9L4FKw==}
     engines: {node: '>=12.0.0'}
 
-  mock-socket@9.3.1:
-    resolution: {integrity: sha512-qxBgB7Qa2sEQgHFjj0dSigq7fX4k6Saisd5Nelwp2q8mlbAFh5dHV9JTTlF8viYJLSSWgMCZFUom8PJcMNBoJw==}
-    engines: {node: '>= 8'}
-
   mockdate@3.0.5:
     resolution: {integrity: sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==}
 
@@ -7417,11 +7210,6 @@ packages:
     resolution: {integrity: sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==}
     engines: {node: '>=6.0.0'}
 
-  node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    deprecated: Use your platform's native DOMException instead
-
   node-fetch@2.6.12:
     resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
     engines: {node: 4.x || >=6.0.0}
@@ -7439,10 +7227,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build-optional-packages@5.1.1:
     resolution: {integrity: sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==}
@@ -8257,9 +8041,6 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
-  rxjs@7.8.1:
-    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
-
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -8276,9 +8057,6 @@ packages:
   satori@0.12.2:
     resolution: {integrity: sha512-3C/laIeE6UUe9A+iQ0A48ywPVCCMKCNSTU5Os101Vhgsjd3AAxGNjyq0uAA8kulMPK5n0csn8JlxPN9riXEjLA==}
     engines: {node: '>=16'}
-
-  scale-ts@1.6.1:
-    resolution: {integrity: sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==}
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
@@ -8419,9 +8197,6 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
-  smoldot@2.0.26:
-    resolution: {integrity: sha512-F+qYmH4z2s2FK+CxGj8moYcd1ekSIKH8ywkdqlOz88Dat35iB1DIYL11aILN46YSGMzQW/lbJNS307zBSDN5Ig==}
 
   socks-proxy-agent@6.2.1:
     resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
@@ -9059,10 +8834,6 @@ packages:
 
   weald@1.1.3:
     resolution: {integrity: sha512-vMWtNbYuPb58NeG2+0sKA0Een4VMDwzf+3oHqh68buWRSOMUBlUeRb11LhV28czV+DUpJHRykifijZDuS9bInA==}
-
-  web-streams-polyfill@3.3.3:
-    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -10479,321 +10250,6 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
-  '@polkadot-api/json-rpc-provider-proxy@0.1.0':
-    optional: true
-
-  '@polkadot-api/json-rpc-provider@0.0.1':
-    optional: true
-
-  '@polkadot-api/metadata-builders@0.3.2':
-    dependencies:
-      '@polkadot-api/substrate-bindings': 0.6.0
-      '@polkadot-api/utils': 0.1.0
-    optional: true
-
-  '@polkadot-api/observable-client@0.3.2(@polkadot-api/substrate-client@0.1.4)(rxjs@7.8.1)':
-    dependencies:
-      '@polkadot-api/metadata-builders': 0.3.2
-      '@polkadot-api/substrate-bindings': 0.6.0
-      '@polkadot-api/substrate-client': 0.1.4
-      '@polkadot-api/utils': 0.1.0
-      rxjs: 7.8.1
-    optional: true
-
-  '@polkadot-api/substrate-bindings@0.6.0':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      '@polkadot-api/utils': 0.1.0
-      '@scure/base': 1.2.6
-      scale-ts: 1.6.1
-    optional: true
-
-  '@polkadot-api/substrate-client@0.1.4':
-    dependencies:
-      '@polkadot-api/json-rpc-provider': 0.0.1
-      '@polkadot-api/utils': 0.1.0
-    optional: true
-
-  '@polkadot-api/utils@0.1.0':
-    optional: true
-
-  '@polkadot/api-augment@12.4.2(supports-color@8.1.1)':
-    dependencies:
-      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/types': 12.4.2
-      '@polkadot/types-augment': 12.4.2
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@polkadot/api-base@12.4.2(supports-color@8.1.1)':
-    dependencies:
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
-      '@polkadot/types': 12.4.2
-      '@polkadot/util': 13.2.2
-      rxjs: 7.8.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@polkadot/api-derive@12.4.2(supports-color@8.1.1)':
-    dependencies:
-      '@polkadot/api': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
-      '@polkadot/types': 12.4.2
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.2.2
-      '@polkadot/util-crypto': 13.2.2(@polkadot/util@13.2.2)
-      rxjs: 7.8.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@polkadot/api@12.4.2(supports-color@8.1.1)':
-    dependencies:
-      '@polkadot/api-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-derive': 12.4.2(supports-color@8.1.1)
-      '@polkadot/keyring': 13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)
-      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-provider': 12.4.2(supports-color@8.1.1)
-      '@polkadot/types': 12.4.2
-      '@polkadot/types-augment': 12.4.2
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/types-create': 12.4.2
-      '@polkadot/types-known': 12.4.2
-      '@polkadot/util': 13.2.2
-      '@polkadot/util-crypto': 13.2.2(@polkadot/util@13.2.2)
-      eventemitter3: 5.0.1
-      rxjs: 7.8.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@polkadot/keyring@13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/util-crypto': 13.2.2(@polkadot/util@13.2.2)
-      tslib: 2.8.1
-
-  '@polkadot/networks@13.2.2':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@substrate/ss58-registry': 1.51.0
-      tslib: 2.8.1
-
-  '@polkadot/rpc-augment@12.4.2(supports-color@8.1.1)':
-    dependencies:
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
-      '@polkadot/types': 12.4.2
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@polkadot/rpc-core@12.4.2(supports-color@8.1.1)':
-    dependencies:
-      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-provider': 12.4.2(supports-color@8.1.1)
-      '@polkadot/types': 12.4.2
-      '@polkadot/util': 13.2.2
-      rxjs: 7.8.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@polkadot/rpc-provider@12.4.2(supports-color@8.1.1)':
-    dependencies:
-      '@polkadot/keyring': 13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)
-      '@polkadot/types': 12.4.2
-      '@polkadot/types-support': 12.4.2
-      '@polkadot/util': 13.2.2
-      '@polkadot/util-crypto': 13.2.2(@polkadot/util@13.2.2)
-      '@polkadot/x-fetch': 13.2.2
-      '@polkadot/x-global': 13.2.2
-      '@polkadot/x-ws': 13.2.2
-      eventemitter3: 5.0.1
-      mock-socket: 9.3.1
-      nock: 13.5.5(supports-color@8.1.1)
-      tslib: 2.8.1
-    optionalDependencies:
-      '@substrate/connect': 0.8.11
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@polkadot/types-augment@12.4.2':
-    dependencies:
-      '@polkadot/types': 12.4.2
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/types-codec@12.4.2':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/x-bigint': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/types-create@12.4.2':
-    dependencies:
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/types-known@12.4.2':
-    dependencies:
-      '@polkadot/networks': 13.2.2
-      '@polkadot/types': 12.4.2
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/types-create': 12.4.2
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/types-support@12.4.2':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/types@12.4.2':
-    dependencies:
-      '@polkadot/keyring': 13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)
-      '@polkadot/types-augment': 12.4.2
-      '@polkadot/types-codec': 12.4.2
-      '@polkadot/types-create': 12.4.2
-      '@polkadot/util': 13.2.2
-      '@polkadot/util-crypto': 13.2.2(@polkadot/util@13.2.2)
-      rxjs: 7.8.1
-      tslib: 2.8.1
-
-  '@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2)':
-    dependencies:
-      '@noble/curves': 1.9.2
-      '@noble/hashes': 1.8.0
-      '@polkadot/networks': 13.2.2
-      '@polkadot/util': 13.2.2
-      '@polkadot/wasm-crypto': 7.4.1(@polkadot/util@13.2.2)(@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)))
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/x-bigint': 13.2.2
-      '@polkadot/x-randomvalues': 13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2))
-      '@scure/base': 1.2.6
-      tslib: 2.8.1
-
-  '@polkadot/util@13.2.2':
-    dependencies:
-      '@polkadot/x-bigint': 13.2.2
-      '@polkadot/x-global': 13.2.2
-      '@polkadot/x-textdecoder': 13.2.2
-      '@polkadot/x-textencoder': 13.2.2
-      '@types/bn.js': 5.1.6
-      bn.js: 5.2.1
-      tslib: 2.8.1
-
-  '@polkadot/wasm-bridge@7.4.1(@polkadot/util@13.2.2)(@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)))':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/x-randomvalues': 13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2))
-      tslib: 2.8.1
-
-  '@polkadot/wasm-crypto-asmjs@7.4.1(@polkadot/util@13.2.2)':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/wasm-crypto-init@7.4.1(@polkadot/util@13.2.2)(@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)))':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.2.2)(@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/x-randomvalues': 13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2))
-      tslib: 2.8.1
-
-  '@polkadot/wasm-crypto-wasm@7.4.1(@polkadot/util@13.2.2)':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.2.2)
-      tslib: 2.8.1
-
-  '@polkadot/wasm-crypto@7.4.1(@polkadot/util@13.2.2)(@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)))':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/wasm-bridge': 7.4.1(@polkadot/util@13.2.2)(@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)))
-      '@polkadot/wasm-crypto-asmjs': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/wasm-crypto-init': 7.4.1(@polkadot/util@13.2.2)(@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)))
-      '@polkadot/wasm-crypto-wasm': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/x-randomvalues': 13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2))
-      tslib: 2.8.1
-
-  '@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2)':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/x-bigint@13.2.2':
-    dependencies:
-      '@polkadot/x-global': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/x-fetch@13.2.2':
-    dependencies:
-      '@polkadot/x-global': 13.2.2
-      node-fetch: 3.3.2
-      tslib: 2.8.1
-
-  '@polkadot/x-global@13.2.2':
-    dependencies:
-      tslib: 2.8.1
-
-  '@polkadot/x-randomvalues@13.2.2(@polkadot/util@13.2.2)(@polkadot/wasm-util@7.4.1(@polkadot/util@13.2.2))':
-    dependencies:
-      '@polkadot/util': 13.2.2
-      '@polkadot/wasm-util': 7.4.1(@polkadot/util@13.2.2)
-      '@polkadot/x-global': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/x-textdecoder@13.2.2':
-    dependencies:
-      '@polkadot/x-global': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/x-textencoder@13.2.2':
-    dependencies:
-      '@polkadot/x-global': 13.2.2
-      tslib: 2.8.1
-
-  '@polkadot/x-ws@13.2.2':
-    dependencies:
-      '@polkadot/x-global': 13.2.2
-      tslib: 2.8.1
-      ws: 8.18.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   '@popperjs/core@2.11.8': {}
 
   '@prisma/debug@5.22.0': {}
@@ -12051,37 +11507,6 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@substrate/connect-extension-protocol@2.2.0':
-    optional: true
-
-  '@substrate/connect-known-chains@1.6.0':
-    optional: true
-
-  '@substrate/connect@0.8.11':
-    dependencies:
-      '@substrate/connect-extension-protocol': 2.2.0
-      '@substrate/connect-known-chains': 1.6.0
-      '@substrate/light-client-extension-helpers': 1.0.0(smoldot@2.0.26)
-      smoldot: 2.0.26
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    optional: true
-
-  '@substrate/light-client-extension-helpers@1.0.0(smoldot@2.0.26)':
-    dependencies:
-      '@polkadot-api/json-rpc-provider': 0.0.1
-      '@polkadot-api/json-rpc-provider-proxy': 0.1.0
-      '@polkadot-api/observable-client': 0.3.2(@polkadot-api/substrate-client@0.1.4)(rxjs@7.8.1)
-      '@polkadot-api/substrate-client': 0.1.4
-      '@substrate/connect-extension-protocol': 2.2.0
-      '@substrate/connect-known-chains': 1.6.0
-      rxjs: 7.8.1
-      smoldot: 2.0.26
-    optional: true
-
-  '@substrate/ss58-registry@1.51.0': {}
-
   '@swc/core-darwin-arm64@1.15.13':
     optional: true
 
@@ -12312,10 +11737,6 @@ snapshots:
   '@types/ansi-html@0.0.0': {}
 
   '@types/basic-auth@1.1.8':
-    dependencies:
-      '@types/node': 20.17.2
-
-  '@types/bn.js@5.1.6':
     dependencies:
       '@types/node': 20.17.2
 
@@ -13769,8 +13190,6 @@ snapshots:
       d3-transition: 3.0.1(d3-selection@3.0.0)
       d3-zoom: 3.0.0
 
-  data-uri-to-buffer@4.0.1: {}
-
   datastore-core@10.0.4:
     dependencies:
       '@libp2p/logger': 5.2.0
@@ -14390,11 +13809,6 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fetch-blob@3.2.0:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.3.3
-
   fflate@0.7.4: {}
 
   file-uri-to-path@1.0.0: {}
@@ -14496,10 +13910,6 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
-
-  formdata-polyfill@4.0.10:
-    dependencies:
-      fetch-blob: 3.2.0
 
   formidable@2.1.2:
     dependencies:
@@ -15555,8 +14965,6 @@ snapshots:
 
   mock-fs@5.4.0: {}
 
-  mock-socket@9.3.1: {}
-
   mockdate@3.0.5: {}
 
   module-details-from-path@1.0.3: {}
@@ -15656,8 +15064,6 @@ snapshots:
 
   node-cron@4.2.1: {}
 
-  node-domexception@1.0.0: {}
-
   node-fetch@2.6.12(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -15669,12 +15075,6 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
-
-  node-fetch@3.3.2:
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.1.1:
     dependencies:
@@ -16548,10 +15948,6 @@ snapshots:
 
   rw@1.3.3: {}
 
-  rxjs@7.8.1:
-    dependencies:
-      tslib: 2.8.1
-
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -16573,9 +15969,6 @@ snapshots:
       parse-css-color: 0.2.1
       postcss-value-parser: 4.2.0
       yoga-wasm-web: 0.3.3
-
-  scale-ts@1.6.1:
-    optional: true
 
   scheduler@0.25.0: {}
 
@@ -16793,14 +16186,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
 
   smart-buffer@4.2.0:
-    optional: true
-
-  smoldot@2.0.26:
-    dependencies:
-      ws: 8.18.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
     optional: true
 
   socks-proxy-agent@6.2.1(supports-color@8.1.1):
@@ -17518,8 +16903,6 @@ snapshots:
     dependencies:
       ms: 4.0.0-nightly.202508271359
       supports-color: 10.2.2
-
-  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
## Summary

Top of stack #12720 (on #12719). Removes `@polkadot/api` entirely: the staking queries only used it for storage-key hashing and SCALE decoding, at the cost of an ~82MB / ~700ms lazy import plus a chain-metadata download on every call.

- New `substrate.ts` (~160 lines): twox128/twox64Concat storage-key hashing (xxhash64 in BigInt) and a SCALE compact decoder, with test vectors verified against `@polkadot/util-crypto`
- `getStakingEraOverview()` now reads `Staking.CurrentEra` and enumerates `Staking.ErasStakersOverview` via `state_getStorage` / `state_getKeysPaged` / `state_queryStorageAt` through the existing `query()` — so the staking reads also gain ClientCore retries and response validation, matching how the block methods already work
- `@polkadot/api` removed from `packages/shared` dependencies (~10MB of node_modules gone)

## Behavior notes

- Validator record keys change from SS58 addresses to hex account ids — they're only used for counting/summing and never persisted
- Trade-off: the SDK adapted to runtime storage-layout changes via downloaded metadata; the hand-rolled decoder would instead fail loudly (decode/validation error → logged → hourly retry). The `PagedExposureMetadata` layout comes from stable upstream `sp_staking`

## Testing

- Live against `mainnet-rpc.avail.so`: identical validator count and stake totals to the `@polkadot/api` implementation captured immediately before the rewrite
- 41 tests passing (hash vectors, compact decoding, DaBeatStatsProvider); typecheck, lint, format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)