### PR TITLE
Archive Superposition

### DIFF
--- a/packages/config/src/projects/superposition/config.jsonc
+++ b/packages/config/src/projects/superposition/config.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "../../../../discovery/schemas/config.v2.schema.json",
+  "archived": true,
   "name": "superposition",
   "import": ["../globalConfig.jsonc"],
   "initialAddresses": ["arb1:0x62bEd4b862254789825Cd6F2352aa2b76B16145e"],

--- a/packages/config/src/projects/superposition/superposition.ts
+++ b/packages/config/src/projects/superposition/superposition.ts
@@ -11,10 +11,12 @@ import { AnytrustDAC } from '../../templates/anytrust-template'
 import { orbitStackL3 } from '../../templates/orbitStack'
 
 const discovery = new ProjectDiscovery('superposition')
+const archivedAt = UnixTime(1788868800) // 2026-09-08T12:00:00Z
 
 export const superposition: ScalingProject = orbitStackL3({
   capability: 'universal',
   addedAt: UnixTime(1736726400), // 2025-01-13T00:00:00Z
+  archivedAt,
   additionalBadges: [BADGES.L3ParentChain.Arbitrum, BADGES.RaaS.Conduit],
   additionalPurposes: ['Gaming', 'Social'],
   reasonsForBeingOther: [
@@ -44,6 +46,7 @@ export const superposition: ScalingProject = orbitStackL3({
     chainId: 55244,
     explorerUrl: 'https://explorer.superposition.so',
     sinceTimestamp: UnixTime(1725644465),
+    untilTimestamp: archivedAt,
     apis: [
       {
         type: 'rpc',


### PR DESCRIPTION
Archives Superposition instead of removing it: the project stays in the config database but is marked inactive from **2026-09-08T12:00:00Z** (`1788868800`).

- `archivedAt` on the project, plus `chainConfig.untilTimestamp` so chain/TVS tracking stops at the same cutoff.
- `"archived": true` in `config.jsonc` so the update monitor skips it during daily rediscovery and daily reminder diffs.

Verified in `packages/config`: `pnpm typecheck`, `pnpm test` (24685 passing), `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)