### PR TITLE
Attribute RateLimiter waits and Http metrics per consumer

### DIFF
--- a/packages/backend-tools/src/metrics/MetricsAggregator.ts
+++ b/packages/backend-tools/src/metrics/MetricsAggregator.ts
@@ -34,19 +34,24 @@ export abstract class MetricsAggregator<T> {
   }
 
   private flush() {
-    if (!this.buffer.length) {
-      return
-    }
-
     const metrics = [...this.buffer]
 
     //clear buffer
     this.buffer.splice(0)
 
-    const aggregatedMetrics = this.aggregate(metrics)
+    // `aggregate` is called even for an empty buffer so implementations can
+    // report state that is not derived from pushed metrics (e.g. queue waits).
+    const aggregated = this.aggregate(metrics)
+    const entries = Array.isArray(aggregated) ? aggregated : [aggregated]
 
-    this.$.logger.info('Http metrics', { ...aggregatedMetrics })
+    for (const entry of entries) {
+      this.$.logger.info('Http metrics', { ...entry })
+    }
   }
 
-  protected abstract aggregate(metrics: T[]): object
+  /**
+   * Returns one object per log line to emit. Return an empty array to emit
+   * nothing.
+   */
+  protected abstract aggregate(metrics: T[]): object | object[]
 }

--- a/packages/backend-tools/src/rate-limit/RateLimiter.test.ts
+++ b/packages/backend-tools/src/rate-limit/RateLimiter.test.ts
@@ -1,7 +1,7 @@
 import FakeTimers from '@sinonjs/fake-timers'
 import { expect } from 'earl'
 
-import { RateLimiter } from './RateLimiter'
+import { DEFAULT_RATE_LIMITER_LABEL, RateLimiter } from './RateLimiter'
 
 describe(RateLimiter.name, () => {
   const cases = [
@@ -54,5 +54,93 @@ describe(RateLimiter.name, () => {
     const promiseB = rateLimiter.call(fn)
     await expect(promiseA).toBeRejectedWith('oops')
     await expect(promiseB).toBeRejectedWith('oops')
+  })
+
+  describe(RateLimiter.prototype.takeStats.name, () => {
+    it('tracks wait, queue depth and dispatch per label', () => {
+      // a non-zero start time lets the first call dispatch immediately
+      const clock = FakeTimers.install({ now: 10_000 })
+      // 1 call per second
+      const rateLimiter = new RateLimiter({ callsPerMinute: 60 })
+
+      let stats: ReturnType<RateLimiter['takeStats']>
+      try {
+        void rateLimiter.call(() => 1, 'a')
+        void rateLimiter.call(() => 2, 'a')
+        void rateLimiter.call(() => 3, 'a')
+        void rateLimiter.call(() => 4, 'b')
+
+        expect(rateLimiter.queueLength).toEqual(3)
+
+        clock.tick(3_000)
+        stats = rateLimiter.takeStats()
+      } finally {
+        clock.uninstall()
+      }
+
+      expect(stats.queueLength).toEqual(0)
+      expect(stats.labels).toEqual({
+        a: {
+          enqueued: 3,
+          dispatched: 3,
+          // dispatched at t=0, t=1000, t=2000
+          waitMsTotal: 3_000,
+          waitMsMax: 2_000,
+          // the first call was dispatched immediately, so at most two waited
+          queueDepthMax: 2,
+        },
+        b: {
+          enqueued: 1,
+          dispatched: 1,
+          waitMsTotal: 3_000,
+          waitMsMax: 3_000,
+          queueDepthMax: 3,
+        },
+      })
+    })
+
+    it('resets counters on every call', () => {
+      const rateLimiter = new RateLimiter({ callsPerMinute: 100_000 })
+      void rateLimiter.call(() => 1, 'a')
+
+      expect(rateLimiter.takeStats().labels.a?.dispatched).toEqual(1)
+      expect(rateLimiter.takeStats().labels).toEqual({})
+    })
+
+    it('uses a default label', () => {
+      const rateLimiter = new RateLimiter({ callsPerMinute: 100_000 })
+      void rateLimiter.call(() => 1)
+
+      const stats = rateLimiter.takeStats()
+      expect(Object.keys(stats.labels)).toEqual([DEFAULT_RATE_LIMITER_LABEL])
+    })
+
+    it('tracks in-flight calls', async () => {
+      const rateLimiter = new RateLimiter({ callsPerMinute: 100_000 })
+      let release: () => void = () => {}
+      const blocked = new Promise<void>((resolve) => {
+        release = resolve
+      })
+
+      const promiseA = rateLimiter.call(() => blocked)
+      const promiseB = rateLimiter.call(() => blocked)
+      // let the second call get past the spacing check
+      await new Promise((resolve) => setTimeout(resolve, 5))
+
+      const before = rateLimiter.takeStats()
+      expect(before.inFlight).toEqual(2)
+      expect(before.inFlightMax).toEqual(2)
+
+      release()
+      await Promise.all([promiseA, promiseB])
+      // the in-flight counter is decremented after the caller is resolved
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      const after = rateLimiter.takeStats()
+      expect(after.inFlight).toEqual(0)
+      // the max is reset to the in-flight count at the previous snapshot
+      expect(after.inFlightMax).toEqual(2)
+      expect(rateLimiter.takeStats().inFlightMax).toEqual(0)
+    })
   })
 })

--- a/packages/backend-tools/src/rate-limit/RateLimiter.ts
+++ b/packages/backend-tools/src/rate-limit/RateLimiter.ts
@@ -2,11 +2,43 @@ interface QueuedFunction<T> {
   (): Promise<T>
   resolve: (value: T) => void
   reject: (reason?: unknown) => void
+  label: string
+  enqueuedAt: number
 }
 
 export interface RateLimiterOptions {
   callsPerMinute: number
 }
+
+export interface RateLimiterLabelStats {
+  /** Calls accepted by `call()` since the last `takeStats()`. */
+  enqueued: number
+  /** Calls whose function was started since the last `takeStats()`. */
+  dispatched: number
+  /** Sum of enqueue → dispatch wait in ms over dispatched calls. */
+  waitMsTotal: number
+  /** Largest enqueue → dispatch wait in ms over dispatched calls. */
+  waitMsMax: number
+  /** Largest queue length observed right after enqueueing a call with this label. */
+  queueDepthMax: number
+}
+
+export interface RateLimiterStats {
+  /**
+   * Per-label counters. A call enqueued in one snapshot window can be
+   * dispatched in the next, so `enqueued` and `dispatched` need not balance
+   * within a single snapshot.
+   */
+  labels: Record<string, RateLimiterLabelStats>
+  /** Calls started and not yet settled at the time of the snapshot. */
+  inFlight: number
+  /** Largest in-flight count since the last `takeStats()`. */
+  inFlightMax: number
+  /** Calls waiting for dispatch at the time of the snapshot. */
+  queueLength: number
+}
+
+export const DEFAULT_RATE_LIMITER_LABEL = 'default'
 
 const MS_PER_MINUTE = 60 * 1000
 
@@ -15,6 +47,9 @@ export class RateLimiter {
   private queue: QueuedFunction<any>[] = []
   private lastCalled = 0
   private readonly minTimeElapsed: number
+  private labelStats = new Map<string, RateLimiterLabelStats>()
+  private inFlight = 0
+  private inFlightMax = 0
 
   constructor(options: RateLimiterOptions) {
     this.minTimeElapsed = MS_PER_MINUTE / options.callsPerMinute
@@ -24,9 +59,27 @@ export class RateLimiter {
     this.queue = []
   }
 
-  call<T>(fn: () => T | Promise<T>): Promise<T> {
+  get queueLength(): number {
+    return this.queue.length
+  }
+
+  /**
+   * @param label Attributes wait and queue statistics to a consumer (for
+   * example the RPC metrics `coreFeature`). It does not affect dispatch
+   * order or spacing.
+   */
+  call<T>(
+    fn: () => T | Promise<T>,
+    label: string = DEFAULT_RATE_LIMITER_LABEL,
+  ): Promise<T> {
     const wrapped = (async () => fn()) as QueuedFunction<T>
+    wrapped.label = label
+    wrapped.enqueuedAt = Date.now()
     this.queue.push(wrapped)
+
+    const stats = this.statsFor(label)
+    stats.enqueued++
+    stats.queueDepthMax = Math.max(stats.queueDepthMax, this.queue.length)
 
     return new Promise((resolve, reject) => {
       wrapped.resolve = resolve
@@ -38,6 +91,39 @@ export class RateLimiter {
   // biome-ignore lint/suspicious/noExplicitAny: generic type
   wrap<A extends any[], R>(fn: (...args: A) => R | Promise<R>) {
     return (...args: A) => this.call(() => fn(...args))
+  }
+
+  /** Returns the statistics collected since the previous call and resets them. */
+  takeStats(): RateLimiterStats {
+    const labels: Record<string, RateLimiterLabelStats> = {}
+    for (const [label, stats] of this.labelStats) {
+      labels[label] = stats
+    }
+    this.labelStats = new Map()
+
+    const result: RateLimiterStats = {
+      labels,
+      inFlight: this.inFlight,
+      inFlightMax: this.inFlightMax,
+      queueLength: this.queue.length,
+    }
+    this.inFlightMax = this.inFlight
+    return result
+  }
+
+  private statsFor(label: string): RateLimiterLabelStats {
+    let stats = this.labelStats.get(label)
+    if (!stats) {
+      stats = {
+        enqueued: 0,
+        dispatched: 0,
+        waitMsTotal: 0,
+        waitMsMax: 0,
+        queueDepthMax: 0,
+      }
+      this.labelStats.set(label, stats)
+    }
+    return stats
   }
 
   private execute(): void {
@@ -58,9 +144,21 @@ export class RateLimiter {
       return
     }
 
+    const stats = this.statsFor(item.label)
+    const waitMs = now - item.enqueuedAt
+    stats.dispatched++
+    stats.waitMsTotal += waitMs
+    stats.waitMsMax = Math.max(stats.waitMsMax, waitMs)
+
+    this.inFlight++
+    this.inFlightMax = Math.max(this.inFlightMax, this.inFlight)
+
     item()
       .then((res) => item.resolve(res))
       .catch((err) => item.reject(err))
-      .finally(() => this.execute())
+      .finally(() => {
+        this.inFlight--
+        this.execute()
+      })
   }
 }

--- a/packages/backend/src/modules/interop/engine/sync/InteropSyncersManager.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropSyncersManager.ts
@@ -273,7 +273,6 @@ export class InteropSyncersManager {
       client = new EthRpcClient(
         http,
         rpcConfig.url,
-        `${EthRpcClient.name}:${chainConfig.name}`,
         undefined,
         undefined,
         this.rpcMetricsAggregator.createRecorder({

--- a/packages/backend/src/modules/interop/examples/snapshot/snapshot.ts
+++ b/packages/backend/src/modules/interop/examples/snapshot/snapshot.ts
@@ -46,12 +46,7 @@ export class RpcSnapshotClient extends RpcClientCompat {
       metricsEnabled: MetricsAggregator.metricsEnabled,
       maxCallsPerMinute: deps.callsPerMinute,
     })
-    const client = new EthRpcClient(
-      http,
-      deps.url,
-      `${RpcSnapshotClient.name}:${deps.chain}`,
-      deps.generateId,
-    )
+    const client = new EthRpcClient(http, deps.url, deps.generateId)
     const retryOptions = toRetryOptions(deps.retryStrategy)
     const compat = new RpcSnapshotClient(
       client,

--- a/packages/shared/src/clients/ClientCore.test.ts
+++ b/packages/shared/src/clients/ClientCore.test.ts
@@ -1,9 +1,12 @@
 import { Logger } from '@l2beat/backend-tools'
 import type { json } from '@l2beat/shared-pure'
 import { expect, mockObject } from 'earl'
-import { ClientCore, UNCATEGORIZED_METRICS_LABEL } from './ClientCore'
+import { ClientCore } from './ClientCore'
 import type { HttpClient } from './http/HttpClient'
-import { withRpcMetricsContext } from './rpc/RpcMetricsContext'
+import {
+  UNCATEGORIZED_METRICS_LABEL,
+  withRpcMetricsContext,
+} from './rpc/RpcMetricsContext'
 
 describe(ClientCore.name, () => {
   describe(ClientCore.prototype.fetch.name, () => {

--- a/packages/shared/src/clients/ClientCore.test.ts
+++ b/packages/shared/src/clients/ClientCore.test.ts
@@ -1,8 +1,9 @@
 import { Logger } from '@l2beat/backend-tools'
 import type { json } from '@l2beat/shared-pure'
 import { expect, mockObject } from 'earl'
-import { ClientCore } from './ClientCore'
+import { ClientCore, UNCATEGORIZED_METRICS_LABEL } from './ClientCore'
 import type { HttpClient } from './http/HttpClient'
+import { withRpcMetricsContext } from './rpc/RpcMetricsContext'
 
 describe(ClientCore.name, () => {
   describe(ClientCore.prototype.fetch.name, () => {
@@ -35,6 +36,40 @@ describe(ClientCore.name, () => {
       await expect(
         async () => await clientCore.fetch('https://api.test.com/data', {}),
       ).toBeRejected()
+    })
+
+    it('Labels metrics with the rpc metrics context core feature', async () => {
+      const { clientCore } = mocks()
+
+      await withRpcMetricsContext({ coreFeature: 'blockSync.fetch' }, () =>
+        clientCore.fetch('https://api.test.com/data', {}),
+      )
+      await clientCore.fetch('https://api.test.com/data', {})
+
+      expect(clientCore.metricsAggregator.buffer.map((m) => m.label)).toEqual([
+        'blockSync.fetch',
+        UNCATEGORIZED_METRICS_LABEL,
+      ])
+      const stats = clientCore.rateLimiter.takeStats()
+      expect(Object.keys(stats.labels).sort()).toEqual([
+        'blockSync.fetch',
+        UNCATEGORIZED_METRICS_LABEL,
+      ])
+      expect(stats.labels['blockSync.fetch']?.dispatched).toEqual(1)
+    })
+
+    it('Keeps the label across retries', async () => {
+      const { clientCore, http } = mocks()
+      http.fetch.rejectsWithOnce(new Error('Network error'))
+
+      await withRpcMetricsContext({ coreFeature: 'blockSync.fetch' }, () =>
+        clientCore.fetch('https://api.test.com/data', {}),
+      )
+
+      expect(
+        clientCore.rateLimiter.takeStats().labels['blockSync.fetch']
+          ?.dispatched,
+      ).toEqual(2)
     })
   })
 })

--- a/packages/shared/src/clients/ClientCore.ts
+++ b/packages/shared/src/clients/ClientCore.ts
@@ -4,7 +4,7 @@ import type { RequestInit } from 'node-fetch'
 import { RetryHandler, type RetryHandlerVariant } from '../tools'
 import { ClientMetricsAggregator } from './ClientMetricsAggregator'
 import type { HttpClient } from './http/HttpClient'
-import { getRpcMetricsContext } from './rpc/RpcMetricsContext'
+import { getRpcMetricsLabel } from './rpc/RpcMetricsContext'
 
 export interface ClientCoreDependencies {
   http: HttpClient
@@ -13,9 +13,6 @@ export interface ClientCoreDependencies {
   callsPerMinute: number
   retryStrategy: RetryHandlerVariant
 }
-
-/** Label used when a call is made outside of any RPC metrics context. */
-export const UNCATEGORIZED_METRICS_LABEL = 'uncategorized'
 
 export abstract class ClientCore {
   rateLimiter: RateLimiter
@@ -49,8 +46,7 @@ export abstract class ClientCore {
     // Resolved here, synchronously in the caller's async context. The rate
     // limiter dispatches later from a timer or another call's completion, so
     // the context is not reliable inside `_fetch`.
-    const label =
-      getRpcMetricsContext()?.coreFeature ?? UNCATEGORIZED_METRICS_LABEL
+    const label = getRpcMetricsLabel()
     try {
       return await this.rateLimiter.call(
         () => this._fetch(url, init, label),

--- a/packages/shared/src/clients/ClientCore.ts
+++ b/packages/shared/src/clients/ClientCore.ts
@@ -4,6 +4,7 @@ import type { RequestInit } from 'node-fetch'
 import { RetryHandler, type RetryHandlerVariant } from '../tools'
 import { ClientMetricsAggregator } from './ClientMetricsAggregator'
 import type { HttpClient } from './http/HttpClient'
+import { getRpcMetricsContext } from './rpc/RpcMetricsContext'
 
 export interface ClientCoreDependencies {
   http: HttpClient
@@ -13,6 +14,9 @@ export interface ClientCoreDependencies {
   retryStrategy: RetryHandlerVariant
 }
 
+/** Label used when a call is made outside of any RPC metrics context. */
+export const UNCATEGORIZED_METRICS_LABEL = 'uncategorized'
+
 export abstract class ClientCore {
   rateLimiter: RateLimiter
   retryHandler: RetryHandler
@@ -20,16 +24,17 @@ export abstract class ClientCore {
 
   constructor(private readonly deps: ClientCoreDependencies) {
     const logger = deps.logger.for(this).tag({ source: deps.sourceName })
+    this.rateLimiter = new RateLimiter({ callsPerMinute: deps.callsPerMinute })
     this.metricsAggregator = new ClientMetricsAggregator({
       logger,
       flushInterval: 30_000,
+      rateLimiter: this.rateLimiter,
     })
 
     this.retryHandler = RetryHandler.create(
       deps.retryStrategy,
       logger.tag({ tag: deps.sourceName, source: deps.sourceName }),
     )
-    this.rateLimiter = new RateLimiter({ callsPerMinute: deps.callsPerMinute })
   }
 
   /**
@@ -41,17 +46,29 @@ export abstract class ClientCore {
    * @returns Parsed JSON object
    */
   async fetch(url: string, init: RequestInit): Promise<json> {
+    // Resolved here, synchronously in the caller's async context. The rate
+    // limiter dispatches later from a timer or another call's completion, so
+    // the context is not reliable inside `_fetch`.
+    const label =
+      getRpcMetricsContext()?.coreFeature ?? UNCATEGORIZED_METRICS_LABEL
     try {
-      return await this.rateLimiter.call(() => this._fetch(url, init))
+      return await this.rateLimiter.call(
+        () => this._fetch(url, init, label),
+        label,
+      )
     } catch (error) {
       return await this.retryHandler.retry(
-        () => this.rateLimiter.call(() => this._fetch(url, init)),
+        () => this.rateLimiter.call(() => this._fetch(url, init, label), label),
         { error, url, init },
       )
     }
   }
 
-  private async _fetch(url: string, init: RequestInit): Promise<json> {
+  private async _fetch(
+    url: string,
+    init: RequestInit,
+    label: string,
+  ): Promise<json> {
     const start = Date.now()
 
     const response = await this.deps.http.fetch(url, init)
@@ -59,7 +76,7 @@ export abstract class ClientCore {
     const duration = Date.now() - start
     const size = Buffer.byteLength(JSON.stringify(response), 'utf8')
 
-    this.metricsAggregator.push({ duration, size: size })
+    this.metricsAggregator.push({ duration, size, label })
 
     const validationInfo = this.validateResponse(response)
 

--- a/packages/shared/src/clients/ClientMetricsAggregator.test.ts
+++ b/packages/shared/src/clients/ClientMetricsAggregator.test.ts
@@ -1,0 +1,103 @@
+import { Logger, type RateLimiter } from '@l2beat/backend-tools'
+import { expect, mockObject } from 'earl'
+import { ClientMetricsAggregator } from './ClientMetricsAggregator'
+
+describe(ClientMetricsAggregator.name, () => {
+  it('aggregates pushed metrics per label', () => {
+    const aggregator = new ClientMetricsAggregator({ logger: Logger.SILENT })
+
+    const result = aggregator.aggregate([
+      { duration: 10, size: 100, label: 'a' },
+      { duration: 30, size: 300, label: 'a' },
+      { duration: 5, size: 50, label: 'b' },
+    ])
+
+    expect(result).toEqual([
+      {
+        label: 'a',
+        count: 2,
+        durationTotal: 40,
+        durationAvg: 20,
+        sizeTotal: 400,
+        sizeAvg: 200,
+      },
+      {
+        label: 'b',
+        count: 1,
+        durationTotal: 5,
+        durationAvg: 5,
+        sizeTotal: 50,
+        sizeAvg: 50,
+      },
+    ])
+  })
+
+  it('merges rate limiter statistics, including labels without completed calls', () => {
+    const rateLimiter = mockObject<RateLimiter>({
+      takeStats: () => ({
+        labels: {
+          a: {
+            enqueued: 3,
+            dispatched: 2,
+            waitMsTotal: 300,
+            waitMsMax: 200,
+            queueDepthMax: 4,
+          },
+          queued: {
+            enqueued: 1,
+            dispatched: 0,
+            waitMsTotal: 0,
+            waitMsMax: 0,
+            queueDepthMax: 5,
+          },
+        },
+        inFlight: 1,
+        inFlightMax: 7,
+        queueLength: 1,
+      }),
+    })
+    const aggregator = new ClientMetricsAggregator({
+      logger: Logger.SILENT,
+      rateLimiter,
+    })
+
+    const result = aggregator.aggregate([
+      { duration: 10, size: 100, label: 'a' },
+    ])
+
+    expect(result).toEqual([
+      {
+        label: 'a',
+        count: 1,
+        durationTotal: 10,
+        durationAvg: 10,
+        sizeTotal: 100,
+        sizeAvg: 100,
+        waitTotal: 300,
+        waitAvg: 150,
+        waitMax: 200,
+        queueDepthMax: 4,
+        limiterInFlightMax: 7,
+      },
+      {
+        label: 'queued',
+        count: 0,
+        durationTotal: 0,
+        durationAvg: 0,
+        sizeTotal: 0,
+        sizeAvg: 0,
+        waitTotal: 0,
+        waitAvg: 0,
+        waitMax: 0,
+        queueDepthMax: 5,
+        limiterInFlightMax: 7,
+      },
+    ])
+    expect(rateLimiter.takeStats).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns nothing when there is no data', () => {
+    const aggregator = new ClientMetricsAggregator({ logger: Logger.SILENT })
+    expect(aggregator.aggregate([])).toEqual([])
+  })
+})

--- a/packages/shared/src/clients/ClientMetricsAggregator.ts
+++ b/packages/shared/src/clients/ClientMetricsAggregator.ts
@@ -1,43 +1,93 @@
-import { MetricsAggregator } from '@l2beat/backend-tools'
+import {
+  MetricsAggregator,
+  type MetricsAggregatorOptions,
+  type RateLimiter,
+} from '@l2beat/backend-tools'
 
-type ClientMetric = {
+export interface ClientMetric {
   duration: number
   size: number
+  /** Consumer attribution, e.g. the RPC metrics `coreFeature`. */
+  label: string
 }
 
-type AggregatedClientMetric = {
-  sizeAvg: number
-  sizeTotal: number
-  durationAvg: number
-  durationTotal: number
+export interface AggregatedClientMetric {
+  label: string
   count: number
+  durationTotal: number
+  durationAvg: number
+  sizeTotal: number
+  sizeAvg: number
+  /** Rate limiter enqueue → dispatch wait for this label, in ms. */
+  waitTotal?: number
+  waitAvg?: number
+  waitMax?: number
+  /** Largest limiter queue length observed when enqueueing this label. */
+  queueDepthMax?: number
+  /** Largest number of concurrently running calls across all labels of the limiter. */
+  limiterInFlightMax?: number
+}
+
+export interface ClientMetricsAggregatorOptions
+  extends MetricsAggregatorOptions {
+  /** When provided, its statistics are merged into the per-label output on every flush. */
+  rateLimiter?: RateLimiter
 }
 
 export class ClientMetricsAggregator extends MetricsAggregator<ClientMetric> {
-  public aggregate(metrics: ClientMetric[]): AggregatedClientMetric {
-    return metrics.reduce(
-      (acc: AggregatedClientMetric, curr, index) => {
-        if (index === metrics.length - 1) {
-          return {
-            sizeAvg: Math.floor((acc.sizeAvg + curr.size) / metrics.length),
-            sizeTotal: acc.sizeTotal + curr.size,
-            durationAvg: Math.floor(
-              (acc.durationAvg + curr.duration) / metrics.length,
-            ),
-            durationTotal: acc.durationTotal + curr.duration,
-            count: acc.count + 1,
-          }
-        }
+  constructor(private readonly options: ClientMetricsAggregatorOptions) {
+    super(options)
+  }
 
-        return {
-          sizeAvg: acc.sizeAvg + curr.size,
-          sizeTotal: acc.sizeTotal + curr.size,
-          durationAvg: acc.durationAvg + curr.duration,
-          durationTotal: acc.durationTotal + curr.duration,
-          count: acc.count + 1,
+  public aggregate(metrics: ClientMetric[]): AggregatedClientMetric[] {
+    const byLabel = new Map<string, AggregatedClientMetric>()
+    const entryFor = (label: string) => {
+      let entry = byLabel.get(label)
+      if (!entry) {
+        entry = {
+          label,
+          count: 0,
+          durationTotal: 0,
+          durationAvg: 0,
+          sizeTotal: 0,
+          sizeAvg: 0,
         }
-      },
-      { sizeAvg: 0, sizeTotal: 0, durationAvg: 0, durationTotal: 0, count: 0 },
-    )
+        byLabel.set(label, entry)
+      }
+      return entry
+    }
+
+    for (const metric of metrics) {
+      const entry = entryFor(metric.label)
+      entry.count++
+      entry.durationTotal += metric.duration
+      entry.sizeTotal += metric.size
+    }
+
+    const limiter = this.options.rateLimiter?.takeStats()
+    if (limiter) {
+      for (const [label, stats] of Object.entries(limiter.labels)) {
+        const entry = entryFor(label)
+        entry.waitTotal = stats.waitMsTotal
+        entry.waitAvg =
+          stats.dispatched > 0
+            ? Math.floor(stats.waitMsTotal / stats.dispatched)
+            : 0
+        entry.waitMax = stats.waitMsMax
+        entry.queueDepthMax = stats.queueDepthMax
+      }
+    }
+
+    const result = [...byLabel.values()]
+    for (const entry of result) {
+      if (entry.count > 0) {
+        entry.durationAvg = Math.floor(entry.durationTotal / entry.count)
+        entry.sizeAvg = Math.floor(entry.sizeTotal / entry.count)
+      }
+      if (limiter) {
+        entry.limiterInFlightMax = limiter.inFlightMax
+      }
+    }
+    return result
   }
 }

--- a/packages/shared/src/clients/rpc/RpcMetricsContext.ts
+++ b/packages/shared/src/clients/rpc/RpcMetricsContext.ts
@@ -21,6 +21,19 @@ export function getRpcMetricsContext(): RpcMetricsContext | undefined {
   return storage.getStore()
 }
 
+/** Label used when a call is made outside of any RPC metrics context. */
+export const UNCATEGORIZED_METRICS_LABEL = 'uncategorized'
+
+/**
+ * Consumer label for client metrics: the active `coreFeature`, or
+ * `UNCATEGORIZED_METRICS_LABEL` outside of a metrics context. Call it
+ * synchronously in the consumer's async context, before handing the work to
+ * a queue or rate limiter, where the context is no longer the caller's.
+ */
+export function getRpcMetricsLabel(): string {
+  return getRpcMetricsContext()?.coreFeature ?? UNCATEGORIZED_METRICS_LABEL
+}
+
 function sanitizeContext(context: RpcMetricsContext): RpcMetricsContext {
   const sanitized: RpcMetricsContext = {}
 

--- a/packages/shared/src/clients2/EthRpcClient.test.ts
+++ b/packages/shared/src/clients2/EthRpcClient.test.ts
@@ -7,7 +7,7 @@ import { Http, MockHttp } from './Http'
 describe(EthRpcClient.name, () => {
   it('correctly calls an endpoint', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(
       200,
       JSON.stringify({ jsonrpc: '2.0', id: 1337, result: '0x1234' }),
@@ -27,7 +27,7 @@ describe(EthRpcClient.name, () => {
 
   it('handles a http error response', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(503, 'Oops, our server is down')
     await expect(client.getBlockNumber()).toBeRejectedWith(
       'RPC call failed. HTTP status: 503, body: Oops, our server is down',
@@ -36,7 +36,7 @@ describe(EthRpcClient.name, () => {
 
   it('handles a jsonrpc error response', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(
       200,
       JSON.stringify({
@@ -52,7 +52,7 @@ describe(EthRpcClient.name, () => {
 
   it('eth_call success', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(
       200,
       JSON.stringify({ jsonrpc: '2.0', id: 1337, result: '0x1234' }),
@@ -66,7 +66,7 @@ describe(EthRpcClient.name, () => {
 
   it('eth_call revert #1', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(
       200,
       JSON.stringify({
@@ -84,7 +84,7 @@ describe(EthRpcClient.name, () => {
 
   it('eth_call revert #2', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(400, 'invalid opcode: INVALID')
     const result = await client.call(
       { to: EthereumAddress.random(), input: '0xdeadbeef' },
@@ -95,7 +95,7 @@ describe(EthRpcClient.name, () => {
 
   it('eth_call fail', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(503, 'Oops, our server is down')
     expect(
       client.call(
@@ -107,7 +107,7 @@ describe(EthRpcClient.name, () => {
 
   it('accepts custom envelope tx with calls and missing top-level input/value', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(
       200,
       JSON.stringify({
@@ -158,7 +158,7 @@ describe(EthRpcClient.name, () => {
 
   it('treats calls: null as missing in transaction response', async () => {
     const http = new MockHttp()
-    const client = new EthRpcClient(http, 'https://rpc.url', '', () => 1337)
+    const client = new EthRpcClient(http, 'https://rpc.url', () => 1337)
     http.queueResponse(
       200,
       JSON.stringify({
@@ -193,7 +193,6 @@ describe(EthRpcClient.name, () => {
     const client = new EthRpcClient(
       http,
       'https://rpc.url',
-      '',
       () => 1337,
       undefined,
       rpcMetrics,
@@ -221,7 +220,7 @@ for (const url of URLS) {
     const MULTICALL3 = EthereumAddress(
       '0xcA11bde05977b3631167028862bE2a173976CA11',
     )
-    const client = new EthRpcClient(new Http(), url, '')
+    const client = new EthRpcClient(new Http(), url)
 
     it(EthRpcClient.prototype.getChainId.name, async () => {
       const chainId = await client.getChainId()

--- a/packages/shared/src/clients2/EthRpcClient.ts
+++ b/packages/shared/src/clients2/EthRpcClient.ts
@@ -32,7 +32,6 @@ export class EthRpcClient {
   constructor(
     private http: Http,
     private url: string,
-    private metricsLabel: string,
     private nextId: () => string | number = randomId,
     private timeout?: number,
     private readonly rpcMetrics?: RpcMetricsRecorder,
@@ -221,7 +220,6 @@ export class EthRpcClient {
 
     try {
       const response = await this.http.fetch(this.url, {
-        metricsLabel: this.metricsLabel,
         method: 'POST',
         body: JSON.stringify({
           jsonrpc: '2.0',

--- a/packages/shared/src/clients2/Http.test.ts
+++ b/packages/shared/src/clients2/Http.test.ts
@@ -1,0 +1,54 @@
+import type { Logger } from '@l2beat/backend-tools'
+import { expect, mockObject } from 'earl'
+import type { RequestInit } from 'node-fetch'
+import {
+  UNCATEGORIZED_METRICS_LABEL,
+  withRpcMetricsContext,
+} from '../clients/rpc/RpcMetricsContext'
+import { Http, type HttpResponse, makeHttpResponse } from './Http'
+
+// Replaces the network call; keeps the rate limiter and metrics paths intact.
+class StubHttp extends Http {
+  protected override async _fetch(
+    _url: string,
+    _init: RequestInit,
+    label: string,
+  ): Promise<HttpResponse> {
+    this._trackMetrics(label, 10, 100)
+    return makeHttpResponse(200, '{}')
+  }
+}
+
+describe(Http.name, () => {
+  it('attributes metrics and limiter waits to the active rpc metrics context', async () => {
+    const logger = mockObject<Logger>({ info: () => {} })
+    const http = new StubHttp({
+      logger,
+      metricsEnabled: true,
+      metricsFlushIntervalMs: 10,
+      maxCallsPerMinute: 100_000,
+    })
+
+    await withRpcMetricsContext({ coreFeature: 'tvs.amount' }, () =>
+      http.fetch('https://rpc.url', { method: 'POST' }),
+    )
+    await http.fetch('https://rpc.url', { method: 'POST' })
+    // let the unref'd flush interval fire
+    await new Promise((resolve) => setTimeout(resolve, 40))
+
+    expect(logger.info).toHaveBeenCalledWith(
+      'Http metrics',
+      expect.subset({
+        label: 'tvs.amount',
+        count: 1,
+        durationTotal: 10,
+        sizeTotal: 100,
+        waitMax: expect.a(Number),
+      }),
+    )
+    expect(logger.info).toHaveBeenCalledWith(
+      'Http metrics',
+      expect.subset({ label: UNCATEGORIZED_METRICS_LABEL, count: 1 }),
+    )
+  })
+})

--- a/packages/shared/src/clients2/Http.ts
+++ b/packages/shared/src/clients2/Http.ts
@@ -1,5 +1,6 @@
 import { Logger, RateLimiter } from '@l2beat/backend-tools'
 import fetch, { Headers, type RequestInit } from 'node-fetch'
+import { getRpcMetricsLabel } from '../clients/rpc/RpcMetricsContext'
 
 export interface HttpOptions {
   timeoutMs: number
@@ -7,10 +8,6 @@ export interface HttpOptions {
   metricsEnabled: boolean
   metricsFlushIntervalMs: number
   logger: Logger
-}
-
-export interface HttpRequestInit extends RequestInit {
-  metricsLabel: string
 }
 
 export interface HttpResponse {
@@ -61,31 +58,32 @@ export class Http {
     }
   }
 
-  async fetch(
-    url: string,
-    { metricsLabel, ...rest }: HttpRequestInit,
-  ): Promise<HttpResponse> {
-    const init: RequestInit = { timeout: this.timeoutMs, ...rest }
+  async fetch(url: string, init: RequestInit): Promise<HttpResponse> {
+    // Resolved here, synchronously in the caller's async context. The rate
+    // limiter dispatches later from a timer or another call's completion, so
+    // the context is not reliable inside `_fetch`.
+    const label = getRpcMetricsLabel()
+    const request: RequestInit = { timeout: this.timeoutMs, ...init }
     if (this.rateLimiter) {
       return await this.rateLimiter.call(
-        () => this._fetch(url, init, metricsLabel),
-        metricsLabel,
+        () => this._fetch(url, request, label),
+        label,
       )
     }
-    return await this._fetch(url, init, metricsLabel)
+    return await this._fetch(url, request, label)
   }
 
-  private async _fetch(
+  protected async _fetch(
     url: string,
     init: RequestInit,
-    metricsLabel: string,
+    label: string,
   ): Promise<HttpResponse> {
     const start = Date.now()
     const res = await fetch(url, init)
     // We need to await text because we don't know if someone wants json or not
     // and we need to actually consume the response body not just the headers
     const body = await res.text()
-    this._trackMetrics(metricsLabel, Date.now() - start, res.size)
+    this._trackMetrics(label, Date.now() - start, res.size)
     return {
       body,
       ok: res.ok,
@@ -94,13 +92,9 @@ export class Http {
     }
   }
 
-  private _trackMetrics(
-    metricsLabel: string,
-    durationMs: number,
-    size: number,
-  ) {
+  protected _trackMetrics(label: string, durationMs: number, size: number) {
     if (!this.metricsEnabled) return
-    const metrics = this.metrics[metricsLabel] ?? {
+    const metrics = this.metrics[label] ?? {
       durationTotal: 0,
       sizeTotal: 0,
       count: 0,
@@ -108,7 +102,7 @@ export class Http {
     metrics.durationTotal += durationMs
     metrics.sizeTotal += size
     metrics.count += 1
-    this.metrics[metricsLabel] = metrics
+    this.metrics[label] = metrics
   }
 
   private _flushMetrics() {

--- a/packages/shared/src/clients2/Http.ts
+++ b/packages/shared/src/clients2/Http.ts
@@ -67,8 +67,9 @@ export class Http {
   ): Promise<HttpResponse> {
     const init: RequestInit = { timeout: this.timeoutMs, ...rest }
     if (this.rateLimiter) {
-      return await this.rateLimiter.call(() =>
-        this._fetch(url, init, metricsLabel),
+      return await this.rateLimiter.call(
+        () => this._fetch(url, init, metricsLabel),
+        metricsLabel,
       )
     }
     return await this._fetch(url, init, metricsLabel)
@@ -111,16 +112,36 @@ export class Http {
   }
 
   private _flushMetrics() {
-    for (const key in this.metrics) {
-      const metrics = this.metrics[key]
-      // Note, there is no division by zero, because there are no zero count
-      // metrics
+    const limiter = this.rateLimiter?.takeStats()
+    const labels = new Set([
+      ...Object.keys(this.metrics),
+      ...Object.keys(limiter?.labels ?? {}),
+    ])
+    for (const label of labels) {
+      const metrics = this.metrics[label] ?? {
+        durationTotal: 0,
+        sizeTotal: 0,
+        count: 0,
+      }
+      const wait = limiter?.labels[label]
       this.logger.info('Http metrics', {
+        label,
         durationTotal: metrics.durationTotal,
-        durationAvg: metrics.durationTotal / metrics.count,
+        durationAvg:
+          metrics.count > 0 ? metrics.durationTotal / metrics.count : 0,
         sizeTotal: metrics.sizeTotal,
-        sizeAvg: metrics.sizeTotal / metrics.count,
+        sizeAvg: metrics.count > 0 ? metrics.sizeTotal / metrics.count : 0,
         count: metrics.count,
+        ...(wait && {
+          waitTotal: wait.waitMsTotal,
+          waitAvg:
+            wait.dispatched > 0
+              ? Math.floor(wait.waitMsTotal / wait.dispatched)
+              : 0,
+          waitMax: wait.waitMsMax,
+          queueDepthMax: wait.queueDepthMax,
+        }),
+        ...(limiter && { limiterInFlightMax: limiter.inFlightMax }),
       })
     }
     this.metrics = {}

--- a/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
+++ b/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
@@ -102,7 +102,6 @@ export class RpcClientCompat implements IRpcClient {
     const client = new EthRpcClient(
       http,
       deps.url,
-      `${RpcClientCompat.name}:${deps.chain}`,
       deps.generateId,
       deps.timeout,
       deps.rpcMetricsAggregator?.createRecorder({


### PR DESCRIPTION
RateLimiter.call() accepts an optional label and records per-label enqueue/dispatch counts, enqueue-to-dispatch wait (total/max), queue depth at enqueue, and limiter-wide in-flight counts, exposed via takeStats(). Dispatch order and spacing are unchanged.

ClientCore resolves the label once per fetch() from the RPC metrics context coreFeature (falling back to 'uncategorized'), reuses it across retries, and passes it to both the limiter and the metrics aggregator. ClientMetricsAggregator now emits one 'Http metrics' line per (client, label) with the limiter statistics merged in, so limiter queueing can be told apart from RPC latency per consumer. The clients2 Http path gets the same treatment and now includes its label in the emitted line.