### PR TITLE
Bump turbo to 2.10.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "esbuild": "^0.25.1",
     "mocha": "^10.2.0",
     "tsx": "^4.9.3",
-    "turbo": "^2.9.6",
+    "turbo": "^2.10.12",
     "typescript": "^7.0.2",
     "wait-for-expect": "^3.0.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^4.9.3
         version: 4.19.2
       turbo:
-        specifier: ^2.9.6
-        version: 2.9.6
+        specifier: ^2.10.12
+        version: 2.10.12
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -111,7 +111,7 @@ importers:
         version: 8.18.1
       '@waku/sdk':
         specifier: 0.0.36
-        version: 0.0.36(@multiformats/multiaddr@12.5.1)
+        version: 0.0.36(@multiformats/multiaddr@12.5.1)(supports-color@10.2.2)
       basic-auth:
         specifier: ^2.0.1
         version: 2.0.1
@@ -217,7 +217,7 @@ importers:
         version: 2.0.16
       cmd-ts:
         specifier: ^0.13.0
-        version: 0.13.0(supports-color@8.1.1)
+        version: 0.13.0(supports-color@10.2.2)
       dotenv:
         specifier: ^16.3.1
         version: 16.4.5
@@ -399,7 +399,7 @@ importers:
         version: 4.17.21
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7(supports-color@10.2.2)
     devDependencies:
       '@l2beat/backend-tools':
         specifier: workspace:*
@@ -482,7 +482,7 @@ importers:
         version: 5.22.0
       prisma-kysely:
         specifier: ^1.8.0
-        version: 1.8.0(encoding@0.1.13)(supports-color@8.1.1)
+        version: 1.8.0(encoding@0.1.13)(supports-color@10.2.2)
       tsx:
         specifier: ^4.9.3
         version: 4.19.2
@@ -518,7 +518,7 @@ importers:
         version: 0.3.2
       cmd-ts:
         specifier: ^0.13.0
-        version: 0.13.0(supports-color@8.1.1)
+        version: 0.13.0(supports-color@10.2.2)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -539,7 +539,7 @@ importers:
         version: 5.0.10
       sqlite3:
         specifier: 5.1.7
-        version: 5.1.7(supports-color@8.1.1)
+        version: 5.1.7(supports-color@10.2.2)
     devDependencies:
       '@l2beat/typescript-config':
         specifier: workspace:*
@@ -666,7 +666,7 @@ importers:
         version: 8.6.0(react@19.0.0)
       express:
         specifier: ^5.0.0
-        version: 5.0.1(supports-color@8.1.1)
+        version: 5.0.1(supports-color@10.2.2)
       fuzzysort:
         specifier: ^3.1.0
         version: 3.1.0
@@ -790,7 +790,7 @@ importers:
         version: 1.5.1
       '@ethereum-sourcify/compilers':
         specifier: ^1.1.1
-        version: 1.1.1(debug@4.4.0(supports-color@8.1.1))
+        version: 1.1.1(debug@4.4.0(supports-color@10.2.2))
       '@ethereum-sourcify/compilers-types':
         specifier: ^1.2.0
         version: 1.2.0
@@ -826,7 +826,7 @@ importers:
         version: 4.1.2
       cmd-ts:
         specifier: ^0.13.0
-        version: 0.13.0(supports-color@8.1.1)
+        version: 0.13.0(supports-color@10.2.2)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -835,7 +835,7 @@ importers:
         version: 5.7.2
       express:
         specifier: ^4.21.1
-        version: 4.21.1(supports-color@8.1.1)
+        version: 4.21.1(supports-color@10.2.2)
       fflate:
         specifier: ^0.7.4
         version: 0.7.4
@@ -1026,13 +1026,13 @@ importers:
         version: link:../validate
       express:
         specifier: ^5.0.0
-        version: 5.0.1(supports-color@8.1.1)
+        version: 5.0.1(supports-color@10.2.2)
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
       swagger-ui-express:
         specifier: ^5.0.1
-        version: 5.0.1(express@5.0.1(supports-color@8.1.1))
+        version: 5.0.1(express@5.0.1(supports-color@10.2.2))
     devDependencies:
       '@l2beat/typescript-config':
         specifier: workspace:*
@@ -1063,7 +1063,7 @@ importers:
         version: link:../validate
       '@polkadot/api':
         specifier: ^12.4.2
-        version: 12.4.2(supports-color@8.1.1)
+        version: 12.4.2(supports-color@10.2.2)
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -1152,7 +1152,7 @@ importers:
         version: 17.2.3
       express:
         specifier: ^5.1.0
-        version: 5.1.0(supports-color@8.1.1)
+        version: 5.1.0(supports-color@10.2.2)
       fuzzysort:
         specifier: 3.1.0
         version: 3.1.0
@@ -1389,7 +1389,7 @@ importers:
         version: 2.8.5
       express:
         specifier: ^5.0.0
-        version: 5.0.1(supports-color@8.1.1)
+        version: 5.0.1(supports-color@10.2.2)
       viem:
         specifier: ^2.8.14
         version: 2.31.6(typescript@7.0.2)(zod@3.24.1)
@@ -4478,33 +4478,33 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/darwin-64@2.9.6':
-    resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
+  '@turbo/darwin-64@2.10.12':
+    resolution: {integrity: sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.6':
-    resolution: {integrity: sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw==}
+  '@turbo/darwin-arm64@2.10.12':
+    resolution: {integrity: sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.6':
-    resolution: {integrity: sha512-YKi05jnNHaD7vevgYwahpzGwbsNNTwzU2c7VZdmdFm7+cGDP4oREUWSsainiMfRqjRuolQxBwRn8wf1jmu+YZA==}
+  '@turbo/linux-64@2.10.12':
+    resolution: {integrity: sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==}
     cpu: [x64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/linux-arm64@2.9.6':
-    resolution: {integrity: sha512-02o/ZS69cOYEDczXvOB2xmyrtzjQ2hVFtWZK1iqxXUfzMmTjZK4UumrfNnjckSg+gqeBfnPRHa0NstA173Ik3g==}
+  '@turbo/linux-arm64@2.10.12':
+    resolution: {integrity: sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==}
     cpu: [arm64]
-    os: [linux]
+    os: [android, linux]
 
-  '@turbo/windows-64@2.9.6':
-    resolution: {integrity: sha512-wVdQjvnBI15wB6JrA+43CtUtagjIMmX6XYO758oZHAsCNSxqRlJtdyujih0D8OCnwCRWiGWGI63zAxR0hO6s9g==}
+  '@turbo/windows-64@2.10.12':
+    resolution: {integrity: sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.6':
-    resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
+  '@turbo/windows-arm64@2.10.12':
+    resolution: {integrity: sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==}
     cpu: [arm64]
     os: [win32]
 
@@ -8780,8 +8780,8 @@ packages:
   turbo-stream@2.4.0:
     resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
-  turbo@2.9.6:
-    resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
+  turbo@2.10.12:
+    resolution: {integrity: sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==}
     hasBin: true
 
   tw-animate-css@1.4.0:
@@ -9687,10 +9687,10 @@ snapshots:
 
   '@ethereum-sourcify/compilers-types@1.2.0': {}
 
-  '@ethereum-sourcify/compilers@1.1.1(debug@4.4.0(supports-color@8.1.1))':
+  '@ethereum-sourcify/compilers@1.1.1(debug@4.4.0(supports-color@10.2.2))':
     dependencies:
       semver: 7.7.4
-      solc: 0.8.34(debug@4.4.0(supports-color@8.1.1))
+      solc: 0.8.34(debug@4.4.0(supports-color@10.2.2))
     transitivePeerDependencies:
       - debug
 
@@ -10517,10 +10517,10 @@ snapshots:
   '@polkadot-api/utils@0.1.0':
     optional: true
 
-  '@polkadot/api-augment@12.4.2(supports-color@8.1.1)':
+  '@polkadot/api-augment@12.4.2(supports-color@10.2.2)':
     dependencies:
-      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
+      '@polkadot/api-base': 12.4.2(supports-color@10.2.2)
+      '@polkadot/rpc-augment': 12.4.2(supports-color@10.2.2)
       '@polkadot/types': 12.4.2
       '@polkadot/types-augment': 12.4.2
       '@polkadot/types-codec': 12.4.2
@@ -10531,9 +10531,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-base@12.4.2(supports-color@8.1.1)':
+  '@polkadot/api-base@12.4.2(supports-color@10.2.2)':
     dependencies:
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-core': 12.4.2(supports-color@10.2.2)
       '@polkadot/types': 12.4.2
       '@polkadot/util': 13.2.2
       rxjs: 7.8.1
@@ -10543,12 +10543,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api-derive@12.4.2(supports-color@8.1.1)':
+  '@polkadot/api-derive@12.4.2(supports-color@10.2.2)':
     dependencies:
-      '@polkadot/api': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
+      '@polkadot/api': 12.4.2(supports-color@10.2.2)
+      '@polkadot/api-augment': 12.4.2(supports-color@10.2.2)
+      '@polkadot/api-base': 12.4.2(supports-color@10.2.2)
+      '@polkadot/rpc-core': 12.4.2(supports-color@10.2.2)
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
       '@polkadot/util': 13.2.2
@@ -10560,15 +10560,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/api@12.4.2(supports-color@8.1.1)':
+  '@polkadot/api@12.4.2(supports-color@10.2.2)':
     dependencies:
-      '@polkadot/api-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-base': 12.4.2(supports-color@8.1.1)
-      '@polkadot/api-derive': 12.4.2(supports-color@8.1.1)
+      '@polkadot/api-augment': 12.4.2(supports-color@10.2.2)
+      '@polkadot/api-base': 12.4.2(supports-color@10.2.2)
+      '@polkadot/api-derive': 12.4.2(supports-color@10.2.2)
       '@polkadot/keyring': 13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)
-      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-provider': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-augment': 12.4.2(supports-color@10.2.2)
+      '@polkadot/rpc-core': 12.4.2(supports-color@10.2.2)
+      '@polkadot/rpc-provider': 12.4.2(supports-color@10.2.2)
       '@polkadot/types': 12.4.2
       '@polkadot/types-augment': 12.4.2
       '@polkadot/types-codec': 12.4.2
@@ -10596,9 +10596,9 @@ snapshots:
       '@substrate/ss58-registry': 1.51.0
       tslib: 2.8.1
 
-  '@polkadot/rpc-augment@12.4.2(supports-color@8.1.1)':
+  '@polkadot/rpc-augment@12.4.2(supports-color@10.2.2)':
     dependencies:
-      '@polkadot/rpc-core': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-core': 12.4.2(supports-color@10.2.2)
       '@polkadot/types': 12.4.2
       '@polkadot/types-codec': 12.4.2
       '@polkadot/util': 13.2.2
@@ -10608,10 +10608,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-core@12.4.2(supports-color@8.1.1)':
+  '@polkadot/rpc-core@12.4.2(supports-color@10.2.2)':
     dependencies:
-      '@polkadot/rpc-augment': 12.4.2(supports-color@8.1.1)
-      '@polkadot/rpc-provider': 12.4.2(supports-color@8.1.1)
+      '@polkadot/rpc-augment': 12.4.2(supports-color@10.2.2)
+      '@polkadot/rpc-provider': 12.4.2(supports-color@10.2.2)
       '@polkadot/types': 12.4.2
       '@polkadot/util': 13.2.2
       rxjs: 7.8.1
@@ -10621,7 +10621,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@polkadot/rpc-provider@12.4.2(supports-color@8.1.1)':
+  '@polkadot/rpc-provider@12.4.2(supports-color@10.2.2)':
     dependencies:
       '@polkadot/keyring': 13.2.2(@polkadot/util-crypto@13.2.2(@polkadot/util@13.2.2))(@polkadot/util@13.2.2)
       '@polkadot/types': 12.4.2
@@ -10633,7 +10633,7 @@ snapshots:
       '@polkadot/x-ws': 13.2.2
       eventemitter3: 5.0.1
       mock-socket: 9.3.1
-      nock: 13.5.5(supports-color@8.1.1)
+      nock: 13.5.5(supports-color@10.2.2)
       tslib: 2.8.1
     optionalDependencies:
       '@substrate/connect': 0.8.11
@@ -10798,10 +10798,10 @@ snapshots:
 
   '@prisma/debug@5.22.0': {}
 
-  '@prisma/debug@5.3.1(supports-color@8.1.1)':
+  '@prisma/debug@5.3.1(supports-color@10.2.2)':
     dependencies:
       '@types/debug': 4.1.8
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4(supports-color@10.2.2)
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -10823,10 +10823,10 @@ snapshots:
       '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
       '@prisma/get-platform': 5.22.0
 
-  '@prisma/fetch-engine@5.3.1(encoding@0.1.13)(supports-color@8.1.1)':
+  '@prisma/fetch-engine@5.3.1(encoding@0.1.13)(supports-color@10.2.2)':
     dependencies:
-      '@prisma/debug': 5.3.1(supports-color@8.1.1)
-      '@prisma/get-platform': 5.3.1(supports-color@8.1.1)
+      '@prisma/debug': 5.3.1(supports-color@10.2.2)
+      '@prisma/get-platform': 5.3.1(supports-color@10.2.2)
       execa: 5.1.1
       find-cache-dir: 3.3.2
       fs-extra: 11.1.1
@@ -10846,9 +10846,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@prisma/generator-helper@5.3.1(supports-color@8.1.1)':
+  '@prisma/generator-helper@5.3.1(supports-color@10.2.2)':
     dependencies:
-      '@prisma/debug': 5.3.1(supports-color@8.1.1)
+      '@prisma/debug': 5.3.1(supports-color@10.2.2)
       '@types/cross-spawn': 6.0.2
       cross-spawn: 7.0.3
       kleur: 4.1.5
@@ -10859,9 +10859,9 @@ snapshots:
     dependencies:
       '@prisma/debug': 5.22.0
 
-  '@prisma/get-platform@5.3.1(supports-color@8.1.1)':
+  '@prisma/get-platform@5.3.1(supports-color@10.2.2)':
     dependencies:
-      '@prisma/debug': 5.3.1(supports-color@8.1.1)
+      '@prisma/debug': 5.3.1(supports-color@10.2.2)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
       fs-jetpack: 5.1.0
@@ -10874,15 +10874,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@prisma/internals@5.3.1(encoding@0.1.13)(supports-color@8.1.1)':
+  '@prisma/internals@5.3.1(encoding@0.1.13)(supports-color@10.2.2)':
     dependencies:
       '@antfu/ni': 0.21.8
       '@opentelemetry/api': 1.4.1
-      '@prisma/debug': 5.3.1(supports-color@8.1.1)
+      '@prisma/debug': 5.3.1(supports-color@10.2.2)
       '@prisma/engines': 5.3.1
-      '@prisma/fetch-engine': 5.3.1(encoding@0.1.13)(supports-color@8.1.1)
-      '@prisma/generator-helper': 5.3.1(supports-color@8.1.1)
-      '@prisma/get-platform': 5.3.1(supports-color@8.1.1)
+      '@prisma/fetch-engine': 5.3.1(encoding@0.1.13)(supports-color@10.2.2)
+      '@prisma/generator-helper': 5.3.1(supports-color@10.2.2)
+      '@prisma/get-platform': 5.3.1(supports-color@10.2.2)
       '@prisma/prisma-schema-wasm': 5.3.1-2.61e140623197a131c2a6189271ffee05a7aa9a59
       archiver: 5.3.2
       arg: 5.0.2
@@ -12287,22 +12287,22 @@ snapshots:
   '@tsconfig/node16@1.0.4':
     optional: true
 
-  '@turbo/darwin-64@2.9.6':
+  '@turbo/darwin-64@2.10.12':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.6':
+  '@turbo/darwin-arm64@2.10.12':
     optional: true
 
-  '@turbo/linux-64@2.9.6':
+  '@turbo/linux-64@2.10.12':
     optional: true
 
-  '@turbo/linux-arm64@2.9.6':
+  '@turbo/linux-arm64@2.10.12':
     optional: true
 
-  '@turbo/windows-64@2.9.6':
+  '@turbo/windows-64@2.10.12':
     optional: true
 
-  '@turbo/windows-arm64@2.9.6':
+  '@turbo/windows-arm64@2.10.12':
     optional: true
 
   '@types/accepts@1.3.7':
@@ -12756,14 +12756,14 @@ snapshots:
 
   '@vue/shared@3.1.5': {}
 
-  '@waku/core@0.0.40(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)':
+  '@waku/core@0.0.40(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)(supports-color@10.2.2)':
     dependencies:
       '@libp2p/ping': 2.0.35
       '@noble/hashes': 1.8.0
-      '@waku/enr': 0.0.33(@multiformats/multiaddr@12.5.1)
+      '@waku/enr': 0.0.33(@multiformats/multiaddr@12.5.1)(supports-color@10.2.2)
       '@waku/interfaces': 0.0.34
       '@waku/proto': 0.0.15
-      '@waku/utils': 0.0.27
+      '@waku/utils': 0.0.27(supports-color@10.2.2)
       debug: 4.4.0(supports-color@8.1.1)
       it-all: 3.0.11
       it-length-prefixed: 9.1.1
@@ -12776,13 +12776,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@waku/discovery@0.0.13(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)':
+  '@waku/discovery@0.0.13(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)(supports-color@10.2.2)':
     dependencies:
-      '@waku/core': 0.0.40(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)
-      '@waku/enr': 0.0.33(@multiformats/multiaddr@12.5.1)
+      '@waku/core': 0.0.40(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)(supports-color@10.2.2)
+      '@waku/enr': 0.0.33(@multiformats/multiaddr@12.5.1)(supports-color@10.2.2)
       '@waku/interfaces': 0.0.34
       '@waku/proto': 0.0.15
-      '@waku/utils': 0.0.27
+      '@waku/utils': 0.0.27(supports-color@10.2.2)
       debug: 4.4.0(supports-color@8.1.1)
       dns-over-http-resolver: 3.0.16
       hi-base32: 0.5.1
@@ -12792,13 +12792,13 @@ snapshots:
       - libp2p
       - supports-color
 
-  '@waku/enr@0.0.33(@multiformats/multiaddr@12.5.1)':
+  '@waku/enr@0.0.33(@multiformats/multiaddr@12.5.1)(supports-color@10.2.2)':
     dependencies:
       '@ethersproject/rlp': 5.7.0
       '@libp2p/crypto': 5.1.6
       '@libp2p/peer-id': 5.1.7
       '@noble/secp256k1': 1.7.2
-      '@waku/utils': 0.0.27
+      '@waku/utils': 0.0.27(supports-color@10.2.2)
       debug: 4.4.0(supports-color@8.1.1)
       js-sha3: 0.9.3
     optionalDependencies:
@@ -12812,7 +12812,7 @@ snapshots:
     dependencies:
       protons-runtime: 5.6.0
 
-  '@waku/sdk@0.0.36(@multiformats/multiaddr@12.5.1)':
+  '@waku/sdk@0.0.36(@multiformats/multiaddr@12.5.1)(supports-color@10.2.2)':
     dependencies:
       '@chainsafe/libp2p-noise': 16.1.3
       '@libp2p/bootstrap': 11.0.42
@@ -12822,12 +12822,12 @@ snapshots:
       '@libp2p/websockets': 9.2.16
       '@noble/hashes': 1.8.0
       '@types/lodash.debounce': 4.0.9
-      '@waku/core': 0.0.40(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)
-      '@waku/discovery': 0.0.13(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)
+      '@waku/core': 0.0.40(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)(supports-color@10.2.2)
+      '@waku/discovery': 0.0.13(@multiformats/multiaddr@12.5.1)(libp2p@2.8.11)(supports-color@10.2.2)
       '@waku/interfaces': 0.0.34
       '@waku/proto': 0.0.15
-      '@waku/sds': 0.0.8
-      '@waku/utils': 0.0.27
+      '@waku/sds': 0.0.8(supports-color@10.2.2)
+      '@waku/utils': 0.0.27(supports-color@10.2.2)
       libp2p: 2.8.11
       lodash.debounce: 4.0.8
     transitivePeerDependencies:
@@ -12836,23 +12836,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@waku/sds@0.0.8':
+  '@waku/sds@0.0.8(supports-color@10.2.2)':
     dependencies:
       '@libp2p/interface': 2.10.4
       '@noble/hashes': 1.8.0
       '@waku/proto': 0.0.15
-      '@waku/utils': 0.0.27
+      '@waku/utils': 0.0.27(supports-color@10.2.2)
       chai: 5.3.3
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
 
-  '@waku/utils@0.0.27':
+  '@waku/utils@0.0.27(supports-color@10.2.2)':
     dependencies:
       '@noble/hashes': 1.8.0
       '@waku/interfaces': 0.0.34
       chai: 4.5.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@10.2.2)
       uint8arrays: 5.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12898,6 +12898,13 @@ snapshots:
   aes-js@3.0.0: {}
 
   after-all-results@2.0.0: {}
+
+  agent-base@6.0.2(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.0(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
@@ -13403,6 +13410,15 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  cmd-ts@0.13.0(supports-color@10.2.2):
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.0(supports-color@10.2.2)
+      didyoumean: 1.2.2
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   cmd-ts@0.13.0(supports-color@8.1.1):
     dependencies:
       chalk: 4.1.2
@@ -13790,23 +13806,35 @@ snapshots:
 
   debounce@2.1.0: {}
 
+  debug@2.6.9(supports-color@10.2.2):
+    dependencies:
+      ms: 2.0.0
+    optionalDependencies:
+      supports-color: 10.2.2
+
   debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
     optionalDependencies:
       supports-color: 8.1.1
 
-  debug@4.3.4(supports-color@8.1.1):
+  debug@4.3.4(supports-color@10.2.2):
     dependencies:
       ms: 2.1.2
     optionalDependencies:
-      supports-color: 8.1.1
+      supports-color: 10.2.2
 
   debug@4.3.6(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
     optionalDependencies:
       supports-color: 8.1.1
+
+  debug@4.4.0(supports-color@10.2.2):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 10.2.2
 
   debug@4.4.0(supports-color@8.1.1):
     dependencies:
@@ -14253,7 +14281,7 @@ snapshots:
 
   expand-template@2.0.3: {}
 
-  express@4.21.1(supports-color@8.1.1):
+  express@4.21.1(supports-color@10.2.2):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
@@ -14280,7 +14308,7 @@ snapshots:
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0(supports-color@8.1.1)
-      serve-static: 1.16.2(supports-color@8.1.1)
+      serve-static: 1.16.2(supports-color@10.2.2)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -14289,7 +14317,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.0.1(supports-color@8.1.1):
+  express@5.0.1(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
       body-parser: 2.1.0(supports-color@8.1.1)
@@ -14317,7 +14345,7 @@ snapshots:
       router: 2.1.0
       safe-buffer: 5.2.1
       send: 1.1.0(supports-color@8.1.1)
-      serve-static: 2.1.0(supports-color@8.1.1)
+      serve-static: 2.1.0(supports-color@10.2.2)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 2.0.0
@@ -14326,7 +14354,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.1.0(supports-color@8.1.1):
+  express@5.1.0(supports-color@10.2.2):
     dependencies:
       accepts: 2.0.0
       body-parser: 2.2.0(supports-color@8.1.1)
@@ -14338,7 +14366,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.0(supports-color@8.1.1)
+      finalhandler: 2.1.0(supports-color@10.2.2)
       fresh: 2.0.0
       http-errors: 2.0.0
       merge-descriptors: 2.0.0
@@ -14350,8 +14378,8 @@ snapshots:
       qs: 6.14.0
       range-parser: 1.2.1
       router: 2.2.0(supports-color@8.1.1)
-      send: 1.2.0(supports-color@8.1.1)
-      serve-static: 2.2.0(supports-color@8.1.1)
+      send: 1.2.0(supports-color@10.2.2)
+      serve-static: 2.2.0(supports-color@10.2.2)
       statuses: 2.0.1
       type-is: 2.0.1
       vary: 1.1.2
@@ -14412,6 +14440,17 @@ snapshots:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  finalhandler@2.1.0(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.0(supports-color@10.2.2)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -14478,9 +14517,9 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  follow-redirects@1.16.0(debug@4.4.0(supports-color@8.1.1)):
+  follow-redirects@1.16.0(debug@4.4.0(supports-color@10.2.2)):
     optionalDependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@10.2.2)
 
   foreground-child@3.3.0:
     dependencies:
@@ -14775,9 +14814,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
+  https-proxy-agent@5.0.1(supports-color@10.2.2):
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
+      agent-base: 6.0.2(supports-color@10.2.2)
       debug: 4.4.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -15359,13 +15398,13 @@ snapshots:
   make-error@1.3.6:
     optional: true
 
-  make-fetch-happen@9.1.0(supports-color@8.1.1):
+  make-fetch-happen@9.1.0(supports-color@10.2.2):
     dependencies:
       agentkeepalive: 4.6.0
       cacache: 15.3.0
       http-cache-semantics: 4.1.1
       http-proxy-agent: 4.0.1(supports-color@8.1.1)
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      https-proxy-agent: 5.0.1(supports-color@10.2.2)
       is-lambda: 1.0.1
       lru-cache: 6.0.0
       minipass: 3.3.6
@@ -15375,7 +15414,7 @@ snapshots:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1(supports-color@8.1.1)
+      socks-proxy-agent: 6.2.1(supports-color@10.2.2)
       ssri: 8.0.1
     transitivePeerDependencies:
       - bluebird
@@ -15640,6 +15679,14 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nock@13.5.5(supports-color@10.2.2):
+    dependencies:
+      debug: 4.4.0(supports-color@10.2.2)
+      json-stringify-safe: 5.0.1
+      propagate: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   nock@13.5.5(supports-color@8.1.1):
     dependencies:
       debug: 4.4.0(supports-color@8.1.1)
@@ -15681,12 +15728,12 @@ snapshots:
       detect-libc: 2.0.4
     optional: true
 
-  node-gyp@8.4.1(supports-color@8.1.1):
+  node-gyp@8.4.1(supports-color@10.2.2):
     dependencies:
       env-paths: 2.2.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      make-fetch-happen: 9.1.0(supports-color@8.1.1)
+      make-fetch-happen: 9.1.0(supports-color@10.2.2)
       nopt: 5.0.0
       npmlog: 6.0.2
       rimraf: 3.0.2
@@ -16104,11 +16151,11 @@ snapshots:
       tar-fs: 2.1.2
       tunnel-agent: 0.6.0
 
-  prisma-kysely@1.8.0(encoding@0.1.13)(supports-color@8.1.1):
+  prisma-kysely@1.8.0(encoding@0.1.13)(supports-color@10.2.2):
     dependencies:
       '@mrleebo/prisma-ast': 0.7.0
-      '@prisma/generator-helper': 5.3.1(supports-color@8.1.1)
-      '@prisma/internals': 5.3.1(encoding@0.1.13)(supports-color@8.1.1)
+      '@prisma/generator-helper': 5.3.1(supports-color@10.2.2)
+      '@prisma/internals': 5.3.1(encoding@0.1.13)(supports-color@10.2.2)
       typescript: 5.9.3
       zod: 3.23.8
     transitivePeerDependencies:
@@ -16596,6 +16643,24 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@0.19.0(supports-color@10.2.2):
+    dependencies:
+      debug: 2.6.9(supports-color@10.2.2)
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   send@0.19.0(supports-color@8.1.1):
     dependencies:
       debug: 2.6.9(supports-color@8.1.1)
@@ -16631,9 +16696,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.0(supports-color@8.1.1):
+  send@1.2.0(supports-color@10.2.2):
     dependencies:
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.0(supports-color@10.2.2)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -16651,30 +16716,30 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  serve-static@1.16.2(supports-color@8.1.1):
+  serve-static@1.16.2(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0(supports-color@8.1.1)
+      send: 0.19.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.1.0(supports-color@8.1.1):
+  serve-static@2.1.0(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.0(supports-color@8.1.1)
+      send: 1.2.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.0(supports-color@8.1.1):
+  serve-static@2.2.0(supports-color@10.2.2):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.0(supports-color@8.1.1)
+      send: 1.2.0(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -16803,9 +16868,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  socks-proxy-agent@6.2.1(supports-color@8.1.1):
+  socks-proxy-agent@6.2.1(supports-color@10.2.2):
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
+      agent-base: 6.0.2(supports-color@10.2.2)
       debug: 4.4.0(supports-color@8.1.1)
       socks: 2.8.4
     transitivePeerDependencies:
@@ -16818,11 +16883,11 @@ snapshots:
       smart-buffer: 4.2.0
     optional: true
 
-  solc@0.8.34(debug@4.4.0(supports-color@8.1.1)):
+  solc@0.8.34(debug@4.4.0(supports-color@10.2.2)):
     dependencies:
       command-exists: 1.2.9
       commander: 8.3.0
-      follow-redirects: 1.16.0(debug@4.4.0(supports-color@8.1.1))
+      follow-redirects: 1.16.0(debug@4.4.0(supports-color@10.2.2))
       js-sha3: 0.8.0
       memorystream: 0.3.1
       semver: 5.7.2
@@ -16877,14 +16942,14 @@ snapshots:
 
   sql-summary@1.0.1: {}
 
-  sqlite3@5.1.7(supports-color@8.1.1):
+  sqlite3@5.1.7(supports-color@10.2.2):
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
       tar: 6.2.1
     optionalDependencies:
-      node-gyp: 8.4.1(supports-color@8.1.1)
+      node-gyp: 8.4.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -17012,9 +17077,9 @@ snapshots:
     dependencies:
       '@scarf/scarf': 1.4.0
 
-  swagger-ui-express@5.0.1(express@5.0.1(supports-color@8.1.1)):
+  swagger-ui-express@5.0.1(express@5.0.1(supports-color@10.2.2)):
     dependencies:
-      express: 5.0.1(supports-color@8.1.1)
+      express: 5.0.1(supports-color@10.2.2)
       swagger-ui-dist: 5.29.1
 
   tabbable@6.2.0: {}
@@ -17261,14 +17326,14 @@ snapshots:
 
   turbo-stream@2.4.0: {}
 
-  turbo@2.9.6:
+  turbo@2.10.12:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.6
-      '@turbo/darwin-arm64': 2.9.6
-      '@turbo/linux-64': 2.9.6
-      '@turbo/linux-arm64': 2.9.6
-      '@turbo/windows-64': 2.9.6
-      '@turbo/windows-arm64': 2.9.6
+      '@turbo/darwin-64': 2.10.12
+      '@turbo/darwin-arm64': 2.10.12
+      '@turbo/linux-64': 2.10.12
+      '@turbo/linux-arm64': 2.10.12
+      '@turbo/windows-64': 2.10.12
+      '@turbo/windows-arm64': 2.10.12
 
   tw-animate-css@1.4.0: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://v2-9-6.turborepo.dev/schema.json",
+  "$schema": "https://v2-10-12.turborepo.dev/schema.json",
   "globalDependencies": [
     "packages/typescript-config/*.json",
     ".discovery.json"


### PR DESCRIPTION
## Summary

- Bump turbo `^2.9.6` → `^2.10.12` (root devDependency) and update the lockfile.

## Why

pnpm 12 prepends a second YAML document (`packageManagerDependencies`) to `pnpm-lock.yaml`. Turbo 2.9 cannot parse it: `turbo prune` fails with "deserializing from YAML containing more than one document is not supported", which breaks every Docker build. Turbo 2.10.12 handles multi-document lockfiles.

This PR is the bottom of a stack; the pnpm 12 bump (#12777) sits on top of it.

## Testing

- [x] `pnpm install --frozen-lockfile` passes (pnpm 11.22.0)
- [x] `turbo prune --docker @l2beat/backend` succeeds
- [x] `turbo run typecheck --dry` shows no config warnings
- [ ] CI green
