### PR TITLE
Run the garden scenery under the nav and into the overscroll

### DIFF
--- a/packages/frontend/src/components/core/Sidebar.tsx
+++ b/packages/frontend/src/components/core/Sidebar.tsx
@@ -63,6 +63,8 @@ function SidebarProvider({
         }
         className={cn(
           'group/sidebar-wrapper flex min-h-svh w-full flex-col bg-background',
+          // A stacking context, so a `PageBackdrop` stays above the background.
+          'has-[[data-backdrop]]:relative has-[[data-backdrop]]:isolate',
           className,
         )}
         {...props}
@@ -114,7 +116,7 @@ function Sidebar({
         )}
         {...props}
       >
-        <div className="flex size-full flex-col gap-6 bg-background">
+        <div className="flex size-full flex-col gap-6 bg-background group-has-[[data-backdrop]]/sidebar-wrapper:bg-transparent">
           {children}
         </div>
       </div>

--- a/packages/frontend/src/layouts/PageBackdrop.tsx
+++ b/packages/frontend/src/layouts/PageBackdrop.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import { cn } from '~/utils/cn'
 
-/** Names the sky colour the root takes for overscroll - see globals.css. */
+/** Names the canvas colour the root takes for overscroll - see globals.css. */
 export type PageBackdropName = 'garden' | 'plot'
 
 /**

--- a/packages/frontend/src/layouts/PageBackdrop.tsx
+++ b/packages/frontend/src/layouts/PageBackdrop.tsx
@@ -1,23 +1,13 @@
 import type { ReactNode } from 'react'
 import { cn } from '~/utils/cn'
 
+/** Names the sky colour the root takes for overscroll - see globals.css. */
 export type PageBackdropName = 'garden' | 'plot'
-
-// The colours the scene meets the viewport edge with, top and bottom.
-const EDGES: Record<PageBackdropName, { sky: string; ground: string }> = {
-  garden: { sky: 'bg-garden-sky', ground: 'bg-garden-ground' },
-  plot: { sky: 'bg-plot-sky', ground: 'bg-plot-ground' },
-}
 
 /**
  * A viewport-sized layer that follows the reader, for `SideNavLayout`'s
  * `backdrop` slot. Sticky rather than fixed so it scrolls away with the page;
  * the negative bottom margin gives back the height it takes up.
- *
- * Rubber-band overscroll drags fixed elements along with the page, so a strip
- * parked just outside the viewport slides into the exposed area: sky above,
- * ground below. The root background in globals.css covers browsers that do
- * not move fixed elements.
  */
 export function PageBackdrop({
   name,
@@ -28,33 +18,16 @@ export function PageBackdrop({
   children: ReactNode
   className?: string
 }) {
-  const edges = EDGES[name]
   return (
-    <>
-      <div
-        aria-hidden
-        data-backdrop={name}
-        className={cn(
-          '-z-10 -mb-[100svh] pointer-events-none sticky top-0 h-svh overflow-hidden',
-          className,
-        )}
-      >
-        {children}
-      </div>
-      <div
-        aria-hidden
-        className={cn(
-          '-top-[100svh] -z-10 pointer-events-none fixed inset-x-0 h-svh',
-          edges.sky,
-        )}
-      />
-      <div
-        aria-hidden
-        className={cn(
-          '-bottom-[100svh] -z-10 pointer-events-none fixed inset-x-0 h-svh',
-          edges.ground,
-        )}
-      />
-    </>
+    <div
+      aria-hidden
+      data-backdrop={name}
+      className={cn(
+        '-z-10 -mb-[100svh] pointer-events-none sticky top-0 h-svh overflow-hidden',
+        className,
+      )}
+    >
+      {children}
+    </div>
   )
 }

--- a/packages/frontend/src/layouts/PageBackdrop.tsx
+++ b/packages/frontend/src/layouts/PageBackdrop.tsx
@@ -1,21 +1,27 @@
 import type { ReactNode } from 'react'
 import { cn } from '~/utils/cn'
 
+export type PageBackdropName = 'garden' | 'plot'
+
 /**
  * A viewport-sized layer that follows the reader, for `SideNavLayout`'s
- * `backdrop` slot. Sticky rather than fixed so it stays inside the content
- * column; the negative bottom margin gives back the height it takes up.
+ * `backdrop` slot. Sticky rather than fixed so it scrolls away with the page;
+ * the negative bottom margin gives back the height it takes up. `name` picks
+ * the root background in globals.css, which is what overscroll reveals.
  */
 export function PageBackdrop({
+  name,
   children,
   className,
 }: {
+  name: PageBackdropName
   children: ReactNode
   className?: string
 }) {
   return (
     <div
       aria-hidden
+      data-backdrop={name}
       className={cn(
         '-z-10 -mb-[100svh] pointer-events-none sticky top-0 h-svh overflow-hidden',
         className,

--- a/packages/frontend/src/layouts/PageBackdrop.tsx
+++ b/packages/frontend/src/layouts/PageBackdrop.tsx
@@ -3,11 +3,21 @@ import { cn } from '~/utils/cn'
 
 export type PageBackdropName = 'garden' | 'plot'
 
+// The colours the scene meets the viewport edge with, top and bottom.
+const EDGES: Record<PageBackdropName, { sky: string; ground: string }> = {
+  garden: { sky: 'bg-garden-sky', ground: 'bg-garden-ground' },
+  plot: { sky: 'bg-plot-sky', ground: 'bg-plot-ground' },
+}
+
 /**
  * A viewport-sized layer that follows the reader, for `SideNavLayout`'s
  * `backdrop` slot. Sticky rather than fixed so it scrolls away with the page;
- * the negative bottom margin gives back the height it takes up. `name` picks
- * the root background in globals.css, which is what overscroll reveals.
+ * the negative bottom margin gives back the height it takes up.
+ *
+ * Rubber-band overscroll drags fixed elements along with the page, so a strip
+ * parked just outside the viewport slides into the exposed area: sky above,
+ * ground below. The root background in globals.css covers browsers that do
+ * not move fixed elements.
  */
 export function PageBackdrop({
   name,
@@ -18,16 +28,33 @@ export function PageBackdrop({
   children: ReactNode
   className?: string
 }) {
+  const edges = EDGES[name]
   return (
-    <div
-      aria-hidden
-      data-backdrop={name}
-      className={cn(
-        '-z-10 -mb-[100svh] pointer-events-none sticky top-0 h-svh overflow-hidden',
-        className,
-      )}
-    >
-      {children}
-    </div>
+    <>
+      <div
+        aria-hidden
+        data-backdrop={name}
+        className={cn(
+          '-z-10 -mb-[100svh] pointer-events-none sticky top-0 h-svh overflow-hidden',
+          className,
+        )}
+      >
+        {children}
+      </div>
+      <div
+        aria-hidden
+        className={cn(
+          '-top-[100svh] -z-10 pointer-events-none fixed inset-x-0 h-svh',
+          edges.sky,
+        )}
+      />
+      <div
+        aria-hidden
+        className={cn(
+          '-bottom-[100svh] -z-10 pointer-events-none fixed inset-x-0 h-svh',
+          edges.ground,
+        )}
+      />
+    </>
   )
 }

--- a/packages/frontend/src/layouts/SideNavLayout.tsx
+++ b/packages/frontend/src/layouts/SideNavLayout.tsx
@@ -82,7 +82,7 @@ export interface SideNavLayoutProps {
   children: React.ReactNode
   childrenWrapperClassName?: string
   variant?: SideNavLayoutVariant
-  /** Scenery behind the whole content column - see `PageBackdrop`. */
+  /** Scenery behind the whole page, nav included - see `PageBackdrop`. */
   backdrop?: React.ReactNode
 }
 
@@ -97,6 +97,7 @@ export function SideNavLayout({
 
   return (
     <SidebarProvider>
+      {backdrop}
       <div className="relative flex grow flex-col lg:flex-row">
         <div className="block lg:hidden">{topChildren}</div>
         <MobileTopNavbar
@@ -112,12 +113,9 @@ export function SideNavLayout({
         <div
           className={cn(
             contentWrapperVariants({ variant }),
-            // A stacking context, so a negative z-index backdrop stays above the page background.
-            backdrop !== undefined && 'relative isolate',
             childrenWrapperClassName,
           )}
         >
-          {backdrop}
           <div className={bannerWrapperVariants({ variant })}>
             {topChildren}
           </div>

--- a/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
+++ b/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
@@ -5,7 +5,7 @@ import { cn } from '~/utils/cn'
 export function GardenBackground() {
   return (
     <PageBackdrop name="garden">
-      <div className="absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-garden-sky to-transparent" />
+      <div className="absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-garden-canvas to-transparent" />
       <Sun className="absolute top-10 right-14 max-md:top-6 max-md:right-6 max-md:scale-75" />
       <svg
         className="absolute bottom-0 left-0 h-36 w-full"

--- a/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
+++ b/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
@@ -18,7 +18,7 @@ export function GardenBackground() {
         />
         <path
           d="M0 130 C260 90 460 150 720 115 C940 85 1080 140 1200 115 L1200 160 L0 160 Z"
-          className="fill-garden-ground"
+          className="fill-garden-border/70"
         />
       </svg>
     </PageBackdrop>

--- a/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
+++ b/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
@@ -4,8 +4,8 @@ import { cn } from '~/utils/cn'
 /** A sky wash, a sun and two hills. */
 export function GardenBackground() {
   return (
-    <PageBackdrop>
-      <div className="absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-[#eaf4e6]/80 to-transparent dark:from-[#141b10]/60" />
+    <PageBackdrop name="garden">
+      <div className="absolute inset-x-0 top-0 h-64 bg-gradient-to-b from-garden-sky to-transparent" />
       <Sun className="absolute top-10 right-14 max-md:top-6 max-md:right-6 max-md:scale-75" />
       <svg
         className="absolute bottom-0 left-0 h-36 w-full"

--- a/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
+++ b/packages/frontend/src/pages/garden/assets/GardenBackground.tsx
@@ -18,7 +18,7 @@ export function GardenBackground() {
         />
         <path
           d="M0 130 C260 90 460 150 720 115 C940 85 1080 140 1200 115 L1200 160 L0 160 Z"
-          className="fill-garden-border/70"
+          className="fill-garden-ground"
         />
       </svg>
     </PageBackdrop>

--- a/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
+++ b/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
@@ -5,8 +5,8 @@ import { cn } from '~/utils/cn'
 /** An early-morning plot: clouds, furrows, seedlings and an empty trellis. */
 export function PlotBackground() {
   return (
-    <PageBackdrop>
-      <div className="absolute inset-x-0 top-0 h-80 bg-gradient-to-b from-[#fdf1de]/85 via-[#f4f6e6]/40 to-transparent dark:from-[#1e1b12]/70 dark:via-[#161c12]/40" />
+    <PageBackdrop name="plot">
+      <div className="absolute inset-x-0 top-0 h-80 bg-gradient-to-b from-plot-sky via-[#f4f6e6]/40 to-transparent dark:via-[#161c12]/40" />
 
       <Cloud className="absolute top-16 left-[7%] w-44 max-md:top-8 max-md:w-28" />
       <Cloud

--- a/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
+++ b/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
@@ -6,7 +6,7 @@ import { cn } from '~/utils/cn'
 export function PlotBackground() {
   return (
     <PageBackdrop name="plot">
-      <div className="absolute inset-x-0 top-0 h-80 bg-gradient-to-b from-plot-sky via-[#f4f6e6]/40 to-transparent dark:via-[#161c12]/40" />
+      <div className="absolute inset-x-0 top-0 h-80 bg-gradient-to-b from-plot-canvas via-[#f4f6e6]/40 to-transparent dark:via-[#161c12]/40" />
 
       <Cloud className="absolute top-16 left-[7%] w-44 max-md:top-8 max-md:w-28" />
       <Cloud

--- a/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
+++ b/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
@@ -41,7 +41,7 @@ export function PlotBackground() {
           />
           <path
             d="M0 96 C300 86 900 86 1200 96 L1200 176 L0 176 Z"
-            className="fill-[#d8c9ac]/70 dark:fill-[#2a251b]/75"
+            className="fill-plot-ground"
           />
           {FURROWS.map((furrow) => (
             <path

--- a/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
+++ b/packages/frontend/src/pages/garden/submit/assets/PlotBackground.tsx
@@ -41,7 +41,7 @@ export function PlotBackground() {
           />
           <path
             d="M0 96 C300 86 900 86 1200 96 L1200 176 L0 176 Z"
-            className="fill-plot-ground"
+            className="fill-[#d8c9ac]/70 dark:fill-[#2a251b]/75"
           />
           {FURROWS.map((furrow) => (
             <path

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -71,8 +71,8 @@
   --garden-border: #cfe3c0;
   --garden-tint: #f2f9ec;
   --garden-soil: #cfc4b0;
-  --garden-sky: #eaf4e6;
-  --plot-sky: #fdf1de;
+  --garden-canvas: #eaf4e6;
+  --plot-canvas: #fdf1de;
 
   /* Chart colors */
   --chart-ethereum: #2a5bd8;
@@ -158,8 +158,8 @@
   --garden-border: #2c3a22;
   --garden-tint: #161f0e;
   --garden-soil: #2a251d;
-  --garden-sky: #141b10;
-  --plot-sky: #1e1b12;
+  --garden-canvas: #141b10;
+  --plot-canvas: #1e1b12;
 
   /* Chart colors */
   --chart-ethereum: #3387ff;
@@ -514,8 +514,8 @@
   --color-garden-border: var(--garden-border);
   --color-garden-tint: var(--garden-tint);
   --color-garden-soil: var(--garden-soil);
-  --color-garden-sky: var(--garden-sky);
-  --color-plot-sky: var(--plot-sky);
+  --color-garden-canvas: var(--garden-canvas);
+  --color-plot-canvas: var(--plot-canvas);
 
   --color-branding-primary: var(--project-primary, var(--ecosystem-primary));
   --color-branding-secondary: var(
@@ -863,12 +863,12 @@
 }
 
 /* Rubber-band overscroll reveals the root background, and only ever one flat
-   colour of it, so both ends of a backdrop page get its sky. */
+   colour of it, so both ends of a backdrop page get its canvas. */
 html:has([data-backdrop="garden"]) {
-  background-color: var(--garden-sky);
+  background-color: var(--garden-canvas);
 }
 html:has([data-backdrop="plot"]) {
-  background-color: var(--plot-sky);
+  background-color: var(--plot-canvas);
 }
 
 /* The Infinite Garden. Referenced from inline styles in CropBadge and the backgrounds. */

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -71,6 +71,8 @@
   --garden-border: #cfe3c0;
   --garden-tint: #f2f9ec;
   --garden-soil: #cfc4b0;
+  --garden-sky: #eaf4e6;
+  --plot-sky: #fdf1de;
 
   /* Chart colors */
   --chart-ethereum: #2a5bd8;
@@ -156,6 +158,8 @@
   --garden-border: #2c3a22;
   --garden-tint: #161f0e;
   --garden-soil: #2a251d;
+  --garden-sky: #141b10;
+  --plot-sky: #1e1b12;
 
   /* Chart colors */
   --chart-ethereum: #3387ff;
@@ -510,6 +514,8 @@
   --color-garden-border: var(--garden-border);
   --color-garden-tint: var(--garden-tint);
   --color-garden-soil: var(--garden-soil);
+  --color-garden-sky: var(--garden-sky);
+  --color-plot-sky: var(--plot-sky);
 
   --color-branding-primary: var(--project-primary, var(--ecosystem-primary));
   --color-branding-secondary: var(
@@ -854,6 +860,15 @@
   to {
     opacity: 0;
   }
+}
+
+/* Overscroll reveals the root background above the page; matching it to the
+   sky of the PageBackdrop on screen keeps the garden pages edge-free there. */
+html:has([data-backdrop="garden"]) {
+  background-color: var(--garden-sky);
+}
+html:has([data-backdrop="plot"]) {
+  background-color: var(--plot-sky);
 }
 
 /* The Infinite Garden. Referenced from inline styles in CropBadge and the backgrounds. */

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -72,7 +72,9 @@
   --garden-tint: #f2f9ec;
   --garden-soil: #cfc4b0;
   --garden-sky: #eaf4e6;
+  --garden-ground: #d6e4cd;
   --plot-sky: #fdf1de;
+  --plot-ground: #dcd2bf;
 
   /* Chart colors */
   --chart-ethereum: #2a5bd8;
@@ -159,7 +161,9 @@
   --garden-tint: #161f0e;
   --garden-soil: #2a251d;
   --garden-sky: #141b10;
+  --garden-ground: #181f12;
   --plot-sky: #1e1b12;
+  --plot-ground: #201c14;
 
   /* Chart colors */
   --chart-ethereum: #3387ff;
@@ -515,7 +519,9 @@
   --color-garden-tint: var(--garden-tint);
   --color-garden-soil: var(--garden-soil);
   --color-garden-sky: var(--garden-sky);
+  --color-garden-ground: var(--garden-ground);
   --color-plot-sky: var(--plot-sky);
+  --color-plot-ground: var(--plot-ground);
 
   --color-branding-primary: var(--project-primary, var(--ecosystem-primary));
   --color-branding-secondary: var(
@@ -862,8 +868,8 @@
   }
 }
 
-/* Overscroll reveals the root background above the page; matching it to the
-   sky of the PageBackdrop on screen keeps the garden pages edge-free there. */
+/* Fallback for browsers whose overscroll does not carry fixed elements along
+   (see PageBackdrop): the root background is what they reveal instead. */
 html:has([data-backdrop="garden"]) {
   background-color: var(--garden-sky);
 }

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -72,9 +72,7 @@
   --garden-tint: #f2f9ec;
   --garden-soil: #cfc4b0;
   --garden-sky: #eaf4e6;
-  --garden-ground: #d6e4cd;
   --plot-sky: #fdf1de;
-  --plot-ground: #dcd2bf;
 
   /* Chart colors */
   --chart-ethereum: #2a5bd8;
@@ -161,9 +159,7 @@
   --garden-tint: #161f0e;
   --garden-soil: #2a251d;
   --garden-sky: #141b10;
-  --garden-ground: #181f12;
   --plot-sky: #1e1b12;
-  --plot-ground: #201c14;
 
   /* Chart colors */
   --chart-ethereum: #3387ff;
@@ -519,9 +515,7 @@
   --color-garden-tint: var(--garden-tint);
   --color-garden-soil: var(--garden-soil);
   --color-garden-sky: var(--garden-sky);
-  --color-garden-ground: var(--garden-ground);
   --color-plot-sky: var(--plot-sky);
-  --color-plot-ground: var(--plot-ground);
 
   --color-branding-primary: var(--project-primary, var(--ecosystem-primary));
   --color-branding-secondary: var(

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -868,8 +868,8 @@
   }
 }
 
-/* Fallback for browsers whose overscroll does not carry fixed elements along
-   (see PageBackdrop): the root background is what they reveal instead. */
+/* Rubber-band overscroll reveals the root background, and only ever one flat
+   colour of it, so both ends of a backdrop page get its sky. */
 html:has([data-backdrop="garden"]) {
   background-color: var(--garden-sky);
 }


### PR DESCRIPTION
Follow-up to #12785.

**Nav cutoff.** Moving the backdrop into the content column cut the sky and hills off at the nav edge. The backdrop now lives in the sidebar wrapper, which spans the whole viewport. The wrapper isolates itself and the nav panel goes transparent only when a `PageBackdrop` is present, both driven by `:has([data-backdrop])`, so no page injects CSS and non-garden pages are untouched.

**Overscroll.** Rubber-band overscroll reveals the root background, and Chromium paints only one flat colour there (checked with a bare test page: fixed strips outside the viewport are never drawn). Each backdrop names itself (`garden` or `plot`) and the root takes that backdrop's canvas colour in light and dark, so the top continues the scene and the bottom shows the same colour.

Verified in mock mode: on `/garden` the root background resolves to the canvas token, the wrapper is `isolate` and the nav panel is transparent; `/garden/submit` carries the plot variant; `/scaling/summary` has none of it. Typecheck and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
