### PR TITLE
Update sxnetwork RPC endpoint and rate limit

### DIFF
--- a/packages/config/src/projects/sxnetwork/sxnetwork.ts
+++ b/packages/config/src/projects/sxnetwork/sxnetwork.ts
@@ -46,8 +46,8 @@ export const sxnetwork: ScalingProject = orbitStackL2({
     apis: [
       {
         type: 'rpc',
-        url: 'https://rpc.sx-rollup.gelato.digital',
-        callsPerMinute: 300,
+        url: 'https://rpc-rollup.sx.technology',
+        callsPerMinute: 150,
       },
     ],
     gasTokens: ['SX'],


### PR DESCRIPTION
## Summary

- Update RPC endpoint from Gelato-hosted to sx.technology-hosted endpoint
- Reduce rate limit from 300 to 150 calls per minute
- Configuration change only, no code logic modifications

## Testing

- Verify new RPC endpoint `https://rpc-rollup.sx.technology` is accessible and responds correctly
- Confirm rate limit of 150 calls per minute is appropriate for indexing workloads
- Run config validation tests to ensure no schema violations