### PR TITLE
OP chains with broken proofs

### DIFF
--- a/packages/config/src/projects/bobanetwork/bobanetwork.ts
+++ b/packages/config/src/projects/bobanetwork/bobanetwork.ts
@@ -26,9 +26,11 @@ export const bobanetwork: ScalingProject = opStackL2({
     },
     getOpStackDaTracking(discovery, { sinceBlock: 22790097 }),
   ],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   display: {
     name: 'Boba Network',
+    warning:
+      'The fault proof system is deployed but is not functional. The chain ID is not included in the superchain registry snapshot embedded in the op-program release that the dispute games commit to, causing the dispute game to panic during execution. Security relies entirely on the permissioned proposer and challengers.',
     shortName: 'Boba',
     slug: 'bobanetwork',
     description:

--- a/packages/config/src/projects/cyber/cyber.ts
+++ b/packages/config/src/projects/cyber/cyber.ts
@@ -66,6 +66,8 @@ export const cyber: ScalingProject = opStackL2({
   ],
   display: {
     name: 'Cyber',
+    warning:
+      'The fault proof system is deployed but is not functional. The dispute game commits to the placeholder absolute prestate from the OP Stack deployment template rather than to a reproducible op-program build for this chain. Security relies entirely on the permissioned proposer and challengers.',
     slug: 'cyber',
     architectureImage: 'opstack-rollup-superchain-opfp-preu16',
     description:

--- a/packages/config/src/projects/funki/funki.ts
+++ b/packages/config/src/projects/funki/funki.ts
@@ -58,6 +58,8 @@ export const funki: ScalingProject = opStackL2({
   ],
   display: {
     name: 'Funki',
+    warning:
+      'The fault proof system is deployed but is not functional. The dispute game commits to the placeholder absolute prestate from the OP Stack deployment template rather than to a reproducible op-program build for this chain. Security relies entirely on the permissioned proposer and challengers.',
     slug: 'funki',
     architectureImage: 'opstack-rollup-superchain-opfp-preu16',
     description:

--- a/packages/config/src/projects/hashkey/hashkey.ts
+++ b/packages/config/src/projects/hashkey/hashkey.ts
@@ -67,9 +67,11 @@ export const hashkey = opStackL2({
     getOpStackDaTracking(discovery, { sinceBlock: 24582182 }),
   ],
   additionalPurposes: ['Exchange'],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   display: {
     name: 'HashKey Chain',
+    warning:
+      'The fault proof system is deployed but is not functional. The chain ID is not included in the superchain registry snapshot embedded in the op-program release that the dispute games commit to, causing the dispute game to panic during execution. Security relies entirely on the permissioned proposer and challengers.',
     slug: 'hashkey',
     description:
       "HashKey Chain is a regulatory-compliant, institutional-grade OP stack Layer 2 solution bridging traditional finance and Web3. It is powered by Hong Kong's premier virtual asset ecosystem.",

--- a/packages/config/src/projects/lisk/lisk.ts
+++ b/packages/config/src/projects/lisk/lisk.ts
@@ -18,9 +18,11 @@ export const lisk: ScalingProject = opStackL2({
   genesisTimestamp: UnixTime(1714728793),
   associatedTokens: ['LSK'],
   additionalBadges: [BADGES.RaaS.Gelato, BADGES.Other.MigratedFromL1],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   display: {
     name: 'Lisk',
+    warning:
+      'The fault proof system is deployed but is not functional. The chain ID is not included in the superchain registry snapshot embedded in the op-program release that the dispute games commit to, causing the dispute game to panic during execution. Security relies entirely on the permissioned proposer and challengers.',
     slug: 'lisk',
     headerWarning:
       'Lisk Chain will shut down on October 31, 2026. See the [announcement](https://lisk.com/blog/posts/introducing-the-new-lisk) and withdraw your funds to Ethereum.',

--- a/packages/config/src/projects/lyra/lyra.ts
+++ b/packages/config/src/projects/lyra/lyra.ts
@@ -19,11 +19,13 @@ export const lyra: ScalingProject = opStackL2({
   additionalPurposes: ['Exchange'],
   discovery,
   reasonsForBeingOther: [
-    REASON_FOR_BEING_OTHER.CLOSED_PROOFS,
+    REASON_FOR_BEING_OTHER.NO_PROOFS,
     REASON_FOR_BEING_OTHER.NO_DA_ORACLE,
   ],
   display: {
     name: 'Derive',
+    warning:
+      'The fault proof system is deployed but is not functional. The dispute game commits to an op-program release that predates the Jovian hardfork active on the chain, so it cannot derive current blocks and no dispute can be resolved correctly by execution. Security relies entirely on the permissioned proposer and challengers.',
     aliases: ['Lyra'],
     slug: 'derive',
     description:

--- a/packages/config/src/projects/metal/metal.ts
+++ b/packages/config/src/projects/metal/metal.ts
@@ -18,9 +18,11 @@ export const metal: ScalingProject = opStackL2({
   daTracking: [getOpStackDaTracking(discovery, { sinceBlock: 19527368 })],
   associatedTokens: ['MTL'],
   additionalBadges: [BADGES.RaaS.Conduit],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   display: {
     name: 'Metal',
+    warning:
+      'The fault proof system is deployed but is not functional. The permissioned dispute game commits to a placeholder absolute prestate (0xdead…) set by OP Stack Upgrade 19, so no dispute can be resolved by execution. Security relies entirely on the permissioned proposer and challenger.',
     slug: 'metal',
     description:
       'Metal L2 is a general-purpose OP stack rollup by Metallicus focused on banking and compliance.',

--- a/packages/config/src/projects/mode/mode.ts
+++ b/packages/config/src/projects/mode/mode.ts
@@ -17,9 +17,11 @@ export const mode: ScalingProject = opStackL2({
   discovery,
   daTracking: [getOpStackDaTracking(discovery, { sinceBlock: 18586931 })],
   additionalBadges: [BADGES.RaaS.Conduit],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   display: {
     name: 'Mode Network',
+    warning:
+      'The fault proof system is deployed but is not functional. The permissioned dispute game commits to a placeholder absolute prestate (0xdead…) set by OP Stack Upgrade 19, so no dispute can be resolved by execution. Security relies entirely on the permissioned proposer and challenger.',
     shortName: 'Mode',
     slug: 'mode',
     description:

--- a/packages/config/src/projects/orderly/orderly.ts
+++ b/packages/config/src/projects/orderly/orderly.ts
@@ -18,11 +18,13 @@ export const orderly: ScalingProject = opStackL2({
   additionalPurposes: ['Exchange'],
   discovery,
   reasonsForBeingOther: [
-    REASON_FOR_BEING_OTHER.CLOSED_PROOFS,
+    REASON_FOR_BEING_OTHER.NO_PROOFS,
     REASON_FOR_BEING_OTHER.NO_DA_ORACLE,
   ],
   display: {
     name: 'Orderly Network',
+    warning:
+      'The fault proof system is deployed but is not functional. The dispute game commits to an op-program release that predates the Jovian hardfork active on the chain, so it cannot derive current blocks and no dispute can be resolved correctly by execution. Security relies entirely on the permissioned proposer and challengers.',
     shortName: 'Orderly',
     slug: 'orderly',
     description:

--- a/packages/config/src/projects/phala/phala.ts
+++ b/packages/config/src/projects/phala/phala.ts
@@ -24,6 +24,8 @@ export const phala: ScalingProject = opStackL2({
   genesisTimestamp: UnixTime.fromDate(new Date('2024-12-16T22:14:09Z')),
   display: {
     name: 'Phala',
+    warning:
+      'The fault proof system is deployed but is not functional. The chain ID is not included in the superchain registry snapshot embedded in the op-program release that the dispute games commit to, causing the dispute game to panic during execution. Security relies entirely on the permissioned proposer and challengers.',
     slug: 'phala',
     description: `Phala is a cloud computing protocol which aims at offering developers a secure and efficient platform for deploying and managing AI-ready applications in a trusted environment (TEE).
       Phala rollup on Ethereum leverages the Op-Succinct stack, a combination of OP stack contracts and Zero-Knowledge Proofs (ZK) using the SP1 zkVM.`,
@@ -60,7 +62,7 @@ export const phala: ScalingProject = opStackL2({
       },
     ],
   },
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   // nonTemplateProofSystem: {
   //   type: 'Validity',
   //   zkCatalogIds: [ProjectId('sp1hypercube')],

--- a/packages/config/src/projects/soneium/soneium.ts
+++ b/packages/config/src/projects/soneium/soneium.ts
@@ -20,9 +20,11 @@ export const soneium = opStackL2({
   discovery,
   daTracking: [getOpStackDaTracking(discovery, { sinceBlock: 21314185 })],
   genesisTimestamp,
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   display: {
     name: 'Soneium',
+    warning:
+      'The fault proof system is deployed but is not functional. The permissioned dispute game commits to a placeholder absolute prestate (0xdead…) set by OP Stack Upgrade 19, so no dispute can be resolved by execution. Security relies entirely on the permissioned proposer and challenger.',
     aliases: ['Sony'],
     slug: 'soneium',
     stateValidationImage: 'opfp',

--- a/packages/config/src/projects/superseed/superseed.ts
+++ b/packages/config/src/projects/superseed/superseed.ts
@@ -16,10 +16,12 @@ export const superseed: ScalingProject = opStackL2({
   capability: 'universal',
   addedAt: UnixTime(1743379200), // 2025-03-31T00:00:00Z
   additionalBadges: [BADGES.RaaS.Conduit],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   isPartOfSuperchain: true,
   display: {
     name: 'Superseed',
+    warning:
+      'The fault proof system is deployed but is not functional. The dispute game commits to an op-program release that predates the Jovian hardfork active on the chain, so it cannot derive current blocks and no dispute can be resolved correctly by execution. Security relies entirely on the permissioned proposer and challengers.',
     slug: 'superseed',
     headerWarning:
       'Superseed is being deprecated. See the [announcement](https://x.com/superseed/status/2079216129059283250) and make sure to bridge off your funds until August 15, 2026.',

--- a/packages/config/src/projects/zircuit/zircuit.ts
+++ b/packages/config/src/projects/zircuit/zircuit.ts
@@ -103,11 +103,13 @@ export const zircuit: ScalingProject = {
     BADGES.Stack.OPStack,
     BADGES.RaaS.Conduit,
   ],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   capability: 'universal',
   type: 'layer2',
   display: {
     name: 'Zircuit',
+    warning:
+      'The fault proof system is deployed but is not functional. The chain ID is not included in the superchain registry snapshot embedded in the op-program release that the dispute games commit to, causing the dispute game to panic during execution. Security relies entirely on the permissioned proposer and challengers.',
     slug: 'zircuit',
     purposes: ['Universal'],
     stacks: ['OP Stack'],
@@ -171,10 +173,7 @@ export const zircuit: ScalingProject = {
       rollupNodeLink: 'https://github.com/zircuit-labs/l2-geth-public',
     },
   ),
-  proofSystem: {
-    type: 'Optimistic',
-    challengeProtocol: 'Interactive',
-  },
+  proofSystem: undefined,
   riskView: {
     stateValidation: {
       ...RISK_VIEW.STATE_FP_INT(

--- a/packages/config/src/projects/zora/zora.ts
+++ b/packages/config/src/projects/zora/zora.ts
@@ -18,9 +18,11 @@ export const zora: ScalingProject = opStackL2({
   daTracking: [getOpStackDaTracking(discovery, { sinceBlock: 17473957 })],
   additionalBadges: [BADGES.RaaS.Conduit],
   additionalPurposes: ['NFT'],
-  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.CLOSED_PROOFS],
+  reasonsForBeingOther: [REASON_FOR_BEING_OTHER.NO_PROOFS],
   display: {
     name: 'Zora',
+    warning:
+      'The fault proof system is deployed but is not functional. The permissioned dispute game commits to a placeholder absolute prestate (0xdead…) set by OP Stack Upgrade 19, so no dispute can be resolved by execution. Security relies entirely on the permissioned proposer and challenger.',
     slug: 'zora',
     description:
       'Zora is a fast, cost-efficient, and scalable Layer 2 built to help bring media onchain, powered by the OP Stack.',


### PR DESCRIPTION
Move chains whose respected PermissionedDisputeGame commits to a prestate that cannot execute for the chain from CLOSED_PROOFS to NO_PROOFS, with a display warning

- Phala, Zircuit, HashKey, Lisk, Boba: chain ID absent from the superchain registry snapshot embedded in the op-program release the games commit to (v1.6.0 / v1.3.1 / op-contracts v1.3.0 / v1.9.0 builds).
- Metal, Mode, Zora, Soneium: OP Stack Upgrade 19 set the permissioned game prestate to the 0xdead placeholder while respectedGameType stays 1.
- Lyra, Orderly, Superseed: prestate is op-program v1.6.0 (April 2025), which has no Jovian derivation logic and no jovian_time in its embedded registry, while all three chains produce Jovian blocks today (17-byte extraData, setL1BlockValuesJovian L1-attributes tx). The program cannot derive current blocks.
- Cyber, Funki (already NO_PROOFS): add the warning; their prestate is the deployment-template placeholder, which predates both chains.