### PR TITLE
Dailies 01/09: Chainlink and Liquity V2

### DIFF
--- a/packages/config/src/projects/_templates/liquityv2/StabilityPool/template.jsonc
+++ b/packages/config/src/projects/_templates/liquityv2/StabilityPool/template.jsonc
@@ -5,6 +5,7 @@
   "ignoreMethods": ["scaleToB", "scaleToS"],
   "ignoreRelatives": ["collToken"],
   "ignoreInWatchMode": [
+    "getCollBalance",
     "getEntireBranchColl",
     "getEntireBranchDebt",
     "getTotalBoldDeposits",

--- a/packages/config/src/projects/chainlink/diffHistory.md
+++ b/packages/config/src/projects/chainlink/diffHistory.md
@@ -1,3 +1,26 @@
+Generated with discovered.json: 0xb5f341defcf0c9bf308c64f0f4d30a407861ed83
+
+# Diff at Tue, 01 Sep 2026 11:22:09 GMT:
+
+- author: Luca Donno (<donnoh99@gmail.com>)
+- comparing to: main@971c51541a4e32a7dcee1adc458d42516d2950ec block: 1786960649
+- current timestamp: 1788261539
+
+## Description
+
+signer rotation.
+
+## Watched changes
+
+```diff
+    contract ChainlinkOracleMultisig (eth:0x21f73D42Eb58Ba49dDB685dc29D3bF5c0f0373CA) [GnosisSafe] {
+    +++ description: The Gnosis Safe that Chainlink uses to administer these price feeds and the Feed Registry. It owns the feed proxies, their aggregators, and the registry, so it can swap the aggregator behind any feed or registry pair and replace the set of oracle signers and how many of them must sign a price. In effect it can set the ETH, stETH, and rETH prices these feeds report, or push a feed into a stale, zero, or reverting state, which makes it their single point of control, held by Chainlink.
+      values.$members.4:
+-        "eth:0x47A1dD4E277530fffb5B5f70A43CCbD542F54e17"
++        "eth:0x80D46daD5A5450a3611CD1d7F9110AEdFA55bfF6"
+    }
+```
+
 Generated with discovered.json: 0x7afaed6b816975f1cb755cc6411089378814d8ff
 
 # Diff at Mon, 17 Aug 2026 09:59:44 GMT:

--- a/packages/config/src/projects/chainlink/discovered.json
+++ b/packages/config/src/projects/chainlink/discovered.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "timestamp": 1786960649,
+  "timestamp": 1788261539,
   "configHash": "0x2b86a003b09a0d3103f1aed20373ea845cea7cf4de8e98609e38190318586c89",
   "entries": [
     {
@@ -193,7 +193,7 @@
           "eth:0x05724B9C8C1dDE1b2f659d7c0676ff63f6d5E781",
           "eth:0x480496c0884D61F2f56707Adb11697F8018898c2",
           "eth:0xB65B6d224351cD61f856c227b2d5cFc611E9B2d8",
-          "eth:0x47A1dD4E277530fffb5B5f70A43CCbD542F54e17",
+          "eth:0x80D46daD5A5450a3611CD1d7F9110AEdFA55bfF6",
           "eth:0xFdE996F00E42b33bdE7C640786333623aCC3f298",
           "eth:0x7052cB84079905400ea52B635cAb6a275fDA8823",
           "eth:0xb7F0643D4ca8c296564Ce335062833e1afa3Afdb",
@@ -207,7 +207,7 @@
         ],
         "multisigThreshold": "4 of 9 (44%)",
         "NAME": "Gnosis Safe",
-        "nonce": 2210,
+        "nonce": 2214,
         "VERSION": "1.1.1"
       },
       "implementationNames": {
@@ -305,7 +305,7 @@
         "latestConfigDigestAndEpoch": {
           "scanLogs": false,
           "configDigest": "0x00015fb1bf262779af44a451aaa926c8e0f02c1f012c0cd445ef41c0b50b818e",
-          "epoch": 14507
+          "epoch": 21735
         },
         "linkAvailableForPayment": 0,
         "maxAnswer": "95780971304118053647396689196894323976171195136475135",
@@ -520,11 +520,6 @@
     },
     {
       "address": "eth:0x43dC29Fe432733F239D8485d7DcdAA867B7175b8",
-      "type": "EOA",
-      "proxyType": "EOA"
-    },
-    {
-      "address": "eth:0x47A1dD4E277530fffb5B5f70A43CCbD542F54e17",
       "type": "EOA",
       "proxyType": "EOA"
     },
@@ -1028,7 +1023,7 @@
         "latestConfigDigestAndEpoch": {
           "scanLogs": false,
           "configDigest": "0x0001e754045b2e3624f54e63b92d76f6f94eda08059db3ae9ed57b8b245f1750",
-          "epoch": 14521
+          "epoch": 21748
         },
         "linkAvailableForPayment": 0,
         "maxAnswer": "95780971304118053647396689196894323976171195136475135",
@@ -1082,6 +1077,11 @@
       "implementationNames": {
         "eth:0x7d4E742018fb52E48b08BE73d041C18B21de6Fb5": "AccessControlledOCR2Aggregator"
       }
+    },
+    {
+      "address": "eth:0x80D46daD5A5450a3611CD1d7F9110AEdFA55bfF6",
+      "type": "EOA",
+      "proxyType": "EOA"
     },
     {
       "address": "eth:0x80eFDeE7F82d0F2aBF3bF29A9A85edF0B42C9e19",
@@ -1414,7 +1414,7 @@
         "latestConfigDigestAndEpoch": {
           "scanLogs": false,
           "configDigest": "0x00019e55be9064246f399af0a3d969ce600228fc619c23c923eb8c0468d1834c",
-          "epoch": 251285
+          "epoch": 258486
         },
         "linkAvailableForPayment": 0,
         "maxAnswer": "95780971304118053647396689196894323976171195136475135",
@@ -2963,8 +2963,8 @@
     "ChainlinkOCR2Aggregator": "0x0ceda58eb8c7016c3e902557f785bc5e4145b201e64548d164ee996a7cf9e701",
     "GnosisSafe": "0x12db59bec64fa8de67bbeb6a6e913f6c5ff1598c0a5fba90282afaf08e2a748c"
   },
-  "usedBlockNumbers": { "ethereum": 25774050 },
-  "permissionsConfigHash": "0x2bd8a0e2c2bc539e58348fb5b2a4a2f530b378ee04b8d1033394f33edea58180",
+  "usedBlockNumbers": { "ethereum": 25882085 },
+  "permissionsConfigHash": "0x14b822d4a659b0667f0b81632d49db216444b8018a72ea52a4c0da460749fa4d",
   "permissions": {
     "eth:0x05FD2a0Ce04700375e475a12d2708F1632992D32": {
       "receivedPermissions": [

--- a/packages/config/src/projects/liquityv2/diffHistory.md
+++ b/packages/config/src/projects/liquityv2/diffHistory.md
@@ -1,4 +1,4 @@
-Generated with discovered.json: 0x6774e2c72e19199d3db7018a8ae996620e1a9e20
+Generated with discovered.json: 0xd2816df365b0fe9e861414b793871414dca24da1
 
 # Diff at Mon, 03 Aug 2026 10:52:30 GMT:
 

--- a/packages/config/src/projects/liquityv2/discovered.json
+++ b/packages/config/src/projects/liquityv2/discovered.json
@@ -403,6 +403,7 @@
       "proxyType": "immutable",
       "description": "The branch's liquidation backstop. Anyone can deposit BOLD here, and those deposits are the first resource used to absorb liquidations: when a trove on this branch is liquidated, the pool burns BOLD to cancel an equal amount of that trove's debt and receives the corresponding collateral in return. Because that collateral is worth more than the debt cancelled, depositors generally come out ahead on each liquidation, and they also earn a share of the interest that branch borrowers pay. Deposits can be withdrawn at any time with no lock-up, as long as a small minimum is left so the pool can never be fully emptied.",
       "ignoreInWatchMode": [
+        "getCollBalance",
         "getEntireBranchColl",
         "getEntireBranchDebt",
         "getTotalBoldDeposits",
@@ -1121,6 +1122,7 @@
       "proxyType": "immutable",
       "description": "The branch's liquidation backstop. Anyone can deposit BOLD here, and those deposits are the first resource used to absorb liquidations: when a trove on this branch is liquidated, the pool burns BOLD to cancel an equal amount of that trove's debt and receives the corresponding collateral in return. Because that collateral is worth more than the debt cancelled, depositors generally come out ahead on each liquidation, and they also earn a share of the interest that branch borrowers pay. Deposits can be withdrawn at any time with no lock-up, as long as a small minimum is left so the pool can never be fully emptied.",
       "ignoreInWatchMode": [
+        "getCollBalance",
         "getEntireBranchColl",
         "getEntireBranchDebt",
         "getTotalBoldDeposits",
@@ -1516,6 +1518,7 @@
       "proxyType": "immutable",
       "description": "The branch's liquidation backstop. Anyone can deposit BOLD here, and those deposits are the first resource used to absorb liquidations: when a trove on this branch is liquidated, the pool burns BOLD to cancel an equal amount of that trove's debt and receives the corresponding collateral in return. Because that collateral is worth more than the debt cancelled, depositors generally come out ahead on each liquidation, and they also earn a share of the interest that branch borrowers pay. Deposits can be withdrawn at any time with no lock-up, as long as a small minimum is left so the pool can never be fully emptied.",
       "ignoreInWatchMode": [
+        "getCollBalance",
         "getEntireBranchColl",
         "getEntireBranchDebt",
         "getTotalBoldDeposits",
@@ -3347,7 +3350,7 @@
     "liquityv2/MultiTroveGetter": "0x6fbb45d11251921c07e800160fe95b7bb7e81f6f3b7d0c02107126e904d8cd9c",
     "liquityv2/RETHPriceFeed": "0x9239003c35204078e41e7035d75de869047da4ec49793a3e311466a01403b348",
     "liquityv2/SortedTroves": "0xb8f8e34f836e20d6f3d87a1a3e36af29c0fccf37d9638cfecd5883a0d30cd815",
-    "liquityv2/StabilityPool": "0x24aa19349ac6c7d6e59fa98d153ab12e76a01a843790dd452a7ae90183e8ef48",
+    "liquityv2/StabilityPool": "0xba648f530c503239a9a18374069eefe18bccba84bc79eb2fff0a8b8e614d04b1",
     "liquityv2/TroveManager": "0x22a74f140b8d053fed03a7cc4a1f4e3df9514c66e1a2805674d8f568798e2919",
     "liquityv2/TroveNFT": "0xd94d2f2b575608ff3a0f812c17c1dd00d78b6345c20c3296953a7a7b14e6ec03",
     "liquityv2/UserProxy": "0x76c1139858057493e9d67b62aaf9bf39fe368ce27ecbde05d644d94d1db2fbcf",


### PR DESCRIPTION
## Summary

- ignore routine `StabilityPool.getCollBalance` changes in Liquity V2 watch mode
- refresh Chainlink discovery after the `ChainlinkOracleMultisig` replaced one owner while remaining 4-of-9
- keep the existing exact OCR epoch exclusion; all tracked OCR configuration digests remain unchanged

## Verification

- verified the Chainlink Safe owner rotation from the successful onchain `swapOwner` transaction and owner events
- replayed both discoveries with `--dev`
- ran live two-snapshot checks for both projects with `--dry-run` (`No changes!`)
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --reporter min` (24,097 passing, 1 pending)
- `pnpm build`
- `git diff --check`
