### PR TITLE
Add DeFi TVL database storage

### DIFF
--- a/packages/database/prisma/migrations/20260831120000_add_defi_tvl/migration.sql
+++ b/packages/database/prisma/migrations/20260831120000_add_defi_tvl/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "DefiTvl" (
+    "timestamp" TIMESTAMP(6) NOT NULL,
+    "sourceTimestamp" TIMESTAMP(6) NOT NULL,
+    "configurationId" CHAR(12) NOT NULL,
+    "projectId" VARCHAR(255) NOT NULL,
+    "chain" VARCHAR(255) NOT NULL,
+    "valueUsd" DOUBLE PRECISION NOT NULL,
+
+    CONSTRAINT "DefiTvl_pkey" PRIMARY KEY ("timestamp", "configurationId", "chain")
+);
+
+-- CreateIndex
+CREATE INDEX "DefiTvl_configurationId_idx" ON "DefiTvl"("configurationId");
+
+-- CreateIndex
+CREATE INDEX "DefiTvl_projectId_timestamp_idx" ON "DefiTvl"("projectId", "timestamp" DESC);

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -266,6 +266,19 @@ model TokenValue {
   @@index([projectId, timestamp, tokenId, valueForProject, valueForSummary])
 }
 
+model DefiTvl {
+  timestamp       DateTime @db.Timestamp(6)
+  sourceTimestamp DateTime @db.Timestamp(6)
+  configurationId String   @db.Char(12)
+  projectId       String   @db.VarChar(255)
+  chain           String   @db.VarChar(255)
+  valueUsd        Float    @db.DoublePrecision
+
+  @@id([timestamp, configurationId, chain])
+  @@index([configurationId])
+  @@index([projectId, timestamp(sort: Desc)])
+}
+
 model TokenMetadata {
   tokenId      String  @db.VarChar(255)
   projectId    String  @db.VarChar(255)

--- a/packages/database/scripts/db-restore/db-restore.ts
+++ b/packages/database/scripts/db-restore/db-restore.ts
@@ -33,6 +33,7 @@ const FEATURES: Record<string, string[]> = {
     'TokenValue',
     'SyncMetadata',
   ],
+  'defi-tvl': ['IndexerState', 'IndexerConfiguration', 'DefiTvl'],
   activity: [
     'IndexerState',
     'IndexerConfiguration',

--- a/packages/database/src/database.ts
+++ b/packages/database/src/database.ts
@@ -15,6 +15,7 @@ import { BlobsRepository } from './repositories/BlobsRepository'
 import { CurrentPriceRepository } from './repositories/CurrentPriceRepository'
 import { DaBeatStatsRepository } from './repositories/DaBeatStatsRepository'
 import { DataAvailabilityRepository } from './repositories/DataAvailabilityRepository'
+import { DefiTvlRepository } from './repositories/DefiTvlRepository'
 import { DiscoveryCacheRepository } from './repositories/DiscoveryCacheRepository'
 import { EcosystemTokenRepository } from './repositories/EcosystemTokenRepository'
 import { FlatSourcesRepository } from './repositories/FlatSourcesRepository'
@@ -101,6 +102,10 @@ export function createDatabase(
 
     // #region Ecosystems
     ecosystemToken: new EcosystemTokenRepository(db),
+    // #endregion
+
+    // #region DeFi
+    defiTvl: new DefiTvlRepository(db),
     // #endregion
 
     // #region UIF

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -44,6 +44,10 @@ export type {
   ProjectsSummedDataAvailabilityRecord,
 } from './repositories/DataAvailabilityRepository'
 export type {
+  DefiTvlRecord,
+  SummedDefiTvlRecord,
+} from './repositories/DefiTvlRepository'
+export type {
   DeployedTokenPrimaryKey,
   DeployedTokenRecord,
   DeployedTokenUpdateable,

--- a/packages/database/src/repositories/DefiTvlRepository.test.ts
+++ b/packages/database/src/repositories/DefiTvlRepository.test.ts
@@ -1,0 +1,103 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { describeDatabase } from '../test/database'
+import type { DefiTvlRecord } from './DefiTvlRepository'
+import { DefiTvlRepository } from './DefiTvlRepository'
+
+describeDatabase(DefiTvlRepository.name, (db) => {
+  const repository = db.defiTvl
+
+  afterEach(async () => {
+    await repository.deleteAll()
+  })
+
+  it('upserts and sums the latest per-chain snapshot per project', async () => {
+    await repository.upsertMany([
+      record('project-a', 'config000001', 'ethereum', 100, 10),
+      record('project-a', 'config000001', 'arbitrum', 100, 20),
+      record('project-a', 'config000001', 'ethereum', 200, 11),
+      record('project-a', 'config000001', 'arbitrum', 200, 22, 205),
+      record('project-b', 'config000002', 'ethereum', 150, 40),
+    ])
+
+    const result = await repository.getLatestByProjects([
+      'project-a',
+      'project-b',
+    ])
+
+    expect(result).toEqualUnsorted([
+      {
+        projectId: 'project-a',
+        timestamp: UnixTime(200),
+        sourceTimestamp: UnixTime(200),
+        valueUsd: 33,
+        chainCount: 2,
+      },
+      {
+        projectId: 'project-b',
+        timestamp: UnixTime(150),
+        sourceTimestamp: UnixTime(150),
+        valueUsd: 40,
+        chainCount: 1,
+      },
+    ])
+  })
+
+  it('returns summed snapshots in the requested range', async () => {
+    await repository.upsertMany([
+      record('project-a', 'config000001', 'ethereum', 100, 10),
+      record('project-a', 'config000001', 'arbitrum', 100, 20),
+      record('project-a', 'config000001', 'ethereum', 200, 11),
+      record('project-a', 'config000001', 'arbitrum', 200, 22),
+    ])
+
+    const result = await repository.getByProjectInRange(
+      'project-a',
+      UnixTime(150),
+      UnixTime(250),
+    )
+
+    expect(result).toEqual([
+      {
+        projectId: 'project-a',
+        timestamp: UnixTime(200),
+        sourceTimestamp: UnixTime(200),
+        valueUsd: 33,
+        chainCount: 2,
+      },
+    ])
+  })
+
+  it('updates a snapshot and deletes all data for a configuration', async () => {
+    await repository.upsertMany([
+      record('project-a', 'config000001', 'ethereum', 100, 10),
+      record('project-b', 'config000002', 'ethereum', 100, 20),
+    ])
+    await repository.upsertMany([
+      record('project-a', 'config000001', 'ethereum', 100, 15, 101),
+    ])
+
+    expect(await repository.deleteByConfigIds(['config000002'])).toEqual(1)
+    expect(await repository.getAll()).toEqualUnsorted([
+      record('project-a', 'config000001', 'ethereum', 100, 15, 101),
+    ])
+  })
+})
+
+function record(
+  projectId: string,
+  configurationId: string,
+  chain: string,
+  timestamp: number,
+  valueUsd: number,
+  sourceTimestamp = timestamp,
+): DefiTvlRecord {
+  return {
+    projectId,
+    configurationId,
+    chain,
+    timestamp: UnixTime(timestamp),
+    sourceTimestamp: UnixTime(sourceTimestamp),
+    valueUsd,
+  }
+}

--- a/packages/database/src/repositories/DefiTvlRepository.test.ts
+++ b/packages/database/src/repositories/DefiTvlRepository.test.ts
@@ -11,8 +11,8 @@ describeDatabase(DefiTvlRepository.name, (db) => {
     await repository.deleteAll()
   })
 
-  it('upserts and sums the latest per-chain snapshot per project', async () => {
-    await repository.upsertMany([
+  it('replaces and sums the latest per-chain snapshot per project', async () => {
+    await repository.replaceMany([
       record('project-a', 'config000001', 'ethereum', 100, 10),
       record('project-a', 'config000001', 'arbitrum', 100, 20),
       record('project-a', 'config000001', 'ethereum', 200, 11),
@@ -44,7 +44,7 @@ describeDatabase(DefiTvlRepository.name, (db) => {
   })
 
   it('returns summed snapshots in the requested range', async () => {
-    await repository.upsertMany([
+    await repository.replaceMany([
       record('project-a', 'config000001', 'ethereum', 100, 10),
       record('project-a', 'config000001', 'arbitrum', 100, 20),
       record('project-a', 'config000001', 'ethereum', 200, 11),
@@ -68,18 +68,53 @@ describeDatabase(DefiTvlRepository.name, (db) => {
     ])
   })
 
-  it('updates a snapshot and deletes all data for a configuration', async () => {
-    await repository.upsertMany([
+  it('removes chains omitted from a replaced snapshot', async () => {
+    await repository.replaceMany([
+      record('project-a', 'config000001', 'ethereum', 100, 10),
+      record('project-a', 'config000001', 'arbitrum', 100, 20),
+      record('project-a', 'config000001', 'arbitrum', 200, 30),
+    ])
+
+    await repository.replaceMany([
+      record('project-a', 'config000001', 'ethereum', 100, 15, 101),
+    ])
+
+    expect(await repository.getAll()).toEqualUnsorted([
+      record('project-a', 'config000001', 'ethereum', 100, 15, 101),
+      record('project-a', 'config000001', 'arbitrum', 200, 30),
+    ])
+  })
+
+  it('deletes data in range for matching configuration', async () => {
+    await repository.replaceMany([
+      record('project-a', 'config000001', 'ethereum', 100, 10),
+      record('project-a', 'config000001', 'ethereum', 200, 20),
+      record('project-a', 'config000001', 'ethereum', 300, 30),
+      record('project-b', 'config000002', 'ethereum', 200, 40),
+    ])
+
+    expect(
+      await repository.deleteByConfigInTimeRange(
+        'config000001',
+        UnixTime(100),
+        UnixTime(200),
+      ),
+    ).toEqual(2)
+    expect(await repository.getAll()).toEqualUnsorted([
+      record('project-a', 'config000001', 'ethereum', 300, 30),
+      record('project-b', 'config000002', 'ethereum', 200, 40),
+    ])
+  })
+
+  it('deletes all data for a configuration', async () => {
+    await repository.replaceMany([
       record('project-a', 'config000001', 'ethereum', 100, 10),
       record('project-b', 'config000002', 'ethereum', 100, 20),
-    ])
-    await repository.upsertMany([
-      record('project-a', 'config000001', 'ethereum', 100, 15, 101),
     ])
 
     expect(await repository.deleteByConfigIds(['config000002'])).toEqual(1)
     expect(await repository.getAll()).toEqualUnsorted([
-      record('project-a', 'config000001', 'ethereum', 100, 15, 101),
+      record('project-a', 'config000001', 'ethereum', 100, 10),
     ])
   })
 })

--- a/packages/database/src/repositories/DefiTvlRepository.ts
+++ b/packages/database/src/repositories/DefiTvlRepository.ts
@@ -1,0 +1,158 @@
+import { UnixTime } from '@l2beat/shared-pure'
+import type { Insertable, Selectable } from 'kysely'
+import { BaseRepository } from '../BaseRepository'
+import type { DefiTvl } from '../kysely/generated/types'
+
+export interface DefiTvlRecord {
+  timestamp: UnixTime
+  sourceTimestamp: UnixTime
+  configurationId: string
+  projectId: string
+  chain: string
+  valueUsd: number
+}
+
+export interface SummedDefiTvlRecord {
+  projectId: string
+  timestamp: UnixTime
+  sourceTimestamp: UnixTime
+  valueUsd: number
+  chainCount: number
+}
+
+export function toRecord(row: Selectable<DefiTvl>): DefiTvlRecord {
+  return {
+    ...row,
+    timestamp: UnixTime.fromDate(row.timestamp),
+    sourceTimestamp: UnixTime.fromDate(row.sourceTimestamp),
+  }
+}
+
+export function toRow(record: DefiTvlRecord): Insertable<DefiTvl> {
+  return {
+    ...record,
+    timestamp: UnixTime.toDate(record.timestamp),
+    sourceTimestamp: UnixTime.toDate(record.sourceTimestamp),
+  }
+}
+
+export class DefiTvlRepository extends BaseRepository {
+  async upsertMany(records: DefiTvlRecord[]): Promise<number> {
+    if (records.length === 0) return 0
+
+    const rows = records.map(toRow)
+    await this.batch(rows, 2_000, async (batch) => {
+      await this.db
+        .insertInto('DefiTvl')
+        .values(batch)
+        .onConflict((oc) =>
+          oc
+            .columns(['timestamp', 'configurationId', 'chain'])
+            .doUpdateSet((eb) => ({
+              sourceTimestamp: eb.ref('excluded.sourceTimestamp'),
+              projectId: eb.ref('excluded.projectId'),
+              valueUsd: eb.ref('excluded.valueUsd'),
+            })),
+        )
+        .execute()
+    })
+
+    return rows.length
+  }
+
+  async getLatestByProjects(
+    projectIds: string[],
+  ): Promise<SummedDefiTvlRecord[]> {
+    if (projectIds.length === 0) return []
+
+    const rows = await this.db
+      .with('latest', (db) =>
+        db
+          .selectFrom('DefiTvl')
+          .select('projectId')
+          .select((eb) => eb.fn.max('timestamp').as('timestamp'))
+          .where('projectId', 'in', projectIds)
+          .groupBy('projectId'),
+      )
+      .selectFrom('DefiTvl as d')
+      .innerJoin('latest as l', (join) =>
+        join
+          .onRef('d.projectId', '=', 'l.projectId')
+          .onRef('d.timestamp', '=', 'l.timestamp'),
+      )
+      .select((eb) => [
+        'd.projectId',
+        'd.timestamp',
+        eb.fn.min('d.sourceTimestamp').as('sourceTimestamp'),
+        eb.cast(eb.fn.sum('d.valueUsd'), 'double precision').as('valueUsd'),
+        eb.fn.count('d.chain').as('chainCount'),
+      ])
+      .groupBy(['d.projectId', 'd.timestamp'])
+      .execute()
+
+    return rows.map(toSummedRecord)
+  }
+
+  async getByProjectInRange(
+    projectId: string,
+    fromInclusive: UnixTime | null,
+    toInclusive: UnixTime,
+  ): Promise<SummedDefiTvlRecord[]> {
+    let query = this.db
+      .selectFrom('DefiTvl')
+      .select((eb) => [
+        'projectId',
+        'timestamp',
+        eb.fn.min('sourceTimestamp').as('sourceTimestamp'),
+        eb.cast(eb.fn.sum('valueUsd'), 'double precision').as('valueUsd'),
+        eb.fn.count('chain').as('chainCount'),
+      ])
+      .where('projectId', '=', projectId)
+      .where('timestamp', '<=', UnixTime.toDate(toInclusive))
+      .groupBy(['projectId', 'timestamp'])
+      .orderBy('timestamp', 'asc')
+
+    if (fromInclusive !== null) {
+      query = query.where('timestamp', '>=', UnixTime.toDate(fromInclusive))
+    }
+
+    const rows = await query.execute()
+    return rows.map(toSummedRecord)
+  }
+
+  async deleteByConfigIds(ids: string[]): Promise<number> {
+    if (ids.length === 0) return 0
+
+    const result = await this.db
+      .deleteFrom('DefiTvl')
+      .where('configurationId', 'in', ids)
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
+  async getAll(): Promise<DefiTvlRecord[]> {
+    const rows = await this.db.selectFrom('DefiTvl').selectAll().execute()
+    return rows.map(toRecord)
+  }
+
+  async deleteAll(): Promise<number> {
+    const result = await this.db.deleteFrom('DefiTvl').executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+}
+
+function toSummedRecord(row: {
+  projectId: string
+  timestamp: Date
+  sourceTimestamp: Date
+  valueUsd: unknown
+  chainCount: unknown
+}): SummedDefiTvlRecord {
+  return {
+    projectId: row.projectId,
+    timestamp: UnixTime.fromDate(row.timestamp),
+    sourceTimestamp: UnixTime.fromDate(row.sourceTimestamp),
+    valueUsd: Number(row.valueUsd),
+    chainCount: Number(row.chainCount),
+  }
+}

--- a/packages/database/src/repositories/DefiTvlRepository.ts
+++ b/packages/database/src/repositories/DefiTvlRepository.ts
@@ -37,24 +37,36 @@ export function toRow(record: DefiTvlRecord): Insertable<DefiTvl> {
 }
 
 export class DefiTvlRepository extends BaseRepository {
-  async upsertMany(records: DefiTvlRecord[]): Promise<number> {
+  async replaceMany(records: DefiTvlRecord[]): Promise<number> {
     if (records.length === 0) return 0
 
     const rows = records.map(toRow)
-    await this.batch(rows, 2_000, async (batch) => {
-      await this.db
-        .insertInto('DefiTvl')
-        .values(batch)
-        .onConflict((oc) =>
-          oc
-            .columns(['timestamp', 'configurationId', 'chain'])
-            .doUpdateSet((eb) => ({
-              sourceTimestamp: eb.ref('excluded.sourceTimestamp'),
-              projectId: eb.ref('excluded.projectId'),
-              valueUsd: eb.ref('excluded.valueUsd'),
-            })),
-        )
-        .execute()
+    const timestampsByConfiguration = new Map<string, Set<UnixTime>>()
+    for (const record of records) {
+      const timestamps =
+        timestampsByConfiguration.get(record.configurationId) ?? new Set()
+      timestamps.add(record.timestamp)
+      timestampsByConfiguration.set(record.configurationId, timestamps)
+    }
+
+    await this.transaction(async () => {
+      for (const [configurationId, timestamps] of timestampsByConfiguration) {
+        await this.batch([...timestamps], 2_000, async (batch) => {
+          await this.db
+            .deleteFrom('DefiTvl')
+            .where('configurationId', '=', configurationId)
+            .where(
+              'timestamp',
+              'in',
+              batch.map((timestamp) => UnixTime.toDate(timestamp)),
+            )
+            .execute()
+        })
+      }
+
+      await this.batch(rows, 2_000, async (batch) => {
+        await this.db.insertInto('DefiTvl').values(batch).execute()
+      })
     })
 
     return rows.length
@@ -126,6 +138,20 @@ export class DefiTvlRepository extends BaseRepository {
     const result = await this.db
       .deleteFrom('DefiTvl')
       .where('configurationId', 'in', ids)
+      .executeTakeFirst()
+    return Number(result.numDeletedRows)
+  }
+
+  async deleteByConfigInTimeRange(
+    configurationId: string,
+    fromInclusive: UnixTime,
+    toInclusive: UnixTime,
+  ): Promise<number> {
+    const result = await this.db
+      .deleteFrom('DefiTvl')
+      .where('configurationId', '=', configurationId)
+      .where('timestamp', '>=', UnixTime.toDate(fromInclusive))
+      .where('timestamp', '<=', UnixTime.toDate(toInclusive))
       .executeTakeFirst()
     return Number(result.numDeletedRows)
   }


### PR DESCRIPTION
## Summary

- Adds provider-neutral persistence for externally sourced DeFi TVL.
- Registers the repository on the shared database object and in the database restore tooling.
- Covers atomic snapshot replacement, per-project aggregation, ranged chart reads, range trimming, and configuration cleanup.

## Why

Complex DeFi protocols should not be forced into the native TVS escrow pipeline. This table provides a separate storage boundary for provider-backed USD TVL while leaving native TVS unchanged.

## Schema and query contract

- One row represents one chain in one project configuration snapshot.
- The primary key is `timestamp + configurationId + chain`.
- Replacing a snapshot first removes every existing row for its `configurationId + timestamp`, then inserts the complete new chain set in the same transaction. This removes chains omitted by a corrected provider response instead of retaining stale rows.
- `sourceTimestamp` preserves provider freshness independently from the hourly indexing timestamp.
- Project reads aggregate chains and return `chainCount`, allowing consumers to reject incomplete snapshots.
- Indexes support configuration cleanup and latest/ranged project reads.

## Stack

1. **Database foundation — this PR**
2. Configuration and ingestion: https://github.com/l2beat/l2beat/pull/12732
3. Frontend and API integration: https://github.com/l2beat/l2beat/pull/12733

This PR changes only `packages/database/**`, keeping the migration isolated from application code.

## Validation

- Prisma/Kysely generation
- Database typecheck, build, and Biome
- `DefiTvlRepository`: 5 PostgreSQL tests passing
- `git diff --check`
