### PR TITLE
Add seven-day changes to privacy TVL and deposits

### DIFF
--- a/packages/frontend/src/components/PercentChange.tsx
+++ b/packages/frontend/src/components/PercentChange.tsx
@@ -11,6 +11,7 @@ const COMPARISON_PERIOD_LABELS: Record<PercentageChangePeriod, string> = {
   '1D': 'one day ago',
   '7D': 'seven days ago',
   last24h: 'the previous 24 hours',
+  last7d: 'the previous seven days',
   last30d: 'the previous 30 days',
 }
 

--- a/packages/frontend/src/components/table/sorting/changeSortColumn.ts
+++ b/packages/frontend/src/components/table/sorting/changeSortColumn.ts
@@ -6,6 +6,7 @@ const CHANGE_SORT_HEADERS: Record<PercentageChangePeriod, string> = {
   '1D': '1D%',
   '7D': '7D%',
   last24h: '24H%',
+  last7d: '7D%',
   last30d: '30D%',
 }
 

--- a/packages/frontend/src/pages/privacy/project/PrivacyProjectPage.tsx
+++ b/packages/frontend/src/pages/privacy/project/PrivacyProjectPage.tsx
@@ -100,6 +100,9 @@ export function PrivacyProjectPage({
                     >
                       <PrivacyProjectStats
                         totalValueLockedUsd={entry.summary.totalValueLockedUsd}
+                        totalValueLockedChange7d={
+                          entry.summary.totalValueLockedChange7d
+                        }
                         hasTvl={entry.hasTvl}
                         assetsCount={entry.assetsCount}
                         bucketsCount={entry.bucketCount}

--- a/packages/frontend/src/pages/privacy/project/components/PrivacyProjectStats.tsx
+++ b/packages/frontend/src/pages/privacy/project/components/PrivacyProjectStats.tsx
@@ -155,7 +155,7 @@ export function PrivacyProjectStats({
           <div className="flex items-center gap-2">
             {formatInteger(deposits.last7d ?? 0)}
             {deposits.change7d !== undefined && (
-              <PercentChange value={deposits.change7d} period="7D" />
+              <PercentChange value={deposits.change7d} period="last7d" />
             )}
           </div>
         }

--- a/packages/frontend/src/pages/privacy/project/components/PrivacyProjectStats.tsx
+++ b/packages/frontend/src/pages/privacy/project/components/PrivacyProjectStats.tsx
@@ -1,6 +1,7 @@
 import { formatCurrency, formatInteger } from '@l2beat/shared-pure'
 import { NoDataBadge } from '~/components/badge/NoDataBadge'
 import { NotApplicableBadge } from '~/components/badge/NotApplicableBadge'
+import { PercentChange } from '~/components/PercentChange'
 import { ProjectSummaryStat } from '~/components/projects/ProjectSummaryStat'
 import type { PrivacyRelayerStat } from '~/server/features/privacy/types'
 import { cn } from '~/utils/cn'
@@ -23,12 +24,14 @@ const RELAYER_STAT_COPY: Record<
 
 interface Props {
   totalValueLockedUsd: number | undefined
+  totalValueLockedChange7d?: number
   hasTvl: boolean
   assetsCount: number
   bucketsCount: number
   deposits: {
     total: number
     last7d: number
+    change7d?: number
     last30d: number
   }
   relayerStat?: PrivacyRelayerStat
@@ -36,6 +39,7 @@ interface Props {
 
 export function PrivacyProjectStats({
   totalValueLockedUsd,
+  totalValueLockedChange7d,
   hasTvl,
   assetsCount,
   bucketsCount,
@@ -75,7 +79,12 @@ export function PrivacyProjectStats({
         {hasTvl && (
           <ProjectSummaryStat
             title="Total Value Locked"
-            value={<TvlValue totalValueLockedUsd={totalValueLockedUsd} />}
+            value={
+              <TvlValue
+                totalValueLockedUsd={totalValueLockedUsd}
+                change7d={totalValueLockedChange7d}
+              />
+            }
           />
         )}
         <NotTrackedStat
@@ -104,7 +113,10 @@ export function PrivacyProjectStats({
             <NoDataBadge />
           ) : (
             <div className="flex flex-col md:gap-1">
-              <span>{formatCurrency(totalValueLockedUsd, 'usd')}</span>
+              <TvlValue
+                totalValueLockedUsd={totalValueLockedUsd}
+                change7d={totalValueLockedChange7d}
+              />
               <span className="font-medium text-paragraph-12 text-secondary leading-normal">
                 across {formatInteger(assetsCount ?? 0)} assets and{' '}
                 {formatInteger(bucketsCount ?? 0)} buckets
@@ -118,7 +130,10 @@ export function PrivacyProjectStats({
         title="TVL"
         value={
           hasTvl ? (
-            <TvlValue totalValueLockedUsd={totalValueLockedUsd} />
+            <TvlValue
+              totalValueLockedUsd={totalValueLockedUsd}
+              change7d={totalValueLockedChange7d}
+            />
           ) : (
             <NotApplicableBadge />
           )
@@ -136,7 +151,14 @@ export function PrivacyProjectStats({
       />
       <ProjectSummaryStat
         title="Deposits 7D"
-        value={formatInteger(deposits.last7d ?? 0)}
+        value={
+          <div className="flex items-center gap-2">
+            {formatInteger(deposits.last7d ?? 0)}
+            {deposits.change7d !== undefined && (
+              <PercentChange value={deposits.change7d} period="7D" />
+            )}
+          </div>
+        }
       />
       <ProjectSummaryStat
         title="Deposits 30D"
@@ -153,13 +175,20 @@ export function PrivacyProjectStats({
 
 function TvlValue({
   totalValueLockedUsd,
+  change7d,
 }: {
   totalValueLockedUsd: number | undefined
+  change7d?: number
 }) {
   if (totalValueLockedUsd === undefined) {
     return <NoDataBadge />
   }
-  return formatCurrency(totalValueLockedUsd, 'usd')
+  return (
+    <div className="flex items-center gap-2">
+      {formatCurrency(totalValueLockedUsd, 'usd')}
+      {change7d !== undefined && <PercentChange value={change7d} period="7D" />}
+    </div>
+  )
 }
 
 function NotTrackedStat({

--- a/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryTable.tsx
+++ b/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryTable.tsx
@@ -8,6 +8,7 @@ import {
 import { useState } from 'react'
 import { NoDataBadge } from '~/components/badge/NoDataBadge'
 import { NotApplicableBadge } from '~/components/badge/NotApplicableBadge'
+import { PercentChange } from '~/components/PercentChange'
 import { PrivacyAttributeTag } from '~/components/PrivacyAttributeTag'
 import { PrimaryCard } from '~/components/primary-card/PrimaryCard'
 import { BasicTable } from '~/components/table/BasicTable'
@@ -18,6 +19,7 @@ import {
 import { TwoRowCell } from '~/components/table/cells/TwoRowCell'
 import { getCommonProjectColumns } from '~/components/table/common-project-columns/CommonProjectColumns'
 import { ColumnsControls } from '~/components/table/controls/ColumnsControls'
+import { withChangeSort } from '~/components/table/sorting/changeSortColumn'
 import {
   adjustTableValue,
   sortTableValues,
@@ -119,28 +121,45 @@ const columns = [
       tooltip: 'Protocol attributes and capabilities.',
     },
   }),
-  columnHelper.accessor('totalValueLockedUsd', {
-    id: 'totalValueLockedUsd',
-    header: 'TVL',
-    cell: (ctx) => {
-      if (!ctx.row.original.hasTvl) {
-        return <NotApplicableBadge />
-      }
+  ...withChangeSort(
+    columnHelper,
+    columnHelper.accessor('totalValueLockedUsd', {
+      id: 'totalValueLockedUsd',
+      header: 'TVL',
+      cell: (ctx) => {
+        if (!ctx.row.original.hasTvl) {
+          return <NotApplicableBadge />
+        }
 
-      const value = ctx.getValue()
-      return (
-        <MetricCell>
-          {value === undefined ? undefined : formatCurrency(value, 'usd')}
-        </MetricCell>
-      )
-    },
-    sortUndefined: 'last',
-    meta: {
-      align: 'right',
-      tooltip:
-        'Total USD value currently held across all tracked assets for the protocol.',
-    },
-  }),
+        const value = ctx.getValue()
+        return (
+          <MetricCell>
+            {value === undefined ? undefined : (
+              <div className="flex items-center justify-end gap-2">
+                {formatCurrency(value, 'usd')}
+                {ctx.row.original.totalValueLockedChange7d !== undefined && (
+                  <PercentChange
+                    value={ctx.row.original.totalValueLockedChange7d}
+                    period="7D"
+                  />
+                )}
+              </div>
+            )}
+          </MetricCell>
+        )
+      },
+      sortUndefined: 'last',
+      meta: {
+        align: 'right',
+        tooltip:
+          'Total USD value currently held across all tracked assets for the protocol.',
+      },
+    }),
+    (row) => ({
+      change: row.totalValueLockedChange7d,
+      period: '7D',
+    }),
+  ),
   columnHelper.accessor('totalDeposits', {
     header: 'Deposits',
     cell: (ctx) => {

--- a/packages/frontend/src/server/features/privacy/getPrivacyProjectDetails.ts
+++ b/packages/frontend/src/server/features/privacy/getPrivacyProjectDetails.ts
@@ -20,6 +20,7 @@ import type { ProjectId } from '@l2beat/shared-pure'
 import { assertUnreachable, UnixTime } from '@l2beat/shared-pure'
 import { env } from '~/env'
 import { getDb } from '~/server/database'
+import { calculatePercentageChange } from '~/utils/calculatePercentageChange'
 import { TOKEN_PLACEHOLDER_ICON_URL } from '~/utils/tokenPlaceholderIconUrl'
 import { getPrivacyProject } from './getPrivacyProjects'
 import type {
@@ -62,6 +63,7 @@ export interface PrivacyProjectDetails {
     deposits: {
       total: number
       last7d: number
+      change7d: number
       last30d: number
     }
     depositedValueUsd: {
@@ -273,6 +275,16 @@ export async function getPrivacyProjectDetails(
       deposits: {
         total: summaryDepositsTotal,
         last7d: summaryDeposits7d,
+        change7d: calculatePercentageChange(
+          summaryDeposits7d,
+          daily30d
+            .filter(
+              (row) =>
+                row.timestamp >= last7dCutoff - 7 * UnixTime.DAY &&
+                row.timestamp < last7dCutoff,
+            )
+            .reduce((sum, row) => sum + row.depositCount, 0),
+        ),
         last30d: summaryDeposits30d,
       },
       depositedValueUsd: {

--- a/packages/frontend/src/server/features/privacy/getPrivacySummaryEntries.ts
+++ b/packages/frontend/src/server/features/privacy/getPrivacySummaryEntries.ts
@@ -8,6 +8,7 @@ import groupBy from 'lodash/groupBy'
 import { env } from '~/env'
 import { getDb } from '~/server/database'
 import { manifest } from '~/utils/Manifest'
+import { get7dTvsBreakdown } from '../layer2s/tvs/get7dTvsBreakdown'
 import type { PrivacyProject } from './types'
 import {
   getPrivacyTrustedSetup,
@@ -25,6 +26,7 @@ export interface PrivacySummaryEntry {
   isTracked: boolean
   hasTvl: boolean
   totalValueLockedUsd?: number
+  totalValueLockedChange7d?: number
   poolsTracked: number
   totalDeposits?: number
   totalValueDeposited30dUsd?: number
@@ -43,6 +45,7 @@ type PrivacySummaryTrackingMetrics = Pick<
   | 'isTracked'
   | 'poolsTracked'
   | 'totalValueLockedUsd'
+  | 'totalValueLockedChange7d'
   | 'totalDeposits'
   | 'totalValueDeposited30dUsd'
 >
@@ -69,30 +72,26 @@ export async function getPrivacySummaryEntries(
   const currentDay = UnixTime.toStartOf(now, 'day')
   const last30dCutoff = currentDay - 30 * UnixTime.DAY
 
-  const [totals, daily30d, tokenValues] = await Promise.all([
+  const [totals, daily30d, tvl] = await Promise.all([
     db.privacyFlowEvent.getBucketTotalsByProjectIds(projectIds),
     db.privacyFlowEvent.getDailyByProjectIds(
       projectIds,
       last30dCutoff,
       currentDay,
     ),
-    db.tvsTokenValue.getLastNonZeroValueByProjects(now, tvlProjectIds),
+    get7dTvsBreakdown({ type: 'projects', projectIds: tvlProjectIds }),
   ])
 
   const totalsByProject = groupBy(totals, (t) => t.projectId)
   const dailyByProject = groupBy(daily30d, (d) => d.projectId)
-  const tokenValuesByProject = groupBy(tokenValues, (v) => v.projectId)
 
   const entries = projects.map((project): PrivacySummaryEntry => {
     const projectId = project.id
     const projectTotals = totalsByProject[projectId] ?? []
     const projectDaily = dailyByProject[projectId] ?? []
-    const tokenValues = tokenValuesByProject[projectId]
-
-    const totalValueLockedUsd = tokenValues?.reduce(
-      (sum, tv) => sum + tv.valueForProject,
-      0,
-    )
+    const projectTvl = tvl.projects[projectId]
+    const totalValueLockedUsd = projectTvl?.breakdown.total
+    const totalValueLockedChange7d = projectTvl?.change.total
     const totalDeposits = projectTotals.reduce(
       (sum, t) => sum + t.depositCount,
       0,
@@ -107,6 +106,7 @@ export async function getPrivacySummaryEntries(
       ...getTrackingMetrics({
         poolsTracked: getPoolsTracked(project),
         totalValueLockedUsd,
+        totalValueLockedChange7d,
         totalDeposits,
         totalValueDeposited30dUsd,
       }),
@@ -129,6 +129,7 @@ function getMockPrivacySummaryEntries(
             project.tvsConfig === undefined
               ? undefined
               : Math.random() * 1_000_000_000,
+          totalValueLockedChange7d: project.tvsConfig ? 0.12 : undefined,
           totalDeposits: Math.round(Math.random() * 10_000),
           totalValueDeposited30dUsd: Math.random() * 100_000_000,
         }),
@@ -169,6 +170,7 @@ function getTrackingMetrics(
       isTracked: false,
       poolsTracked: metrics.poolsTracked,
       totalValueLockedUsd: metrics.totalValueLockedUsd,
+      totalValueLockedChange7d: metrics.totalValueLockedChange7d,
     }
   }
 

--- a/packages/frontend/src/server/features/privacy/project/getPrivacyProjectEntry.ts
+++ b/packages/frontend/src/server/features/privacy/project/getPrivacyProjectEntry.ts
@@ -60,9 +60,11 @@ export interface ProjectPrivacyEntry {
   reproducibility: PrivacySummaryValue
   summary: {
     totalValueLockedUsd: number | undefined
+    totalValueLockedChange7d: number | undefined
     deposits: {
       total: number
       last7d: number
+      change7d: number
       last30d: number
     }
     relayerStat?: PrivacyRelayerStat
@@ -82,22 +84,21 @@ export async function getPrivacyProjectEntry(
   helpers: SsrHelpers,
 ): Promise<ProjectPrivacyEntry> {
   const defaultChartRange = optionToRange('1y')
-  const [contractUtils, allProjects, tvs, totalValueLockedUsd] =
-    await Promise.all([
-      getContractUtils(),
-      ps.getProjects({
-        optional: [
-          'display',
-          'daBridge',
-          'scalingInfo',
-          'daLayer',
-          'privacyInfo',
-          'defiInfo',
-        ],
-      }),
-      get7dTvsBreakdown({ type: 'all' }),
-      getTotalValueLockedUsd(details, helpers, defaultChartRange),
-    ])
+  const [contractUtils, allProjects, tvs] = await Promise.all([
+    getContractUtils(),
+    ps.getProjects({
+      optional: [
+        'display',
+        'daBridge',
+        'scalingInfo',
+        'daLayer',
+        'privacyInfo',
+        'defiInfo',
+      ],
+    }),
+    get7dTvsBreakdown({ type: 'all' }),
+    prefetchCharts(details, helpers, defaultChartRange),
+  ])
 
   const permissionsSection = getPermissionsSection(
     {
@@ -327,7 +328,12 @@ export async function getPrivacyProjectEntry(
     privacy: details.privacy,
     reproducibility: details.reproducibility,
     summary: {
-      totalValueLockedUsd,
+      totalValueLockedUsd: details.hasTvl
+        ? tvs.projects[details.id]?.breakdown.total
+        : undefined,
+      totalValueLockedChange7d: details.hasTvl
+        ? tvs.projects[details.id]?.change.total
+        : undefined,
       deposits: details.summary.deposits,
       relayerStat: details.summary.relayerStat,
     },
@@ -342,11 +348,11 @@ export async function getPrivacyProjectEntry(
   }
 }
 
-async function getTotalValueLockedUsd(
+async function prefetchCharts(
   details: PrivacyProjectDetails,
   helpers: SsrHelpers,
   range: ChartRange,
-): Promise<number | undefined> {
+): Promise<void> {
   const flowsPrefetch =
     details.assets.length > 0
       ? helpers.queryClient.prefetchQuery(
@@ -363,7 +369,7 @@ async function getTotalValueLockedUsd(
   }
 
   // The flows chart prefetch rides along so both charts are dehydrated for the client
-  const [tvlChart] = await Promise.all([
+  await Promise.all([
     helpers.queryClient.fetchQuery(
       helpers.trpc.tvs.chartByProjects.queryOptions({
         projectIds: [details.id],
@@ -372,6 +378,4 @@ async function getTotalValueLockedUsd(
     ),
     flowsPrefetch,
   ])
-
-  return tvlChart.chart.at(-1)?.[1][details.id] ?? undefined
 }

--- a/packages/frontend/src/utils/calculatePercentageChange.ts
+++ b/packages/frontend/src/utils/calculatePercentageChange.ts
@@ -1,4 +1,9 @@
-export type PercentageChangePeriod = '1D' | '7D' | 'last24h' | 'last30d'
+export type PercentageChangePeriod =
+  | '1D'
+  | '7D'
+  | 'last24h'
+  | 'last7d'
+  | 'last30d'
 
 export function calculatePercentageChange(now: number, then: number) {
   if (now === then || then === 0 || now < 0.01) {


### PR DESCRIPTION
Adds seven-day TVL percentage changes to the privacy summary table and project header, plus Deposits 7D change against the preceding seven-day window. The TVL table header supports sorting by value or 7D% using the existing table controls.

Both pages use the existing seven-day TVL breakdown. Change indicators reuse the shared percentage formatting and comparison tooltips.

Validation: frontend typecheck, Biome checks, existing table sorting test, and HTTP 200 responses for the privacy summary and Tornado Cash detail page.

Closes L2B-14518.
