### PR TITLE
feat(frontend): set Postgres statement_timeout on frontend connections

### DIFF
--- a/packages/frontend/README.md
+++ b/packages/frontend/README.md
@@ -40,6 +40,9 @@ If you are running `pnpm dev` or `pnpm build` you need to set the following envi
 - create file `.env` in frontend root folder
 - `DATABASE_URL` - database connection url (read-only access is sufficient)
 
+Optional database tuning:
+- `DATABASE_STATEMENT_TIMEOUT_MS` - Postgres `statement_timeout` applied to every frontend connection, in milliseconds (default `20000`). Keep it below the HTTP request timeout so the database gives up before the response does.
+
 Optional for interop debugging:
 - `INTEROP_AGGREGATE_TIMESTAMP_OVERRIDE` - if present, interop aggregate queries use the earliest timestamp from the timestamp's day instead of the latest timestamp
 

--- a/packages/frontend/src/env.ts
+++ b/packages/frontend/src/env.ts
@@ -10,6 +10,14 @@ const stringArray = z.string().transform((val) => {
   return val.split(',')
 })
 
+const positiveInteger = z
+  .string()
+  .transform(Number)
+  .check(
+    (val) => Number.isInteger(val) && val > 0,
+    'Expected a positive integer',
+  )
+
 const featureFlag = coerceBoolean.optional()
 
 const CLIENT_CONFIG = {
@@ -40,6 +48,9 @@ const SERVER_CONFIG = {
     .default('postgresql://postgres:password@localhost:5432/l2beat_local'),
   DATABASE_LOG_ENABLED: coerceBoolean.default(false),
   TOKENS_DATABASE_LOG_ENABLED: coerceBoolean.default(false),
+  // Postgres kills any statement running longer than this, so a slow or
+  // abandoned request cannot keep occupying the database.
+  DATABASE_STATEMENT_TIMEOUT_MS: positiveInteger.default(20_000),
   DISABLE_CACHE: coerceBoolean.default(false),
   MOCK: coerceBoolean.default(false),
   EXCLUDED_ACTIVITY_PROJECTS: stringArray.optional(),
@@ -114,6 +125,7 @@ function getRawEnv(): Record<
     TOKENS_DATABASE_URL: process.env.TOKENS_DATABASE_URL,
     DATABASE_LOG_ENABLED: process.env.DATABASE_LOG_ENABLED,
     TOKENS_DATABASE_LOG_ENABLED: process.env.TOKENS_DATABASE_LOG_ENABLED,
+    DATABASE_STATEMENT_TIMEOUT_MS: process.env.DATABASE_STATEMENT_TIMEOUT_MS,
     DISABLE_CACHE: process.env.DISABLE_CACHE,
     MOCK: process.env.MOCK,
     NODE_ENV: process.env.NODE_ENV,

--- a/packages/frontend/src/server/database.ts
+++ b/packages/frontend/src/server/database.ts
@@ -13,6 +13,7 @@ export function getDb() {
           connectionString: env.DATABASE_URL,
           ssl: ssl(),
           ...pool(),
+          ...statementTimeout(),
           log: env.DATABASE_LOG_ENABLED ? makeDbLogger('Database') : undefined,
         })
       : createThrowingProxy()
@@ -75,6 +76,16 @@ export function pool() {
         min: 2,
       }
   }
+}
+
+/**
+ * Server-side timeout: Postgres cancels the statement itself, so the query
+ * stops even when the HTTP request that started it has already timed out or
+ * been abandoned. `query_timeout` would only reject the client promise and
+ * leave the statement running.
+ */
+export function statementTimeout() {
+  return { statement_timeout: env.DATABASE_STATEMENT_TIMEOUT_MS }
 }
 
 export function makeDbLogger(tag: string) {

--- a/packages/frontend/src/server/tokenDb.ts
+++ b/packages/frontend/src/server/tokenDb.ts
@@ -1,6 +1,11 @@
 import { createTokenDatabase, type TokenDatabase } from '@l2beat/database'
 import { env } from '~/env'
-import { createConnectionTag, makeDbLogger, pool } from './database'
+import {
+  createConnectionTag,
+  makeDbLogger,
+  pool,
+  statementTimeout,
+} from './database'
 
 let db: TokenDatabase | undefined
 
@@ -15,6 +20,7 @@ export function getTokenDb() {
               ? { rejectUnauthorized: false }
               : undefined,
           ...pool(),
+          ...statementTimeout(),
           log: env.TOKENS_DATABASE_LOG_ENABLED
             ? makeDbLogger('TokenDatabase')
             : undefined,


### PR DESCRIPTION
## Summary
- Abandoned or timed-out HTTP requests (e.g. spammed tRPC chart routes) kept their queries running on Postgres, holding pool connections and DB CPU long after the 25s `connect-timeout` gave up on the response.
- Adds `DATABASE_STATEMENT_TIMEOUT_MS` (default `20000`, validated as a positive integer) and applies it as a server-side `statement_timeout` to both the main and token database pools. Postgres cancels the statement itself, unlike `query_timeout`, which only rejects the client promise.
- `pg` sends `statement_timeout` in the connection startup packet, so every pooled connection gets it with no changes to `@l2beat/database`.

## Before merging
Check p99 of the heaviest chart queries in production (e.g. `layer2` filter on the `max` range). Anything legitimately running over 20s will now fail with `canceling statement due to statement timeout`. The env var can be raised on Coolify without a redeploy.

## Test plan
- [x] `pnpm typecheck` in `packages/frontend`
- [x] `pnpm test` in `packages/frontend` (464 passing)
- [x] `pnpm lint:fix` and `pnpm format:fix`
- [ ] Deploy to staging and confirm `SHOW statement_timeout` on an `FE-staging` connection returns `20s`

🤖 Generated with [Claude Code](https://claude.com/claude-code)