### PR TITLE
Cut interop syncer DB round trips and prepare capture items once per block

### DIFF
--- a/packages/backend/src/modules/interop/engine/capture/getItemsToCapture.test.ts
+++ b/packages/backend/src/modules/interop/engine/capture/getItemsToCapture.test.ts
@@ -1,0 +1,91 @@
+import type { Block, Log } from '@l2beat/shared-pure'
+import { expect } from 'earl'
+import { getItemsToCapture } from './getItemsToCapture'
+
+describe(getItemsToCapture.name, () => {
+  it('groups logs by transaction in block order and skips unmatched items', () => {
+    const block = makeBlock([
+      { hash: '0xa' },
+      { hash: undefined },
+      { hash: '0xb' },
+      { hash: '0xc' },
+    ])
+    const logs = [
+      makeLog('0xb', 0),
+      makeLog('0xa', 1),
+      makeLog('0xb', 2),
+      makeLog('0xunknown', 3),
+    ]
+
+    const { txsToCapture, logsToCapture } = getItemsToCapture(
+      'ethereum',
+      block,
+      logs,
+    )
+
+    expect(txsToCapture.map((t) => t.tx.hash)).toEqual(['0xa', '0xb', '0xc'])
+    expect(txsToCapture.map((t) => t.txLogs.map((l) => l.logIndex))).toEqual([
+      [1],
+      [0, 2],
+      [],
+    ])
+    expect(logsToCapture.map((l) => [l.tx.hash, l.log.logIndex])).toEqual([
+      ['0xa', 1],
+      ['0xb', 0],
+      ['0xb', 2],
+    ])
+    expect(logsToCapture[0]?.txLogs).toEqual(txsToCapture[0]?.txLogs)
+    expect(logsToCapture[0]?.block).toEqual(block)
+    expect(logsToCapture[0]?.chain).toEqual('ethereum')
+  })
+
+  it('shares the prepared items for the same block and logs objects', () => {
+    const block = makeBlock([{ hash: '0xa' }])
+    const logs = [makeLog('0xa', 0)]
+
+    const first = getItemsToCapture('ethereum', block, logs)
+    const again = getItemsToCapture('ethereum', block, logs)
+    const otherLogs = getItemsToCapture('ethereum', block, [...logs])
+    const otherChain = getItemsToCapture('base', block, logs)
+    const otherBlock = getItemsToCapture(
+      'ethereum',
+      makeBlock([{ hash: '0xa' }]),
+      logs,
+    )
+
+    expect(again).toExactlyEqual(first)
+    expect(otherLogs).not.toExactlyEqual(first)
+    expect(otherChain).not.toExactlyEqual(first)
+    expect(otherBlock).not.toExactlyEqual(first)
+    expect(otherLogs).toEqual(first)
+  })
+})
+
+function makeBlock(transactions: Block['transactions']): Block {
+  return {
+    number: 100,
+    hash: '0xblock',
+    logsBloom: '0x',
+    timestamp: 1_000,
+    transactions: transactions.map((tx) => ({
+      from: '0x0000000000000000000000000000000000000001',
+      to: '0x0000000000000000000000000000000000000002',
+      data: '0x',
+      type: '0x2',
+      value: 0n,
+      ...tx,
+    })),
+  }
+}
+
+function makeLog(transactionHash: string, logIndex: number): Log {
+  return {
+    address: '0x0000000000000000000000000000000000000003',
+    topics: ['0x01'],
+    data: '0x',
+    blockNumber: 100,
+    blockHash: '0xblock',
+    transactionHash,
+    logIndex,
+  }
+}

--- a/packages/backend/src/modules/interop/engine/capture/getItemsToCapture.ts
+++ b/packages/backend/src/modules/interop/engine/capture/getItemsToCapture.ts
@@ -3,22 +3,66 @@ import type { Log as ViemLog } from 'viem'
 import { toInteropTransaction } from '../../dto/interopTransaction'
 import type { LogToCapture, TxToCapture } from '../../plugins/types'
 
-export function getItemsToCapture(chain: string, block: Block, logs: Log[]) {
-  const viemLogs = logs.map(logToViemLog)
+export interface ItemsToCapture {
+  txsToCapture: TxToCapture[]
+  logsToCapture: LogToCapture[]
+}
+
+// BlockIndexer passes the same block and logs objects to every block processor,
+// and InteropSyncersManager passes them on to every cluster syncer. Preparing
+// the items once per block and sharing them saves one full pass per consumer
+// (18 on a chain with 17 clusters). Consumers must treat the items as
+// read-only. The WeakMap lets the entry go away with the block itself.
+const preparedBlocks = new WeakMap<
+  Block,
+  { chain: string; logs: Log[]; items: ItemsToCapture }
+>()
+
+export function getItemsToCapture(
+  chain: string,
+  block: Block,
+  logs: Log[],
+): ItemsToCapture {
+  const prepared = preparedBlocks.get(block)
+  if (prepared && prepared.chain === chain && prepared.logs === logs) {
+    return prepared.items
+  }
+  const items = prepareItemsToCapture(chain, block, logs)
+  preparedBlocks.set(block, { chain, logs, items })
+  return items
+}
+
+function prepareItemsToCapture(
+  chain: string,
+  block: Block,
+  logs: Log[],
+): ItemsToCapture {
+  const logsByTx = new Map<string, ViemLog[]>()
+  for (const log of logs) {
+    const viemLog = logToViemLog(log)
+    const txLogs = logsByTx.get(log.transactionHash)
+    if (txLogs) {
+      txLogs.push(viemLog)
+    } else {
+      logsByTx.set(log.transactionHash, [viemLog])
+    }
+  }
+
+  const txsToCapture: TxToCapture[] = []
   const logsToCapture: LogToCapture[] = []
-  const txsToCapture = block.transactions
-    .filter((x) => !!x.hash) // TODO: why can this be missing!?
-    .map(
-      (tx): TxToCapture => ({
-        block,
-        tx: toInteropTransaction(tx),
-        chain,
-        txLogs: viemLogs.filter((log) => log.transactionHash === tx.hash),
-      }),
-    )
-  for (const tx of txsToCapture) {
-    for (const log of tx.txLogs) {
-      logsToCapture.push({ log, ...tx })
+  for (const tx of block.transactions) {
+    if (!tx.hash) {
+      continue // TODO: why can this be missing!?
+    }
+    const txToCapture: TxToCapture = {
+      block,
+      tx: toInteropTransaction(tx),
+      chain,
+      txLogs: logsByTx.get(tx.hash) ?? [],
+    }
+    txsToCapture.push(txToCapture)
+    for (const log of txToCapture.txLogs) {
+      logsToCapture.push({ log, ...txToCapture })
     }
   }
   return { txsToCapture, logsToCapture }

--- a/packages/backend/src/modules/interop/engine/sync/FollowingState.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/FollowingState.test.ts
@@ -4,6 +4,7 @@ import type {
   InteropEventRecord,
 } from '@l2beat/database'
 import { type Block, type Log, UnixTime } from '@l2beat/shared-pure'
+import { install } from '@sinonjs/fake-timers'
 import { expect, mockFn, mockObject } from 'earl'
 import type {
   InteropEvent,
@@ -304,6 +305,115 @@ describe(FollowingState.name, () => {
         [],
         [],
       )
+    })
+
+    it('reads the resync state and synced range once for consecutive blocks', async () => {
+      const getResyncState = mockFn().resolvesTo({
+        resyncFrom: undefined,
+        wipeRequired: false,
+      })
+      const getLastSyncedRange = mockFn().resolvesTo(
+        makeSyncedRange({ fromBlock: 90n, toBlock: 99n }),
+      )
+      const saveProducedInteropEvents = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        getResyncState,
+        getLastSyncedRange,
+        saveProducedInteropEvents,
+      })
+      const state = new FollowingState(syncer, Logger.SILENT)
+
+      await state.processNewestBlock(BLOCK, LOGS)
+      await state.processNewestBlock(makeBlock(101, UnixTime(1_010)), LOGS)
+
+      expect(getResyncState).toHaveBeenCalledTimes(1)
+      expect(getLastSyncedRange).toHaveBeenCalledTimes(1)
+      expect(saveProducedInteropEvents).toHaveBeenCalledTimes(2)
+      expect(saveProducedInteropEvents.calls[1]?.args[1]).toEqual({
+        fromBlock: 90n,
+        fromTimestamp: UnixTime(0),
+        toBlock: 101n,
+        toTimestamp: UnixTime(1_010),
+      })
+    })
+
+    it('does not advance the cached range when saving fails', async () => {
+      const getLastSyncedRange = mockFn().resolvesTo(
+        makeSyncedRange({ fromBlock: 90n, toBlock: 99n }),
+      )
+      const saveProducedInteropEvents = mockFn()
+        .rejectsWithOnce(new Error('db down'))
+        .resolvesTo(undefined)
+      const syncer = createSyncer({
+        getLastSyncedRange,
+        saveProducedInteropEvents,
+      })
+      const state = new FollowingState(syncer, Logger.SILENT)
+
+      await expect(state.processNewestBlock(BLOCK, LOGS)).toBeRejectedWith(
+        'db down',
+      )
+      const nextState = await state.processNewestBlock(BLOCK, LOGS)
+
+      expect(nextState).toEqual(state)
+      expect(getLastSyncedRange).toHaveBeenCalledTimes(1)
+      expect(saveProducedInteropEvents).toHaveBeenCalledTimes(2)
+      expect(saveProducedInteropEvents.calls[1]?.args[1]).toEqual(
+        saveProducedInteropEvents.calls[0]?.args[1],
+      )
+    })
+
+    it('checks for a resync request again after the interval', async () => {
+      const clock = install({ now: 1_000_000 })
+      try {
+        const getResyncState = mockFn()
+          .resolvesToOnce({ resyncFrom: undefined, wipeRequired: false })
+          .resolvesTo({ resyncFrom: UnixTime(1), wipeRequired: false })
+        const syncer = createSyncer({
+          getResyncState,
+          getLastSyncedRange: mockFn().resolvesTo(
+            makeSyncedRange({ fromBlock: 90n, toBlock: 99n }),
+          ),
+        })
+        const state = new FollowingState(syncer, Logger.SILENT)
+
+        await state.processNewestBlock(BLOCK, LOGS)
+        clock.tick(9_999)
+        const sameState = await state.processNewestBlock(
+          makeBlock(101, UnixTime(1_010)),
+          LOGS,
+        )
+        clock.tick(1)
+        const nextState = await state.processNewestBlock(
+          makeBlock(102, UnixTime(1_020)),
+          LOGS,
+        )
+
+        expect(sameState).toEqual(state)
+        expect(nextState).toBeA(CatchingUpState)
+        expect(getResyncState).toHaveBeenCalledTimes(2)
+      } finally {
+        clock.uninstall()
+      }
+    })
+
+    it('counts a status check as a resync check', async () => {
+      const getResyncState = mockFn().resolvesTo({
+        resyncFrom: undefined,
+        wipeRequired: false,
+      })
+      const syncer = createSyncer({
+        getResyncState,
+        getLastSyncedRange: mockFn().resolvesTo(
+          makeSyncedRange({ fromBlock: 90n, toBlock: 99n }),
+        ),
+      })
+      const state = new FollowingState(syncer, Logger.SILENT)
+
+      await state.checkStatus()
+      await state.processNewestBlock(BLOCK, LOGS)
+
+      expect(getResyncState).toHaveBeenCalledTimes(1)
     })
 
     it('captures pending historical txs before processing the current block', async () => {

--- a/packages/backend/src/modules/interop/engine/sync/FollowingState.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/FollowingState.test.ts
@@ -151,7 +151,6 @@ describe(FollowingState.name, () => {
         .returnsOnce([eventA])
         .returnsOnce([eventB, eventC])
       const saveProducedInteropEvents = mockFn().resolvesTo(undefined)
-      const clearChainSyncError = mockFn().resolvesTo(undefined)
       const syncer = createSyncer({
         getLastSyncedRange: mockFn().resolvesTo(
           makeSyncedRange({ fromBlock: 90n, toBlock: 99n }),
@@ -162,7 +161,6 @@ describe(FollowingState.name, () => {
         }),
         captureLog,
         saveProducedInteropEvents,
-        clearChainSyncError,
       })
       const state = new FollowingState(syncer, Logger.SILENT)
 
@@ -182,7 +180,6 @@ describe(FollowingState.name, () => {
         [],
         [],
       )
-      expect(clearChainSyncError).toHaveBeenCalled()
     })
 
     it('bootstraps range from the oldest event when no synced range exists', async () => {
@@ -394,7 +391,6 @@ function createSyncer(
     }),
     captureTx: mockFn().returns(undefined),
     saveProducedInteropEvents: mockFn().resolvesTo(undefined),
-    clearChainSyncError: mockFn().resolvesTo(undefined),
     blockProcessingStats: mockObject<
       InteropEventSyncer['blockProcessingStats']
     >({

--- a/packages/backend/src/modules/interop/engine/sync/FollowingState.ts
+++ b/packages/backend/src/modules/interop/engine/sync/FollowingState.ts
@@ -97,7 +97,6 @@ export class FollowingState implements BlockProcessorState {
         checkedInHistoryEvents,
       )
 
-      this.syncer.clearChainSyncError()
       this.status = 'idle'
       return this
     } finally {

--- a/packages/backend/src/modules/interop/engine/sync/FollowingState.ts
+++ b/packages/backend/src/modules/interop/engine/sync/FollowingState.ts
@@ -8,10 +8,24 @@ import type {
   SyncerState,
 } from './InteropEventSyncer'
 
+// Resync and wipe requests come from the backoffice. They are honoured by
+// CatchingUpState, so noticing them a few seconds late only costs a few more
+// rows in a range that is about to be replaced. The check cannot rely on the
+// checkStatus tick alone: that tick is skipped while a block is being processed.
+const RESYNC_CHECK_INTERVAL_MS = 10_000
+
 export class FollowingState implements BlockProcessorState {
   type = 'blockProcessor' as const
   name = 'following'
   status = 'starting'
+
+  // The syncer is the only writer of its synced range while following, so the
+  // last committed range is kept here instead of being read for every block.
+  // Catch-up and wipe both go through CatchingUpState, which creates a new
+  // FollowingState afterwards and thereby drops this cache.
+  private syncedRangeLoaded = false
+  private syncedRange?: BlockRangeWithTimestamps
+  private resyncCheckedAt = Number.NEGATIVE_INFINITY
 
   constructor(
     private readonly syncer: InteropEventSyncer,
@@ -19,9 +33,7 @@ export class FollowingState implements BlockProcessorState {
   ) {}
 
   async checkStatus(): Promise<SyncerState> {
-    const { resyncFrom, wipeRequired } = await this.syncer.getResyncState()
-
-    if (wipeRequired || resyncFrom !== undefined) {
+    if (await this.isResyncRequested()) {
       return new CatchingUpState(this.syncer, this.logger)
     }
 
@@ -35,20 +47,14 @@ export class FollowingState implements BlockProcessorState {
     const start = performance.now()
     let cpuMs = 0
     try {
-      const { resyncFrom, wipeRequired } = await this.syncer.getResyncState()
-
-      if (wipeRequired) {
+      const resyncCheckDue =
+        Date.now() - this.resyncCheckedAt >= RESYNC_CHECK_INTERVAL_MS
+      if (resyncCheckDue && (await this.isResyncRequested())) {
         return new CatchingUpState(this.syncer, this.logger)
       }
 
-      const resyncRequested = resyncFrom !== undefined
-      const lastSyncedRecord = resyncRequested
-        ? undefined
-        : await this.syncer.getLastSyncedRange()
-
       const decision = decideFollowingAction({
-        resyncRequested,
-        lastSyncedRecord,
+        lastSyncedRecord: await this.getSyncedRange(),
         blockNumber: BigInt(block.number),
         blockTimestamp: block.timestamp,
       })
@@ -96,12 +102,29 @@ export class FollowingState implements BlockProcessorState {
         fulfilledCreatorEvents,
         checkedInHistoryEvents,
       )
+      this.syncedRange = updatedSyncedRange
 
       this.status = 'idle'
       return this
     } finally {
       this.syncer.blockProcessingStats.record(performance.now() - start, cpuMs)
     }
+  }
+
+  private async isResyncRequested(): Promise<boolean> {
+    const { resyncFrom, wipeRequired } = await this.syncer.getResyncState()
+    this.resyncCheckedAt = Date.now()
+    return wipeRequired || resyncFrom !== undefined
+  }
+
+  private async getSyncedRange(): Promise<
+    BlockRangeWithTimestamps | undefined
+  > {
+    if (!this.syncedRangeLoaded) {
+      this.syncedRange = await this.syncer.getLastSyncedRange()
+      this.syncedRangeLoaded = true
+    }
+    return this.syncedRange
   }
 
   // If Syncer runs for the first time on existing data,
@@ -133,15 +156,10 @@ export type FollowingDecision =
   | { type: 'process'; updatedSyncedRange: BlockRangeWithTimestamps }
 
 export function decideFollowingAction(params: {
-  resyncRequested: boolean
   lastSyncedRecord?: BlockRangeWithTimestamps
   blockNumber: bigint
   blockTimestamp: UnixTime
 }): FollowingDecision {
-  if (params.resyncRequested) {
-    return { type: 'catchUp' } // CatchingUp state takes care of resync requests
-  }
-
   if (!params.lastSyncedRecord) {
     return { type: 'bootstrap' } // Looks like a first run ever, see if we already are synced
   }

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -2,6 +2,7 @@ import { Logger } from '@l2beat/backend-tools'
 import type { InteropPluginName } from '@l2beat/config'
 import type {
   BlockRangeWithTimestamps,
+  Database,
   InteropEventRecord,
   InteropPluginSyncedRangeRecord,
 } from '@l2beat/database'
@@ -76,9 +77,9 @@ describe(InteropEventSyncer.name, () => {
     it('does not clear errors when checking blockProcessor status', async () => {
       const setLastError = mockFn().resolvesTo(undefined)
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             setLastError,
             findByPluginNameAndChain: mockFn().resolvesTo(undefined),
@@ -226,9 +227,9 @@ describe(InteropEventSyncer.name, () => {
     it('stores last error when state throws', async () => {
       const setLastError = mockFn().resolvesTo(undefined)
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             setLastError,
           }),
@@ -252,9 +253,9 @@ describe(InteropEventSyncer.name, () => {
     it('clears a possibly stale stored error once on the first success', async () => {
       const setLastError = mockFn().resolvesTo(undefined)
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             setLastError,
           }),
@@ -274,9 +275,9 @@ describe(InteropEventSyncer.name, () => {
     it('clears the stored error once after recovering from a failure', async () => {
       const setLastError = mockFn().resolvesTo(undefined)
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             setLastError,
           }),
@@ -303,9 +304,9 @@ describe(InteropEventSyncer.name, () => {
     it('keeps the stored error when a status check succeeds', async () => {
       const setLastError = mockFn().resolvesTo(undefined)
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             setLastError,
           }),
@@ -583,14 +584,14 @@ describe(InteropEventSyncer.name, () => {
           updateDerivedFulfilled,
           updateDerivedCheckedInHistory,
         }),
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncedRange: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncedRange']
+            Database['interopPluginSyncedRange']
           >({
             upsert,
           }),
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             setLastError,
           }),
@@ -631,14 +632,14 @@ describe(InteropEventSyncer.name, () => {
           updateDerivedFulfilled: mockFn().resolvesTo(undefined),
           updateDerivedCheckedInHistory: mockFn().resolvesTo(undefined),
         }),
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncedRange: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncedRange']
+            Database['interopPluginSyncedRange']
           >({
             upsert,
           }),
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             setLastError,
           }),
@@ -676,9 +677,9 @@ describe(InteropEventSyncer.name, () => {
   describe(InteropEventSyncer.prototype.getResyncState.name, () => {
     it('returns empty resync state when no resync requested', async () => {
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             findByPluginNameAndChain: mockFn().resolvesTo(undefined),
           }),
@@ -695,9 +696,9 @@ describe(InteropEventSyncer.name, () => {
 
     it('returns resync state when present', async () => {
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncState: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncState']
+            Database['interopPluginSyncState']
           >({
             findByPluginNameAndChain: mockFn().resolvesTo({
               resyncRequestedFrom: UnixTime(123),
@@ -895,13 +896,13 @@ describe(InteropEventSyncer.name, () => {
       const oldestEvent = makeInteropEventRecord()
       const getOldestEventForPluginAndChain = mockFn().resolvesTo(oldestEvent)
       const syncer = createSyncer({
-        db: mockObject<InteropEventSyncer['db']>({
+        db: mockObject<Database>({
           interopPluginSyncedRange: mockObject<
-            InteropEventSyncer['db']['interopPluginSyncedRange']
+            Database['interopPluginSyncedRange']
           >({
             findByPluginNameAndChain: mockFn().resolvesTo(lastRange),
           }),
-          interopEvent: mockObject<InteropEventSyncer['db']['interopEvent']>({
+          interopEvent: mockObject<Database['interopEvent']>({
             getOldestEventForPluginAndChain,
           }),
         }),
@@ -931,8 +932,8 @@ describe(InteropEventSyncer.name, () => {
             makePlugin({ name: 'wormhole' }),
           ],
         }),
-        db: mockObject<InteropEventSyncer['db']>({
-          interopEvent: mockObject<InteropEventSyncer['db']['interopEvent']>({
+        db: mockObject<Database>({
+          interopEvent: mockObject<Database['interopEvent']>({
             getOldestEventForPluginAndChain,
           }),
         }),
@@ -1244,30 +1245,26 @@ function mockStore() {
   })
 }
 
-function mockDb(): InteropEventSyncer['db'] {
-  return mockObject<InteropEventSyncer['db']>({
+function mockDb(): Database {
+  return mockObject<Database>({
     transaction: mockFn().executes(async (cb) => await cb()),
-    interopPluginSyncedRange: mockObject<
-      InteropEventSyncer['db']['interopPluginSyncedRange']
-    >({
+    interopPluginSyncedRange: mockObject<Database['interopPluginSyncedRange']>({
       findByPluginNameAndChain: mockFn().resolvesTo(makeSyncedRangeRecord()),
       upsert: mockFn().resolvesTo(undefined),
     }),
-    interopPluginSyncState: mockObject<
-      InteropEventSyncer['db']['interopPluginSyncState']
-    >({
+    interopPluginSyncState: mockObject<Database['interopPluginSyncState']>({
       setLastError: mockFn().resolvesTo(undefined),
       findByPluginNameAndChain: mockFn().resolvesTo(undefined),
     }),
-    interopEvent: mockObject<InteropEventSyncer['db']['interopEvent']>({
+    interopEvent: mockObject<Database['interopEvent']>({
       getOldestEventForPluginAndChain: mockFn().resolvesTo(
         makeInteropEventRecord(),
       ),
     }),
-    interopMessage: mockObject<InteropEventSyncer['db']['interopMessage']>({
+    interopMessage: mockObject<Database['interopMessage']>({
       deleteForPlugin: mockFn().resolvesTo(undefined),
     }),
-    interopTransfer: mockObject<InteropEventSyncer['db']['interopTransfer']>({
+    interopTransfer: mockObject<Database['interopTransfer']>({
       deleteForPlugin: mockFn().resolvesTo(undefined),
     }),
   })

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -728,6 +728,45 @@ describe(InteropEventSyncer.name, () => {
       expect(syncer.runInTransactionCalls).toEqual(3)
       expect(setLastError.calls.at(-1)?.args[2]).toEqual(null)
     })
+
+    it('still considers the error stored when the transaction rolls back after the clear', async () => {
+      const setLastError = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        cluster: makeCluster({
+          name: 'clusterName',
+          plugins: [makePlugin({ name: 'across' })],
+        }),
+        db: mockObject<Database>({
+          interopPluginSyncedRange: mockObject<
+            Database['interopPluginSyncedRange']
+          >({
+            upsert: mockFn().resolvesTo(undefined),
+          }),
+          interopPluginSyncState: mockObject<
+            Database['interopPluginSyncState']
+          >({
+            setLastError,
+          }),
+        }),
+      })
+
+      syncer.failNextCommit = true
+      await expect(
+        syncer.saveProducedInteropEvents([], makeSyncedRange()),
+      ).toBeRejectedWith('commit failed')
+      expect(setLastError).toHaveBeenCalledTimes(1)
+
+      // the clear was rolled back with the transaction, so it is written again
+      await syncer.saveProducedInteropEvents([], makeSyncedRange())
+      expect(syncer.runInTransactionCalls).toEqual(2)
+      expect(setLastError).toHaveBeenCalledTimes(2)
+      expect(setLastError.calls[1]?.args[2]).toEqual(null)
+
+      // and only now is it considered cleared
+      await syncer.saveProducedInteropEvents([], makeSyncedRange())
+      expect(syncer.runInTransactionCalls).toEqual(2)
+      expect(setLastError).toHaveBeenCalledTimes(2)
+    })
   })
 
   describe(InteropEventSyncer.prototype.getResyncState.name, () => {
@@ -1044,6 +1083,8 @@ describe(InteropEventSyncer.name, () => {
 
 class TestSyncer extends InteropEventSyncer {
   runInTransactionCalls = 0
+  /** Runs the callback, then fails the transaction as if COMMIT had failed. */
+  failNextCommit = false
 
   public triggerStatePublic<T extends SyncerState>(
     state: T,
@@ -1056,7 +1097,12 @@ class TestSyncer extends InteropEventSyncer {
     fn: () => Promise<T>,
   ): Promise<T> {
     this.runInTransactionCalls++
-    return await fn()
+    const result = await fn()
+    if (this.failNextCommit) {
+      this.failNextCommit = false
+      throw new Error('commit failed')
+    }
+    return result
   }
 }
 

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -261,12 +261,12 @@ describe(InteropEventSyncer.name, () => {
           }),
         }),
       })
-      const { state: timeLoopState } = makeTimeLoopState()
-      syncer.state = timeLoopState
+      const { state: blockProcessorState } = makeBlockProcessorState()
+      syncer.state = blockProcessorState
 
-      await syncer.run()
-      await syncer.run()
-      await syncer.run()
+      await syncer.processNewestBlock(makeBlock(1), [])
+      await syncer.processNewestBlock(makeBlock(2), [])
+      await syncer.processNewestBlock(makeBlock(3), [])
 
       expect(setLastError.calls.length).toEqual(1)
       expect(setLastError).toHaveBeenCalledWith('clusterName', 'ethereum', null)
@@ -283,15 +283,16 @@ describe(InteropEventSyncer.name, () => {
           }),
         }),
       })
-      const { state: timeLoopState, run } = makeTimeLoopState()
-      syncer.state = timeLoopState
+      const { state: blockProcessorState, processNewestBlock } =
+        makeBlockProcessorState()
+      syncer.state = blockProcessorState
 
-      await syncer.run() // clears the stale error
-      run.throwsOnce(new Error('boom'))
-      await syncer.run()
+      await syncer.processNewestBlock(makeBlock(1), []) // clears the stale error
+      processNewestBlock.throwsOnce(new Error('boom'))
+      await syncer.processNewestBlock(makeBlock(2), [])
       expect(syncer.hasError).toEqual(true)
-      await syncer.run()
-      await syncer.run()
+      await syncer.processNewestBlock(makeBlock(3), [])
+      await syncer.processNewestBlock(makeBlock(4), [])
 
       expect(syncer.hasError).toEqual(false)
       expect(setLastError.calls.map((c) => c.args[2])).toEqual([
@@ -299,6 +300,61 @@ describe(InteropEventSyncer.name, () => {
         expect.includes('boom'),
         null,
       ])
+    })
+
+    it('keeps the stored error when a block processor switches to catching up', async () => {
+      const setLastError = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        db: mockObject<Database>({
+          interopPluginSyncState: mockObject<
+            Database['interopPluginSyncState']
+          >({
+            setLastError,
+          }),
+        }),
+      })
+      const { state: timeLoopState } = makeTimeLoopState()
+      const { state: blockProcessorState, processNewestBlock } =
+        makeBlockProcessorState(timeLoopState)
+      processNewestBlock.throwsOnce(new Error('boom'))
+      syncer.state = blockProcessorState
+
+      // the failed block is followed by the next one, which only detects the gap
+      await syncer.processNewestBlock(makeBlock(1), [])
+      await syncer.processNewestBlock(makeBlock(2), [])
+
+      expect(syncer.state as SyncerState).toEqual(timeLoopState)
+      expect(setLastError.calls.length).toEqual(1)
+      expect(setLastError.calls[0]?.args[2]).toInclude('boom')
+    })
+
+    it('clears the stored error only once catch-up returns to following', async () => {
+      const setLastError = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        db: mockObject<Database>({
+          interopPluginSyncState: mockObject<
+            Database['interopPluginSyncState']
+          >({
+            setLastError,
+          }),
+        }),
+      })
+      const { state: blockProcessorState } = makeBlockProcessorState()
+      const run = mockFn<[], Promise<SyncerState>>()
+      const timeLoopState: TimeloopState = {
+        type: 'timeLoop',
+        name: 'catchingUp',
+        status: 'idle',
+        run,
+      }
+      run.resolvesToOnce(timeLoopState).resolvesTo(blockProcessorState)
+      syncer.state = timeLoopState
+
+      await syncer.run() // still catching up
+      expect(setLastError).not.toHaveBeenCalled()
+
+      await syncer.run() // back to following
+      expect(setLastError).toHaveBeenCalledWith('clusterName', 'ethereum', null)
     })
 
     it('keeps the stored error when a status check succeeds', async () => {

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -245,9 +245,82 @@ describe(InteropEventSyncer.name, () => {
 
       await syncer.run()
 
-      expect(setLastError.calls.length).toEqual(2)
-      expect(setLastError.calls[0]?.args[2]).toEqual(null)
-      expect(setLastError.calls[1]?.args[2]).toInclude('boom')
+      expect(setLastError.calls.length).toEqual(1)
+      expect(setLastError.calls[0]?.args[2]).toInclude('boom')
+    })
+
+    it('clears a possibly stale stored error once on the first success', async () => {
+      const setLastError = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        db: mockObject<InteropEventSyncer['db']>({
+          interopPluginSyncState: mockObject<
+            InteropEventSyncer['db']['interopPluginSyncState']
+          >({
+            setLastError,
+          }),
+        }),
+      })
+      const { state: timeLoopState } = makeTimeLoopState()
+      syncer.state = timeLoopState
+
+      await syncer.run()
+      await syncer.run()
+      await syncer.run()
+
+      expect(setLastError.calls.length).toEqual(1)
+      expect(setLastError).toHaveBeenCalledWith('clusterName', 'ethereum', null)
+    })
+
+    it('clears the stored error once after recovering from a failure', async () => {
+      const setLastError = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        db: mockObject<InteropEventSyncer['db']>({
+          interopPluginSyncState: mockObject<
+            InteropEventSyncer['db']['interopPluginSyncState']
+          >({
+            setLastError,
+          }),
+        }),
+      })
+      const { state: timeLoopState, run } = makeTimeLoopState()
+      syncer.state = timeLoopState
+
+      await syncer.run() // clears the stale error
+      run.throwsOnce(new Error('boom'))
+      await syncer.run()
+      expect(syncer.hasError).toEqual(true)
+      await syncer.run()
+      await syncer.run()
+
+      expect(syncer.hasError).toEqual(false)
+      expect(setLastError.calls.map((c) => c.args[2])).toEqual([
+        null,
+        expect.includes('boom'),
+        null,
+      ])
+    })
+
+    it('keeps the stored error when a status check succeeds', async () => {
+      const setLastError = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        db: mockObject<InteropEventSyncer['db']>({
+          interopPluginSyncState: mockObject<
+            InteropEventSyncer['db']['interopPluginSyncState']
+          >({
+            setLastError,
+          }),
+        }),
+      })
+      const { state: blockProcessorState, processNewestBlock } =
+        makeBlockProcessorState()
+      processNewestBlock.throwsOnce(new Error('boom'))
+      syncer.state = blockProcessorState
+
+      await syncer.processNewestBlock(makeBlock(1), [])
+      await syncer.run()
+
+      expect(setLastError.calls.length).toEqual(1)
+      expect(setLastError.calls[0]?.args[2]).toInclude('boom')
     })
   })
 
@@ -542,6 +615,11 @@ describe(InteropEventSyncer.name, () => {
         ...makeSyncedRange(),
       })
       expect(setLastError).toHaveBeenCalledWith('clusterName', 'ethereum', null)
+
+      await syncer.saveProducedInteropEvents([], makeSyncedRange())
+
+      expect(syncer.runInTransactionCalls).toEqual(2)
+      expect(setLastError.calls.length).toEqual(1)
     })
   })
 

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.test.ts
@@ -615,11 +615,61 @@ describe(InteropEventSyncer.name, () => {
         ...makeSyncedRange(),
       })
       expect(setLastError).toHaveBeenCalledWith('clusterName', 'ethereum', null)
+    })
+
+    it('writes only the range, outside a transaction, when there is nothing else to write', async () => {
+      const saveNewEvents = mockFn().resolvesTo(undefined)
+      const upsert = mockFn().resolvesTo(undefined)
+      const setLastError = mockFn().resolvesTo(undefined)
+      const syncer = createSyncer({
+        cluster: makeCluster({
+          name: 'clusterName',
+          plugins: [makePlugin({ name: 'across' })],
+        }),
+        store: mockObject<InteropEventStore>({
+          saveNewEvents,
+          updateDerivedFulfilled: mockFn().resolvesTo(undefined),
+          updateDerivedCheckedInHistory: mockFn().resolvesTo(undefined),
+        }),
+        db: mockObject<InteropEventSyncer['db']>({
+          interopPluginSyncedRange: mockObject<
+            InteropEventSyncer['db']['interopPluginSyncedRange']
+          >({
+            upsert,
+          }),
+          interopPluginSyncState: mockObject<
+            InteropEventSyncer['db']['interopPluginSyncState']
+          >({
+            setLastError,
+          }),
+        }),
+      })
+
+      // a stored error may exist after start-up, so the first save clears it
+      await syncer.saveProducedInteropEvents([], makeSyncedRange())
+      expect(syncer.runInTransactionCalls).toEqual(1)
+      expect(setLastError).toHaveBeenCalledWith('clusterName', 'ethereum', null)
 
       await syncer.saveProducedInteropEvents([], makeSyncedRange())
+      await syncer.saveProducedInteropEvents([], makeSyncedRange())
 
+      expect(syncer.runInTransactionCalls).toEqual(1)
+      expect(saveNewEvents).toHaveBeenCalledTimes(1)
+      expect(setLastError).toHaveBeenCalledTimes(1)
+      expect(upsert).toHaveBeenCalledTimes(3)
+
+      // events make it a multi-statement write again
+      await syncer.saveProducedInteropEvents(
+        [{ ...makeInteropEvent(), plugin: 'cluster' }],
+        makeSyncedRange(),
+      )
       expect(syncer.runInTransactionCalls).toEqual(2)
-      expect(setLastError.calls.length).toEqual(1)
+
+      // so does a stored error
+      await syncer.saveChainSyncError(new Error('boom'))
+      await syncer.saveProducedInteropEvents([], makeSyncedRange())
+      expect(syncer.runInTransactionCalls).toEqual(3)
+      expect(setLastError.calls.at(-1)?.args[2]).toEqual(null)
     })
   })
 

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
@@ -183,7 +183,14 @@ export class InteropEventSyncer extends TimeLoop {
         async () => {
           this.state = await fn(state)
           this.hasError = false
-          if (options?.clearError ?? true) {
+          // A transition into (or a tick spent in) CatchingUpState has not
+          // synced anything yet, so the stored error stays until either data
+          // is persisted (see saveProducedInteropEvents) or the syncer is
+          // following again.
+          if (
+            (options?.clearError ?? true) &&
+            this.state.type === 'blockProcessor'
+          ) {
             await this.clearChainSyncError()
           }
         },

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
@@ -148,6 +148,10 @@ export class InteropEventSyncer extends TimeLoop {
   public latestBlockNumber?: bigint
   public waitingForWipe = false
   public hasError = false
+  // InteropPluginSyncState.lastError may hold a value from a previous run or a
+  // failed attempt. It is cleared lazily on the next success, so steady-state
+  // block processing never writes to that table.
+  private storedErrorMayExist = true
   public readonly blockProcessingStats = new BlockProcessingStats()
   // Number of times the log range has been halved due to size-limit errors.
   public logRangeDivider?: number
@@ -177,11 +181,11 @@ export class InteropEventSyncer extends TimeLoop {
         'interop.sync',
         this.getRpcMetricsContext(),
         async () => {
+          this.state = await fn(state)
+          this.hasError = false
           if (options?.clearError ?? true) {
             await this.clearChainSyncError()
           }
-          this.state = await fn(state)
-          this.hasError = false
         },
       )
     } catch (error) {
@@ -333,15 +337,21 @@ export class InteropEventSyncer extends TimeLoop {
     })
   }
 
+  /** Writes only when an error may be stored, see `storedErrorMayExist`. */
   async clearChainSyncError() {
+    if (!this.storedErrorMayExist) {
+      return
+    }
     await this.db.interopPluginSyncState.setLastError(
       this.cluster.name,
       this.chain,
       null,
     )
+    this.storedErrorMayExist = false
   }
 
   async saveChainSyncError(error: unknown) {
+    this.storedErrorMayExist = true
     await this.db.interopPluginSyncState.setLastError(
       this.cluster.name,
       this.chain,

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
@@ -317,17 +317,30 @@ export class InteropEventSyncer extends TimeLoop {
     fulfilledCreatorEvents: InteropEvent[] = [],
     checkedInHistoryEvents: InteropEvent[] = [],
   ) {
-    await this.runInTransaction(async () => {
-      await this.store.saveNewEvents(interopEvents) // TODO: make this idempotent?
-      await this.store.updateDerivedFulfilled(fulfilledCreatorEvents)
-      await this.store.updateDerivedCheckedInHistory(checkedInHistoryEvents)
-      await this.db.interopPluginSyncedRange.upsert({
+    const upsertRange = () =>
+      this.db.interopPluginSyncedRange.upsert({
         pluginName: this.cluster.name,
         chain: this.chain,
         ...fullRange,
       })
-      await this.clearChainSyncError()
-    })
+
+    const hasEventWrites =
+      interopEvents.length > 0 ||
+      fulfilledCreatorEvents.length > 0 ||
+      checkedInHistoryEvents.length > 0
+    if (!hasEventWrites && !this.storedErrorMayExist) {
+      // Most followed blocks produce nothing. A single upsert is atomic on its
+      // own, so skip the BEGIN/COMMIT round trips.
+      await upsertRange()
+    } else {
+      await this.runInTransaction(async () => {
+        await this.store.saveNewEvents(interopEvents) // TODO: make this idempotent?
+        await this.store.updateDerivedFulfilled(fulfilledCreatorEvents)
+        await this.store.updateDerivedCheckedInHistory(checkedInHistoryEvents)
+        await upsertRange()
+        await this.clearChainSyncError()
+      })
+    }
 
     this.logger.debug('Events captured for resyncable cluster', {
       plugin: this.cluster.name,

--- a/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
+++ b/packages/backend/src/modules/interop/engine/sync/InteropEventSyncer.ts
@@ -192,6 +192,7 @@ export class InteropEventSyncer extends TimeLoop {
             this.state.type === 'blockProcessor'
           ) {
             await this.clearChainSyncError()
+            this.storedErrorMayExist = false
           }
         },
       )
@@ -347,6 +348,9 @@ export class InteropEventSyncer extends TimeLoop {
         await upsertRange()
         await this.clearChainSyncError()
       })
+      // Only now is the clear committed; a rollback above must leave the flag
+      // set so the next attempt writes it again.
+      this.storedErrorMayExist = false
     }
 
     this.logger.debug('Events captured for resyncable cluster', {
@@ -357,7 +361,11 @@ export class InteropEventSyncer extends TimeLoop {
     })
   }
 
-  /** Writes only when an error may be stored, see `storedErrorMayExist`. */
+  /**
+   * Writes only when an error may be stored, see `storedErrorMayExist`. The
+   * caller resets that flag once the write is known to be committed, because
+   * this may run inside a transaction that still rolls back afterwards.
+   */
   async clearChainSyncError() {
     if (!this.storedErrorMayExist) {
       return
@@ -367,7 +375,6 @@ export class InteropEventSyncer extends TimeLoop {
       this.chain,
       null,
     )
-    this.storedErrorMayExist = false
   }
 
   async saveChainSyncError(error: unknown) {


### PR DESCRIPTION
## Why

Interop event syncers run one instance per resyncable cluster per chain (17 clusters today). In following mode every one of them did, for every block:

- `setLastError(null)` three times (before the state ran, inside the save transaction, and once more un-awaited afterwards),
- a SELECT of the resync request and a SELECT of the last synced range,
- a `BEGIN` / range upsert / `COMMIT` even when the block produced no events,
- its own `getItemsToCapture` pass over the block, with a per-transaction filter over all logs.

That is 8 statements per block per cluster (136 per Robinhood block, 7 of them awaited in sequence) and 18 conversions of the same block. On the two 340-row bookkeeping tables this showed up as ~3,000 row updates/s and heavy bloat, and it is the main reason Robinhood only catches up at ~1.4× chain speed.

## What

- **Clear the sync error only on the error→ok transition.** A private flag tracks whether a stored error may exist; `clearChainSyncError` writes only then. The floating post-save clear is removed (it was also an unhandled-rejection hazard).
- **Cache the synced range in `FollowingState`.** The syncer is the only writer of its range while following. Catch-up and wipe both go through `CatchingUpState`, which creates a new `FollowingState`, so the cache is dropped with the state. The resync check runs at most every 10 s from the block path; the `checkStatus` tick alone is not enough because it is skipped while a block is being processed.
- **Skip the transaction when only the range changes.** A single upsert is atomic on its own; the transaction stays whenever events, derived updates or an error clear are written.
- **Prepare capture items once per block.** `BlockIndexer` passes the same block and logs objects to every processor, and the manager to every syncer, so `getItemsToCapture` memoizes per block object (WeakMap, checked against chain and logs reference). Logs are grouped by transaction in one pass instead of a filter per transaction.

## Effect

| per block per cluster, steady state | before | after |
|---|---|---|
| SQL statements | 8 (7 awaited in sequence) | 1 (+1 SELECT per 10 s) |

| capture CPU per block, 17 clusters + legacy processor | before | after |
|---|---|---|
| 40 txs / 40 logs (Robinhood median) | 1.25 ms | 0.27 ms |
| 200 txs / 1,000 logs | 33.7 ms | 2.6 ms |

## Behaviour changes to be aware of

- A resync or wipe request from the backoffice is noticed up to 10 s later than before (the catch-up path already had that latency).
- The stored error now stays visible until a retry actually succeeds, instead of flickering to `null` when the retry starts.
- All clusters now share the prepared capture items. No plugin mutates its input (grepped for in-place mutation of `txLogs`, `topics`, `transactions`, `Object.assign`, `delete`); the `block` object and `txLogs` arrays were already shared within a cluster before.

## After deploy

- `BlockProcessingStats` wall time should converge on CPU time; the row-update rate on `InteropPluginSyncState` / `InteropPluginSyncedRange` should drop to roughly the block rate × 17.
- One-off `VACUUM FULL` + reindex on those two tables; autovacuum will not reclaim the accumulated bloat.

## Tests

- 6 new/updated cases in `InteropEventSyncer.test.ts` and `FollowingState.test.ts`, 2 new in `getItemsToCapture.test.ts`.
- All 1,476 interop tests and backend typecheck pass.

Discovery notes: `docs/interop-performance-discovery-claude.md` (S1.4, S1.5, S1.6, S1.10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
