### PR TITLE
Probe block timestamps without tx bodies and demote per-block logs

### DIFF
--- a/packages/backend/src/modules/block-sync/BlockIndexer.ts
+++ b/packages/backend/src/modules/block-sync/BlockIndexer.ts
@@ -132,7 +132,7 @@ export class BlockIndexer extends ManagedChildIndexer {
             () => processor.processBlock(block, logs),
           )
           const duration = Date.now() - start
-          this.logger.info('Processor finished', {
+          this.logger.debug('Processor finished', {
             processor: processor.constructor.name,
             durationMs: Number.parseFloat(duration.toFixed(2)),
           })
@@ -144,7 +144,7 @@ export class BlockIndexer extends ManagedChildIndexer {
           })
         }
       }
-      this.logger.info('Processed block', {
+      this.logger.debug('Processed block', {
         blockNumber: block.number,
         logs: logs.length,
       })

--- a/packages/backend/src/modules/interop/examples/snapshot/replay.ts
+++ b/packages/backend/src/modules/interop/examples/snapshot/replay.ts
@@ -70,6 +70,11 @@ export class RpcReplay implements Omit<RpcClientCompat, 'ethRpcClient'> {
     throw new ReplayError(key)
   }
 
+  async getBlockTimestamp(blockNumber: number): Promise<number> {
+    const block = await this.getBlock(blockNumber, false)
+    return block.timestamp
+  }
+
   getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const key = this.buildSnapshotKey([
       'blockParentBeaconRoot',

--- a/packages/shared/src/clients/rpc/RpcClient.test.ts
+++ b/packages/shared/src/clients/rpc/RpcClient.test.ts
@@ -83,6 +83,27 @@ describe(RpcClient.name, () => {
     })
   })
 
+  describe(RpcClient.prototype.getBlockTimestamp.name, () => {
+    it('fetches the block without tx bodies and returns its timestamp', async () => {
+      const http = mockObject<HttpClient>({
+        fetch: async () => mockResponse(100),
+      })
+      const rpc = mockClient({ http, generateId: () => 'unique-id' })
+
+      const result = await rpc.getBlockTimestamp(100)
+
+      expect(result).toEqual(100)
+      expect(http.fetch.calls[0].args[1]?.body).toEqual(
+        JSON.stringify({
+          method: 'eth_getBlockByNumber',
+          params: ['0x64', false],
+          id: 'unique-id',
+          jsonrpc: '2.0',
+        }),
+      )
+    })
+  })
+
   describe(RpcClient.prototype.getTransaction.name, () => {
     it('fetches tx from rpc and parses response', async () => {
       const http = mockObject<HttpClient>({

--- a/packages/shared/src/clients/rpc/RpcClient.ts
+++ b/packages/shared/src/clients/rpc/RpcClient.ts
@@ -76,6 +76,12 @@ export class RpcClient extends ClientCore implements IRpcClient {
     return await this.getBlock(blockNumber, true)
   }
 
+  /** Calls eth_getBlockByNumber on RPC without transaction bodies. */
+  async getBlockTimestamp(blockNumber: number): Promise<number> {
+    const block = await this.getBlock(blockNumber, false)
+    return block.timestamp
+  }
+
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {
     const block = await this.getBlock(blockNumber, false)
 

--- a/packages/shared/src/clients/types.ts
+++ b/packages/shared/src/clients/types.ts
@@ -4,6 +4,11 @@ import type { SvmBlock } from './rpc-svm/types'
 export interface BlockClient {
   getLatestBlockNumber(): Promise<number>
   getBlockWithTransactions(blockNumber: number | 'latest'): Promise<Block>
+  /** Optional capability: fetch a block timestamp without transaction bodies.
+   *  Optional only for compatibility with clients that have no header-only
+   *  call (Fuel, Starknet); RpcClient, which backs every EVM chain, implements
+   *  it, so BlockProvider timestamp probes use it wherever it matters. */
+  getBlockTimestamp?(blockNumber: number): Promise<number>
   /** Optional capability: batch-fetch block timestamps. Implementations are
    *  expected to chunk requests internally. */
   getBlockTimestamps?(blockNumbers: number[]): Promise<Map<number, number>>

--- a/packages/shared/src/clients2/compatibility/RpcClientCompat.test.ts
+++ b/packages/shared/src/clients2/compatibility/RpcClientCompat.test.ts
@@ -1,0 +1,27 @@
+import { expect, mockFn, mockObject } from 'earl'
+import type { EthRpcClient, RpcBlock } from '../EthRpcClient'
+import { RpcClientCompat } from './RpcClientCompat'
+
+describe(RpcClientCompat.name, () => {
+  describe(RpcClientCompat.prototype.getBlockTimestamp.name, () => {
+    it('fetches the block without transaction bodies', async () => {
+      const header = {
+        hash: `0x${'ab'.repeat(32)}`,
+        number: 100n,
+        timestamp: 1_000n,
+        logsBloom: '0x',
+        transactions: [],
+      } as unknown as RpcBlock
+      const getBlockByNumber = mockFn().resolvesTo(header)
+      const client = new RpcClientCompat(
+        mockObject<EthRpcClient>({ getBlockByNumber }),
+        'chain',
+      )
+
+      const timestamp = await client.getBlockTimestamp(100)
+
+      expect(timestamp).toEqual(1_000)
+      expect(getBlockByNumber).toHaveBeenOnlyCalledWith(100n, false)
+    })
+  })
+})

--- a/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
+++ b/packages/shared/src/clients2/compatibility/RpcClientCompat.ts
@@ -49,6 +49,7 @@ export interface IRpcClient extends BlockClient, LogsClient {
   getBlockWithTransactions(
     blockNumber: number | 'latest',
   ): Promise<EVMBlockWithTransactions>
+  getBlockTimestamp(blockNumber: number): Promise<number>
   getBlockParentBeaconRoot(blockNumber: number): Promise<string>
   getBlock(blockNumber: 'latest' | number, includeTxs: false): Promise<EVMBlock>
   getBlock(
@@ -128,6 +129,11 @@ export class RpcClientCompat implements IRpcClient {
     blockNumber: number | 'latest',
   ): Promise<EVMBlockWithTransactions> {
     return await this.getBlock(blockNumber, true)
+  }
+
+  async getBlockTimestamp(blockNumber: number): Promise<number> {
+    const block = await this.getBlock(blockNumber, false)
+    return block.timestamp
   }
 
   async getBlockParentBeaconRoot(blockNumber: number): Promise<string> {

--- a/packages/shared/src/providers/block/BlockProvider.test.ts
+++ b/packages/shared/src/providers/block/BlockProvider.test.ts
@@ -66,6 +66,7 @@ describe(BlockProvider.name, () => {
     it('finds the closest block number to given timestamp', async () => {
       const client = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: async (n: number) => block(n),
       })
 
@@ -79,14 +80,35 @@ describe(BlockProvider.name, () => {
       expect(client.getLatestBlockNumber).toHaveBeenCalledTimes(1)
     })
 
+    it('probes timestamps without transaction bodies when the client supports it', async () => {
+      const getBlockTimestamp = mockFn(async (n: number) => n * 100)
+      const client = mockObject<BlockClient>({
+        getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp,
+        getBlockWithTransactions: mockFn(),
+      })
+
+      const provider = new BlockProvider('chain', [client])
+
+      const blockNumber = await provider.getBlockNumberAtOrBefore(
+        UnixTime(800 * 100),
+      )
+
+      expect(blockNumber).toEqual(800)
+      expect(getBlockTimestamp).toHaveBeenCalled()
+      expect(client.getBlockWithTransactions).not.toHaveBeenCalled()
+    })
+
     it('calls other client when there are errors', async () => {
       const client = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: mockFn().rejectsWith(new Error('error')),
       })
 
       const client2 = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 1000,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: async (n: number) => block(n),
       })
 
@@ -104,6 +126,7 @@ describe(BlockProvider.name, () => {
     it('falls back to 0 when start is above client latest', async () => {
       const client = mockObject<BlockClient>({
         getLatestBlockNumber: async () => 500,
+        getBlockTimestamp: undefined,
         getBlockWithTransactions: async (n: number) => block(n),
       })
 

--- a/packages/shared/src/providers/block/BlockProvider.ts
+++ b/packages/shared/src/providers/block/BlockProvider.ts
@@ -78,7 +78,12 @@ export class BlockProvider {
           timestamp,
           effectiveStart,
           end,
-          (number: number) => client.getBlockWithTransactions(number),
+          // Only the timestamp is needed, so skip transaction bodies when the
+          // client can fetch a block without them.
+          async (number: number) =>
+            client.getBlockTimestamp
+              ? { timestamp: await client.getBlockTimestamp(number) }
+              : await client.getBlockWithTransactions(number),
         )
       } catch (error) {
         if (index === this.clients.length - 1) throw error


### PR DESCRIPTION
## Why

Two small block-sync costs identified in the interop performance discovery (`docs/interop-performance-discovery-claude.md`, S1.8 and S0.3):

- `BlockNumberIndexer` ticks every 10 s and calls `BlockProvider.getBlockNumberAtOrBefore`, which interpolates/binary-searches with ~5–8 block probes. Each probe fetched the block **with transaction bodies** even though only the timestamp is used. On Robinhood that is ~1 MB of payload per tick and about 5% of the chain's RPC budget; on Base-sized blocks it is several MB.
- `BlockIndexer` logged `Processor finished` and `Processed block` at info for every block and processor, ~2.6M documents a day for Robinhood alone, each one stringified and shipped to Elasticsearch.

## What

- **Header-only timestamp probes.** `BlockClient` gets an optional `getBlockTimestamp(blockNumber)` capability. `RpcClient` implements it with `eth_getBlockByNumber(n, false)`. `BlockProvider.getBlockNumberAtOrBefore` prefers it and falls back to `getBlockWithTransactions` for clients that do not implement it (Fuel, Starknet, Aztec). Same RPC method, same call count, same limiter accounting; only the `includeTxs` flag changes.
- **Per-block log lines to debug.** The two per-block messages move to debug. The per-batch `Processed blocks` and `Fetched blocks and logs` lines stay at info, and the `Metrics` line that the "[Interop] Out of sync" alert and the RPC budget dashboard rely on is untouched.

## Checked before changing the log level

Searched Kibana saved objects (visualization `visState` and `searchSourceJSON`, lens `state`, saved searches) and all 23 alerting rules for `Processed block` / `Processor finished`: no references.

## Blast radius

`getBlockNumberAtOrBefore` is also used by activity's and DA's `BlockTargetIndexer`, TVS's `BlockTimestampIndexer` and privacy's timestamp indexer. They all get the same timestamps from smaller responses; there is no semantic change.

## Tests

- `RpcClient.getBlockTimestamp` sends `[n, false]` and returns the timestamp.
- `BlockProvider` prefers the header probe and never calls `getBlockWithTransactions` when the capability exists; existing fallback tests keep passing with the capability absent.
- Shared and backend typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
