### PR TITLE
Add interop TVS coverage dashboard

### DIFF
--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -80,6 +80,9 @@ export type {
 } from './repositories/InteropRecentPricesRepository'
 export {
   hasAnyInteropTransferFinancialsFilter,
+  type InteropDeploymentStatsRecord,
+  type InteropSupplyChangeRequest,
+  type InteropSupplyChangeStatsRecord,
   type InteropSuspiciousTransferRecord,
   type InteropTokenRouteRecord,
   type InteropTransferFinancialsFilter,

--- a/packages/database/src/repositories/InteropTransferRepository.test.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.test.ts
@@ -1155,6 +1155,89 @@ describeDatabase(InteropTransferRepository.name, (db) => {
         ])
       })
 
+      it('filters mint and burn legs by their own timestamps', async () => {
+        const address = EthereumAddress.random()
+        const mintInside = transfer(
+          'plugin',
+          'mint-inside',
+          'transfer',
+          UnixTime(200),
+          'ethereum',
+          'base',
+        )
+        mintInside.srcTime = UnixTime(90)
+        mintInside.dstTime = UnixTime(200)
+        mintInside.dstTokenAddress = address
+        mintInside.dstWasMinted = true
+        mintInside.dstRawAmount = 10n
+
+        const burnInside = transfer(
+          'plugin',
+          'burn-inside',
+          'transfer',
+          UnixTime(400),
+          'base',
+          'ethereum',
+        )
+        burnInside.srcTime = UnixTime(200)
+        burnInside.dstTime = UnixTime(400)
+        burnInside.srcTokenAddress = address
+        burnInside.srcWasBurned = true
+        burnInside.srcRawAmount = 4n
+
+        const burnOutside = transfer(
+          'plugin',
+          'burn-outside',
+          'transfer',
+          UnixTime(200),
+          'base',
+          'ethereum',
+        )
+        burnOutside.srcTime = UnixTime(90)
+        burnOutside.dstTime = UnixTime(200)
+        burnOutside.srcTokenAddress = address
+        burnOutside.srcWasBurned = true
+        burnOutside.srcRawAmount = 100n
+
+        const mintOutside = transfer(
+          'plugin',
+          'mint-outside',
+          'transfer',
+          UnixTime(400),
+          'ethereum',
+          'base',
+        )
+        mintOutside.srcTime = UnixTime(200)
+        mintOutside.dstTime = UnixTime(400)
+        mintOutside.dstTokenAddress = address
+        mintOutside.dstWasMinted = true
+        mintOutside.dstRawAmount = 100n
+
+        await repository.insertMany([
+          mintInside,
+          burnInside,
+          burnOutside,
+          mintOutside,
+        ])
+
+        const result = await repository.getSupplyChangeStatsByRange(
+          [{ chain: 'base', address }],
+          UnixTime(100),
+          UnixTime(300),
+        )
+
+        expect(result).toEqual([
+          {
+            chain: 'base',
+            address,
+            mintedRaw: '10',
+            burnedRaw: '4',
+            transferCount: 2,
+            missingAmountCount: 0,
+          },
+        ])
+      })
+
       it('does not query for an empty request list', async () => {
         const result = await repository.getSupplyChangeStatsByRange(
           [],

--- a/packages/database/src/repositories/InteropTransferRepository.test.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.test.ts
@@ -1013,6 +1013,160 @@ describeDatabase(InteropTransferRepository.name, (db) => {
     })
   })
 
+  describe(
+    InteropTransferRepository.prototype.getDeploymentStatsByRange.name,
+    () => {
+      it('aggregates both token sides within the requested window', async () => {
+        const srcAddress = EthereumAddress.random()
+        const dstAddress = EthereumAddress.random()
+        const first = transfer(
+          'plugin',
+          'first',
+          'transfer',
+          UnixTime(200),
+          'ethereum',
+          'base',
+        )
+        const second = transfer(
+          'plugin',
+          'second',
+          'transfer',
+          UnixTime(300),
+          'ethereum',
+          'base',
+        )
+        first.srcTokenAddress = second.srcTokenAddress = srcAddress
+        first.dstTokenAddress = second.dstTokenAddress = dstAddress
+        first.srcValueUsd = 100
+        second.srcValueUsd = 50
+        first.dstValueUsd = 90
+        second.dstValueUsd = undefined
+        first.bridgeType = second.bridgeType = 'lockAndMint'
+
+        await repository.insertMany([
+          transfer('plugin', 'outside', 'transfer', UnixTime(100)),
+          first,
+          second,
+        ])
+
+        const result = await repository.getDeploymentStatsByRange(
+          UnixTime(100),
+          UnixTime(300),
+        )
+        const src = result.find((row) => row.chain === 'ethereum')
+        const dst = result.find((row) => row.chain === 'base')
+
+        expect(result).toHaveLength(2)
+        expect(src).toEqual({
+          chain: 'ethereum',
+          address: srcAddress,
+          abstractTokenId: 'ethereum',
+          symbol: 'ETH',
+          plugin: 'plugin',
+          volumeUsd: 150,
+          transferCount: 2,
+          valuedTransferCount: 2,
+        })
+        expect(dst).toEqual({
+          chain: 'base',
+          address: dstAddress,
+          abstractTokenId: 'ethereum',
+          symbol: 'ETH',
+          plugin: 'plugin',
+          volumeUsd: 90,
+          transferCount: 2,
+          valuedTransferCount: 1,
+        })
+      })
+    },
+  )
+
+  describe(
+    InteropTransferRepository.prototype.getSupplyChangeStatsByRange.name,
+    () => {
+      it('sums retained mints and burns for the requested deployments', async () => {
+        const address = EthereumAddress.random()
+        const paddedAddress = Address32.from(address)
+        const mint = transfer(
+          'plugin',
+          'mint',
+          'transfer',
+          UnixTime(200),
+          'ethereum',
+          'base',
+        )
+        mint.dstTokenAddress = paddedAddress
+        mint.dstWasMinted = true
+        mint.dstRawAmount = 10n
+
+        const burn = transfer(
+          'plugin',
+          'burn',
+          'transfer',
+          UnixTime(300),
+          'base',
+          'ethereum',
+        )
+        burn.srcTokenAddress = address
+        burn.srcWasBurned = true
+        burn.srcRawAmount = 4n
+
+        const missingAmount = transfer(
+          'plugin',
+          'missing',
+          'transfer',
+          UnixTime(250),
+          'ethereum',
+          'base',
+        )
+        missingAmount.dstTokenAddress = address
+        missingAmount.dstWasMinted = true
+        missingAmount.dstRawAmount = undefined
+
+        const outside = transfer(
+          'plugin',
+          'outside',
+          'transfer',
+          UnixTime(100),
+          'ethereum',
+          'base',
+        )
+        outside.dstTokenAddress = address
+        outside.dstWasMinted = true
+        outside.dstRawAmount = 100n
+
+        await repository.insertMany([mint, burn, missingAmount, outside])
+
+        const result = await repository.getSupplyChangeStatsByRange(
+          [{ chain: 'base', address }],
+          UnixTime(100),
+          UnixTime(300),
+        )
+
+        expect(result).toEqual([
+          {
+            chain: 'base',
+            address,
+            mintedRaw: '10',
+            burnedRaw: '4',
+            transferCount: 3,
+            missingAmountCount: 1,
+          },
+        ])
+      })
+
+      it('does not query for an empty request list', async () => {
+        const result = await repository.getSupplyChangeStatsByRange(
+          [],
+          UnixTime(100),
+          UnixTime(300),
+        )
+
+        expect(result).toEqual([])
+      })
+    },
+  )
+
   describe(InteropTransferRepository.prototype.getProjectTransfers.name, () => {
     const snapshotTimestamp = UnixTime(2_000_000)
 

--- a/packages/database/src/repositories/InteropTransferRepository.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.ts
@@ -69,6 +69,30 @@ export interface InteropTransferRecord {
   isProcessed: boolean
 }
 
+export interface InteropDeploymentStatsRecord {
+  chain: string
+  address: string
+  abstractTokenId: string | undefined
+  symbol: string | undefined
+  plugin: string
+  volumeUsd: number
+  transferCount: number
+  valuedTransferCount: number
+}
+
+export interface InteropSupplyChangeRequest {
+  chain: string
+  address: string
+}
+
+export interface InteropSupplyChangeStatsRecord
+  extends InteropSupplyChangeRequest {
+  mintedRaw: string
+  burnedRaw: string
+  transferCount: number
+  missingAmountCount: number
+}
+
 export interface InteropTransferUpdate {
   srcAbstractTokenId: string | null
   srcSymbol: string | null
@@ -474,6 +498,174 @@ export class InteropTransferRepository extends BaseRepository {
       .execute()
 
     return rows.map(toRecord)
+  }
+
+  async getDeploymentStatsByRange(
+    fromExclusive: UnixTime,
+    toInclusive: UnixTime,
+  ): Promise<InteropDeploymentStatsRecord[]> {
+    interface Row {
+      chain: string
+      address: string
+      abstractTokenId: string | null
+      symbol: string | null
+      plugin: string
+      volumeUsd: number
+      transferCount: number
+      valuedTransferCount: number
+    }
+
+    // Keep the aggregation close to the data. A seven-day raw transfer window
+    // can contain hundreds of thousands of rows, while the coverage view needs
+    // one row per deployment/plugin combination.
+    const query = sql<Row>`
+      WITH window_transfers AS MATERIALIZED (
+        SELECT
+          plugin,
+          timestamp,
+          "srcChain",
+          "srcTokenAddress",
+          "srcAbstractTokenId",
+          "srcSymbol",
+          "srcValueUsd",
+          "dstChain",
+          "dstTokenAddress",
+          "dstAbstractTokenId",
+          "dstSymbol",
+          "dstValueUsd"
+        FROM "InteropTransfer"
+        WHERE timestamp > ${UnixTime.toDate(fromExclusive)}
+          AND timestamp <= ${UnixTime.toDate(toInclusive)}
+      ),
+      sides AS (
+        SELECT
+          "srcChain" AS chain,
+          "srcTokenAddress" AS address,
+          "srcAbstractTokenId" AS "abstractTokenId",
+          "srcSymbol" AS symbol,
+          "srcValueUsd" AS "valueUsd",
+          plugin
+        FROM window_transfers
+        WHERE "srcTokenAddress" IS NOT NULL
+
+        UNION ALL
+
+        SELECT
+          "dstChain" AS chain,
+          "dstTokenAddress" AS address,
+          "dstAbstractTokenId" AS "abstractTokenId",
+          "dstSymbol" AS symbol,
+          "dstValueUsd" AS "valueUsd",
+          plugin
+        FROM window_transfers
+        WHERE "dstTokenAddress" IS NOT NULL
+          AND (
+            "srcTokenAddress" IS NULL
+            OR "srcChain" <> "dstChain"
+            OR "srcTokenAddress" <> "dstTokenAddress"
+          )
+      )
+      SELECT
+        chain,
+        address,
+        max("abstractTokenId") AS "abstractTokenId",
+        max(symbol) AS symbol,
+        plugin,
+        sum(coalesce("valueUsd", 0))::double precision AS "volumeUsd",
+        count(*)::integer AS "transferCount",
+        count("valueUsd")::integer AS "valuedTransferCount"
+      FROM sides
+      GROUP BY chain, address, plugin
+    `.compile(this.db)
+
+    const result = await this.db.executeQuery(query)
+    return result.rows.map((row) => ({
+      chain: row.chain,
+      address: row.address,
+      abstractTokenId: row.abstractTokenId ?? undefined,
+      symbol: row.symbol ?? undefined,
+      plugin: row.plugin,
+      volumeUsd: Number(row.volumeUsd),
+      transferCount: Number(row.transferCount),
+      valuedTransferCount: Number(row.valuedTransferCount),
+    }))
+  }
+
+  async getSupplyChangeStatsByRange(
+    requests: InteropSupplyChangeRequest[],
+    fromExclusive: UnixTime,
+    toInclusive: UnixTime,
+  ): Promise<InteropSupplyChangeStatsRecord[]> {
+    if (requests.length === 0) return []
+
+    interface Row {
+      chain: string
+      address: string
+      mintedRaw: string
+      burnedRaw: string
+      transferCount: number
+      missingAmountCount: number
+    }
+
+    const query = sql<Row>`
+      WITH targets AS (
+        SELECT *
+        FROM unnest(
+          ${requests.map((request) => request.chain)}::varchar[],
+          ${requests.map((request) => request.address)}::varchar[]
+        ) AS target(chain, address)
+      ),
+      legs AS (
+        SELECT
+          target.chain,
+          target.address,
+          transfer."dstRawAmount" AS minted,
+          NULL::numeric AS burned
+        FROM targets AS target
+        JOIN "InteropTransfer" AS transfer
+          ON transfer."dstChain" = target.chain
+          AND right(lower(transfer."dstTokenAddress"), 40) = right(lower(target.address), 40)
+        WHERE transfer.timestamp > ${UnixTime.toDate(fromExclusive)}
+          AND transfer.timestamp <= ${UnixTime.toDate(toInclusive)}
+          AND transfer."dstWasMinted" IS TRUE
+
+        UNION ALL
+
+        SELECT
+          target.chain,
+          target.address,
+          NULL::numeric AS minted,
+          transfer."srcRawAmount" AS burned
+        FROM targets AS target
+        JOIN "InteropTransfer" AS transfer
+          ON transfer."srcChain" = target.chain
+          AND right(lower(transfer."srcTokenAddress"), 40) = right(lower(target.address), 40)
+        WHERE transfer.timestamp > ${UnixTime.toDate(fromExclusive)}
+          AND transfer.timestamp <= ${UnixTime.toDate(toInclusive)}
+          AND transfer."srcWasBurned" IS TRUE
+      )
+      SELECT
+        chain,
+        address,
+        coalesce(sum(minted), 0)::text AS "mintedRaw",
+        coalesce(sum(burned), 0)::text AS "burnedRaw",
+        count(*)::integer AS "transferCount",
+        count(*) FILTER (
+          WHERE (minted IS NULL AND burned IS NULL)
+        )::integer AS "missingAmountCount"
+      FROM legs
+      GROUP BY chain, address
+    `.compile(this.db)
+
+    const result = await this.db.executeQuery(query)
+    return result.rows.map((row) => ({
+      chain: row.chain,
+      address: row.address,
+      mintedRaw: row.mintedRaw,
+      burnedRaw: row.burnedRaw,
+      transferCount: Number(row.transferCount),
+      missingAmountCount: Number(row.missingAmountCount),
+    }))
   }
 
   async getByType(

--- a/packages/database/src/repositories/InteropTransferRepository.ts
+++ b/packages/database/src/repositories/InteropTransferRepository.ts
@@ -625,8 +625,8 @@ export class InteropTransferRepository extends BaseRepository {
         JOIN "InteropTransfer" AS transfer
           ON transfer."dstChain" = target.chain
           AND right(lower(transfer."dstTokenAddress"), 40) = right(lower(target.address), 40)
-        WHERE transfer.timestamp > ${UnixTime.toDate(fromExclusive)}
-          AND transfer.timestamp <= ${UnixTime.toDate(toInclusive)}
+        WHERE coalesce(transfer."dstTime", transfer.timestamp) > ${UnixTime.toDate(fromExclusive)}
+          AND coalesce(transfer."dstTime", transfer.timestamp) <= ${UnixTime.toDate(toInclusive)}
           AND transfer."dstWasMinted" IS TRUE
 
         UNION ALL
@@ -640,8 +640,8 @@ export class InteropTransferRepository extends BaseRepository {
         JOIN "InteropTransfer" AS transfer
           ON transfer."srcChain" = target.chain
           AND right(lower(transfer."srcTokenAddress"), 40) = right(lower(target.address), 40)
-        WHERE transfer.timestamp > ${UnixTime.toDate(fromExclusive)}
-          AND transfer.timestamp <= ${UnixTime.toDate(toInclusive)}
+        WHERE coalesce(transfer."srcTime", transfer.timestamp) > ${UnixTime.toDate(fromExclusive)}
+          AND coalesce(transfer."srcTime", transfer.timestamp) <= ${UnixTime.toDate(toInclusive)}
           AND transfer."srcWasBurned" IS TRUE
       )
       SELECT

--- a/packages/token-backend/src/chains/clients/coingecko/CoingeckoClient.test.ts
+++ b/packages/token-backend/src/chains/clients/coingecko/CoingeckoClient.test.ts
@@ -58,6 +58,44 @@ describe(CoingeckoClient.name, () => {
     })
   })
 
+  it('fetches circulating supplies in one markets request', async () => {
+    const fetch = mockFetch([
+      {
+        id: 'usd-coin',
+        circulating_supply: 75_000_000_000,
+        last_updated: '2026-09-03T07:57:20.000Z',
+      },
+      {
+        id: 'missing-supply',
+        circulating_supply: null,
+        last_updated: null,
+      },
+    ])
+    const client = new CoingeckoClient({ callsPerMinute: 100_000 })
+
+    const result = await client.getCoinsMarketData([
+      'usd-coin',
+      'missing-supply',
+    ])
+
+    expect(result).toEqual([
+      {
+        id: 'usd-coin',
+        circulating_supply: 75_000_000_000,
+        last_updated: '2026-09-03T07:57:20.000Z',
+      },
+      {
+        id: 'missing-supply',
+        circulating_supply: null,
+        last_updated: null,
+      },
+    ])
+    expect(fetch.calls[0]?.args[0]).toEqual(
+      'https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=usd-coin%2Cmissing-supply&per_page=2&sparkline=false',
+    )
+    expect(fetch.calls[0]?.args[1]).toEqual({ headers: {} })
+  })
+
   it('constructs the market chart range request', async () => {
     const fetch = mockFetch({
       prices: [[1592611200000, 228.9]],

--- a/packages/token-backend/src/chains/clients/coingecko/CoingeckoClient.ts
+++ b/packages/token-backend/src/chains/clients/coingecko/CoingeckoClient.ts
@@ -10,6 +10,8 @@ import {
   CoinListPlatformEntrySchema,
   type CoinMarketChartRangeData,
   CoinMarketChartRangeResultSchema,
+  type CoinMarketData,
+  CoinMarketDataSchema,
   CoinSchema,
 } from './types'
 
@@ -52,6 +54,28 @@ export class CoingeckoClient {
 
     const data = await response.json()
     return CoinSchema.parse(data)
+  }
+
+  async getCoinsMarketData(ids: string[]): Promise<CoinMarketData[]> {
+    if (ids.length === 0) return []
+
+    const url = this.buildUrl('/coins/markets', {
+      vs_currency: 'usd',
+      ids: ids.join(','),
+      per_page: ids.length.toString(),
+      sparkline: 'false',
+    })
+
+    const response = await this.fetch(url)
+
+    if (!response.ok) {
+      throw new Error(
+        `CoinGecko API error: ${response.status} ${response.statusText}`,
+      )
+    }
+
+    const data = await response.json()
+    return v.array(CoinMarketDataSchema).parse(data)
   }
 
   async getCoinList(options?: {

--- a/packages/token-backend/src/chains/clients/coingecko/types.ts
+++ b/packages/token-backend/src/chains/clients/coingecko/types.ts
@@ -10,6 +10,13 @@ export const CoinSchema = v.object({
   platforms: v.record(v.string(), v.string()),
 })
 
+export type CoinMarketData = v.infer<typeof CoinMarketDataSchema>
+export const CoinMarketDataSchema = v.object({
+  id: v.string(),
+  circulating_supply: v.union([v.number(), v.null()]),
+  last_updated: v.union([v.string(), v.null()]),
+})
+
 export type CoinListEntry = v.infer<typeof CoinListEntrySchema>
 export const CoinListEntrySchema = v.object({
   id: v.string(),

--- a/packages/token-backend/src/trpc/appRouter.ts
+++ b/packages/token-backend/src/trpc/appRouter.ts
@@ -7,6 +7,7 @@ import { planRouter } from './routers/plan'
 import { searchRouter } from './routers/search'
 import { tokenDbHistoryRouter } from './routers/tokenDbHistory'
 import { tokenIngestionQueueRouter } from './routers/tokenIngestionQueue'
+import { tvsCoverageRouter } from './routers/tvsCoverage'
 import { router } from './trpc'
 
 interface AppRouterDeps {
@@ -26,6 +27,7 @@ export function createAppRouter({
     search: searchRouter,
     tokenDbHistory: tokenDbHistoryRouter,
     tokenIngestionQueue: tokenIngestionQueueRouter,
+    tvsCoverage: tvsCoverageRouter({ coingeckoClient }),
   })
 }
 

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.test.ts
@@ -7,9 +7,25 @@ import type {
 import { UnixTime } from '@l2beat/shared-pure'
 import { expect, mockFn, mockObject } from 'earl'
 import {
+  evictExpiredCacheEntries,
   getSupplyChangeEvidence,
   supplyChangeWindow,
 } from './getSupplyChangeEvidence'
+
+describe(evictExpiredCacheEntries.name, () => {
+  it('deletes expired entries and keeps live entries', () => {
+    const cache = new Map([
+      ['expired', { expiresAt: 100, value: 1 }],
+      ['live', { expiresAt: 101, value: 2 }],
+    ])
+
+    evictExpiredCacheEntries(cache, 100)
+
+    expect(Array.from(cache.entries())).toEqual([
+      ['live', { expiresAt: 101, value: 2 }],
+    ])
+  })
+})
 
 describe(getSupplyChangeEvidence.name, () => {
   it('reconciles retained bridge flows with supply change', async () => {

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.test.ts
@@ -1,0 +1,188 @@
+import type {
+  AbstractTokenRecord,
+  Database,
+  DeployedTokenRecord,
+  TokenDatabase,
+} from '@l2beat/database'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import {
+  getSupplyChangeEvidence,
+  supplyChangeWindow,
+} from './getSupplyChangeEvidence'
+
+describe(getSupplyChangeEvidence.name, () => {
+  it('reconciles retained bridge flows with supply change', async () => {
+    const tokenAddress = address(1)
+    const now = UnixTime(
+      8 * UnixTime.DAY + 5 * UnixTime.HOUR + 30 * UnixTime.MINUTE,
+    )
+    const { from, to } = supplyChangeWindow(now)
+    const interopTransfer = mockObject<Database['interopTransfer']>({
+      getSupplyChangeStatsByRange: mockFn().resolvesTo([
+        {
+          chain: 'chain-a',
+          address: tokenAddress,
+          mintedRaw: '6000000',
+          burnedRaw: '1000000',
+          transferCount: 3,
+          missingAmountCount: 0,
+        },
+      ]),
+    })
+    const tvsBlockTimestamp = mockObject<Database['tvsBlockTimestamp']>({
+      findBlockNumberByChainAndTimestamp: mockFn().executes(
+        async (_chain: string, timestamp: UnixTime) =>
+          timestamp === from ? 100 : 200,
+      ),
+    })
+    const deployedToken = mockObject<TokenDatabase['deployedToken']>({
+      getByChainAndAddress: mockFn().resolvesTo([
+        token('chain-a', tokenAddress, 6, UnixTime(1)),
+      ]),
+    })
+    const chain = mockObject<TokenDatabase['chain']>({
+      getAll: mockFn().resolvesTo([
+        {
+          name: 'chain-a',
+          chainId: 1,
+          explorerUrl: null,
+          aliases: null,
+          apis: [{ type: 'rpc', url: 'https://rpc.example' }],
+        },
+      ]),
+    })
+    const reads: number[] = []
+
+    const result = await getSupplyChangeEvidence(
+      mockObject<Database>({ interopTransfer, tvsBlockTimestamp }),
+      mockObject<TokenDatabase>({ deployedToken, chain }),
+      [{ chain: 'chain-a', address: tokenAddress }],
+      {
+        now,
+        readTotalSupplyAt: async ({ blockNumber }) => {
+          reads.push(blockNumber)
+          return BigInt(blockNumber === 100 ? 100_000_000 : 105_000_000)
+        },
+      },
+    )
+
+    expect(result).toEqual([
+      {
+        chain: 'chain-a',
+        address: tokenAddress,
+        from,
+        to,
+        supplyStart: '100',
+        supplyEnd: '105',
+        supplyChange: '5',
+        interopMinted: '6',
+        interopBurned: '1',
+        interopNet: '5',
+        unexplainedChange: '0',
+        bridgeShareOfSupplyChange: 100,
+        transferCount: 3,
+      },
+    ])
+    expect(reads).toEqualUnsorted([100, 200])
+    expect(interopTransfer.getSupplyChangeStatsByRange).toHaveBeenCalledWith(
+      [{ chain: 'chain-a', address: tokenAddress }],
+      from,
+      to,
+    )
+  })
+
+  it('uses zero starting supply when the token was deployed in the window', async () => {
+    const tokenAddress = address(1)
+    const now = UnixTime(10 * UnixTime.DAY)
+    const { from } = supplyChangeWindow(now)
+    const readTotalSupplyAt = mockFn().resolvesTo(2n * 10n ** 18n)
+    const interopTransfer = mockObject<Database['interopTransfer']>({
+      getSupplyChangeStatsByRange: mockFn().resolvesTo([
+        {
+          chain: 'chain-a',
+          address: tokenAddress,
+          mintedRaw: (2n * 10n ** 18n).toString(),
+          burnedRaw: '0',
+          transferCount: 1,
+          missingAmountCount: 0,
+        },
+      ]),
+    })
+    const tvsBlockTimestamp = mockObject<Database['tvsBlockTimestamp']>({
+      findBlockNumberByChainAndTimestamp: mockFn().executes(
+        async (_chain: string, timestamp: UnixTime) =>
+          timestamp === from ? undefined : 200,
+      ),
+    })
+    const deployedToken = mockObject<TokenDatabase['deployedToken']>({
+      getByChainAndAddress: mockFn().resolvesTo([
+        token('chain-a', tokenAddress, 18, UnixTime(from + 1)),
+      ]),
+    })
+    const chain = mockObject<TokenDatabase['chain']>({
+      getAll: mockFn().resolvesTo([
+        {
+          name: 'chain-a',
+          chainId: 1,
+          explorerUrl: null,
+          aliases: null,
+          apis: [{ type: 'rpc', url: 'https://rpc.example' }],
+        },
+      ]),
+    })
+
+    const result = await getSupplyChangeEvidence(
+      mockObject<Database>({ interopTransfer, tvsBlockTimestamp }),
+      mockObject<TokenDatabase>({ deployedToken, chain }),
+      [{ chain: 'chain-a', address: tokenAddress }],
+      { now, readTotalSupplyAt },
+    )
+
+    expect(result[0]?.supplyStart).toEqual('0')
+    expect(result[0]?.supplyEnd).toEqual('2')
+    expect(result[0]?.bridgeShareOfSupplyChange).toEqual(100)
+    expect(readTotalSupplyAt).toHaveBeenCalledTimes(1)
+  })
+})
+
+function token(
+  chain: string,
+  tokenAddress: string,
+  decimals: number,
+  deploymentTimestamp: UnixTime,
+): {
+  deployedToken: DeployedTokenRecord
+  abstractToken: AbstractTokenRecord
+} {
+  return {
+    deployedToken: {
+      chain,
+      address: tokenAddress,
+      abstractTokenId: 'TOKEN',
+      symbol: 'TKN',
+      decimals,
+      deploymentTimestamp,
+      comment: null,
+      metadata: null,
+      ignored: false,
+    },
+    abstractToken: {
+      id: 'TOKEN',
+      symbol: 'TKN',
+      coingeckoId: null,
+      issuer: null,
+      category: 'other',
+      iconUrl: null,
+      coingeckoListingTimestamp: null,
+      additionalCoingeckoEntries: null,
+      comment: null,
+      reviewed: true,
+      isPriceUnreliable: false,
+    },
+  }
+}
+
+function address(value: number): string {
+  return `0x${value.toString(16).padStart(40, '0')}`
+}

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.ts
@@ -47,7 +47,7 @@ export async function getSupplyChangeEvidence(
       requests.slice(0, SUPPLY_CHANGE_EVIDENCE_LIMIT).map((request) => {
         const normalized = {
           chain: request.chain,
-          address: normalizeTokenAddress(request.address),
+          address: normalizeTokenAddress(request.chain, request.address),
         }
         return [requestKey(normalized), normalized]
       }),
@@ -266,5 +266,5 @@ async function mapConcurrent<T, R>(
 }
 
 function requestKey(request: SupplyChangeEvidenceRequest): string {
-  return `${request.chain}:${normalizeTokenAddress(request.address)}`
+  return `${request.chain}:${normalizeTokenAddress(request.chain, request.address)}`
 }

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.ts
@@ -1,0 +1,270 @@
+import type { Database, TokenDatabase } from '@l2beat/database'
+import { UnixTime } from '@l2beat/shared-pure'
+import { createPublicClient, erc20Abi, formatUnits, http } from 'viem'
+import { normalizeTokenAddress } from './model'
+
+export const SUPPLY_CHANGE_EVIDENCE_LIMIT = 25
+
+export interface SupplyChangeEvidenceRequest {
+  chain: string
+  address: string
+}
+
+export interface SupplyChangeEvidence extends SupplyChangeEvidenceRequest {
+  from: number
+  to: number
+  supplyStart: string
+  supplyEnd: string
+  supplyChange: string
+  interopMinted: string
+  interopBurned: string
+  interopNet: string
+  unexplainedChange: string
+  bridgeShareOfSupplyChange?: number
+  transferCount: number
+}
+
+type ReadTotalSupplyAt = (request: {
+  chain: string
+  address: `0x${string}`
+  rpcUrl: string
+  blockNumber: number
+}) => Promise<bigint | undefined>
+
+interface SupplyChangeEvidenceDependencies {
+  now?: UnixTime
+  readTotalSupplyAt?: ReadTotalSupplyAt
+}
+
+export async function getSupplyChangeEvidence(
+  db: Database,
+  tokenDb: TokenDatabase,
+  requests: SupplyChangeEvidenceRequest[],
+  dependencies: SupplyChangeEvidenceDependencies = {},
+): Promise<SupplyChangeEvidence[]> {
+  const uniqueRequests = Array.from(
+    new Map(
+      requests.slice(0, SUPPLY_CHANGE_EVIDENCE_LIMIT).map((request) => {
+        const normalized = {
+          chain: request.chain,
+          address: normalizeTokenAddress(request.address),
+        }
+        return [requestKey(normalized), normalized]
+      }),
+    ).values(),
+  )
+  const evmRequests = uniqueRequests.filter(
+    (
+      request,
+    ): request is SupplyChangeEvidenceRequest & { address: `0x${string}` } =>
+      /^0x[0-9a-f]{40}$/i.test(request.address),
+  )
+  if (evmRequests.length === 0) return []
+
+  const { from, to } = supplyChangeWindow(dependencies.now ?? UnixTime.now())
+  const [tokens, chains, interopStats] = await Promise.all([
+    tokenDb.deployedToken.getByChainAndAddress(evmRequests),
+    tokenDb.chain.getAll(),
+    db.interopTransfer.getSupplyChangeStatsByRange(evmRequests, from, to),
+  ])
+  const tokensByKey = new Map(
+    tokens.map((token) => [requestKey(token.deployedToken), token]),
+  )
+  const rpcUrlsByChain = new Map(
+    chains.flatMap((chain) => {
+      const rpc = chain.apis?.find((api) => api.type === 'rpc')
+      return rpc ? [[chain.name, rpc.url] as const] : []
+    }),
+  )
+  const statsByKey = new Map(
+    interopStats.map((stats) => [requestKey(stats), stats]),
+  )
+  const eligibleRequests = evmRequests.filter((request) => {
+    const stats = statsByKey.get(requestKey(request))
+    return (
+      tokensByKey.has(requestKey(request)) &&
+      rpcUrlsByChain.has(request.chain) &&
+      stats !== undefined &&
+      stats.transferCount > 0 &&
+      stats.missingAmountCount === 0
+    )
+  })
+  const eligibleChains = Array.from(
+    new Set(eligibleRequests.map((request) => request.chain)),
+  )
+  const blockNumbers = new Map<
+    string,
+    { from: number | undefined; to: number | undefined }
+  >()
+  await Promise.all(
+    eligibleChains.map(async (chain) => {
+      const [fromBlock, toBlock] = await Promise.all([
+        db.tvsBlockTimestamp.findBlockNumberByChainAndTimestamp(chain, from),
+        db.tvsBlockTimestamp.findBlockNumberByChainAndTimestamp(chain, to),
+      ])
+      blockNumbers.set(chain, { from: fromBlock, to: toBlock })
+    }),
+  )
+
+  const readTotalSupplyAt =
+    dependencies.readTotalSupplyAt ?? readCachedTotalSupplyAt
+  const evidence = await mapConcurrent(
+    eligibleRequests,
+    5,
+    async (request): Promise<SupplyChangeEvidence | undefined> => {
+      const token = tokensByKey.get(requestKey(request))
+      const stats = statsByKey.get(requestKey(request))
+      const rpcUrl = rpcUrlsByChain.get(request.chain)
+      const blocks = blockNumbers.get(request.chain)
+      if (!token || !stats || !rpcUrl || !blocks?.to) return undefined
+      if (
+        token.deployedToken.deploymentTimestamp <= from &&
+        blocks.from === undefined
+      ) {
+        return undefined
+      }
+
+      const [supplyStart, supplyEnd] = await Promise.all([
+        token.deployedToken.deploymentTimestamp > from
+          ? Promise.resolve(0n)
+          : readTotalSupplyAt({
+              ...request,
+              rpcUrl,
+              blockNumber: blocks.from as number,
+            }),
+        readTotalSupplyAt({
+          ...request,
+          rpcUrl,
+          blockNumber: blocks.to,
+        }),
+      ])
+      if (supplyStart === undefined || supplyEnd === undefined) return undefined
+
+      const interopMinted = BigInt(stats.mintedRaw)
+      const interopBurned = BigInt(stats.burnedRaw)
+      const interopNet = interopMinted - interopBurned
+      const supplyChange = supplyEnd - supplyStart
+      const unexplainedChange = supplyChange - interopNet
+
+      return {
+        ...request,
+        from,
+        to,
+        supplyStart: formatUnits(supplyStart, token.deployedToken.decimals),
+        supplyEnd: formatUnits(supplyEnd, token.deployedToken.decimals),
+        supplyChange: formatUnits(supplyChange, token.deployedToken.decimals),
+        interopMinted: formatUnits(interopMinted, token.deployedToken.decimals),
+        interopBurned: formatUnits(interopBurned, token.deployedToken.decimals),
+        interopNet: formatUnits(interopNet, token.deployedToken.decimals),
+        unexplainedChange: formatUnits(
+          unexplainedChange,
+          token.deployedToken.decimals,
+        ),
+        bridgeShareOfSupplyChange: percentage(interopNet, supplyChange),
+        transferCount: stats.transferCount,
+      }
+    },
+  )
+
+  return evidence.filter((item) => item !== undefined)
+}
+
+export function supplyChangeWindow(now: UnixTime): {
+  from: UnixTime
+  to: UnixTime
+} {
+  return {
+    from: UnixTime(
+      UnixTime.toStartOf(now - 7 * UnixTime.DAY, 'hour') + UnixTime.HOUR,
+    ),
+    to: UnixTime(UnixTime.toStartOf(now, 'hour') - UnixTime.HOUR),
+  }
+}
+
+function percentage(numerator: bigint, denominator: bigint) {
+  if (denominator === 0n) return undefined
+  return Number((numerator * 10_000n) / denominator) / 100
+}
+
+interface CachedSupply {
+  value: bigint | undefined
+  expiresAt: number
+}
+
+const supplyCache = new Map<string, CachedSupply>()
+const inFlightSupplies = new Map<string, Promise<bigint | undefined>>()
+
+async function readCachedTotalSupplyAt(request: {
+  chain: string
+  address: `0x${string}`
+  rpcUrl: string
+  blockNumber: number
+}): Promise<bigint | undefined> {
+  const key = `${requestKey(request)}:${request.blockNumber}`
+  const cached = supplyCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+
+  const inFlight = inFlightSupplies.get(key)
+  if (inFlight) return await inFlight
+
+  const promise = readTotalSupplyAt(request)
+  inFlightSupplies.set(key, promise)
+
+  try {
+    const value = await promise
+    supplyCache.set(key, {
+      value,
+      expiresAt: Date.now() + (value === undefined ? 30_000 : 10 * 60_000),
+    })
+    return value
+  } finally {
+    inFlightSupplies.delete(key)
+  }
+}
+
+async function readTotalSupplyAt(request: {
+  address: `0x${string}`
+  rpcUrl: string
+  blockNumber: number
+}): Promise<bigint | undefined> {
+  try {
+    const client = createPublicClient({
+      transport: http(request.rpcUrl, {
+        retryCount: 0,
+        timeout: 5_000,
+      }),
+    })
+    return await client.readContract({
+      address: request.address,
+      abi: erc20Abi,
+      functionName: 'totalSupply',
+      blockNumber: BigInt(request.blockNumber),
+    })
+  } catch {
+    return undefined
+  }
+}
+
+async function mapConcurrent<T, R>(
+  values: T[],
+  concurrency: number,
+  fn: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length)
+  let next = 0
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next++
+        results[index] = await fn(values[index])
+      }
+    }),
+  )
+
+  return results
+}
+
+function requestKey(request: SupplyChangeEvidenceRequest): string {
+  return `${request.chain}:${normalizeTokenAddress(request.address)}`
+}

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyChangeEvidence.ts
@@ -3,7 +3,7 @@ import { UnixTime } from '@l2beat/shared-pure'
 import { createPublicClient, erc20Abi, formatUnits, http } from 'viem'
 import { normalizeTokenAddress } from './model'
 
-export const SUPPLY_CHANGE_EVIDENCE_LIMIT = 25
+export const SUPPLY_CHANGE_EVIDENCE_LIMIT = 100
 
 export interface SupplyChangeEvidenceRequest {
   chain: string
@@ -42,6 +42,7 @@ export async function getSupplyChangeEvidence(
   requests: SupplyChangeEvidenceRequest[],
   dependencies: SupplyChangeEvidenceDependencies = {},
 ): Promise<SupplyChangeEvidence[]> {
+  evictExpiredCacheEntries(supplyCache, Date.now())
   const uniqueRequests = Array.from(
     new Map(
       requests.slice(0, SUPPLY_CHANGE_EVIDENCE_LIMIT).map((request) => {
@@ -194,6 +195,15 @@ interface CachedSupply {
 const supplyCache = new Map<string, CachedSupply>()
 const inFlightSupplies = new Map<string, Promise<bigint | undefined>>()
 
+export function evictExpiredCacheEntries<T extends { expiresAt: number }>(
+  cache: Map<string, T>,
+  now: number,
+) {
+  for (const [key, value] of cache) {
+    if (value.expiresAt <= now) cache.delete(key)
+  }
+}
+
 async function readCachedTotalSupplyAt(request: {
   chain: string
   address: `0x${string}`
@@ -202,7 +212,9 @@ async function readCachedTotalSupplyAt(request: {
 }): Promise<bigint | undefined> {
   const key = `${requestKey(request)}:${request.blockNumber}`
   const cached = supplyCache.get(key)
-  if (cached && cached.expiresAt > Date.now()) return cached.value
+  const now = Date.now()
+  if (cached && cached.expiresAt > now) return cached.value
+  if (cached) supplyCache.delete(key)
 
   const inFlight = inFlightSupplies.get(key)
   if (inFlight) return await inFlight

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
@@ -1,0 +1,169 @@
+import type {
+  AbstractTokenRecord,
+  Database,
+  DeployedTokenRecord,
+  TokenDatabase,
+} from '@l2beat/database'
+import { UnixTime } from '@l2beat/shared-pure'
+import { expect, mockFn, mockObject } from 'earl'
+import { getSupplyEstimates, SUPPLY_ESTIMATE_LIMIT } from './getSupplyEstimates'
+
+describe(getSupplyEstimates.name, () => {
+  it('reads supplies and combines them with current interop prices', async () => {
+    const pricedAddress = address(1)
+    const unpricedAddress = address(2)
+    const vaultAssetAddress = address(3)
+    const deployedToken = mockObject<TokenDatabase['deployedToken']>({
+      getByChainAndAddress: mockFn().resolvesTo([
+        token('chain-a', pricedAddress, 18, 'priced'),
+        token('chain-a', unpricedAddress, 6, null),
+      ]),
+    })
+    const chain = mockObject<TokenDatabase['chain']>({
+      getAll: mockFn().resolvesTo([
+        {
+          name: 'chain-a',
+          chainId: 1,
+          explorerUrl: null,
+          aliases: null,
+          apis: [{ type: 'rpc', url: 'https://rpc.example' }],
+        },
+      ]),
+    })
+    const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
+      getClosestPricesAtOrBefore: mockFn().resolvesTo(new Map([[0, 2]])),
+    })
+    const reads: string[] = []
+
+    const result = await getSupplyEstimates(
+      mockObject<Database>({ interopRecentPrices }),
+      mockObject<TokenDatabase>({ deployedToken, chain }),
+      [
+        { chain: 'chain-a', address: pricedAddress },
+        { chain: 'chain-a', address: unpricedAddress },
+        { chain: 'solana', address: 'not-an-evm-address' },
+        { chain: 'chain-a', address: pricedAddress.toUpperCase() },
+      ],
+      {
+        readTotalSupply: async (request) => {
+          reads.push(request.address)
+          return request.address === pricedAddress
+            ? 100n * 10n ** 18n
+            : 50n * 10n ** 6n
+        },
+        readVaultAsset: async (request) =>
+          request.address === pricedAddress
+            ? { address: vaultAssetAddress, symbol: 'ASSET' }
+            : undefined,
+        getCoinsMarketData: async (ids) => {
+          expect(ids).toEqual(['priced'])
+          return [
+            {
+              id: 'priced',
+              circulating_supply: 25,
+              last_updated: '2026-09-03T07:57:20.000Z',
+            },
+          ]
+        },
+      },
+    )
+
+    expect(result).toEqual([
+      {
+        chain: 'chain-a',
+        address: pricedAddress,
+        totalSupply: '100',
+        potentialTvsUsd: 200,
+        coingeckoCirculatingSupply: 25,
+        coingeckoUpdatedAt: '2026-09-03T07:57:20.000Z',
+        vaultAsset: {
+          address: vaultAssetAddress,
+          symbol: 'ASSET',
+        },
+      },
+      {
+        chain: 'chain-a',
+        address: unpricedAddress,
+        totalSupply: '50',
+        potentialTvsUsd: undefined,
+        coingeckoCirculatingSupply: undefined,
+        coingeckoUpdatedAt: undefined,
+        vaultAsset: undefined,
+      },
+      { chain: 'solana', address: 'not-an-evm-address' },
+    ])
+    expect(reads).toEqual([pricedAddress, unpricedAddress])
+  })
+
+  it('caps work before querying repositories', async () => {
+    const getByChainAndAddress = mockFn().resolvesTo([])
+    const deployedToken = mockObject<TokenDatabase['deployedToken']>({
+      getByChainAndAddress,
+    })
+    const chain = mockObject<TokenDatabase['chain']>({
+      getAll: mockFn().resolvesTo([]),
+    })
+    const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
+      getClosestPricesAtOrBefore: mockFn().resolvesTo(new Map()),
+    })
+    const requests = Array.from(
+      { length: SUPPLY_ESTIMATE_LIMIT + 1 },
+      (_, i) => ({
+        chain: 'chain-a',
+        address: address(i + 1),
+      }),
+    )
+
+    const result = await getSupplyEstimates(
+      mockObject<Database>({ interopRecentPrices }),
+      mockObject<TokenDatabase>({ deployedToken, chain }),
+      requests,
+    )
+
+    expect(result).toHaveLength(SUPPLY_ESTIMATE_LIMIT)
+    expect(getByChainAndAddress.calls[0]?.args[0]).toHaveLength(
+      SUPPLY_ESTIMATE_LIMIT,
+    )
+  })
+})
+
+function token(
+  chain: string,
+  tokenAddress: string,
+  decimals: number,
+  coingeckoId: string | null,
+): {
+  deployedToken: DeployedTokenRecord
+  abstractToken: AbstractTokenRecord
+} {
+  return {
+    deployedToken: {
+      chain,
+      address: tokenAddress,
+      abstractTokenId: 'TOKEN',
+      symbol: 'TKN',
+      decimals,
+      deploymentTimestamp: UnixTime(1),
+      comment: null,
+      metadata: null,
+      ignored: false,
+    },
+    abstractToken: {
+      id: 'TOKEN',
+      symbol: 'TKN',
+      coingeckoId,
+      issuer: null,
+      category: 'other',
+      iconUrl: null,
+      coingeckoListingTimestamp: null,
+      additionalCoingeckoEntries: null,
+      comment: null,
+      reviewed: true,
+      isPriceUnreliable: false,
+    },
+  }
+}
+
+function address(value: number): string {
+  return `0x${value.toString(16).padStart(40, '0')}`
+}

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
@@ -73,7 +73,8 @@ describe(getSupplyEstimates.name, () => {
         chain: 'chain-a',
         address: pricedAddress,
         totalSupply: '100',
-        potentialTvsUsd: 200,
+        estimatedValueUsd: 50,
+        estimatedValueBasis: 'coingeckoCirculatingSupply',
         coingeckoCirculatingSupply: 25,
         coingeckoUpdatedAt: '2026-09-03T07:57:20.000Z',
         vaultAsset: {
@@ -85,7 +86,8 @@ describe(getSupplyEstimates.name, () => {
         chain: 'chain-a',
         address: unpricedAddress,
         totalSupply: '50',
-        potentialTvsUsd: undefined,
+        estimatedValueUsd: undefined,
+        estimatedValueBasis: undefined,
         coingeckoCirculatingSupply: undefined,
         coingeckoUpdatedAt: undefined,
         vaultAsset: undefined,
@@ -93,6 +95,49 @@ describe(getSupplyEstimates.name, () => {
       { chain: 'solana', address: 'not-an-evm-address' },
     ])
     expect(reads).toEqual([pricedAddress, unpricedAddress])
+  })
+
+  it('uses total supply when it is below global circulating supply', async () => {
+    const tokenAddress = address(1)
+    const deployedToken = mockObject<TokenDatabase['deployedToken']>({
+      getByChainAndAddress: mockFn().resolvesTo([
+        token('chain-a', tokenAddress, 18, 'priced'),
+      ]),
+    })
+    const chain = mockObject<TokenDatabase['chain']>({
+      getAll: mockFn().resolvesTo([
+        {
+          name: 'chain-a',
+          chainId: 1,
+          explorerUrl: null,
+          aliases: null,
+          apis: [{ type: 'rpc', url: 'https://rpc.example' }],
+        },
+      ]),
+    })
+    const interopRecentPrices = mockObject<Database['interopRecentPrices']>({
+      getClosestPricesAtOrBefore: mockFn().resolvesTo(new Map([[0, 2]])),
+    })
+
+    const result = await getSupplyEstimates(
+      mockObject<Database>({ interopRecentPrices }),
+      mockObject<TokenDatabase>({ deployedToken, chain }),
+      [{ chain: 'chain-a', address: tokenAddress }],
+      {
+        readTotalSupply: async () => 100n * 10n ** 18n,
+        readVaultAsset: async () => undefined,
+        getCoinsMarketData: async () => [
+          {
+            id: 'priced',
+            circulating_supply: 250,
+            last_updated: '2026-09-03T07:57:20.000Z',
+          },
+        ],
+      },
+    )
+
+    expect(result[0]?.estimatedValueUsd).toEqual(200)
+    expect(result[0]?.estimatedValueBasis).toEqual('totalSupply')
   })
 
   it('does not calculate value from a price marked as unreliable', async () => {
@@ -141,7 +186,8 @@ describe(getSupplyEstimates.name, () => {
         chain: 'chain-a',
         address: tokenAddress,
         totalSupply: '100',
-        potentialTvsUsd: undefined,
+        estimatedValueUsd: undefined,
+        estimatedValueBasis: undefined,
         coingeckoCirculatingSupply: 50,
         coingeckoUpdatedAt: '2026-09-03T07:57:20.000Z',
         vaultAsset: undefined,

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
@@ -74,7 +74,6 @@ describe(getSupplyEstimates.name, () => {
         address: pricedAddress,
         totalSupply: '100',
         estimatedValueUsd: 50,
-        estimatedValueBasis: 'coingeckoCirculatingSupply',
         coingeckoCirculatingSupply: 25,
         coingeckoUpdatedAt: '2026-09-03T07:57:20.000Z',
         vaultAsset: {
@@ -87,7 +86,6 @@ describe(getSupplyEstimates.name, () => {
         address: unpricedAddress,
         totalSupply: '50',
         estimatedValueUsd: undefined,
-        estimatedValueBasis: undefined,
         coingeckoCirculatingSupply: undefined,
         coingeckoUpdatedAt: undefined,
         vaultAsset: undefined,
@@ -137,7 +135,6 @@ describe(getSupplyEstimates.name, () => {
     )
 
     expect(result[0]?.estimatedValueUsd).toEqual(200)
-    expect(result[0]?.estimatedValueBasis).toEqual('totalSupply')
   })
 
   it('does not calculate value from a price marked as unreliable', async () => {
@@ -187,7 +184,6 @@ describe(getSupplyEstimates.name, () => {
         address: tokenAddress,
         totalSupply: '100',
         estimatedValueUsd: undefined,
-        estimatedValueBasis: undefined,
         coingeckoCirculatingSupply: 50,
         coingeckoUpdatedAt: '2026-09-03T07:57:20.000Z',
         vaultAsset: undefined,

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.test.ts
@@ -95,6 +95,61 @@ describe(getSupplyEstimates.name, () => {
     expect(reads).toEqual([pricedAddress, unpricedAddress])
   })
 
+  it('does not calculate value from a price marked as unreliable', async () => {
+    const tokenAddress = address(1)
+    const getClosestPricesAtOrBefore = mockFn().resolvesTo(new Map([[0, 2]]))
+    const deployedToken = mockObject<TokenDatabase['deployedToken']>({
+      getByChainAndAddress: mockFn().resolvesTo([
+        token('chain-a', tokenAddress, 18, 'unreliable', true),
+      ]),
+    })
+    const chain = mockObject<TokenDatabase['chain']>({
+      getAll: mockFn().resolvesTo([
+        {
+          name: 'chain-a',
+          chainId: 1,
+          explorerUrl: null,
+          aliases: null,
+          apis: [{ type: 'rpc', url: 'https://rpc.example' }],
+        },
+      ]),
+    })
+
+    const result = await getSupplyEstimates(
+      mockObject<Database>({
+        interopRecentPrices: mockObject<Database['interopRecentPrices']>({
+          getClosestPricesAtOrBefore,
+        }),
+      }),
+      mockObject<TokenDatabase>({ deployedToken, chain }),
+      [{ chain: 'chain-a', address: tokenAddress }],
+      {
+        readTotalSupply: async () => 100n * 10n ** 18n,
+        readVaultAsset: async () => undefined,
+        getCoinsMarketData: async () => [
+          {
+            id: 'unreliable',
+            circulating_supply: 50,
+            last_updated: '2026-09-03T07:57:20.000Z',
+          },
+        ],
+      },
+    )
+
+    expect(result).toEqual([
+      {
+        chain: 'chain-a',
+        address: tokenAddress,
+        totalSupply: '100',
+        potentialTvsUsd: undefined,
+        coingeckoCirculatingSupply: 50,
+        coingeckoUpdatedAt: '2026-09-03T07:57:20.000Z',
+        vaultAsset: undefined,
+      },
+    ])
+    expect(getClosestPricesAtOrBefore.calls[0]?.args[0]).toEqual([])
+  })
+
   it('caps work before querying repositories', async () => {
     const getByChainAndAddress = mockFn().resolvesTo([])
     const deployedToken = mockObject<TokenDatabase['deployedToken']>({
@@ -132,6 +187,7 @@ function token(
   tokenAddress: string,
   decimals: number,
   coingeckoId: string | null,
+  isPriceUnreliable = false,
 ): {
   deployedToken: DeployedTokenRecord
   abstractToken: AbstractTokenRecord
@@ -159,7 +215,7 @@ function token(
       additionalCoingeckoEntries: null,
       comment: null,
       reviewed: true,
-      isPriceUnreliable: false,
+      isPriceUnreliable,
     },
   }
 }

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
@@ -21,7 +21,6 @@ export interface SupplyEstimateRequest {
 export interface SupplyEstimate extends SupplyEstimateRequest {
   totalSupply?: string
   estimatedValueUsd?: number
-  estimatedValueBasis?: 'totalSupply' | 'coingeckoCirculatingSupply'
   coingeckoCirculatingSupply?: number
   coingeckoUpdatedAt?: string
   vaultAsset?: VaultAsset
@@ -168,12 +167,6 @@ export async function getSupplyEstimates(
       ...request,
       totalSupply,
       estimatedValueUsd,
-      estimatedValueBasis:
-        estimatedValueUsd === undefined
-          ? undefined
-          : useCirculatingSupply
-            ? 'coingeckoCirculatingSupply'
-            : 'totalSupply',
       coingeckoCirculatingSupply,
       coingeckoUpdatedAt: coinMarket?.last_updated ?? undefined,
       vaultAsset: vaultAssets[index],

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
@@ -20,7 +20,8 @@ export interface SupplyEstimateRequest {
 
 export interface SupplyEstimate extends SupplyEstimateRequest {
   totalSupply?: string
-  potentialTvsUsd?: number
+  estimatedValueUsd?: number
+  estimatedValueBasis?: 'totalSupply' | 'coingeckoCirculatingSupply'
   coingeckoCirculatingSupply?: number
   coingeckoUpdatedAt?: string
   vaultAsset?: VaultAsset
@@ -145,16 +146,35 @@ export async function getSupplyEstimates(
       ? coinMarketsById.get(token.abstractToken.coingeckoId)
       : undefined
     const supply = totalSupply === undefined ? undefined : Number(totalSupply)
-    const potentialTvsUsd =
-      supply !== undefined && Number.isFinite(supply) && priceUsd !== undefined
-        ? supply * priceUsd
+    const coingeckoCirculatingSupply =
+      coinMarket?.circulating_supply ?? undefined
+    const useCirculatingSupply =
+      supply !== undefined &&
+      coingeckoCirculatingSupply !== undefined &&
+      Number.isFinite(coingeckoCirculatingSupply) &&
+      coingeckoCirculatingSupply >= 0 &&
+      coingeckoCirculatingSupply < supply
+    const estimatedSupply = useCirculatingSupply
+      ? coingeckoCirculatingSupply
+      : supply
+    const estimatedValueUsd =
+      estimatedSupply !== undefined &&
+      Number.isFinite(estimatedSupply) &&
+      priceUsd !== undefined
+        ? estimatedSupply * priceUsd
         : undefined
 
     estimatesByKey.set(requestKey(request), {
       ...request,
       totalSupply,
-      potentialTvsUsd,
-      coingeckoCirculatingSupply: coinMarket?.circulating_supply ?? undefined,
+      estimatedValueUsd,
+      estimatedValueBasis:
+        estimatedValueUsd === undefined
+          ? undefined
+          : useCirculatingSupply
+            ? 'coingeckoCirculatingSupply'
+            : 'totalSupply',
+      coingeckoCirculatingSupply,
       coingeckoUpdatedAt: coinMarket?.last_updated ?? undefined,
       vaultAsset: vaultAssets[index],
     })

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
@@ -11,7 +11,7 @@ import {
 import type { CoinMarketData } from '../../../chains/clients/coingecko/types'
 import { normalizeTokenAddress } from './model'
 
-export const SUPPLY_ESTIMATE_LIMIT = 25
+export const SUPPLY_ESTIMATE_LIMIT = 100
 
 export interface SupplyEstimateRequest {
   chain: string

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
@@ -65,7 +65,7 @@ export async function getSupplyEstimates(
       requests.slice(0, SUPPLY_ESTIMATE_LIMIT).map((request) => {
         const normalized = {
           chain: request.chain,
-          address: normalizeTokenAddress(request.address),
+          address: normalizeTokenAddress(request.chain, request.address),
         }
         return [requestKey(normalized), normalized]
       }),
@@ -92,7 +92,7 @@ export async function getSupplyEstimates(
   const priceRequests = evmRequests.flatMap((request, requestId) => {
     const token = tokensByKey.get(requestKey(request))
     const coingeckoId = token?.abstractToken?.coingeckoId
-    return coingeckoId
+    return coingeckoId && token?.abstractToken?.isPriceUnreliable === false
       ? [{ requestId, coingeckoId, timestamp: UnixTime.now() }]
       : []
   })
@@ -138,7 +138,9 @@ export async function getSupplyEstimates(
   for (const [index, request] of evmRequests.entries()) {
     const token = tokensByKey.get(requestKey(request))
     const totalSupply = supplies[index]
-    const priceUsd = prices.get(index)
+    const priceUsd = token?.abstractToken?.isPriceUnreliable
+      ? undefined
+      : prices.get(index)
     const coinMarket = token?.abstractToken?.coingeckoId
       ? coinMarketsById.get(token.abstractToken.coingeckoId)
       : undefined
@@ -261,6 +263,7 @@ const erc4626ProbeAbi = parseAbi([
 ])
 
 async function readVaultAsset(request: {
+  chain: string
   address: `0x${string}`
   rpcUrl: string
 }): Promise<VaultAsset | undefined> {
@@ -304,7 +307,7 @@ async function readVaultAsset(request: {
     }
 
     return {
-      address: normalizeTokenAddress(asset),
+      address: normalizeTokenAddress(request.chain, asset),
       symbol: symbol || undefined,
     }
   } catch {
@@ -333,5 +336,5 @@ async function mapConcurrent<T, R>(
 }
 
 function requestKey(request: SupplyEstimateRequest): string {
-  return `${request.chain}:${normalizeTokenAddress(request.address)}`
+  return `${request.chain}:${normalizeTokenAddress(request.chain, request.address)}`
 }

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getSupplyEstimates.ts
@@ -1,0 +1,337 @@
+import type { Database, TokenDatabase } from '@l2beat/database'
+import { UnixTime } from '@l2beat/shared-pure'
+import {
+  createPublicClient,
+  erc20Abi,
+  formatUnits,
+  http,
+  parseAbi,
+  zeroAddress,
+} from 'viem'
+import type { CoinMarketData } from '../../../chains/clients/coingecko/types'
+import { normalizeTokenAddress } from './model'
+
+export const SUPPLY_ESTIMATE_LIMIT = 25
+
+export interface SupplyEstimateRequest {
+  chain: string
+  address: string
+}
+
+export interface SupplyEstimate extends SupplyEstimateRequest {
+  totalSupply?: string
+  potentialTvsUsd?: number
+  coingeckoCirculatingSupply?: number
+  coingeckoUpdatedAt?: string
+  vaultAsset?: VaultAsset
+}
+
+export interface VaultAsset {
+  address: string
+  symbol?: string
+}
+
+type ReadTotalSupply = (request: {
+  chain: string
+  address: `0x${string}`
+  rpcUrl: string
+}) => Promise<bigint | undefined>
+
+type ReadVaultAsset = (request: {
+  chain: string
+  address: `0x${string}`
+  rpcUrl: string
+}) => Promise<VaultAsset | undefined>
+
+type GetCoinsMarketData = (ids: string[]) => Promise<CoinMarketData[]>
+
+interface SupplyEstimateDependencies {
+  readTotalSupply?: ReadTotalSupply
+  readVaultAsset?: ReadVaultAsset
+  getCoinsMarketData?: GetCoinsMarketData
+}
+
+export async function getSupplyEstimates(
+  db: Database,
+  tokenDb: TokenDatabase,
+  requests: SupplyEstimateRequest[],
+  dependencies: SupplyEstimateDependencies = {},
+): Promise<SupplyEstimate[]> {
+  const readTotalSupply = dependencies.readTotalSupply ?? readCachedTotalSupply
+  const readVaultAsset = dependencies.readVaultAsset ?? readCachedVaultAsset
+  const getCoinsMarketData = dependencies.getCoinsMarketData
+  const uniqueRequests = Array.from(
+    new Map(
+      requests.slice(0, SUPPLY_ESTIMATE_LIMIT).map((request) => {
+        const normalized = {
+          chain: request.chain,
+          address: normalizeTokenAddress(request.address),
+        }
+        return [requestKey(normalized), normalized]
+      }),
+    ).values(),
+  )
+
+  const evmRequests = uniqueRequests.filter(
+    (request): request is SupplyEstimateRequest & { address: `0x${string}` } =>
+      /^0x[0-9a-f]{40}$/i.test(request.address),
+  )
+  const [tokens, chains] = await Promise.all([
+    tokenDb.deployedToken.getByChainAndAddress(evmRequests),
+    tokenDb.chain.getAll(),
+  ])
+  const tokensByKey = new Map(
+    tokens.map((token) => [requestKey(token.deployedToken), token]),
+  )
+  const rpcUrlsByChain = new Map(
+    chains.flatMap((chain) => {
+      const rpc = chain.apis?.find((api) => api.type === 'rpc')
+      return rpc ? [[chain.name, rpc.url] as const] : []
+    }),
+  )
+  const priceRequests = evmRequests.flatMap((request, requestId) => {
+    const token = tokensByKey.get(requestKey(request))
+    const coingeckoId = token?.abstractToken?.coingeckoId
+    return coingeckoId
+      ? [{ requestId, coingeckoId, timestamp: UnixTime.now() }]
+      : []
+  })
+  const coingeckoIds = Array.from(
+    new Set(
+      evmRequests.flatMap((request) => {
+        const id = tokensByKey.get(requestKey(request))?.abstractToken
+          ?.coingeckoId
+        return id ? [id] : []
+      }),
+    ),
+  )
+
+  const [prices, supplies, vaultAssets, coinMarkets] = await Promise.all([
+    db.interopRecentPrices.getClosestPricesAtOrBefore(
+      priceRequests,
+      UnixTime.DAY,
+    ),
+    mapConcurrent(evmRequests, 5, async (request) => {
+      const token = tokensByKey.get(requestKey(request))
+      const rpcUrl = rpcUrlsByChain.get(request.chain)
+      if (!token || !rpcUrl) return undefined
+
+      const raw = await readTotalSupply({ ...request, rpcUrl })
+      if (raw === undefined) return undefined
+
+      return formatUnits(raw, token.deployedToken.decimals)
+    }),
+    mapConcurrent(evmRequests, 10, async (request) => {
+      const token = tokensByKey.get(requestKey(request))
+      const rpcUrl = rpcUrlsByChain.get(request.chain)
+      if (!token || !rpcUrl) return undefined
+
+      return await readVaultAsset({ ...request, rpcUrl })
+    }),
+    getCoinsMarketData && coingeckoIds.length > 0
+      ? getCoinsMarketData(coingeckoIds).catch(() => [])
+      : Promise.resolve([]),
+  ])
+  const coinMarketsById = new Map(coinMarkets.map((coin) => [coin.id, coin]))
+
+  const estimatesByKey = new Map<string, SupplyEstimate>()
+  for (const [index, request] of evmRequests.entries()) {
+    const token = tokensByKey.get(requestKey(request))
+    const totalSupply = supplies[index]
+    const priceUsd = prices.get(index)
+    const coinMarket = token?.abstractToken?.coingeckoId
+      ? coinMarketsById.get(token.abstractToken.coingeckoId)
+      : undefined
+    const supply = totalSupply === undefined ? undefined : Number(totalSupply)
+    const potentialTvsUsd =
+      supply !== undefined && Number.isFinite(supply) && priceUsd !== undefined
+        ? supply * priceUsd
+        : undefined
+
+    estimatesByKey.set(requestKey(request), {
+      ...request,
+      totalSupply,
+      potentialTvsUsd,
+      coingeckoCirculatingSupply: coinMarket?.circulating_supply ?? undefined,
+      coingeckoUpdatedAt: coinMarket?.last_updated ?? undefined,
+      vaultAsset: vaultAssets[index],
+    })
+  }
+
+  return uniqueRequests.map(
+    (request) => estimatesByKey.get(requestKey(request)) ?? request,
+  )
+}
+
+interface CachedSupply {
+  value: bigint | undefined
+  expiresAt: number
+}
+
+const supplyCache = new Map<string, CachedSupply>()
+const inFlightSupplies = new Map<string, Promise<bigint | undefined>>()
+
+interface CachedVaultAsset {
+  value: VaultAsset | undefined
+  expiresAt: number
+}
+
+const vaultAssetCache = new Map<string, CachedVaultAsset>()
+const inFlightVaultAssets = new Map<string, Promise<VaultAsset | undefined>>()
+
+async function readCachedTotalSupply(request: {
+  chain: string
+  address: `0x${string}`
+  rpcUrl: string
+}): Promise<bigint | undefined> {
+  const key = requestKey(request)
+  const cached = supplyCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+
+  const inFlight = inFlightSupplies.get(key)
+  if (inFlight) return await inFlight
+
+  const promise = readTotalSupply(request)
+  inFlightSupplies.set(key, promise)
+
+  try {
+    const value = await promise
+    supplyCache.set(key, {
+      value,
+      expiresAt: Date.now() + (value === undefined ? 30_000 : 5 * 60_000),
+    })
+    return value
+  } finally {
+    inFlightSupplies.delete(key)
+  }
+}
+
+async function readTotalSupply(request: {
+  address: `0x${string}`
+  rpcUrl: string
+}): Promise<bigint | undefined> {
+  try {
+    const client = createPublicClient({
+      transport: http(request.rpcUrl, {
+        retryCount: 0,
+        timeout: 5_000,
+      }),
+    })
+    return await client.readContract({
+      address: request.address,
+      abi: erc20Abi,
+      functionName: 'totalSupply',
+    })
+  } catch {
+    return undefined
+  }
+}
+
+async function readCachedVaultAsset(request: {
+  chain: string
+  address: `0x${string}`
+  rpcUrl: string
+}): Promise<VaultAsset | undefined> {
+  const key = requestKey(request)
+  const cached = vaultAssetCache.get(key)
+  if (cached && cached.expiresAt > Date.now()) return cached.value
+
+  const inFlight = inFlightVaultAssets.get(key)
+  if (inFlight) return await inFlight
+
+  const promise = readVaultAsset(request)
+  inFlightVaultAssets.set(key, promise)
+
+  try {
+    const value = await promise
+    vaultAssetCache.set(key, {
+      value,
+      expiresAt: Date.now() + (value === undefined ? 30_000 : 5 * 60_000),
+    })
+    return value
+  } finally {
+    inFlightVaultAssets.delete(key)
+  }
+}
+
+const erc4626ProbeAbi = parseAbi([
+  'function asset() view returns (address)',
+  'function totalAssets() view returns (uint256)',
+  'function convertToAssets(uint256 shares) view returns (uint256)',
+])
+
+async function readVaultAsset(request: {
+  address: `0x${string}`
+  rpcUrl: string
+}): Promise<VaultAsset | undefined> {
+  try {
+    const client = createPublicClient({
+      transport: http(request.rpcUrl, {
+        retryCount: 0,
+        timeout: 2_500,
+      }),
+    })
+    const asset = await client.readContract({
+      address: request.address,
+      abi: erc4626ProbeAbi,
+      functionName: 'asset',
+    })
+    if (asset === zeroAddress) return undefined
+
+    await Promise.all([
+      client.readContract({
+        address: request.address,
+        abi: erc4626ProbeAbi,
+        functionName: 'totalAssets',
+      }),
+      client.readContract({
+        address: request.address,
+        abi: erc4626ProbeAbi,
+        functionName: 'convertToAssets',
+        args: [1n],
+      }),
+    ])
+
+    let symbol: string | undefined
+    try {
+      symbol = await client.readContract({
+        address: asset,
+        abi: erc20Abi,
+        functionName: 'symbol',
+      })
+    } catch {
+      // The asset address remains useful when metadata is unavailable.
+    }
+
+    return {
+      address: normalizeTokenAddress(asset),
+      symbol: symbol || undefined,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+async function mapConcurrent<T, R>(
+  values: T[],
+  concurrency: number,
+  fn: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length)
+  let next = 0
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next++
+        results[index] = await fn(values[index])
+      }
+    }),
+  )
+
+  return results
+}
+
+function requestKey(request: SupplyEstimateRequest): string {
+  return `${request.chain}:${normalizeTokenAddress(request.address)}`
+}

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getTvsCoverageData.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getTvsCoverageData.ts
@@ -1,0 +1,156 @@
+import { INTEROP_CHAINS, type Project, ProjectService } from '@l2beat/config'
+import type { Database, TokenDatabase } from '@l2beat/database'
+import { UnixTime } from '@l2beat/shared-pure'
+import {
+  aggregateInteropDeploymentStats,
+  attachInteropRoles,
+  buildCoverage,
+  type CoverageRow,
+  collectProjectTvsDeployments,
+  type ProjectTvsDeployment,
+  type TvsProjectInput,
+} from './model'
+
+export interface TvsCoverageData {
+  generatedAt: number
+  window: {
+    hours: number
+    from: number
+    to: number
+  }
+  chains: {
+    chain: string
+    chainName: string
+    projectName: string | undefined
+    projectIconUrl: string | undefined
+    explorerUrl: string | undefined
+    interopVolumeUsd: number
+  }[]
+  plugins: {
+    id: string
+    name: string
+    iconUrl: string | undefined
+  }[]
+  tvsDeployments: ProjectTvsDeployment[]
+  rows: CoverageRow[]
+}
+
+const projectService = new ProjectService()
+
+export async function getTvsCoverageData(
+  db: Database,
+  tokenDb: TokenDatabase,
+  hours: number,
+): Promise<TvsCoverageData> {
+  const to = UnixTime.now()
+  const from = UnixTime(to - hours * UnixTime.HOUR)
+  const [
+    deploymentStats,
+    deployedTokens,
+    abstractTokens,
+    tokenRelations,
+    projects,
+    interopProjects,
+  ] = await Promise.all([
+    db.interopTransfer.getDeploymentStatsByRange(from, to),
+    tokenDb.deployedToken.getAll(),
+    tokenDb.abstractToken.getAll(),
+    tokenDb.tokenRelation.getAllRoutes(),
+    projectService.getProjects({
+      select: ['chainConfig'],
+      optional: ['tvsConfig'],
+    }),
+    projectService.getProjects({ select: ['interopConfig'] }),
+  ])
+
+  const projectInputs: TvsProjectInput[] = projects.map((project) => ({
+    projectName: project.name,
+    projectIconUrl: `https://l2beat.com/icons/${project.slug}.png`,
+    chain: project.chainConfig.name,
+    explorerUrl: project.chainConfig.explorerUrl,
+    tokens: project.tvsConfig,
+  }))
+  const rows = attachInteropRoles(
+    buildCoverage(
+      aggregateInteropDeploymentStats(
+        deploymentStats,
+        deployedTokens,
+        abstractTokens,
+      ),
+      projectInputs,
+      deployedTokens,
+    ),
+    tokenRelations,
+  )
+
+  return {
+    generatedAt: UnixTime.now(),
+    window: { hours, from, to },
+    chains: buildChains(rows, projectInputs),
+    plugins: buildPlugins(rows, interopProjects),
+    tvsDeployments: collectProjectTvsDeployments(projectInputs),
+    rows,
+  }
+}
+
+function buildPlugins(
+  rows: CoverageRow[],
+  projects: Project<'interopConfig'>[],
+) {
+  const observedPlugins = new Set(rows.flatMap((row) => row.plugins))
+
+  return Array.from(observedPlugins, (id) => {
+    const candidates = projects.filter((project) =>
+      project.interopConfig.plugins.some((plugin) => plugin.plugin === id),
+    )
+    const project =
+      candidates.find((candidate) =>
+        candidate.interopConfig.plugins.some(
+          (plugin) =>
+            plugin.plugin === id &&
+            plugin.chain === undefined &&
+            plugin.abstractTokenId === undefined,
+        ),
+      ) ?? candidates[0]
+
+    return {
+      id,
+      name: project?.interopConfig.name ?? project?.name ?? id,
+      iconUrl: project
+        ? `https://l2beat.com/icons/${project.slug}.png`
+        : undefined,
+    }
+  }).sort((a, b) => a.name.localeCompare(b.name))
+}
+
+function buildChains(rows: CoverageRow[], projects: TvsProjectInput[]) {
+  const detailsByChain = new Map(
+    INTEROP_CHAINS.map((chain) => [chain.id, chain]),
+  )
+  const projectsByChain = new Map(
+    projects.map((project) => [project.chain, project]),
+  )
+  const volumeByChain = new Map<string, number>()
+
+  for (const row of rows) {
+    volumeByChain.set(
+      row.chain,
+      (volumeByChain.get(row.chain) ?? 0) + row.volumeUsd,
+    )
+  }
+
+  return Array.from(volumeByChain, ([chain, interopVolumeUsd]) => {
+    const project = projectsByChain.get(chain)
+    return {
+      chain,
+      chainName: detailsByChain.get(chain)?.name ?? chain,
+      projectName: project?.projectName,
+      projectIconUrl: project?.projectIconUrl,
+      explorerUrl: project?.explorerUrl,
+      interopVolumeUsd,
+    }
+  }).sort(
+    (a, b) =>
+      b.interopVolumeUsd - a.interopVolumeUsd || a.chain.localeCompare(b.chain),
+  )
+}

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/getTvsCoverageData.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/getTvsCoverageData.ts
@@ -42,7 +42,8 @@ export async function getTvsCoverageData(
   tokenDb: TokenDatabase,
   hours: number,
 ): Promise<TvsCoverageData> {
-  const to = UnixTime.now()
+  const generatedAt = UnixTime.now()
+  const to = generatedAt
   const from = UnixTime(to - hours * UnixTime.HOUR)
   const [
     deploymentStats,
@@ -79,16 +80,17 @@ export async function getTvsCoverageData(
       ),
       projectInputs,
       deployedTokens,
+      generatedAt,
     ),
     tokenRelations,
   )
 
   return {
-    generatedAt: UnixTime.now(),
+    generatedAt,
     window: { hours, from, to },
     chains: buildChains(rows, projectInputs),
     plugins: buildPlugins(rows, interopProjects),
-    tvsDeployments: collectProjectTvsDeployments(projectInputs),
+    tvsDeployments: collectProjectTvsDeployments(projectInputs, generatedAt),
     rows,
   }
 }

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/index.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/index.ts
@@ -1,0 +1,50 @@
+import { v } from '@l2beat/validate'
+import type { CoingeckoClient } from '../../../chains/clients/coingecko/CoingeckoClient'
+import { readOnlyProcedure } from '../../procedures'
+import { router } from '../../trpc'
+import {
+  getSupplyChangeEvidence,
+  SUPPLY_CHANGE_EVIDENCE_LIMIT,
+} from './getSupplyChangeEvidence'
+import { getSupplyEstimates, SUPPLY_ESTIMATE_LIMIT } from './getSupplyEstimates'
+import { getTvsCoverageData } from './getTvsCoverageData'
+
+const WindowHours = v.union([v.literal(24), v.literal(72), v.literal(168)])
+const SupplyEstimateRequests = v
+  .array(v.object({ chain: v.string(), address: v.string() }))
+  .check(
+    (requests) => requests.length <= SUPPLY_ESTIMATE_LIMIT,
+    `Expected at most ${SUPPLY_ESTIMATE_LIMIT} tokens`,
+  )
+const SupplyChangeEvidenceRequests = v
+  .array(v.object({ chain: v.string(), address: v.string() }))
+  .check(
+    (requests) => requests.length <= SUPPLY_CHANGE_EVIDENCE_LIMIT,
+    `Expected at most ${SUPPLY_CHANGE_EVIDENCE_LIMIT} tokens`,
+  )
+
+export function tvsCoverageRouter({
+  coingeckoClient,
+}: {
+  coingeckoClient: CoingeckoClient
+}) {
+  return router({
+    get: readOnlyProcedure
+      .input(v.object({ hours: WindowHours }))
+      .query(({ ctx, input }) =>
+        getTvsCoverageData(ctx.db, ctx.tokenDb, input.hours),
+      ),
+    getSupplyEstimates: readOnlyProcedure
+      .input(SupplyEstimateRequests)
+      .query(({ ctx, input }) =>
+        getSupplyEstimates(ctx.db, ctx.tokenDb, input, {
+          getCoinsMarketData: (ids) => coingeckoClient.getCoinsMarketData(ids),
+        }),
+      ),
+    getSupplyChangeEvidence: readOnlyProcedure
+      .input(SupplyChangeEvidenceRequests)
+      .query(({ ctx, input }) =>
+        getSupplyChangeEvidence(ctx.db, ctx.tokenDb, input),
+      ),
+  })
+}

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/model.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/model.test.ts
@@ -1,0 +1,464 @@
+import type { TvsToken } from '@l2beat/config'
+import type {
+  AbstractTokenRecord,
+  DeployedTokenRecord,
+  InteropDeploymentStatsRecord,
+  TokenRelationRoute,
+} from '@l2beat/database'
+import { EthereumAddress, TokenId, UnixTime } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import {
+  aggregateInteropDeploymentStats,
+  attachInteropRoles,
+  buildCoverage,
+  type CoverageRow,
+  collectAmountDeployments,
+  collectProjectTvsDeployments,
+  type InteropDeployment,
+  normalizeTokenAddress,
+  type TvsProjectInput,
+} from './model'
+
+describe(normalizeTokenAddress.name, () => {
+  it('crops Address32-padded EVM addresses and keeps native', () => {
+    expect(
+      normalizeTokenAddress(
+        '0x000000000000000000000000A0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      ),
+    ).toEqual('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
+    expect(normalizeTokenAddress('NATIVE')).toEqual('native')
+  })
+})
+
+describe(collectAmountDeployments.name, () => {
+  it('collects token deployments, including native, but not escrow holders', () => {
+    const result = collectAmountDeployments({
+      type: 'calculation',
+      operator: 'sum',
+      arguments: [
+        {
+          type: 'balanceOfEscrow',
+          chain: 'ethereum',
+          address: EthereumAddress(
+            '0x1111111111111111111111111111111111111111',
+          ),
+          escrowAddress: EthereumAddress(
+            '0x2222222222222222222222222222222222222222',
+          ),
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+        },
+        {
+          type: 'balanceOfEscrow',
+          chain: 'base',
+          address: 'native',
+          escrowAddress: EthereumAddress(
+            '0x3333333333333333333333333333333333333333',
+          ),
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+        },
+        {
+          type: 'const',
+          value: '1',
+          decimals: 0,
+          sinceTimestamp: UnixTime(1),
+        },
+      ],
+    })
+
+    expect(result).toEqual([
+      {
+        chain: 'ethereum',
+        address: EthereumAddress('0x1111111111111111111111111111111111111111'),
+      },
+      { chain: 'base', address: 'native' },
+    ])
+  })
+})
+
+describe(collectProjectTvsDeployments.name, () => {
+  it('keeps project scope and removes duplicate formula deployments', () => {
+    const tokenAddress = EthereumAddress(
+      '0x1111111111111111111111111111111111111111',
+    )
+    const projects = [
+      project('arbitrum', [
+        token('first', {
+          type: 'totalSupply',
+          chain: 'arbitrum',
+          address: tokenAddress,
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+        }),
+        token('second', {
+          type: 'totalSupply',
+          chain: 'arbitrum',
+          address: tokenAddress,
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+        }),
+      ]),
+      project('an-arbitrum-l3', [
+        token('escrowed', {
+          type: 'balanceOfEscrow',
+          chain: 'arbitrum',
+          address: tokenAddress,
+          escrowAddress: EthereumAddress(
+            '0x2222222222222222222222222222222222222222',
+          ),
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+        }),
+      ]),
+    ]
+
+    expect(collectProjectTvsDeployments(projects)).toEqual([
+      {
+        projectChain: 'arbitrum',
+        tokenChain: 'arbitrum',
+        address: tokenAddress,
+      },
+      {
+        projectChain: 'an-arbitrum-l3',
+        tokenChain: 'arbitrum',
+        address: tokenAddress,
+      },
+    ])
+  })
+})
+
+describe(aggregateInteropDeploymentStats.name, () => {
+  it('merges normalized deployment groups and resolves TokenDB identity', () => {
+    const address = EthereumAddress(
+      '0x1111111111111111111111111111111111111111',
+    )
+    const padded = `0x${'0'.repeat(24)}${address.slice(2)}`
+    const stats: InteropDeploymentStatsRecord[] = [
+      deploymentStats({
+        address,
+        plugin: 'one',
+        volumeUsd: 100,
+        transferCount: 2,
+        valuedTransferCount: 2,
+      }),
+      deploymentStats({
+        address: padded,
+        plugin: 'two',
+        volumeUsd: 50,
+        transferCount: 3,
+        valuedTransferCount: 1,
+      }),
+    ]
+
+    const result = aggregateInteropDeploymentStats(
+      stats,
+      [deployed('ethereum', address, 'TOKEN1', 'TKN')],
+      [abstract('TOKEN1', 'TKN')],
+    )
+
+    expect(result).toHaveLength(1)
+    expect(result[0]?.abstractTokenId).toEqual('TOKEN1')
+    expect(result[0]?.symbol).toEqual('TKN')
+    expect(result[0]?.volumeUsd).toEqual(150)
+    expect(result[0]?.transferCount).toEqual(5)
+    expect(result[0]?.unvaluedTransferCount).toEqual(2)
+    expect(result[0]?.plugins).toEqual(['one', 'two'])
+  })
+})
+
+describe(buildCoverage.name, () => {
+  it('includes exact deployments and other deployments of the same asset', () => {
+    const l1Address = EthereumAddress(
+      '0x1111111111111111111111111111111111111111',
+    )
+    const exactAddress = EthereumAddress(
+      '0x2222222222222222222222222222222222222222',
+    )
+    const sameAssetAddress = EthereumAddress(
+      '0x3333333333333333333333333333333333333333',
+    )
+    const missingAddress = EthereumAddress(
+      '0x4444444444444444444444444444444444444444',
+    )
+    const unknownAddress = EthereumAddress(
+      '0x5555555555555555555555555555555555555555',
+    )
+    const projects: TvsProjectInput[] = [
+      project('chain-exact', [
+        token('exact-TKN', {
+          type: 'totalSupply',
+          chain: 'chain-exact',
+          address: exactAddress,
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+        }),
+      ]),
+      project('chain-same', [
+        token('canonical-TKN', {
+          type: 'balanceOfEscrow',
+          chain: 'ethereum',
+          address: l1Address,
+          escrowAddress: EthereumAddress(
+            '0x6666666666666666666666666666666666666666',
+          ),
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+        }),
+      ]),
+      project('chain-missing', []),
+      project('chain-unknown', []),
+      project('chain-no-config', undefined),
+    ]
+    const deployedTokens = [
+      deployed('ethereum', l1Address, 'TOKEN1', 'TKN'),
+      deployed('chain-exact', exactAddress, 'TOKEN1', 'TKN'),
+      deployed('chain-same', sameAssetAddress, 'TOKEN1', 'TKN'),
+      deployed('chain-missing', missingAddress, 'TOKEN1', 'TKN'),
+      deployed('chain-unknown', unknownAddress, null, '???'),
+    ]
+    const deployments: InteropDeployment[] = [
+      interopDeployment('chain-exact', exactAddress, 'TOKEN1'),
+      interopDeployment('chain-same', sameAssetAddress, 'TOKEN1'),
+      interopDeployment('chain-missing', missingAddress, 'TOKEN1'),
+      interopDeployment('chain-unknown', unknownAddress, undefined),
+      interopDeployment('chain-no-config', exactAddress, 'TOKEN1'),
+    ]
+
+    const result = buildCoverage(deployments, projects, deployedTokens)
+
+    expect(
+      Object.fromEntries(result.map((row) => [row.chain, row.included])),
+    ).toEqual({
+      'chain-exact': true,
+      'chain-same': true,
+      'chain-missing': false,
+      'chain-unknown': false,
+    })
+    expect(result.some((row) => row.chain === 'chain-no-config')).toEqual(false)
+  })
+})
+
+describe(attachInteropRoles.name, () => {
+  it('derives factual roles from token relations', () => {
+    const base = address(1)
+    const polygon = address(2)
+    const other = address(3)
+    const unresolved = address(4)
+    const nonMinting = address(5)
+    const both = address(6)
+    const rows = [
+      coverageRow('base', base, ['layerzero-v2-ofts', 'cctp-v2']),
+      coverageRow('polygonpos', polygon, ['layerzero-v2-ofts']),
+      coverageRow('other', other, ['cctp-v2']),
+      coverageRow('unknown', unresolved, ['layerzero-v2-ofts']),
+      coverageRow('intent', nonMinting, ['across']),
+      coverageRow('both', both, ['layerzero-v2-ofts']),
+    ]
+    const relations: TokenRelationRoute[] = [
+      {
+        tokenAChain: 'base',
+        tokenAAddress: base,
+        tokenBChain: 'polygonpos',
+        tokenBAddress: polygon,
+        plugin: 'layerzero-v2-ofts',
+        bridgeType: 'lockAndMint',
+        lockedToken: 'B',
+      },
+      {
+        tokenAChain: 'base',
+        tokenAAddress: base,
+        tokenBChain: 'other',
+        tokenBAddress: other,
+        plugin: 'cctp-v2',
+        bridgeType: 'burnAndMint',
+        lockedToken: null,
+      },
+      {
+        tokenAChain: 'unknown',
+        tokenAAddress: unresolved,
+        tokenBChain: 'other',
+        tokenBAddress: other,
+        plugin: 'layerzero-v2-ofts',
+        bridgeType: 'lockAndMint',
+        lockedToken: null,
+      },
+      {
+        tokenAChain: 'intent',
+        tokenAAddress: nonMinting,
+        tokenBChain: 'other',
+        tokenBAddress: other,
+        plugin: 'across',
+        bridgeType: 'nonMinting',
+        lockedToken: null,
+      },
+      {
+        tokenAChain: 'both',
+        tokenAAddress: both,
+        tokenBChain: 'locked-peer',
+        tokenBAddress: address(7),
+        plugin: 'layerzero-v2-ofts',
+        bridgeType: 'lockAndMint',
+        lockedToken: 'B',
+      },
+      {
+        tokenAChain: 'both',
+        tokenAAddress: both,
+        tokenBChain: 'minted-peer',
+        tokenBAddress: address(8),
+        plugin: 'layerzero-v2-ofts',
+        bridgeType: 'lockAndMint',
+        lockedToken: 'A',
+      },
+    ]
+
+    const result = attachInteropRoles(rows, relations)
+
+    expect(
+      Object.fromEntries(
+        result.map((row) => [
+          row.chain,
+          { role: row.role, roles: row.pluginRoles },
+        ]),
+      ),
+    ).toEqual({
+      base: {
+        role: 'minted',
+        roles: [
+          { plugin: 'layerzero-v2-ofts', roles: ['minted'] },
+          { plugin: 'cctp-v2', roles: ['burnAndMint'] },
+        ],
+      },
+      polygonpos: {
+        role: 'locked',
+        roles: [{ plugin: 'layerzero-v2-ofts', roles: ['locked'] }],
+      },
+      other: {
+        role: 'burnAndMint',
+        roles: [{ plugin: 'cctp-v2', roles: ['burnAndMint'] }],
+      },
+      unknown: {
+        role: 'unknown',
+        roles: [{ plugin: 'layerzero-v2-ofts', roles: ['unknown'] }],
+      },
+      intent: { role: undefined, roles: [] },
+      both: {
+        role: 'both',
+        roles: [
+          {
+            plugin: 'layerzero-v2-ofts',
+            roles: ['locked', 'minted'],
+          },
+        ],
+      },
+    })
+  })
+})
+
+function abstract(id: string, symbol: string): AbstractTokenRecord {
+  return {
+    id,
+    symbol,
+    coingeckoId: null,
+    issuer: null,
+    category: 'other',
+    iconUrl: null,
+    coingeckoListingTimestamp: null,
+    additionalCoingeckoEntries: null,
+    comment: null,
+    reviewed: true,
+    isPriceUnreliable: false,
+  }
+}
+
+function deployed(
+  chain: string,
+  address: string,
+  abstractTokenId: string | null,
+  symbol: string,
+): DeployedTokenRecord {
+  return {
+    chain,
+    address,
+    abstractTokenId,
+    symbol,
+    decimals: 18,
+    deploymentTimestamp: UnixTime(1),
+    comment: null,
+    metadata: null,
+    ignored: false,
+  }
+}
+
+function project(
+  chain: string,
+  tokens: TvsProjectInput['tokens'],
+): TvsProjectInput {
+  return { chain, projectName: chain, tokens }
+}
+
+function token(id: string, amount: TvsToken['amount']): TvsToken {
+  return {
+    mode: 'custom',
+    id: TokenId(id),
+    symbol: 'TKN',
+    name: 'Token',
+    priceId: 'token',
+    amount,
+    category: 'other',
+    source: 'native',
+    isAssociated: false,
+  }
+}
+
+function interopDeployment(
+  chain: string,
+  address: string,
+  abstractTokenId: string | undefined,
+): InteropDeployment {
+  return {
+    chain,
+    address,
+    abstractTokenId,
+    abstractSymbol: abstractTokenId ? 'TKN' : undefined,
+    symbol: abstractTokenId ? 'TKN' : undefined,
+    ignored: false,
+    volumeUsd: 100,
+    transferCount: 1,
+    unvaluedTransferCount: 0,
+    plugins: ['plugin'],
+  }
+}
+
+function deploymentStats(
+  overrides: Partial<InteropDeploymentStatsRecord>,
+): InteropDeploymentStatsRecord {
+  return {
+    chain: 'ethereum',
+    address: 'native',
+    abstractTokenId: undefined,
+    symbol: undefined,
+    plugin: 'plugin',
+    volumeUsd: 0,
+    transferCount: 0,
+    valuedTransferCount: 0,
+    ...overrides,
+  }
+}
+
+function coverageRow(
+  chain: string,
+  tokenAddress: string,
+  plugins: string[],
+): CoverageRow {
+  return {
+    ...interopDeployment(chain, tokenAddress, 'TOKEN1'),
+    included: false,
+    pluginRoles: [],
+    plugins,
+  }
+}
+
+function address(value: number): string {
+  return `0x${value.toString(16).padStart(40, '0')}`
+}

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/model.test.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/model.test.ts
@@ -23,10 +23,24 @@ describe(normalizeTokenAddress.name, () => {
   it('crops Address32-padded EVM addresses and keeps native', () => {
     expect(
       normalizeTokenAddress(
+        'base',
         '0x000000000000000000000000A0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
       ),
     ).toEqual('0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48')
-    expect(normalizeTokenAddress('NATIVE')).toEqual('native')
+    expect(normalizeTokenAddress('base', 'NATIVE')).toEqual('native')
+  })
+
+  it('preserves full-width non-EVM token addresses', () => {
+    const starknetAddress =
+      '0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+    const solanaAddress = 'AbCdEfGhijkLmnoPqrstUvwxyz123456789'
+
+    expect(normalizeTokenAddress('starknet', starknetAddress)).toEqual(
+      starknetAddress,
+    )
+    expect(normalizeTokenAddress('solana', solanaAddress)).toEqual(
+      solanaAddress,
+    )
   })
 })
 
@@ -74,6 +88,48 @@ describe(collectAmountDeployments.name, () => {
       },
       { chain: 'base', address: 'native' },
     ])
+  })
+
+  it('keeps only active formulas and requires both sides of a diff', () => {
+    const active = {
+      type: 'totalSupply' as const,
+      chain: 'base',
+      address: EthereumAddress('0x1111111111111111111111111111111111111111'),
+      decimals: 18,
+      sinceTimestamp: UnixTime(100),
+      untilTimestamp: UnixTime(300),
+    }
+    const expired = {
+      ...active,
+      address: EthereumAddress('0x2222222222222222222222222222222222222222'),
+      untilTimestamp: UnixTime(200),
+    }
+    const future = {
+      ...active,
+      address: EthereumAddress('0x3333333333333333333333333333333333333333'),
+      sinceTimestamp: UnixTime(200),
+    }
+
+    expect(
+      collectAmountDeployments(
+        {
+          type: 'calculation',
+          operator: 'sum',
+          arguments: [active, expired, future],
+        },
+        UnixTime(200),
+      ),
+    ).toEqual([{ chain: 'base', address: active.address }])
+    expect(
+      collectAmountDeployments(
+        {
+          type: 'calculation',
+          operator: 'diff',
+          arguments: [active, expired],
+        },
+        UnixTime(200),
+      ),
+    ).toEqual([])
   })
 })
 
@@ -165,6 +221,20 @@ describe(aggregateInteropDeploymentStats.name, () => {
     expect(result[0]?.unvaluedTransferCount).toEqual(2)
     expect(result[0]?.plugins).toEqual(['one', 'two'])
   })
+
+  it('does not merge full-width Starknet addresses with the same suffix', () => {
+    const suffix = 'a'.repeat(40)
+    const first = `0x${'1'.repeat(24)}${suffix}`
+    const second = `0x${'2'.repeat(24)}${suffix}`
+    const stats = [
+      deploymentStats({ chain: 'starknet', address: first }),
+      deploymentStats({ chain: 'starknet', address: second }),
+    ]
+
+    const result = aggregateInteropDeploymentStats(stats, [], [])
+
+    expect(result.map((row) => row.address)).toEqualUnsorted([first, second])
+  })
 })
 
 describe(buildCoverage.name, () => {
@@ -236,6 +306,36 @@ describe(buildCoverage.name, () => {
       'chain-unknown': false,
     })
     expect(result.some((row) => row.chain === 'chain-no-config')).toEqual(false)
+  })
+
+  it('does not count inactive TVS formulas as coverage', () => {
+    const tokenAddress = EthereumAddress(
+      '0x1111111111111111111111111111111111111111',
+    )
+    const projects = [
+      project('base', [
+        token('expired-TKN', {
+          type: 'totalSupply',
+          chain: 'base',
+          address: tokenAddress,
+          decimals: 18,
+          sinceTimestamp: UnixTime(1),
+          untilTimestamp: UnixTime(100),
+        }),
+      ]),
+    ]
+    const deployedTokens = [deployed('base', tokenAddress, 'TOKEN1', 'TKN')]
+    const deployments = [interopDeployment('base', tokenAddress, 'TOKEN1')]
+
+    const result = buildCoverage(
+      deployments,
+      projects,
+      deployedTokens,
+      UnixTime(200),
+    )
+
+    expect(result[0]?.included).toEqual(false)
+    expect(collectProjectTvsDeployments(projects, UnixTime(200))).toEqual([])
   })
 })
 

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/model.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/model.ts
@@ -77,11 +77,15 @@ interface TvsProjectIndex {
   tokens: IndexedTvsToken[]
 }
 
-export function normalizeTokenAddress(address: string): string {
+const NON_EVM_TOKEN_ADDRESS_CHAINS = new Set(['solana', 'starknet', 'tron'])
+
+export function normalizeTokenAddress(chain: string, address: string): string {
   const normalized = address.toLowerCase()
-  if (normalized === 'native' || !normalized.startsWith('0x')) {
-    return normalized
+  if (normalized === 'native') return normalized
+  if (NON_EVM_TOKEN_ADDRESS_CHAINS.has(chain)) {
+    return normalized.startsWith('0x') ? normalized : address
   }
+  if (!normalized.startsWith('0x')) return address
 
   try {
     return Address32.cropToEthereumAddress(
@@ -94,36 +98,78 @@ export function normalizeTokenAddress(address: string): string {
 
 export function collectAmountDeployments(
   formula: Formula,
+  timestamp?: number,
 ): { chain: string; address: string }[] {
+  const result = collectFormulaDeployments(formula, timestamp)
+  return result.active ? result.deployments : []
+}
+
+function collectFormulaDeployments(
+  formula: Formula,
+  timestamp: number | undefined,
+): {
+  active: boolean
+  deployments: { chain: string; address: string }[]
+} {
   switch (formula.type) {
-    case 'calculation':
-      return uniqueDeployments(
-        formula.arguments.flatMap((argument) =>
-          collectAmountDeployments(argument),
-        ),
-      )
+    case 'calculation': {
+      const activeArguments = formula.arguments
+        .map((argument) => collectFormulaDeployments(argument, timestamp))
+        .filter((argument) => argument.active)
+      const active =
+        formula.operator === 'diff'
+          ? activeArguments.length >= 2
+          : activeArguments.length >= 1
+
+      return {
+        active,
+        deployments: active
+          ? uniqueDeployments(
+              activeArguments.flatMap((argument) => argument.deployments),
+            )
+          : [],
+      }
+    }
     case 'value':
-      return collectAmountDeployments(formula.amount)
+      return collectFormulaDeployments(formula.amount, timestamp)
     case 'balanceOfEscrow':
     case 'starknetBalanceOf':
     case 'totalSupply':
     case 'starknetTotalSupply':
     case 'circulatingSupply':
-      return [{ chain: formula.chain, address: formula.address }]
+      return {
+        active: isFormulaActive(formula, timestamp),
+        deployments: [{ chain: formula.chain, address: formula.address }],
+      }
     case 'const':
-      return []
+      return {
+        active: isFormulaActive(formula, timestamp),
+        deployments: [],
+      }
   }
+}
+
+function isFormulaActive(
+  formula: Extract<Formula, { sinceTimestamp: number }>,
+  timestamp: number | undefined,
+) {
+  if (timestamp === undefined) return true
+  return (
+    formula.sinceTimestamp < timestamp &&
+    (formula.untilTimestamp === undefined || formula.untilTimestamp > timestamp)
+  )
 }
 
 export function collectProjectTvsDeployments(
   projects: TvsProjectInput[],
+  timestamp?: number,
 ): ProjectTvsDeployment[] {
   const deployments = projects.flatMap((project) =>
     (project.tokens ?? []).flatMap((token) =>
-      collectAmountDeployments(token.amount).map((deployment) => ({
+      collectAmountDeployments(token.amount, timestamp).map((deployment) => ({
         projectChain: project.chain,
         tokenChain: deployment.chain,
-        address: normalizeTokenAddress(deployment.address),
+        address: normalizeTokenAddress(deployment.chain, deployment.address),
       })),
     ),
   )
@@ -146,7 +192,7 @@ export function aggregateInteropDeploymentStats(
   const mutable = new Map<string, MutableInteropDeployment>()
 
   for (const stat of stats) {
-    const address = normalizeTokenAddress(stat.address)
+    const address = normalizeTokenAddress(stat.chain, stat.address)
     const key = deploymentKey(stat.chain, address)
     const current = mutable.get(key) ?? {
       chain: stat.chain,
@@ -178,8 +224,13 @@ export function buildCoverage(
   deployments: InteropDeployment[],
   projects: TvsProjectInput[],
   deployedTokens: DeployedTokenRecord[],
+  timestamp?: number,
 ): CoverageRow[] {
-  const projectIndices = buildTvsProjectIndices(projects, deployedTokens)
+  const projectIndices = buildTvsProjectIndices(
+    projects,
+    deployedTokens,
+    timestamp,
+  )
 
   return deployments.flatMap((deployment) => {
     const projectIndex = projectIndices.get(deployment.chain)
@@ -338,6 +389,7 @@ function finalizeInteropDeployments(
 function buildTvsProjectIndices(
   projects: TvsProjectInput[],
   deployedTokens: DeployedTokenRecord[],
+  timestamp: number | undefined,
 ) {
   const deployedByKey = new Map(
     deployedTokens.map((token) => [
@@ -350,7 +402,7 @@ function buildTvsProjectIndices(
   for (const project of projects) {
     const tokens = (project.tokens ?? []).map((token) => {
       const exactDeploymentKeys = new Set(
-        collectAmountDeployments(token.amount).map((deployment) =>
+        collectAmountDeployments(token.amount, timestamp).map((deployment) =>
           deploymentKey(deployment.chain, deployment.address),
         ),
       )
@@ -390,7 +442,7 @@ function isIncluded(
 }
 
 function deploymentKey(chain: string, address: string): string {
-  return `${chain}:${normalizeTokenAddress(address)}`
+  return `${chain}:${normalizeTokenAddress(chain, address)}`
 }
 
 function uniqueDeployments(

--- a/packages/token-backend/src/trpc/routers/tvsCoverage/model.ts
+++ b/packages/token-backend/src/trpc/routers/tvsCoverage/model.ts
@@ -1,0 +1,407 @@
+import type { Formula, TvsToken } from '@l2beat/config'
+import type {
+  AbstractTokenRecord,
+  DeployedTokenRecord,
+  InteropDeploymentStatsRecord,
+  TokenRelationRoute,
+} from '@l2beat/database'
+import { Address32 } from '@l2beat/shared-pure'
+
+export interface TvsProjectInput {
+  projectName: string
+  projectIconUrl?: string
+  chain: string
+  explorerUrl?: string
+  tokens?: TvsToken[]
+}
+
+export interface ProjectTvsDeployment {
+  projectChain: string
+  tokenChain: string
+  address: string
+}
+
+export interface InteropDeployment {
+  chain: string
+  address: string
+  symbol?: string
+  abstractTokenId?: string
+  abstractSymbol?: string
+  issuer?: string
+  iconUrl?: string
+  ignored: boolean
+  volumeUsd: number
+  transferCount: number
+  unvaluedTransferCount: number
+  plugins: string[]
+}
+
+export interface CoverageRow extends InteropDeployment {
+  included: boolean
+  role?: InteropTokenRole
+  pluginRoles: PluginRole[]
+}
+
+export type InteropTokenRole =
+  | 'locked'
+  | 'minted'
+  | 'burnAndMint'
+  | 'both'
+  | 'unknown'
+
+export type InteropRelationRole = Exclude<InteropTokenRole, 'both'>
+
+export interface PluginRole {
+  plugin: string
+  roles: InteropRelationRole[]
+}
+
+interface MutableInteropDeployment {
+  chain: string
+  address: string
+  observedSymbols: Set<string>
+  observedAbstractTokenIds: Set<string>
+  volumeUsd: number
+  transferCount: number
+  unvaluedTransferCount: number
+  plugins: Set<string>
+}
+
+interface IndexedTvsToken {
+  exactDeploymentKeys: Set<string>
+  abstractTokenIds: Set<string>
+}
+
+interface TvsProjectIndex {
+  project: TvsProjectInput
+  tokens: IndexedTvsToken[]
+}
+
+export function normalizeTokenAddress(address: string): string {
+  const normalized = address.toLowerCase()
+  if (normalized === 'native' || !normalized.startsWith('0x')) {
+    return normalized
+  }
+
+  try {
+    return Address32.cropToEthereumAddress(
+      Address32.from(normalized),
+    ).toLowerCase()
+  } catch {
+    return normalized
+  }
+}
+
+export function collectAmountDeployments(
+  formula: Formula,
+): { chain: string; address: string }[] {
+  switch (formula.type) {
+    case 'calculation':
+      return uniqueDeployments(
+        formula.arguments.flatMap((argument) =>
+          collectAmountDeployments(argument),
+        ),
+      )
+    case 'value':
+      return collectAmountDeployments(formula.amount)
+    case 'balanceOfEscrow':
+    case 'starknetBalanceOf':
+    case 'totalSupply':
+    case 'starknetTotalSupply':
+    case 'circulatingSupply':
+      return [{ chain: formula.chain, address: formula.address }]
+    case 'const':
+      return []
+  }
+}
+
+export function collectProjectTvsDeployments(
+  projects: TvsProjectInput[],
+): ProjectTvsDeployment[] {
+  const deployments = projects.flatMap((project) =>
+    (project.tokens ?? []).flatMap((token) =>
+      collectAmountDeployments(token.amount).map((deployment) => ({
+        projectChain: project.chain,
+        tokenChain: deployment.chain,
+        address: normalizeTokenAddress(deployment.address),
+      })),
+    ),
+  )
+
+  return Array.from(
+    new Map(
+      deployments.map((deployment) => [
+        `${deployment.projectChain}:${deployment.tokenChain}:${deployment.address}`,
+        deployment,
+      ]),
+    ).values(),
+  )
+}
+
+export function aggregateInteropDeploymentStats(
+  stats: InteropDeploymentStatsRecord[],
+  deployedTokens: DeployedTokenRecord[],
+  abstractTokens: AbstractTokenRecord[],
+): InteropDeployment[] {
+  const mutable = new Map<string, MutableInteropDeployment>()
+
+  for (const stat of stats) {
+    const address = normalizeTokenAddress(stat.address)
+    const key = deploymentKey(stat.chain, address)
+    const current = mutable.get(key) ?? {
+      chain: stat.chain,
+      address,
+      observedSymbols: new Set<string>(),
+      observedAbstractTokenIds: new Set<string>(),
+      volumeUsd: 0,
+      transferCount: 0,
+      unvaluedTransferCount: 0,
+      plugins: new Set<string>(),
+    }
+
+    if (stat.symbol) current.observedSymbols.add(stat.symbol)
+    if (stat.abstractTokenId) {
+      current.observedAbstractTokenIds.add(stat.abstractTokenId)
+    }
+    current.volumeUsd += stat.volumeUsd
+    current.transferCount += stat.transferCount
+    current.unvaluedTransferCount +=
+      stat.transferCount - stat.valuedTransferCount
+    current.plugins.add(stat.plugin)
+    mutable.set(key, current)
+  }
+
+  return finalizeInteropDeployments(mutable, deployedTokens, abstractTokens)
+}
+
+export function buildCoverage(
+  deployments: InteropDeployment[],
+  projects: TvsProjectInput[],
+  deployedTokens: DeployedTokenRecord[],
+): CoverageRow[] {
+  const projectIndices = buildTvsProjectIndices(projects, deployedTokens)
+
+  return deployments.flatMap((deployment) => {
+    const projectIndex = projectIndices.get(deployment.chain)
+    if (!projectIndex || projectIndex.project.tokens === undefined) return []
+
+    return [
+      {
+        ...deployment,
+        included: isIncluded(deployment, projectIndex),
+        pluginRoles: [],
+      },
+    ]
+  })
+}
+
+export function attachInteropRoles(
+  rows: CoverageRow[],
+  relations: TokenRelationRoute[],
+): CoverageRow[] {
+  const rolesByDeployment = new Map<
+    string,
+    Map<string, Set<InteropRelationRole>>
+  >()
+
+  for (const relation of relations) {
+    addRelationRole(rolesByDeployment, relation, 'A')
+    addRelationRole(rolesByDeployment, relation, 'B')
+  }
+
+  return rows.map((row) => {
+    const byPlugin = rolesByDeployment.get(
+      deploymentKey(row.chain, row.address),
+    )
+    const pluginRoles = row.plugins.flatMap((plugin) => {
+      const roles = sortRoles(byPlugin?.get(plugin))
+      return roles.length > 0 ? [{ plugin, roles }] : []
+    })
+
+    return {
+      ...row,
+      role: collapseRoles(new Set(pluginRoles.flatMap(({ roles }) => roles))),
+      pluginRoles,
+    }
+  })
+}
+
+function addRelationRole(
+  rolesByDeployment: Map<string, Map<string, Set<InteropRelationRole>>>,
+  relation: TokenRelationRoute,
+  endpoint: 'A' | 'B',
+) {
+  const role = getRelationRole(relation, endpoint)
+  if (!role) return
+
+  const chain = endpoint === 'A' ? relation.tokenAChain : relation.tokenBChain
+  const address =
+    endpoint === 'A' ? relation.tokenAAddress : relation.tokenBAddress
+  const key = deploymentKey(chain, address)
+  const byPlugin = rolesByDeployment.get(key) ?? new Map()
+  const roles = byPlugin.get(relation.plugin) ?? new Set()
+  roles.add(role)
+  byPlugin.set(relation.plugin, roles)
+  rolesByDeployment.set(key, byPlugin)
+}
+
+function getRelationRole(
+  relation: TokenRelationRoute,
+  endpoint: 'A' | 'B',
+): InteropRelationRole | undefined {
+  switch (relation.bridgeType) {
+    case 'burnAndMint':
+      return 'burnAndMint'
+    case 'lockAndMint':
+      if (relation.lockedToken === null) return 'unknown'
+      return relation.lockedToken === endpoint ? 'locked' : 'minted'
+    case 'unknown':
+      return 'unknown'
+    case 'nonMinting':
+      return undefined
+  }
+}
+
+function collapseRoles(
+  roles: Set<InteropRelationRole> | undefined,
+): InteropTokenRole | undefined {
+  if (!roles || roles.size === 0) return undefined
+
+  if (roles.has('locked') && roles.has('minted')) return 'both'
+  if (roles.has('locked')) return 'locked'
+  if (roles.has('minted')) return 'minted'
+  if (roles.has('burnAndMint')) return 'burnAndMint'
+  return 'unknown'
+}
+
+function sortRoles(
+  roles: Set<InteropRelationRole> | undefined,
+): InteropRelationRole[] {
+  if (!roles) return []
+  const order: InteropRelationRole[] = [
+    'locked',
+    'minted',
+    'burnAndMint',
+    'unknown',
+  ]
+  return order.filter((role) => roles.has(role))
+}
+
+function finalizeInteropDeployments(
+  deployments: Map<string, MutableInteropDeployment>,
+  deployedTokens: DeployedTokenRecord[],
+  abstractTokens: AbstractTokenRecord[],
+): InteropDeployment[] {
+  const deployedByKey = new Map(
+    deployedTokens.map((token) => [
+      deploymentKey(token.chain, token.address),
+      token,
+    ]),
+  )
+  const abstractById = new Map(abstractTokens.map((token) => [token.id, token]))
+
+  return Array.from(deployments.entries(), ([key, deployment]) => {
+    const deployedToken = deployedByKey.get(key)
+    const abstractTokenId =
+      deployedToken?.abstractTokenId ??
+      Array.from(deployment.observedAbstractTokenIds)[0]
+    const abstractToken = abstractTokenId
+      ? abstractById.get(abstractTokenId)
+      : undefined
+
+    return {
+      chain: deployment.chain,
+      address: deployment.address,
+      symbol:
+        deployedToken?.symbol ??
+        Array.from(deployment.observedSymbols)[0] ??
+        abstractToken?.symbol,
+      abstractTokenId: abstractTokenId ?? undefined,
+      abstractSymbol: abstractToken?.symbol,
+      issuer: abstractToken?.issuer ?? undefined,
+      iconUrl: abstractToken?.iconUrl ?? undefined,
+      ignored: deployedToken?.ignored ?? false,
+      volumeUsd: deployment.volumeUsd,
+      transferCount: deployment.transferCount,
+      unvaluedTransferCount: deployment.unvaluedTransferCount,
+      plugins: Array.from(deployment.plugins).sort(),
+    }
+  }).sort(
+    (a, b) =>
+      b.volumeUsd - a.volumeUsd ||
+      b.transferCount - a.transferCount ||
+      a.chain.localeCompare(b.chain) ||
+      a.address.localeCompare(b.address),
+  )
+}
+
+function buildTvsProjectIndices(
+  projects: TvsProjectInput[],
+  deployedTokens: DeployedTokenRecord[],
+) {
+  const deployedByKey = new Map(
+    deployedTokens.map((token) => [
+      deploymentKey(token.chain, token.address),
+      token,
+    ]),
+  )
+  const result = new Map<string, TvsProjectIndex>()
+
+  for (const project of projects) {
+    const tokens = (project.tokens ?? []).map((token) => {
+      const exactDeploymentKeys = new Set(
+        collectAmountDeployments(token.amount).map((deployment) =>
+          deploymentKey(deployment.chain, deployment.address),
+        ),
+      )
+      const abstractTokenIds = new Set<string>()
+
+      for (const key of exactDeploymentKeys) {
+        const abstractTokenId = deployedByKey.get(key)?.abstractTokenId
+        if (abstractTokenId) abstractTokenIds.add(abstractTokenId)
+      }
+
+      return { exactDeploymentKeys, abstractTokenIds }
+    })
+
+    result.set(project.chain, { project, tokens })
+  }
+
+  return result
+}
+
+function isIncluded(
+  deployment: InteropDeployment,
+  projectIndex: TvsProjectIndex | undefined,
+): boolean {
+  if (!projectIndex || projectIndex.project.tokens === undefined) return false
+
+  const key = deploymentKey(deployment.chain, deployment.address)
+  if (projectIndex.tokens.some((token) => token.exactDeploymentKeys.has(key))) {
+    return true
+  }
+
+  return Boolean(
+    deployment.abstractTokenId &&
+      projectIndex.tokens.some((token) =>
+        token.abstractTokenIds.has(deployment.abstractTokenId as string),
+      ),
+  )
+}
+
+function deploymentKey(chain: string, address: string): string {
+  return `${chain}:${normalizeTokenAddress(address)}`
+}
+
+function uniqueDeployments(
+  deployments: { chain: string; address: string }[],
+): { chain: string; address: string }[] {
+  return Array.from(
+    new Map(
+      deployments.map((deployment) => [
+        deploymentKey(deployment.chain, deployment.address),
+        deployment,
+      ]),
+    ).values(),
+  )
+}

--- a/packages/token-ui/src/App.tsx
+++ b/packages/token-ui/src/App.tsx
@@ -17,6 +17,7 @@ import { TokenHistoryPage } from './pages/tokens/TokenHistoryPage'
 import { TokenIngestionQueuePage } from './pages/tokens/TokenIngestionQueuePage'
 import { TokenSuggestionsPage } from './pages/tokens/TokenSuggestionsPage'
 import { TokensSummaryPage } from './pages/tokens/TokensSummaryPage'
+import { TokenTvsCoveragePage } from './pages/tokens/TokenTvsCoveragePage'
 import { TRPCReactProvider } from './react-query/trpc'
 
 const TokenRelationsGraphPage = lazy(() =>
@@ -58,6 +59,10 @@ export function App() {
                   <TokenRelationsGraphPage />
                 </Suspense>
               }
+            />
+            <Route
+              path="/tokens/tvs-coverage"
+              element={<TokenTvsCoveragePage />}
             />
             <Route path="/search/:search" element={<SearchPage />} />
             <Route path="/tokens/new" element={<AddTokensPage />} />

--- a/packages/token-ui/src/components/AppSidebar.tsx
+++ b/packages/token-ui/src/components/AppSidebar.tsx
@@ -5,6 +5,7 @@ import {
   ListChecksIcon,
   NetworkIcon,
   PanelsTopLeftIcon,
+  TablePropertiesIcon,
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
 
@@ -55,6 +56,11 @@ const items = [
         title: 'Graph',
         url: '/tokens/relations-graph',
         icon: NetworkIcon,
+      },
+      {
+        title: 'TVS gaps',
+        url: '/tokens/tvs-coverage',
+        icon: TablePropertiesIcon,
       },
     ],
   },

--- a/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
@@ -1,0 +1,1216 @@
+import { formatCurrency } from '@l2beat/shared-pure'
+import type { RouterOutputs } from '@l2beat/token-backend'
+import { useQueries, useQuery } from '@tanstack/react-query'
+import {
+  ArrowDownIcon,
+  ArrowUpDownIcon,
+  ArrowUpIcon,
+  RotateCwIcon,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Badge } from '~/components/core/Badge'
+import { Button } from '~/components/core/Button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/core/Card'
+import { Input } from '~/components/core/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/core/Select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/components/core/Table'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '~/components/core/Tooltip'
+import { ExplorerLink } from '~/components/ExplorerLink'
+import { LoadingState } from '~/components/LoadingState'
+import { AppLayout } from '~/layouts/AppLayout'
+import { useTRPC } from '~/react-query/trpc'
+import { cn } from '~/utils/cn'
+
+type CoverageData = RouterOutputs['tvsCoverage']['get']
+type CoverageRow = CoverageData['rows'][number]
+type PluginDetails = CoverageData['plugins'][number]
+type SupplyEstimate = RouterOutputs['tvsCoverage']['getSupplyEstimates'][number]
+type SupplyChangeEvidence =
+  RouterOutputs['tvsCoverage']['getSupplyChangeEvidence'][number]
+type VaultAsset = NonNullable<SupplyEstimate['vaultAsset']>
+type CoverageFilter = 'missing' | 'included' | 'all'
+type WindowHours = 24 | 72 | 168
+type SortDirection = 'asc' | 'desc'
+type SortKey =
+  | 'chain'
+  | 'token'
+  | 'totalSupply'
+  | 'potentialTvsUsd'
+  | 'volumeUsd'
+  | 'included'
+  | 'role'
+  | 'plugins'
+
+interface SortState {
+  key: SortKey
+  direction: SortDirection
+}
+
+const PAGE_SIZE = 25
+const MAX_VISIBLE_PLUGINS = 4
+const SUPPLY_REQUEST_DEBOUNCE_MS = 300
+const COINGECKO_CIRCULATING_WARNING_RATIO = 1.1
+
+export function TokenTvsCoveragePage() {
+  const trpc = useTRPC()
+  const [hours, setHours] = useState<WindowHours>(168)
+  const [chain, setChain] = useState('all')
+  const [coverage, setCoverage] = useState<CoverageFilter>('missing')
+  const [minimumVolume, setMinimumVolume] = useState('0')
+  const [search, setSearch] = useState('')
+  const [visibleRows, setVisibleRows] = useState(PAGE_SIZE)
+  const [sort, setSort] = useState<SortState>({
+    key: 'volumeUsd',
+    direction: 'desc',
+  })
+  const {
+    data,
+    error,
+    isError,
+    isFetching,
+    isLoading,
+    refetch: refetchCoverage,
+  } = useQuery(
+    trpc.tvsCoverage.get.queryOptions(
+      { hours },
+      {
+        staleTime: 2 * 60 * 1000,
+        refetchOnWindowFocus: false,
+      },
+    ),
+  )
+
+  useEffect(() => {
+    if (
+      chain !== 'all' &&
+      data !== undefined &&
+      !data.chains.some((candidate) => candidate.chain === chain)
+    ) {
+      setChain('all')
+    }
+  }, [chain, data])
+
+  const chainsById = useMemo(
+    () => new Map(data?.chains.map((chain) => [chain.chain, chain])),
+    [data],
+  )
+  const pluginsById = useMemo(
+    () => new Map((data?.plugins ?? []).map((plugin) => [plugin.id, plugin])),
+    [data],
+  )
+  const tvsDeploymentKeys = useMemo(
+    () =>
+      new Set(
+        (data?.tvsDeployments ?? []).map((deployment) =>
+          projectTvsDeploymentKey(
+            deployment.projectChain,
+            deployment.tokenChain,
+            deployment.address,
+          ),
+        ),
+      ),
+    [data],
+  )
+  const rows = useMemo(() => {
+    const needle = search.trim().toLowerCase()
+    const threshold = Number(minimumVolume) || 0
+
+    return (data?.rows ?? []).filter((row) => {
+      const chainInfo = chainsById.get(row.chain)
+      if (chain !== 'all' && row.chain !== chain) return false
+      if (coverage !== 'all' && (coverage === 'included') !== row.included) {
+        return false
+      }
+      if (row.volumeUsd < threshold) return false
+      if (!needle) return true
+
+      return [
+        row.chain,
+        chainInfo?.chainName,
+        chainInfo?.projectName,
+        row.address,
+        row.symbol,
+        row.abstractSymbol,
+        row.issuer,
+        row.role,
+        ...row.plugins,
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(needle)
+    })
+  }, [chain, chainsById, coverage, data, minimumVolume, search])
+
+  const candidateRows = useMemo(
+    () => rows.slice(0, visibleRows),
+    [rows, visibleRows],
+  )
+  const supplyRequests = useMemo(
+    () =>
+      candidateRows.map((row) => ({
+        chain: row.chain,
+        address: row.address,
+      })),
+    [candidateRows],
+  )
+  const [debouncedSupplyRequests, setDebouncedSupplyRequests] =
+    useState(supplyRequests)
+
+  useEffect(() => {
+    const timeout = window.setTimeout(
+      () => setDebouncedSupplyRequests(supplyRequests),
+      SUPPLY_REQUEST_DEBOUNCE_MS,
+    )
+    return () => window.clearTimeout(timeout)
+  }, [supplyRequests])
+
+  const supplyRequestBatches = useMemo(
+    () => chunks(debouncedSupplyRequests, PAGE_SIZE),
+    [debouncedSupplyRequests],
+  )
+  const supplyQueries = useQueries({
+    queries: supplyRequestBatches.map((requests) =>
+      trpc.tvsCoverage.getSupplyEstimates.queryOptions(requests, {
+        staleTime: 2 * 60 * 1000,
+        refetchOnWindowFocus: false,
+      }),
+    ),
+  })
+  const supplyEstimates = useMemo(
+    () => supplyQueries.flatMap((query) => query.data ?? []),
+    [supplyQueries],
+  )
+  const isFetchingSupplies = supplyQueries.some((query) => query.isFetching)
+  const isLoadingSupplies =
+    isFetchingSupplies ||
+    debouncedSupplyRequests.length !== supplyRequests.length
+  const supplyByDeployment = useMemo(
+    () =>
+      new Map(
+        supplyEstimates?.map((estimate) => [
+          deploymentKey(estimate.chain, estimate.address),
+          estimate,
+        ]),
+      ),
+    [supplyEstimates],
+  )
+  const supplyChangeRequests = useMemo(
+    () =>
+      candidateRows
+        .filter(
+          (row) =>
+            row.role === 'minted' ||
+            row.role === 'burnAndMint' ||
+            row.role === 'both',
+        )
+        .map((row) => ({ chain: row.chain, address: row.address })),
+    [candidateRows],
+  )
+  const [debouncedSupplyChangeRequests, setDebouncedSupplyChangeRequests] =
+    useState(supplyChangeRequests)
+
+  useEffect(() => {
+    const timeout = window.setTimeout(
+      () => setDebouncedSupplyChangeRequests(supplyChangeRequests),
+      SUPPLY_REQUEST_DEBOUNCE_MS,
+    )
+    return () => window.clearTimeout(timeout)
+  }, [supplyChangeRequests])
+
+  const supplyChangeRequestBatches = useMemo(
+    () => chunks(debouncedSupplyChangeRequests, PAGE_SIZE),
+    [debouncedSupplyChangeRequests],
+  )
+  const supplyChangeQueries = useQueries({
+    queries: supplyChangeRequestBatches.map((requests) =>
+      trpc.tvsCoverage.getSupplyChangeEvidence.queryOptions(requests, {
+        staleTime: 10 * 60 * 1000,
+        refetchOnWindowFocus: false,
+      }),
+    ),
+  })
+  const supplyChangeByDeployment = useMemo(
+    () =>
+      new Map(
+        supplyChangeQueries
+          .flatMap((query) => query.data ?? [])
+          .map((evidence) => [
+            deploymentKey(evidence.chain, evidence.address),
+            evidence,
+          ]),
+      ),
+    [supplyChangeQueries],
+  )
+  const isFetchingSupplyChanges = supplyChangeQueries.some(
+    (query) => query.isFetching,
+  )
+  const shownRows = useMemo(
+    () =>
+      sortRows(
+        candidateRows,
+        sort,
+        supplyByDeployment,
+        chainsById,
+        pluginsById,
+      ),
+    [candidateRows, chainsById, pluginsById, sort, supplyByDeployment],
+  )
+  const sortBy = (key: SortKey) => {
+    setSort((current) => ({
+      key,
+      direction:
+        current.key === key
+          ? current.direction === 'asc'
+            ? 'desc'
+            : 'asc'
+          : defaultSortDirection(key),
+    }))
+  }
+  const volume = rows.reduce((sum, row) => sum + row.volumeUsd, 0)
+  const hasMoreRows = candidateRows.length < rows.length
+  const nextBatchSize = Math.min(PAGE_SIZE, rows.length - candidateRows.length)
+  const summary = data
+    ? `${rows.length.toLocaleString()} rows · ${formatCurrency(volume, 'usd')}${
+        hasMoreRows ? ` · ${candidateRows.length.toLocaleString()} shown` : ''
+      }`
+    : undefined
+
+  return (
+    <AppLayout>
+      <Card className="flex h-[calc(100vh-16px)] flex-col">
+        <CardHeader className="gap-3 border-b">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+            <CardTitle>Interop → TVS gaps</CardTitle>
+            {summary && <CardDescription>{summary}</CardDescription>}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Select
+              value={String(hours)}
+              onValueChange={(value) => {
+                setHours(Number(value) as WindowHours)
+                setVisibleRows(PAGE_SIZE)
+              }}
+            >
+              <SelectTrigger size="sm" className="w-28" aria-label="Window">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="24">24 hours</SelectItem>
+                <SelectItem value="72">3 days</SelectItem>
+                <SelectItem value="168">7 days</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={chain}
+              onValueChange={(value) => {
+                setChain(value)
+                setVisibleRows(PAGE_SIZE)
+              }}
+            >
+              <SelectTrigger size="sm" className="w-40" aria-label="Chain">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All chains</SelectItem>
+                {data?.chains.map((chain) => (
+                  <SelectItem key={chain.chain} value={chain.chain}>
+                    {chain.chainName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+
+            <Select
+              value={coverage}
+              onValueChange={(value) => {
+                setCoverage(value as CoverageFilter)
+                setVisibleRows(PAGE_SIZE)
+              }}
+            >
+              <SelectTrigger
+                size="sm"
+                className="w-28"
+                aria-label="TVS coverage"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="missing">Missing</SelectItem>
+                <SelectItem value="included">Included</SelectItem>
+                <SelectItem value="all">All</SelectItem>
+              </SelectContent>
+            </Select>
+
+            <Input
+              type="number"
+              min="0"
+              step="1000"
+              inputMode="numeric"
+              value={minimumVolume}
+              onChange={(event) => {
+                setMinimumVolume(event.target.value)
+                setVisibleRows(PAGE_SIZE)
+              }}
+              className="h-8 w-28"
+              placeholder="Min volume"
+              aria-label="Minimum volume"
+            />
+            <Input
+              type="search"
+              value={search}
+              onChange={(event) => {
+                setSearch(event.target.value)
+                setVisibleRows(PAGE_SIZE)
+              }}
+              className="h-8 w-40 min-w-40 flex-1"
+              placeholder="Search"
+              aria-label="Search"
+              autoComplete="off"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="size-8"
+              disabled={
+                isFetching || isLoadingSupplies || isFetchingSupplyChanges
+              }
+              aria-label={
+                isFetching || isLoadingSupplies || isFetchingSupplyChanges
+                  ? 'Refreshing'
+                  : 'Refresh'
+              }
+              onClick={() => {
+                void refetchCoverage()
+                for (const query of supplyQueries) void query.refetch()
+                for (const query of supplyChangeQueries) void query.refetch()
+              }}
+            >
+              <RotateCwIcon
+                className={cn(
+                  (isFetching ||
+                    isLoadingSupplies ||
+                    isFetchingSupplyChanges) &&
+                    'animate-spin',
+                )}
+              />
+            </Button>
+          </div>
+        </CardHeader>
+
+        <CardContent className="min-h-0 flex-1 overflow-y-auto">
+          {isLoading ? (
+            <LoadingState className="h-full" />
+          ) : isError ? (
+            <div className="grid h-full place-items-center p-4 text-center text-destructive text-sm">
+              {error.message}
+            </div>
+          ) : (
+            <Table className="min-w-[980px] table-fixed">
+              <TableHeader className="sticky top-0 z-10 bg-card">
+                <TableRow>
+                  <TableHead className="w-12 text-right">#</TableHead>
+                  <SortableTableHead
+                    className="w-40"
+                    label="Chain"
+                    sortKey="chain"
+                    sort={sort}
+                    onSort={sortBy}
+                  />
+                  <SortableTableHead
+                    className="w-44"
+                    label="Token"
+                    sortKey="token"
+                    sort={sort}
+                    onSort={sortBy}
+                  />
+                  <SortableTableHead
+                    className="w-28"
+                    label="totalSupply()"
+                    sortKey="totalSupply"
+                    sort={sort}
+                    onSort={sortBy}
+                    align="right"
+                  />
+                  <SortableTableHead
+                    className="w-28"
+                    label="Supply value"
+                    sortKey="potentialTvsUsd"
+                    sort={sort}
+                    onSort={sortBy}
+                    align="right"
+                  />
+                  <SortableTableHead
+                    className="w-28"
+                    label="Volume"
+                    sortKey="volumeUsd"
+                    sort={sort}
+                    onSort={sortBy}
+                    align="right"
+                  />
+                  <SortableTableHead
+                    className="w-20"
+                    label="TVS"
+                    sortKey="included"
+                    sort={sort}
+                    onSort={sortBy}
+                  />
+                  <SortableTableHead
+                    className="w-20"
+                    label="Role"
+                    sortKey="role"
+                    sort={sort}
+                    onSort={sortBy}
+                  />
+                  <SortableTableHead
+                    className="w-24"
+                    label="Via"
+                    sortKey="plugins"
+                    sort={sort}
+                    onSort={sortBy}
+                  />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {shownRows.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={9}
+                      className="h-24 text-center text-muted-foreground"
+                    >
+                      No results
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  shownRows.map((row, index) => {
+                    const chainInfo = chainsById.get(row.chain)
+                    const symbol = row.abstractSymbol ?? row.symbol ?? 'Unknown'
+                    const supply = supplyByDeployment.get(
+                      deploymentKey(row.chain, row.address),
+                    )
+                    const supplyChange = supplyChangeByDeployment.get(
+                      deploymentKey(row.chain, row.address),
+                    )
+                    const vaultAssetIncluded = supply?.vaultAsset
+                      ? tvsDeploymentKeys.has(
+                          projectTvsDeploymentKey(
+                            row.chain,
+                            row.chain,
+                            supply.vaultAsset.address,
+                          ),
+                        )
+                      : false
+                    const rolesByPlugin = new Map(
+                      (row.pluginRoles ?? []).map(({ plugin, roles }) => [
+                        plugin,
+                        roles,
+                      ]),
+                    )
+
+                    return (
+                      <TableRow key={`${row.chain}:${row.address}`}>
+                        <TableCell className="text-right text-muted-foreground tabular-nums">
+                          {index + 1}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2 font-medium">
+                            {chainInfo?.projectIconUrl && (
+                              <img
+                                src={chainInfo.projectIconUrl}
+                                alt=""
+                                width={20}
+                                height={20}
+                                className="size-5 rounded-sm object-cover"
+                                onError={(event) => {
+                                  event.currentTarget.style.visibility =
+                                    'hidden'
+                                }}
+                              />
+                            )}
+                            {chainInfo?.chainName ?? row.chain}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <img
+                              src={tokenIconUrl(row.iconUrl)}
+                              alt=""
+                              width={24}
+                              height={24}
+                              className="size-6 rounded-full bg-muted object-cover"
+                              onError={(event) => {
+                                if (
+                                  !event.currentTarget.src.endsWith(
+                                    '/images/token-placeholder.png',
+                                  )
+                                ) {
+                                  event.currentTarget.src =
+                                    '/images/token-placeholder.png'
+                                } else {
+                                  event.currentTarget.style.visibility =
+                                    'hidden'
+                                }
+                              }}
+                            />
+                            <div className="min-w-0">
+                              <div className="flex flex-wrap items-center gap-1">
+                                <span className="font-medium">{symbol}</span>
+                                {row.ignored && (
+                                  <span className="ml-1 font-normal text-muted-foreground text-xs">
+                                    ignored
+                                  </span>
+                                )}
+                                {supply?.vaultAsset && (
+                                  <VaultAssetBadges
+                                    asset={supply.vaultAsset}
+                                    included={vaultAssetIncluded}
+                                    chainName={
+                                      chainInfo?.chainName ?? row.chain
+                                    }
+                                  />
+                                )}
+                              </div>
+                              <Address
+                                row={row}
+                                explorerUrl={chainInfo?.explorerUrl}
+                              />
+                            </div>
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          <div className="flex flex-col items-end gap-1">
+                            <span
+                              title={
+                                supply?.totalSupply === undefined
+                                  ? undefined
+                                  : `${supply.totalSupply} ${symbol}`
+                              }
+                            >
+                              {supply?.totalSupply === undefined
+                                ? isLoadingSupplies
+                                  ? '…'
+                                  : '—'
+                                : formatTokenSupply(supply.totalSupply)}
+                            </span>
+                            <CoinGeckoCirculatingSupplyBadge
+                              estimate={supply}
+                              symbol={symbol}
+                            />
+                            {supplyChange?.bridgeShareOfSupplyChange !==
+                              undefined && (
+                              <SupplyChangeBadge evidence={supplyChange} />
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right font-medium tabular-nums">
+                          {supply?.potentialTvsUsd === undefined
+                            ? isLoadingSupplies
+                              ? '…'
+                              : '—'
+                            : formatCurrency(supply.potentialTvsUsd, 'usd')}
+                        </TableCell>
+                        <TableCell className="text-right tabular-nums">
+                          <div className="font-medium">
+                            {formatCurrency(row.volumeUsd, 'usd')}
+                          </div>
+                          <div className="text-muted-foreground text-xs">
+                            {row.transferCount.toLocaleString()} txs
+                            {row.unvaluedTransferCount > 0 && (
+                              <>
+                                {' · '}
+                                {row.unvaluedTransferCount.toLocaleString()}{' '}
+                                unvalued
+                              </>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <CoverageBadge included={row.included} />
+                        </TableCell>
+                        <TableCell className="text-muted-foreground text-xs">
+                          {formatInteropRole(row.role)}
+                        </TableCell>
+                        <TableCell>
+                          <PluginIconStack
+                            plugins={row.plugins.map((id) => ({
+                              ...(pluginsById.get(id) ?? {
+                                id,
+                                name: id,
+                                iconUrl: undefined,
+                              }),
+                              roles: rolesByPlugin.get(id),
+                            }))}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })
+                )}
+                {shownRows.length > 0 && hasMoreRows && (
+                  <TableRow className="hover:bg-transparent">
+                    <TableCell colSpan={9} className="py-3 text-center">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        disabled={isLoadingSupplies}
+                        onClick={() =>
+                          setVisibleRows((current) =>
+                            Math.min(current + PAGE_SIZE, rows.length),
+                          )
+                        }
+                      >
+                        {isLoadingSupplies
+                          ? 'Loading…'
+                          : `Load ${nextBatchSize} more`}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </AppLayout>
+  )
+}
+
+function Address({
+  row,
+  explorerUrl,
+}: {
+  row: CoverageRow
+  explorerUrl: string | undefined
+}) {
+  const value = shortAddress(row.address)
+  const className = 'font-mono text-muted-foreground text-xs'
+
+  if (explorerUrl && /^0x[0-9a-f]{40}$/i.test(row.address)) {
+    return (
+      <div className={className} title={row.address}>
+        <ExplorerLink
+          explorerUrl={explorerUrl}
+          value={row.address}
+          type="address"
+        >
+          {value}
+        </ExplorerLink>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className} title={row.address}>
+      {value}
+    </div>
+  )
+}
+
+function CoverageBadge({ included }: { included: boolean }) {
+  return (
+    <Badge
+      variant="outline"
+      className={
+        included
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-900 dark:bg-emerald-950 dark:text-emerald-300'
+          : 'border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300'
+      }
+    >
+      {included ? 'Included' : 'Missing'}
+    </Badge>
+  )
+}
+
+function tokenIconUrl(iconUrl: string | undefined) {
+  if (!iconUrl) return '/images/token-placeholder.png'
+  return iconUrl.startsWith('/') ? `https://l2beat.com${iconUrl}` : iconUrl
+}
+
+function shortAddress(address: string) {
+  if (address.length <= 16) return address
+  return `${address.slice(0, 8)}…${address.slice(-5)}`
+}
+
+function deploymentKey(chain: string, address: string) {
+  return `${chain}:${address.toLowerCase()}`
+}
+
+function projectTvsDeploymentKey(
+  projectChain: string,
+  tokenChain: string,
+  address: string,
+) {
+  return `${projectChain}:${deploymentKey(tokenChain, address)}`
+}
+
+function VaultAssetBadges({
+  asset,
+  included,
+  chainName,
+}: {
+  asset: VaultAsset
+  included: boolean
+  chainName: string
+}) {
+  const label = asset.symbol ?? shortAddress(asset.address)
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex"
+            tabIndex={0}
+            aria-label={`Backed by: ${label}`}
+          >
+            <Badge
+              variant="outline"
+              className="h-5 max-w-32 px-1.5 font-normal text-[10px]"
+            >
+              Backed by: {label}
+            </Badge>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="space-y-0.5">
+          <div>ERC-4626 asset(): {label}</div>
+          <div className="font-mono opacity-75">{asset.address}</div>
+        </TooltipContent>
+      </Tooltip>
+      {included && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className="inline-flex"
+              tabIndex={0}
+              aria-label={`${label} is already included in ${chainName} TVS`}
+            >
+              <Badge
+                variant="outline"
+                className="h-5 border-amber-300 bg-amber-50 px-1.5 font-normal text-[10px] text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+              >
+                In TVS
+              </Badge>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {label} is already used by {chainName} TVS. Supply value can
+            overlap.
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  )
+}
+
+function SupplyChangeBadge({ evidence }: { evidence: SupplyChangeEvidence }) {
+  const percentage = evidence.bridgeShareOfSupplyChange
+  if (percentage === undefined) return null
+  const percentageLabel = formatBridgePercentage(percentage)
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex"
+          tabIndex={0}
+          aria-label={`Tracked Interop net is ${percentageLabel} of the total supply change`}
+        >
+          <Badge
+            variant="outline"
+            className="h-5 px-1.5 font-normal text-[10px] text-muted-foreground"
+          >
+            Δ via Interop: {percentageLabel}
+          </Badge>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="w-72 space-y-1.5 text-left text-xs">
+        <div className="font-medium">Retained Interop window</div>
+        <div className="opacity-75">
+          {formatEvidenceTimestamp(evidence.from)} →{' '}
+          {formatEvidenceTimestamp(evidence.to)}
+        </div>
+        <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 tabular-nums">
+          <span className="opacity-75">totalSupply()</span>
+          <span className="text-right">
+            {formatTokenSupply(evidence.supplyStart)} →{' '}
+            {formatTokenSupply(evidence.supplyEnd)}
+          </span>
+          <span className="opacity-75">Supply Δ</span>
+          <span className="text-right">
+            {formatSignedTokenAmount(evidence.supplyChange)}
+          </span>
+          <span className="opacity-75">Interop mints</span>
+          <span className="text-right">
+            {formatSignedTokenAmount(evidence.interopMinted)}
+          </span>
+          <span className="opacity-75">Interop burns</span>
+          <span className="text-right">
+            {formatBurnedTokenAmount(evidence.interopBurned)}
+          </span>
+          <span className="opacity-75">Interop net</span>
+          <span className="text-right">
+            {formatSignedTokenAmount(evidence.interopNet)}
+          </span>
+          <span className="opacity-75">Unexplained Δ</span>
+          <span className="text-right">
+            {formatSignedTokenAmount(evidence.unexplainedChange)}
+          </span>
+          <span className="opacity-75">Transfers</span>
+          <span className="text-right">
+            {evidence.transferCount.toLocaleString()}
+          </span>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function CoinGeckoCirculatingSupplyBadge({
+  estimate,
+  symbol,
+}: {
+  estimate: SupplyEstimate | undefined
+  symbol: string
+}) {
+  const totalSupply = Number(estimate?.totalSupply)
+  const circulatingSupply = estimate?.coingeckoCirculatingSupply
+  if (
+    circulatingSupply === undefined ||
+    circulatingSupply <= 0 ||
+    !Number.isFinite(totalSupply) ||
+    totalSupply <= circulatingSupply * COINGECKO_CIRCULATING_WARNING_RATIO
+  ) {
+    return null
+  }
+
+  const circulatingLabel = formatTokenSupply(String(circulatingSupply))
+  const totalLabel = formatTokenSupply(String(totalSupply))
+  const differenceLabel = formatTokenSupply(
+    String(totalSupply - circulatingSupply),
+  )
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex"
+          tabIndex={0}
+          aria-label={`CoinGecko reports ${circulatingLabel} ${symbol} circulating globally, below this contract's total supply of ${totalLabel}`}
+        >
+          <Badge
+            variant="outline"
+            className="h-5 border-amber-300 bg-amber-50 px-1.5 font-normal text-[10px] text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+          >
+            CG circ. {circulatingLabel}
+          </Badge>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="w-64 space-y-1 text-left text-xs">
+        <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 tabular-nums">
+          <span className="opacity-75">totalSupply()</span>
+          <span className="text-right">{totalLabel}</span>
+          <span className="opacity-75">CG circulating</span>
+          <span className="text-right">{circulatingLabel}</span>
+          <span className="opacity-75">Difference</span>
+          <span className="text-right">{differenceLabel}</span>
+        </div>
+        <div className="opacity-75">Global CoinGecko value</div>
+        {estimate?.coingeckoUpdatedAt && (
+          <div className="opacity-75">
+            Updated {formatCoinGeckoTimestamp(estimate.coingeckoUpdatedAt)}
+          </div>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function formatTokenSupply(supply: string) {
+  const value = Number(supply)
+  if (!Number.isFinite(value)) return supply
+
+  return new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 2,
+  }).format(value)
+}
+
+function formatSignedTokenAmount(value: string) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return value
+  if (numeric === 0) return '0'
+  return `${numeric > 0 ? '+' : '−'}${formatTokenSupply(
+    String(Math.abs(numeric)),
+  )}`
+}
+
+function formatBurnedTokenAmount(value: string) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return value
+  if (numeric === 0) return '0'
+  return `−${formatTokenSupply(String(Math.abs(numeric)))}`
+}
+
+function formatBridgePercentage(value: number) {
+  if (value > 999) return '>999%'
+  if (value < -999) return '<−999%'
+  return `${new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 1,
+  }).format(value)}%`
+}
+
+function formatEvidenceTimestamp(timestamp: number) {
+  return `${new Date(timestamp * 1000)
+    .toISOString()
+    .slice(0, 16)
+    .replace('T', ' ')} UTC`
+}
+
+function formatCoinGeckoTimestamp(timestamp: string) {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) return timestamp
+  return `${date.toISOString().slice(0, 16).replace('T', ' ')} UTC`
+}
+
+function SortableTableHead({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  align = 'left',
+  className,
+}: {
+  label: string
+  sortKey: SortKey
+  sort: SortState
+  onSort: (key: SortKey) => void
+  align?: 'left' | 'right'
+  className?: string
+}) {
+  const active = sort.key === sortKey
+  const Icon = active
+    ? sort.direction === 'asc'
+      ? ArrowUpIcon
+      : ArrowDownIcon
+    : ArrowUpDownIcon
+
+  return (
+    <TableHead
+      className={className}
+      aria-sort={
+        active
+          ? sort.direction === 'asc'
+            ? 'ascending'
+            : 'descending'
+          : 'none'
+      }
+    >
+      <button
+        type="button"
+        className={cn(
+          'flex w-full items-center gap-1 py-2',
+          align === 'right' && 'justify-end',
+        )}
+        aria-label={`Sort by ${label}`}
+        onClick={() => onSort(sortKey)}
+      >
+        {label}
+        <Icon
+          aria-hidden="true"
+          className={cn('size-3 shrink-0', !active && 'opacity-30')}
+        />
+      </button>
+    </TableHead>
+  )
+}
+
+function defaultSortDirection(key: SortKey): SortDirection {
+  return ['chain', 'token', 'included', 'role', 'plugins'].includes(key)
+    ? 'asc'
+    : 'desc'
+}
+
+function sortRows(
+  rows: CoverageRow[],
+  sort: SortState,
+  supplies: Map<
+    string,
+    RouterOutputs['tvsCoverage']['getSupplyEstimates'][number]
+  >,
+  chains: Map<string, CoverageData['chains'][number]>,
+  plugins: Map<string, PluginDetails>,
+) {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const left = sortValue(a.row, sort.key, supplies, chains, plugins)
+      const right = sortValue(b.row, sort.key, supplies, chains, plugins)
+      if (left === undefined && right === undefined) return a.index - b.index
+      if (left === undefined) return 1
+      if (right === undefined) return -1
+
+      const compared =
+        typeof left === 'number' && typeof right === 'number'
+          ? left - right
+          : String(left).localeCompare(String(right), undefined, {
+              numeric: true,
+            })
+      return compared === 0
+        ? a.index - b.index
+        : sort.direction === 'asc'
+          ? compared
+          : -compared
+    })
+    .map(({ row }) => row)
+}
+
+function sortValue(
+  row: CoverageRow,
+  key: SortKey,
+  supplies: Map<
+    string,
+    RouterOutputs['tvsCoverage']['getSupplyEstimates'][number]
+  >,
+  chains: Map<string, CoverageData['chains'][number]>,
+  plugins: Map<string, PluginDetails>,
+): string | number | undefined {
+  const supply = supplies.get(deploymentKey(row.chain, row.address))
+
+  switch (key) {
+    case 'chain':
+      return chains.get(row.chain)?.chainName ?? row.chain
+    case 'token':
+      return row.abstractSymbol ?? row.symbol
+    case 'totalSupply': {
+      const value = supply?.totalSupply
+      return value === undefined ? undefined : Number(value)
+    }
+    case 'potentialTvsUsd':
+      return supply?.potentialTvsUsd
+    case 'volumeUsd':
+      return row.volumeUsd
+    case 'included':
+      return row.included ? 'Included' : 'Missing'
+    case 'role':
+      return row.role ? formatInteropRole(row.role) : undefined
+    case 'plugins':
+      return row.plugins.map((id) => plugins.get(id)?.name ?? id).join(', ')
+  }
+}
+
+function chunks<T>(values: T[], size: number): T[][] {
+  return Array.from({ length: Math.ceil(values.length / size) }, (_, index) =>
+    values.slice(index * size, (index + 1) * size),
+  )
+}
+
+function formatInteropRole(role: CoverageRow['role']) {
+  switch (role) {
+    case 'locked':
+      return 'Locked'
+    case 'minted':
+      return 'Minted'
+    case 'burnAndMint':
+      return 'Burn/mint'
+    case 'both':
+      return 'Both'
+    case 'unknown':
+      return 'Unknown'
+    case undefined:
+      return '—'
+  }
+}
+
+function PluginIconStack({
+  plugins,
+}: {
+  plugins: (PluginDetails & {
+    roles?: CoverageRow['pluginRoles'][number]['roles']
+  })[]
+}) {
+  const visible = plugins.slice(0, MAX_VISIBLE_PLUGINS)
+  const hidden = plugins.slice(MAX_VISIBLE_PLUGINS)
+  const names = plugins
+    .map((plugin) =>
+      plugin.roles && plugin.roles.length > 0
+        ? `${plugin.name}: ${plugin.roles
+            .map((role) => formatInteropRole(role))
+            .join(' + ')}`
+        : plugin.name,
+    )
+    .join(', ')
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className="-space-x-1.5 flex items-center"
+          aria-label={`Via ${names}`}
+          role="img"
+          tabIndex={0}
+          title={names}
+        >
+          {visible.map((plugin, index) => (
+            <span
+              key={plugin.id}
+              aria-hidden="true"
+              className="relative block size-5 shrink-0 rounded-full bg-white shadow"
+              style={{ zIndex: visible.length - index }}
+            >
+              {plugin.iconUrl ? (
+                <img
+                  src={plugin.iconUrl}
+                  alt=""
+                  width={20}
+                  height={20}
+                  className="size-5 rounded-full object-cover"
+                  onError={(event) => {
+                    event.currentTarget.style.visibility = 'hidden'
+                  }}
+                />
+              ) : (
+                <span className="grid size-5 place-items-center rounded-full bg-muted font-medium text-[9px] text-muted-foreground uppercase">
+                  {plugin.name.slice(0, 1)}
+                </span>
+              )}
+            </span>
+          ))}
+          {hidden.length > 0 && (
+            <span
+              aria-hidden="true"
+              className="relative grid size-5 shrink-0 place-items-center rounded-full bg-muted font-medium text-[9px] text-muted-foreground shadow"
+            >
+              +{hidden.length}
+            </span>
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>{names}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
@@ -616,23 +616,12 @@ export function TokenTvsCoveragePage() {
                             )}
                           </div>
                         </TableCell>
-                        <TableCell className="text-right tabular-nums">
-                          <div className="flex flex-col items-end gap-1">
-                            <span className="font-medium">
-                              {supply?.estimatedValueUsd === undefined
-                                ? isLoadingSupplies
-                                  ? '…'
-                                  : '—'
-                                : formatCurrency(
-                                    supply.estimatedValueUsd,
-                                    'usd',
-                                  )}
-                            </span>
-                            <EstimatedValueBasisBadge
-                              estimate={supply}
-                              symbol={symbol}
-                            />
-                          </div>
+                        <TableCell className="text-right font-medium tabular-nums">
+                          {supply?.estimatedValueUsd === undefined
+                            ? isLoadingSupplies
+                              ? '…'
+                              : '—'
+                            : formatCurrency(supply.estimatedValueUsd, 'usd')}
                         </TableCell>
                         <TableCell className="text-right tabular-nums">
                           <div className="font-medium">
@@ -949,48 +938,6 @@ function CoinGeckoCirculatingSupplyBadge({
             Updated {formatCoinGeckoTimestamp(estimate.coingeckoUpdatedAt)}
           </div>
         )}
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
-function EstimatedValueBasisBadge({
-  estimate,
-  symbol,
-}: {
-  estimate: SupplyEstimate | undefined
-  symbol: string
-}) {
-  if (
-    estimate?.estimatedValueBasis !== 'coingeckoCirculatingSupply' ||
-    estimate.coingeckoCirculatingSupply === undefined
-  ) {
-    return null
-  }
-
-  const circulatingLabel = formatTokenSupply(
-    String(estimate.coingeckoCirculatingSupply),
-  )
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className="inline-flex"
-          tabIndex={0}
-          aria-label={`Estimated value uses CoinGecko global circulating supply of ${circulatingLabel} ${symbol}`}
-        >
-          <Badge
-            variant="outline"
-            className="h-5 border-amber-300 bg-amber-50 px-1.5 font-normal text-[10px] text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
-          >
-            CG circ.
-          </Badge>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent className="max-w-64 text-left text-xs">
-        Using CoinGecko global circulating supply ({circulatingLabel} {symbol})
-        because it is lower than local totalSupply().
       </TooltipContent>
     </Tooltip>
   )

--- a/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
@@ -1,6 +1,6 @@
 import { formatCurrency } from '@l2beat/shared-pure'
 import type { RouterOutputs } from '@l2beat/token-backend'
-import { useQueries, useQuery } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import {
   ArrowDownIcon,
   ArrowUpDownIcon,
@@ -189,23 +189,14 @@ export function TokenTvsCoveragePage() {
     return () => window.clearTimeout(timeout)
   }, [supplyRequests])
 
-  const supplyRequestBatches = useMemo(
-    () => chunks(debouncedSupplyRequests, PAGE_SIZE),
-    [debouncedSupplyRequests],
+  const supplyQuery = useQuery(
+    trpc.tvsCoverage.getSupplyEstimates.queryOptions(debouncedSupplyRequests, {
+      staleTime: 2 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    }),
   )
-  const supplyQueries = useQueries({
-    queries: supplyRequestBatches.map((requests) =>
-      trpc.tvsCoverage.getSupplyEstimates.queryOptions(requests, {
-        staleTime: 2 * 60 * 1000,
-        refetchOnWindowFocus: false,
-      }),
-    ),
-  })
-  const supplyEstimates = useMemo(
-    () => supplyQueries.flatMap((query) => query.data ?? []),
-    [supplyQueries],
-  )
-  const isFetchingSupplies = supplyQueries.some((query) => query.isFetching)
+  const supplyEstimates = supplyQuery.data ?? []
+  const isFetchingSupplies = supplyQuery.isFetching
   const isLoadingSupplies =
     isFetchingSupplies ||
     debouncedSupplyRequests.length !== supplyRequests.length
@@ -241,33 +232,26 @@ export function TokenTvsCoveragePage() {
     return () => window.clearTimeout(timeout)
   }, [supplyChangeRequests])
 
-  const supplyChangeRequestBatches = useMemo(
-    () => chunks(debouncedSupplyChangeRequests, PAGE_SIZE),
-    [debouncedSupplyChangeRequests],
-  )
-  const supplyChangeQueries = useQueries({
-    queries: supplyChangeRequestBatches.map((requests) =>
-      trpc.tvsCoverage.getSupplyChangeEvidence.queryOptions(requests, {
+  const supplyChangeQuery = useQuery(
+    trpc.tvsCoverage.getSupplyChangeEvidence.queryOptions(
+      debouncedSupplyChangeRequests,
+      {
         staleTime: 10 * 60 * 1000,
         refetchOnWindowFocus: false,
-      }),
+      },
     ),
-  })
+  )
   const supplyChangeByDeployment = useMemo(
     () =>
       new Map(
-        supplyChangeQueries
-          .flatMap((query) => query.data ?? [])
-          .map((evidence) => [
-            deploymentKey(evidence.chain, evidence.address),
-            evidence,
-          ]),
+        (supplyChangeQuery.data ?? []).map((evidence) => [
+          deploymentKey(evidence.chain, evidence.address),
+          evidence,
+        ]),
       ),
-    [supplyChangeQueries],
+    [supplyChangeQuery.data],
   )
-  const isFetchingSupplyChanges = supplyChangeQueries.some(
-    (query) => query.isFetching,
-  )
+  const isFetchingSupplyChanges = supplyChangeQuery.isFetching
   const sortedRows = useMemo(
     () =>
       sortRows(rankedRows, sort, supplyByDeployment, chainsById, pluginsById),
@@ -413,8 +397,8 @@ export function TokenTvsCoveragePage() {
               }
               onClick={() => {
                 void refetchCoverage()
-                for (const query of supplyQueries) void query.refetch()
-                for (const query of supplyChangeQueries) void query.refetch()
+                void supplyQuery.refetch()
+                void supplyChangeQuery.refetch()
               }}
             >
               <RotateCwIcon
@@ -1131,12 +1115,6 @@ function sortValue(
     case 'plugins':
       return row.plugins.map((id) => plugins.get(id)?.name ?? id).join(', ')
   }
-}
-
-function chunks<T>(values: T[], size: number): T[][] {
-  return Array.from({ length: Math.ceil(values.length / size) }, (_, index) =>
-    values.slice(index * size, (index + 1) * size),
-  )
 }
 
 function formatInteropRole(role: CoverageRow['role']) {

--- a/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
@@ -70,9 +70,11 @@ interface SortState {
 }
 
 const PAGE_SIZE = 25
+const MAX_SORTABLE_ROWS = 100
 const MAX_VISIBLE_PLUGINS = 4
 const SUPPLY_REQUEST_DEBOUNCE_MS = 300
 const COINGECKO_CIRCULATING_WARNING_RATIO = 1.1
+const CASE_SENSITIVE_TOKEN_ADDRESS_CHAINS = new Set(['solana', 'tron'])
 
 export function TokenTvsCoveragePage() {
   const trpc = useTRPC()
@@ -134,7 +136,7 @@ export function TokenTvsCoveragePage() {
       ),
     [data],
   )
-  const rows = useMemo(() => {
+  const filteredRows = useMemo(() => {
     const needle = search.trim().toLowerCase()
     const threshold = Number(minimumVolume) || 0
 
@@ -164,17 +166,17 @@ export function TokenTvsCoveragePage() {
     })
   }, [chain, chainsById, coverage, data, minimumVolume, search])
 
-  const candidateRows = useMemo(
-    () => rows.slice(0, visibleRows),
-    [rows, visibleRows],
+  const rankedRows = useMemo(
+    () => filteredRows.slice(0, MAX_SORTABLE_ROWS),
+    [filteredRows],
   )
   const supplyRequests = useMemo(
     () =>
-      candidateRows.map((row) => ({
+      rankedRows.map((row) => ({
         chain: row.chain,
         address: row.address,
       })),
-    [candidateRows],
+    [rankedRows],
   )
   const [debouncedSupplyRequests, setDebouncedSupplyRequests] =
     useState(supplyRequests)
@@ -219,15 +221,14 @@ export function TokenTvsCoveragePage() {
   )
   const supplyChangeRequests = useMemo(
     () =>
-      candidateRows
-        .filter(
-          (row) =>
-            row.role === 'minted' ||
-            row.role === 'burnAndMint' ||
-            row.role === 'both',
+      rankedRows
+        .filter((row) =>
+          row.pluginRoles.some(({ roles }) =>
+            roles.some((role) => role === 'minted' || role === 'burnAndMint'),
+          ),
         )
         .map((row) => ({ chain: row.chain, address: row.address })),
-    [candidateRows],
+    [rankedRows],
   )
   const [debouncedSupplyChangeRequests, setDebouncedSupplyChangeRequests] =
     useState(supplyChangeRequests)
@@ -267,16 +268,14 @@ export function TokenTvsCoveragePage() {
   const isFetchingSupplyChanges = supplyChangeQueries.some(
     (query) => query.isFetching,
   )
-  const shownRows = useMemo(
+  const sortedRows = useMemo(
     () =>
-      sortRows(
-        candidateRows,
-        sort,
-        supplyByDeployment,
-        chainsById,
-        pluginsById,
-      ),
-    [candidateRows, chainsById, pluginsById, sort, supplyByDeployment],
+      sortRows(rankedRows, sort, supplyByDeployment, chainsById, pluginsById),
+    [chainsById, pluginsById, rankedRows, sort, supplyByDeployment],
+  )
+  const shownRows = useMemo(
+    () => sortedRows.slice(0, visibleRows),
+    [sortedRows, visibleRows],
   )
   const sortBy = (key: SortKey) => {
     setSort((current) => ({
@@ -289,13 +288,21 @@ export function TokenTvsCoveragePage() {
           : defaultSortDirection(key),
     }))
   }
-  const volume = rows.reduce((sum, row) => sum + row.volumeUsd, 0)
-  const hasMoreRows = candidateRows.length < rows.length
-  const nextBatchSize = Math.min(PAGE_SIZE, rows.length - candidateRows.length)
+  const volume = filteredRows.reduce((sum, row) => sum + row.volumeUsd, 0)
+  const hasMoreRows = shownRows.length < rankedRows.length
+  const nextBatchSize = Math.min(
+    PAGE_SIZE,
+    rankedRows.length - shownRows.length,
+  )
   const summary = data
-    ? `${rows.length.toLocaleString()} rows · ${formatCurrency(volume, 'usd')}${
-        hasMoreRows ? ` · ${candidateRows.length.toLocaleString()} shown` : ''
-      }`
+    ? `${filteredRows.length.toLocaleString()} rows · ${formatCurrency(
+        volume,
+        'usd',
+      )}${
+        filteredRows.length > rankedRows.length
+          ? ` · top ${rankedRows.length.toLocaleString()} by volume`
+          : ''
+      }${hasMoreRows ? ` · ${shownRows.length.toLocaleString()} shown` : ''}`
     : undefined
 
   return (
@@ -680,7 +687,7 @@ export function TokenTvsCoveragePage() {
                         disabled={isLoadingSupplies}
                         onClick={() =>
                           setVisibleRows((current) =>
-                            Math.min(current + PAGE_SIZE, rows.length),
+                            Math.min(current + PAGE_SIZE, rankedRows.length),
                           )
                         }
                       >
@@ -757,7 +764,10 @@ function shortAddress(address: string) {
 }
 
 function deploymentKey(chain: string, address: string) {
-  return `${chain}:${address.toLowerCase()}`
+  const normalized = CASE_SENSITIVE_TOKEN_ADDRESS_CHAINS.has(chain)
+    ? address
+    : address.toLowerCase()
+  return `${chain}:${normalized}`
 }
 
 function projectTvsDeploymentKey(

--- a/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
+++ b/packages/token-ui/src/pages/tokens/TokenTvsCoveragePage.tsx
@@ -58,7 +58,7 @@ type SortKey =
   | 'chain'
   | 'token'
   | 'totalSupply'
-  | 'potentialTvsUsd'
+  | 'estimatedValueUsd'
   | 'volumeUsd'
   | 'included'
   | 'role'
@@ -73,7 +73,6 @@ const PAGE_SIZE = 25
 const MAX_SORTABLE_ROWS = 100
 const MAX_VISIBLE_PLUGINS = 4
 const SUPPLY_REQUEST_DEBOUNCE_MS = 300
-const COINGECKO_CIRCULATING_WARNING_RATIO = 1.1
 const CASE_SENSITIVE_TOKEN_ADDRESS_CHAINS = new Set(['solana', 'tron'])
 
 export function TokenTvsCoveragePage() {
@@ -85,7 +84,7 @@ export function TokenTvsCoveragePage() {
   const [search, setSearch] = useState('')
   const [visibleRows, setVisibleRows] = useState(PAGE_SIZE)
   const [sort, setSort] = useState<SortState>({
-    key: 'volumeUsd',
+    key: 'estimatedValueUsd',
     direction: 'desc',
   })
   const {
@@ -449,8 +448,8 @@ export function TokenTvsCoveragePage() {
                   />
                   <SortableTableHead
                     className="w-28"
-                    label="Supply value"
-                    sortKey="potentialTvsUsd"
+                    label="Est. value"
+                    sortKey="estimatedValueUsd"
                     sort={sort}
                     onSort={sortBy}
                     align="right"
@@ -617,12 +616,23 @@ export function TokenTvsCoveragePage() {
                             )}
                           </div>
                         </TableCell>
-                        <TableCell className="text-right font-medium tabular-nums">
-                          {supply?.potentialTvsUsd === undefined
-                            ? isLoadingSupplies
-                              ? '…'
-                              : '—'
-                            : formatCurrency(supply.potentialTvsUsd, 'usd')}
+                        <TableCell className="text-right tabular-nums">
+                          <div className="flex flex-col items-end gap-1">
+                            <span className="font-medium">
+                              {supply?.estimatedValueUsd === undefined
+                                ? isLoadingSupplies
+                                  ? '…'
+                                  : '—'
+                                : formatCurrency(
+                                    supply.estimatedValueUsd,
+                                    'usd',
+                                  )}
+                            </span>
+                            <EstimatedValueBasisBadge
+                              estimate={supply}
+                              symbol={symbol}
+                            />
+                          </div>
                         </TableCell>
                         <TableCell className="text-right tabular-nums">
                           <div className="font-medium">
@@ -812,8 +822,7 @@ function VaultAssetBadges({
             </span>
           </TooltipTrigger>
           <TooltipContent>
-            {label} is already used by {chainName} TVS. Supply value can
-            overlap.
+            {label} is already used by {chainName} TVS. Value can overlap.
           </TooltipContent>
         </Tooltip>
       )}
@@ -895,9 +904,10 @@ function CoinGeckoCirculatingSupplyBadge({
   const circulatingSupply = estimate?.coingeckoCirculatingSupply
   if (
     circulatingSupply === undefined ||
-    circulatingSupply <= 0 ||
+    !Number.isFinite(circulatingSupply) ||
+    circulatingSupply < 0 ||
     !Number.isFinite(totalSupply) ||
-    totalSupply <= circulatingSupply * COINGECKO_CIRCULATING_WARNING_RATIO
+    totalSupply <= circulatingSupply
   ) {
     return null
   }
@@ -933,12 +943,54 @@ function CoinGeckoCirculatingSupplyBadge({
           <span className="opacity-75">Difference</span>
           <span className="text-right">{differenceLabel}</span>
         </div>
-        <div className="opacity-75">Global CoinGecko value</div>
+        <div className="opacity-75">Global CoinGecko supply</div>
         {estimate?.coingeckoUpdatedAt && (
           <div className="opacity-75">
             Updated {formatCoinGeckoTimestamp(estimate.coingeckoUpdatedAt)}
           </div>
         )}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function EstimatedValueBasisBadge({
+  estimate,
+  symbol,
+}: {
+  estimate: SupplyEstimate | undefined
+  symbol: string
+}) {
+  if (
+    estimate?.estimatedValueBasis !== 'coingeckoCirculatingSupply' ||
+    estimate.coingeckoCirculatingSupply === undefined
+  ) {
+    return null
+  }
+
+  const circulatingLabel = formatTokenSupply(
+    String(estimate.coingeckoCirculatingSupply),
+  )
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex"
+          tabIndex={0}
+          aria-label={`Estimated value uses CoinGecko global circulating supply of ${circulatingLabel} ${symbol}`}
+        >
+          <Badge
+            variant="outline"
+            className="h-5 border-amber-300 bg-amber-50 px-1.5 font-normal text-[10px] text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+          >
+            CG circ.
+          </Badge>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-64 text-left text-xs">
+        Using CoinGecko global circulating supply ({circulatingLabel} {symbol})
+        because it is lower than local totalSupply().
       </TooltipContent>
     </Tooltip>
   )
@@ -1104,8 +1156,8 @@ function sortValue(
       const value = supply?.totalSupply
       return value === undefined ? undefined : Number(value)
     }
-    case 'potentialTvsUsd':
-      return supply?.potentialTvsUsd
+    case 'estimatedValueUsd':
+      return supply?.estimatedValueUsd
     case 'volumeUsd':
       return row.volumeUsd
     case 'included':

--- a/packages/token-ui/vite.config.mts
+++ b/packages/token-ui/vite.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/trpc': {
-        target: 'http://localhost:3000',
+        target: process.env.TOKEN_BACKEND_URL ?? 'http://localhost:3000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

Adds **TVS gaps** below the token relations graph to surface token deployments seen in interop but missing from each chain's TVS config.

- Filter by 1/3/7-day interop activity, chain, Missing/Included/All, volume, and search.
- Match active TVS formulas by exact deployment or shared TokenDB identity.
- Show token and chain logos, interop volume/transactions, token role, and bridge plugins.
- Enrich the top 100 matches by interop volume and display 25 at a time.
- Estimate value as min(local total supply, CoinGecko global circulating supply) × price and sort by it by default.
- Surface ERC-4626 backing and whether that asset is already in chain TVS.
- Show CoinGecko circulating supply when it is below local total supply.
- Compare seven-day supply changes with indexed interop mint and burn legs.
- Aggregate the transfer window in PostgreSQL and apply one bounded RPC request per enrichment endpoint.

Companion token additions: #12747.

## Validation

- Database: build, typecheck, lint, format; 829 tests passing against a disposable PostgreSQL database.
- Token backend: build, typecheck, lint, format; 222 tests passing.
- Token UI: build, typecheck, lint, format; 93 tests passing.
- Browser smoke-tested the single-request enrichment, default estimated-value sorting, circulation-capped values, stable load-more ordering, and filters.
