### PR TITLE
Redesign the CROPS project section as a garden bed

### DIFF
--- a/packages/frontend/src/components/projects/sections/GardenCropsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/GardenCropsSection.tsx
@@ -18,10 +18,6 @@ export function GardenCropsSection({
   return (
     <ProjectSection
       {...sectionProps}
-      // The green marks a protocol that is in the garden; a miss stays plain.
-      className={
-        inGarden ? 'border border-garden-border bg-garden-tint' : undefined
-      }
       headerAccessory={
         <a
           href={GARDEN_PATH}

--- a/packages/frontend/src/components/projects/sections/GardenCropsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/GardenCropsSection.tsx
@@ -1,17 +1,7 @@
-import type {
-  ResolvedCropEvaluation,
-  ResolvedCrops,
-} from '@l2beat/config/build/crops/canonicalCrops'
+import type { ResolvedCrops } from '@l2beat/config/build/crops/canonicalCrops'
 import { CustomLinkIcon } from '~/icons/Outlink'
-import {
-  CropFindings,
-  CropNote,
-  CropPlantBadge,
-  getCropStatusText,
-} from '~/pages/garden/components/CropBadge'
-import { CROP_COLUMNS } from '~/pages/garden/crops'
 import { GARDEN_PATH } from '~/pages/garden/submit/links'
-import { cn } from '~/utils/cn'
+import { CropsBed } from './crops/CropsBed'
 import { ProjectSection } from './ProjectSection'
 import type { ProjectSectionProps } from './types'
 
@@ -42,79 +32,7 @@ export function GardenCropsSection({
         </a>
       }
     >
-      <p
-        className={cn(
-          'font-medium text-paragraph-14',
-          inGarden ? 'text-garden-accent' : 'text-secondary',
-        )}
-      >
-        {inGarden
-          ? 'The protocol makes it to the CROPS garden!'
-          : "The protocol doesn't make it to the CROPS garden yet."}
-      </p>
-      <div className="mt-4 grid gap-2 md:grid-cols-2 md:gap-2.5">
-        {CROP_COLUMNS.map((column, index) => (
-          <CropCard
-            key={column.key}
-            letter={column.letter}
-            label={column.label}
-            note={column.note}
-            evaluation={crops[column.key]}
-            delay={index * 0.09}
-            onGreen={inGarden}
-          />
-        ))}
-      </div>
+      <CropsBed crops={crops} inGarden={inGarden} />
     </ProjectSection>
-  )
-}
-
-function CropCard({
-  letter,
-  label,
-  note,
-  evaluation,
-  delay,
-  onGreen,
-}: {
-  letter: string
-  label: string
-  note: string | undefined
-  evaluation: ResolvedCropEvaluation
-  delay: number
-  onGreen: boolean
-}) {
-  return (
-    // Off the green the card sits on the secondary surface, and the transparent
-    // plant needs to know that to knock its interior out - see `--crop-plant-bg`.
-    <div
-      className={cn(
-        'flex flex-col rounded-lg p-3 md:p-3.5',
-        onGreen
-          ? 'bg-surface-primary'
-          : 'bg-surface-secondary [--crop-plant-bg:var(--surface-secondary)]',
-      )}
-    >
-      <div className="flex items-center gap-2.5">
-        <CropPlantBadge
-          letter={letter}
-          label={label}
-          status={evaluation.status}
-          sentiment={evaluation.sentiment}
-          delay={delay}
-          compact
-        />
-        <div>
-          <h3 className="font-bold text-paragraph-15 leading-tight">{label}</h3>
-          <p className="text-paragraph-12 text-secondary">
-            {getCropStatusText(evaluation.status, evaluation.sentiment)}
-          </p>
-        </div>
-      </div>
-      <CropNote note={note} className="mt-2.5 text-paragraph-12 leading-snug" />
-      <div className="text-paragraph-13">
-        <CropFindings evaluation={evaluation} />
-      </div>
-    </div>
   )
 }

--- a/packages/frontend/src/components/projects/sections/crops/CropsBed.tsx
+++ b/packages/frontend/src/components/projects/sections/crops/CropsBed.tsx
@@ -1,8 +1,4 @@
-import type {
-  CropKey,
-  ResolvedCrops,
-} from '@l2beat/config/build/crops/canonicalCrops'
-import { useState } from 'react'
+import type { ResolvedCrops } from '@l2beat/config/build/crops/canonicalCrops'
 import {
   CropFindings,
   CropNote,
@@ -12,9 +8,8 @@ import {
 import { cn } from '~/utils/cn'
 import {
   type CropEntry,
-  countInBloom,
   SENTIMENT_BORDER,
-  SENTIMENT_ROOT,
+  SENTIMENT_SWATCH,
   SENTIMENT_TEXT,
   SENTIMENT_TINT,
   toCropEntries,
@@ -28,8 +23,7 @@ import {
 
 /**
  * The four plants stand full-size in one garden bed, and each roots straight
- * down into its own findings column, so nothing is behind a click. Hovering
- * either half of a crop dims the other three.
+ * down into its own findings column, so nothing is behind a click.
  */
 export function CropsBed({
   crops,
@@ -39,28 +33,22 @@ export function CropsBed({
   inGarden: boolean
 }) {
   const entries = toCropEntries(crops)
-  const [litKey, setLitKey] = useState<CropKey | undefined>()
-  const lightUp = (key: CropKey) => ({
-    lit: litKey === undefined || litKey === key,
-    onEnter: () => setLitKey(key),
-    onLeave: () => setLitKey(undefined),
-  })
 
   return (
     <div className="@container">
+      <Verdict inGarden={inGarden} entries={entries} />
       <div
         className={cn(
-          'relative overflow-hidden rounded-t-xl border border-b-0',
+          'relative mt-4 overflow-hidden rounded-t-xl border border-b-0',
           inGarden
             ? 'border-garden-border'
             : 'border-divider dark:border-transparent',
         )}
       >
         <Sky inGarden={inGarden} />
-        <Verdict inGarden={inGarden} bloomCount={countInBloom(crops)} />
-        <div className="relative grid grid-cols-4 items-end pt-4">
+        <div className="relative grid grid-cols-4 items-end pt-7">
           {entries.map((entry) => (
-            <Plant key={entry.key} entry={entry} {...lightUp(entry.key)} />
+            <Plant key={entry.key} entry={entry} />
           ))}
         </div>
         <Soil />
@@ -74,55 +62,28 @@ export function CropsBed({
         )}
       >
         {entries.map((entry) => (
-          <Findings key={entry.key} entry={entry} {...lightUp(entry.key)} />
+          <Findings key={entry.key} entry={entry} />
         ))}
       </div>
     </div>
   )
 }
 
-interface LightUp {
-  lit: boolean
-  onEnter: () => void
-  onLeave: () => void
-}
-
-function Plant({
-  entry,
-  lit,
-  onEnter,
-  onLeave,
-}: { entry: CropEntry } & LightUp) {
+function Plant({ entry }: { entry: CropEntry }) {
   const { definition, evaluation, index } = entry
   return (
     <a
       href={`#crop-${entry.key}`}
       aria-label={`${definition.label}: ${getCropStatusText(evaluation.status, evaluation.sentiment)}`}
-      onMouseEnter={onEnter}
-      onMouseLeave={onLeave}
-      onFocus={onEnter}
-      onBlur={onLeave}
-      className={cn(
-        'group relative flex flex-col items-center gap-1.5 pb-2 outline-none transition-opacity duration-300',
-        lit ? 'opacity-100' : 'opacity-45',
-      )}
+      className="flex flex-col items-center gap-1.5 pb-2"
     >
-      <span className="relative flex items-end justify-center">
-        <span
-          aria-hidden
-          className="absolute bottom-1 h-3 w-[70%] rounded-[100%] bg-black/15 opacity-0 blur-[4px] transition-opacity duration-300 group-hover:opacity-100 dark:bg-black/60"
-        />
-        <CropPlantArt
-          status={evaluation.status}
-          sentiment={evaluation.sentiment}
-          delay={index * 0.12}
-          width={80}
-          className={cn(
-            'group-hover:-translate-y-1 group-focus-visible:-translate-y-1 relative transition-transform duration-300',
-            '@max-[519.9px]:[&>svg]:h-[62px] @max-[519.9px]:[&>svg]:w-[53px]',
-          )}
-        />
-      </span>
+      <CropPlantArt
+        status={evaluation.status}
+        sentiment={evaluation.sentiment}
+        delay={index * 0.12}
+        width={80}
+        className="@max-[519.9px]:[&>svg]:h-[62px] @max-[519.9px]:[&>svg]:w-[53px]"
+      />
       <LetterChip entry={entry} className="size-7 text-[11px]" />
     </a>
   )
@@ -166,36 +127,17 @@ function LetterChip({
   )
 }
 
-function Findings({
-  entry,
-  lit,
-  onEnter,
-  onLeave,
-}: { entry: CropEntry } & LightUp) {
-  const { definition, evaluation, index } = entry
+function Findings({ entry }: { entry: CropEntry }) {
+  const { definition, evaluation } = entry
   return (
     <div
       id={`crop-${entry.key}`}
-      onMouseEnter={onEnter}
-      onMouseLeave={onLeave}
       className={cn(
-        'relative scroll-mt-24 transition-opacity duration-300',
-        '@min-[720px]:px-3 @min-[720px]:pt-8 @min-[720px]:pb-2 @min-[720px]:first:pl-0 @min-[720px]:last:pr-0',
+        'scroll-mt-24',
+        '@min-[720px]:px-3 @min-[720px]:pt-5 @min-[720px]:pb-2 @min-[720px]:first:pl-0 @min-[720px]:last:pr-0',
         '@min-[900px]:px-5',
-        lit ? 'opacity-100' : 'opacity-50',
       )}
-      style={{
-        animation: `garden-pop .45s ease-out ${0.4 + index * 0.08}s both`,
-      }}
     >
-      <span
-        aria-hidden
-        className={cn(
-          'absolute top-0 left-1/2 h-6 border-l-2 border-dashed',
-          '@max-[719.9px]:hidden',
-          SENTIMENT_ROOT[evaluation.sentiment],
-        )}
-      />
       <h3 className="flex items-center gap-2 font-bold text-paragraph-15 leading-tight">
         <LetterChip
           entry={entry}
@@ -211,10 +153,6 @@ function Findings({
       >
         {getCropStatusText(evaluation.status, evaluation.sentiment)}
       </p>
-      <CropNote
-        note={definition.note}
-        className="mt-2 text-[12px] leading-snug"
-      />
       <div
         className={cn(
           'text-paragraph-13 leading-snug',
@@ -223,32 +161,52 @@ function Findings({
       >
         <CropFindings evaluation={evaluation} />
       </div>
+      <CropNote
+        note={definition.note}
+        className="mt-3 text-[12px] leading-snug"
+      />
     </div>
   )
 }
 
+/** The verdict as a headline, with a swatch per crop so the tally can be read at a glance. */
 function Verdict({
   inGarden,
-  bloomCount,
+  entries,
 }: {
   inGarden: boolean
-  bloomCount: number
+  entries: CropEntry[]
 }) {
+  const bloomCount = entries.filter(
+    (e) => e.evaluation.sentiment === 'good',
+  ).length
   return (
-    <div className="relative z-10 flex items-center gap-2 px-4 pt-4">
-      <span
+    <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+      <p
         className={cn(
-          'rounded-full px-2.5 py-1 font-bold text-[11px] uppercase tracking-[.12em]',
-          inGarden
-            ? 'bg-garden-accent text-white'
-            : 'bg-primary/85 text-surface-primary',
+          'font-bold text-heading-20 leading-tight',
+          inGarden ? 'text-garden-accent' : 'text-primary',
         )}
       >
-        {inGarden ? 'In the garden' : 'Not in the garden'}
-      </span>
-      <span className="font-medium text-[12px] text-secondary">
-        {bloomCount} of 4 in bloom
-      </span>
+        {inGarden ? 'Grows in the garden.' : 'Not in the garden yet.'}
+      </p>
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-[12px] text-secondary uppercase tracking-wider">
+          {bloomCount} of 4 in bloom
+        </span>
+        <span className="flex gap-1" aria-hidden>
+          {entries.map((entry) => (
+            <span
+              key={entry.key}
+              title={entry.definition.label}
+              className={cn(
+                'h-2 w-5 rounded-sm',
+                SENTIMENT_SWATCH[entry.evaluation.sentiment],
+              )}
+            />
+          ))}
+        </span>
+      </div>
     </div>
   )
 }
@@ -265,7 +223,7 @@ function Sky({ inGarden }: { inGarden: boolean }) {
         )}
       />
       {inGarden && (
-        <span className="absolute top-3 right-4 size-14 rounded-full bg-[#ffd54a]/70 blur-[2px] dark:bg-[#e9e2c4]/10 dark:blur-[3px]" />
+        <span className="absolute top-3 right-4 size-14 rounded-full bg-[#ffd54a]/70 blur-[2px] dark:hidden" />
       )}
       <svg
         className="absolute inset-x-0 bottom-0 h-10 w-full"

--- a/packages/frontend/src/components/projects/sections/crops/CropsBed.tsx
+++ b/packages/frontend/src/components/projects/sections/crops/CropsBed.tsx
@@ -1,0 +1,295 @@
+import type {
+  CropKey,
+  ResolvedCrops,
+} from '@l2beat/config/build/crops/canonicalCrops'
+import { useState } from 'react'
+import {
+  CropFindings,
+  CropNote,
+  CropPlantArt,
+  getCropStatusText,
+} from '~/pages/garden/components/CropBadge'
+import { cn } from '~/utils/cn'
+import {
+  type CropEntry,
+  countInBloom,
+  SENTIMENT_BORDER,
+  SENTIMENT_ROOT,
+  SENTIMENT_TEXT,
+  SENTIMENT_TINT,
+  toCropEntries,
+} from './cropsShared'
+
+// Layout follows the section's own width (container queries), because the
+// side nav collapsing under 1200px makes a landscape tablet wider than a 13"
+// laptop. Measured inner widths: 680-760px on 1280px laptops and portrait
+// tablets, 930-1110px on landscape tablets, 360-400px on phones. Four rooted
+// columns from 720px, two with inline chips from 520px, one below.
+
+/**
+ * The four plants stand full-size in one garden bed, and each roots straight
+ * down into its own findings column, so nothing is behind a click. Hovering
+ * either half of a crop dims the other three.
+ */
+export function CropsBed({
+  crops,
+  inGarden,
+}: {
+  crops: ResolvedCrops
+  inGarden: boolean
+}) {
+  const entries = toCropEntries(crops)
+  const [litKey, setLitKey] = useState<CropKey | undefined>()
+  const lightUp = (key: CropKey) => ({
+    lit: litKey === undefined || litKey === key,
+    onEnter: () => setLitKey(key),
+    onLeave: () => setLitKey(undefined),
+  })
+
+  return (
+    <div className="@container">
+      <div
+        className={cn(
+          'relative overflow-hidden rounded-t-xl border border-b-0',
+          inGarden
+            ? 'border-garden-border'
+            : 'border-divider dark:border-transparent',
+        )}
+      >
+        <Sky inGarden={inGarden} />
+        <Verdict inGarden={inGarden} bloomCount={countInBloom(crops)} />
+        <div className="relative grid grid-cols-4 items-end pt-4">
+          {entries.map((entry) => (
+            <Plant key={entry.key} entry={entry} {...lightUp(entry.key)} />
+          ))}
+        </div>
+        <Soil />
+      </div>
+
+      <div
+        className={cn(
+          'grid grid-cols-4',
+          '@max-[719.9px]:grid-cols-2 @max-[719.9px]:gap-x-6 @max-[719.9px]:gap-y-5 @max-[719.9px]:pt-4',
+          '@max-[519.9px]:grid-cols-1',
+        )}
+      >
+        {entries.map((entry) => (
+          <Findings key={entry.key} entry={entry} {...lightUp(entry.key)} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface LightUp {
+  lit: boolean
+  onEnter: () => void
+  onLeave: () => void
+}
+
+function Plant({
+  entry,
+  lit,
+  onEnter,
+  onLeave,
+}: { entry: CropEntry } & LightUp) {
+  const { definition, evaluation, index } = entry
+  return (
+    <a
+      href={`#crop-${entry.key}`}
+      aria-label={`${definition.label}: ${getCropStatusText(evaluation.status, evaluation.sentiment)}`}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      onFocus={onEnter}
+      onBlur={onLeave}
+      className={cn(
+        'group relative flex flex-col items-center gap-1.5 pb-2 outline-none transition-opacity duration-300',
+        lit ? 'opacity-100' : 'opacity-45',
+      )}
+    >
+      <span className="relative flex items-end justify-center">
+        <span
+          aria-hidden
+          className="absolute bottom-1 h-3 w-[70%] rounded-[100%] bg-black/15 opacity-0 blur-[4px] transition-opacity duration-300 group-hover:opacity-100 dark:bg-black/60"
+        />
+        <CropPlantArt
+          status={evaluation.status}
+          sentiment={evaluation.sentiment}
+          delay={index * 0.12}
+          width={80}
+          className={cn(
+            'group-hover:-translate-y-1 group-focus-visible:-translate-y-1 relative transition-transform duration-300',
+            '@max-[519.9px]:[&>svg]:h-[62px] @max-[519.9px]:[&>svg]:w-[53px]',
+          )}
+        />
+      </span>
+      <LetterChip entry={entry} className="size-7 text-[11px]" />
+    </a>
+  )
+}
+
+/** The letter under the plant, as on the garden badge. Dashed when the review is not final. */
+function LetterChip({
+  entry,
+  className,
+}: {
+  entry: CropEntry
+  className?: string
+}) {
+  const { status, sentiment } = entry.evaluation
+  const isDashed = status === 'partiallyReviewed' || status === 'notReviewed'
+  return (
+    <span
+      className={cn(
+        'relative grid place-items-center rounded-full border-[1.5px] font-bold',
+        // A solid backdrop under the tint keeps the sky from showing through.
+        'bg-[var(--crop-plant-bg,var(--surface-primary))]',
+        SENTIMENT_TEXT[sentiment],
+        isDashed
+          ? 'border-crop-neutral border-dashed'
+          : SENTIMENT_BORDER[sentiment],
+        className,
+      )}
+      style={{
+        animation: `garden-pop .5s ease-out ${entry.index * 0.12}s both`,
+      }}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'absolute inset-0 rounded-full',
+          SENTIMENT_TINT[sentiment],
+        )}
+      />
+      <span className="relative">{entry.definition.letter}</span>
+    </span>
+  )
+}
+
+function Findings({
+  entry,
+  lit,
+  onEnter,
+  onLeave,
+}: { entry: CropEntry } & LightUp) {
+  const { definition, evaluation, index } = entry
+  return (
+    <div
+      id={`crop-${entry.key}`}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+      className={cn(
+        'relative scroll-mt-24 transition-opacity duration-300',
+        '@min-[720px]:px-3 @min-[720px]:pt-8 @min-[720px]:pb-2 @min-[720px]:first:pl-0 @min-[720px]:last:pr-0',
+        '@min-[900px]:px-5',
+        lit ? 'opacity-100' : 'opacity-50',
+      )}
+      style={{
+        animation: `garden-pop .45s ease-out ${0.4 + index * 0.08}s both`,
+      }}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'absolute top-0 left-1/2 h-6 border-l-2 border-dashed',
+          '@max-[719.9px]:hidden',
+          SENTIMENT_ROOT[evaluation.sentiment],
+        )}
+      />
+      <h3 className="flex items-center gap-2 font-bold text-paragraph-15 leading-tight">
+        <LetterChip
+          entry={entry}
+          className={'@max-[719.9px]:grid hidden size-[22px] text-[10px]'}
+        />
+        {definition.label}
+      </h3>
+      <p
+        className={cn(
+          'mt-0.5 font-semibold text-[11px] uppercase tracking-[.14em]',
+          SENTIMENT_TEXT[evaluation.sentiment],
+        )}
+      >
+        {getCropStatusText(evaluation.status, evaluation.sentiment)}
+      </p>
+      <CropNote
+        note={definition.note}
+        className="mt-2 text-[12px] leading-snug"
+      />
+      <div
+        className={cn(
+          'text-paragraph-13 leading-snug',
+          '@min-[900px]:text-paragraph-14',
+        )}
+      >
+        <CropFindings evaluation={evaluation} />
+      </div>
+    </div>
+  )
+}
+
+function Verdict({
+  inGarden,
+  bloomCount,
+}: {
+  inGarden: boolean
+  bloomCount: number
+}) {
+  return (
+    <div className="relative z-10 flex items-center gap-2 px-4 pt-4">
+      <span
+        className={cn(
+          'rounded-full px-2.5 py-1 font-bold text-[11px] uppercase tracking-[.12em]',
+          inGarden
+            ? 'bg-garden-accent text-white'
+            : 'bg-primary/85 text-surface-primary',
+        )}
+      >
+        {inGarden ? 'In the garden' : 'Not in the garden'}
+      </span>
+      <span className="font-medium text-[12px] text-secondary">
+        {bloomCount} of 4 in bloom
+      </span>
+    </div>
+  )
+}
+
+function Sky({ inGarden }: { inGarden: boolean }) {
+  return (
+    <div aria-hidden className="absolute inset-0">
+      <div
+        className={cn(
+          'absolute inset-0 bg-gradient-to-b',
+          inGarden
+            ? 'from-garden-canvas via-garden-tint to-garden-tint'
+            : 'from-surface-secondary/70 via-surface-secondary/30 to-surface-secondary/20',
+        )}
+      />
+      {inGarden && (
+        <span className="absolute top-3 right-4 size-14 rounded-full bg-[#ffd54a]/70 blur-[2px] dark:bg-[#e9e2c4]/10 dark:blur-[3px]" />
+      )}
+      <svg
+        className="absolute inset-x-0 bottom-0 h-10 w-full"
+        viewBox="0 0 1200 60"
+        preserveAspectRatio="none"
+      >
+        <path
+          d="M0 40 C200 15 380 55 600 32 C820 10 1000 50 1200 28 L1200 60 L0 60 Z"
+          className={
+            inGarden
+              ? 'fill-garden-border/60'
+              : 'fill-surface-secondary dark:fill-surface-secondary/60'
+          }
+        />
+      </svg>
+    </div>
+  )
+}
+
+function Soil() {
+  return (
+    <div
+      aria-hidden
+      className="relative h-3 w-full bg-garden-soil [background-image:radial-gradient(circle_at_10%_60%,rgba(0,0,0,.08)_1px,transparent_1.5px),radial-gradient(circle_at_60%_30%,rgba(0,0,0,.08)_1px,transparent_1.5px)] [background-size:22px_12px,17px_12px]"
+    />
+  )
+}

--- a/packages/frontend/src/components/projects/sections/crops/cropsShared.ts
+++ b/packages/frontend/src/components/projects/sections/crops/cropsShared.ts
@@ -22,12 +22,6 @@ export function toCropEntries(crops: ResolvedCrops): CropEntry[] {
   }))
 }
 
-/** How many of the four crops are in bloom, for the verdict tally. */
-export function countInBloom(crops: ResolvedCrops): number {
-  return toCropEntries(crops).filter((c) => c.evaluation.sentiment === 'good')
-    .length
-}
-
 // Mirrors CropBadge's PALETTE so the project page cannot drift from the garden.
 export const SENTIMENT_TEXT: Record<CropSentiment, string> = {
   good: 'text-crop-good-ink',
@@ -50,10 +44,10 @@ export const SENTIMENT_TINT: Record<CropSentiment, string> = {
   neutral: 'bg-crop-neutral/15',
 }
 
-/** The dashed root that ties a plant to its findings. */
-export const SENTIMENT_ROOT: Record<CropSentiment, string> = {
-  good: 'border-crop-good/65',
-  warning: 'border-crop-warning/65',
-  bad: 'border-crop-bad/65',
-  neutral: 'border-crop-neutral',
+/** The verdict tally swatches. */
+export const SENTIMENT_SWATCH: Record<CropSentiment, string> = {
+  good: 'bg-crop-good',
+  warning: 'bg-crop-warning',
+  bad: 'bg-crop-bad',
+  neutral: 'bg-crop-neutral/60',
 }

--- a/packages/frontend/src/components/projects/sections/crops/cropsShared.ts
+++ b/packages/frontend/src/components/projects/sections/crops/cropsShared.ts
@@ -1,0 +1,59 @@
+import type {
+  CropKey,
+  CropSentiment,
+  ResolvedCrops,
+} from '@l2beat/config/build/crops/canonicalCrops'
+import { CROP_COLUMNS, type CropDefinition } from '~/pages/garden/crops'
+
+/** A crop's definition and its evaluation together, in garden order. */
+export interface CropEntry {
+  definition: CropDefinition
+  key: CropKey
+  evaluation: ResolvedCrops[CropKey]
+  index: number
+}
+
+export function toCropEntries(crops: ResolvedCrops): CropEntry[] {
+  return CROP_COLUMNS.map((definition, index) => ({
+    definition,
+    key: definition.key,
+    evaluation: crops[definition.key],
+    index,
+  }))
+}
+
+/** How many of the four crops are in bloom, for the verdict tally. */
+export function countInBloom(crops: ResolvedCrops): number {
+  return toCropEntries(crops).filter((c) => c.evaluation.sentiment === 'good')
+    .length
+}
+
+// Mirrors CropBadge's PALETTE so the project page cannot drift from the garden.
+export const SENTIMENT_TEXT: Record<CropSentiment, string> = {
+  good: 'text-crop-good-ink',
+  warning: 'text-crop-warning-ink',
+  bad: 'text-crop-bad-ink',
+  neutral: 'text-secondary',
+}
+
+export const SENTIMENT_BORDER: Record<CropSentiment, string> = {
+  good: 'border-crop-good/50',
+  warning: 'border-crop-warning/50',
+  bad: 'border-crop-bad/50',
+  neutral: 'border-crop-neutral/60',
+}
+
+export const SENTIMENT_TINT: Record<CropSentiment, string> = {
+  good: 'bg-crop-good/10',
+  warning: 'bg-crop-warning/10',
+  bad: 'bg-crop-bad/10',
+  neutral: 'bg-crop-neutral/15',
+}
+
+/** The dashed root that ties a plant to its findings. */
+export const SENTIMENT_ROOT: Record<CropSentiment, string> = {
+  good: 'border-crop-good/65',
+  warning: 'border-crop-warning/65',
+  bad: 'border-crop-bad/65',
+  neutral: 'border-crop-neutral',
+}

--- a/packages/frontend/src/pages/garden/components/CropBadge.tsx
+++ b/packages/frontend/src/pages/garden/components/CropBadge.tsx
@@ -278,16 +278,45 @@ export function CropPlantSample({
   )
 }
 
+/** The bare plant at any size, for layouts where it is the hero rather than a badge. */
+export function CropPlantArt({
+  status,
+  sentiment,
+  delay,
+  width,
+  className,
+}: {
+  status: ProjectCropStatus
+  sentiment: CropSentiment
+  delay: number
+  width: number
+  className?: string
+}) {
+  return (
+    <span className={cn('flex items-end', PALETTE[sentiment].plant, className)}>
+      <CropPlant
+        status={status}
+        sentiment={sentiment}
+        delay={delay}
+        width={width}
+      />
+    </span>
+  )
+}
+
 function CropPlant({
   status,
   sentiment,
   delay,
   compact,
+  width,
 }: {
   status: ProjectCropStatus
   sentiment: CropSentiment
   delay: number
   compact?: boolean
+  /** Overrides the badge sizes; height follows the 34:40 viewBox. */
+  width?: number
 }) {
   const grow: CSSProperties = {
     transformBox: 'fill-box',
@@ -316,11 +345,12 @@ function CropPlant({
   })
 
   const shape = PLANT_SHAPE[sentiment]
+  const svgWidth = width ?? (compact ? 27 : 34)
 
   return (
     <svg
-      width={compact ? 27 : 34}
-      height={compact ? 32 : 40}
+      width={svgWidth}
+      height={(svgWidth * 40) / 34}
       viewBox="0 0 34 40"
       className="block overflow-visible"
       aria-hidden


### PR DESCRIPTION
## Summary
- Replace the four grey text boxes in the project page CROPS section with a garden bed: a verdict headline with a per-crop swatch tally, the four plants full-size on a shared soil strip with their letter chips, and each crop's findings directly beneath its plant.
- Layout follows the section's own width via container queries (four columns from 720px, 2×2 with inline chips from 520px, one column below), because the side nav collapsing under 1200px makes landscape tablets wider than a 13" laptop.
- Export `CropPlantArt` from `CropBadge` so the plant SVG can render at any size; share the sentiment class maps in `cropsShared.ts`.
- The Security caveat moves under its findings; no hover effects or column load animations.

Stacked on `conf-change` (#12594).

## Test plan
- [ ] `CLIENT_SIDE_GARDEN_ENABLED=true MOCK=true pnpm dev`, open `/layer2s/projects/aztecnetwork` (not in garden, one wilting crop) and `/privacy/projects/tornado-cash` (in garden)
- [ ] Check light and dark, and viewports 390 / 768 / 834 / 1024 / 1280 / 1440
- [ ] `tsc --noEmit` and biome pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)