### PR TITLE
Fix flaky ManagedMultiIndexer e2e tests by isolating test schemas

### DIFF
--- a/packages/backend/scripts/run_tests.sh
+++ b/packages/backend/scripts/run_tests.sh
@@ -2,7 +2,12 @@
 source .env
 
 if [ -n "$TEST_DB_URL" ]; then
-    export PRISMA_DB_URL=$TEST_DB_URL && pnpm db:migrate && mocha --timeout 10000 $@
+    # Package test suites run in parallel against a single Postgres server, so each
+    # one gets its own schema. Sharing "public" lets suites truncate each other's rows.
+    SCHEMA=backend_test
+    export PRISMA_DB_URL="$TEST_DB_URL?schema=$SCHEMA"
+    export TEST_DB_URL="$TEST_DB_URL?options=-c%20search_path%3D$SCHEMA"
+    pnpm db:migrate && mocha --timeout 10000 $@
 else
     mocha --timeout 10000 $@
 fi

--- a/packages/database/scripts/run_tests.sh
+++ b/packages/database/scripts/run_tests.sh
@@ -2,7 +2,12 @@
 source .env
 
 if [ -n "$TEST_DB_URL" ]; then
-    export PRISMA_DB_URL=$TEST_DB_URL && pnpm db:migrate && mocha --timeout 10000 $@
+    # Package test suites run in parallel against a single Postgres server, so each
+    # one gets its own schema. Sharing "public" lets suites truncate each other's rows.
+    SCHEMA=database_test
+    export PRISMA_DB_URL="$TEST_DB_URL?schema=$SCHEMA"
+    export TEST_DB_URL="$TEST_DB_URL?options=-c%20search_path%3D$SCHEMA"
+    pnpm db:migrate && mocha --timeout 10000 $@
 else
     mocha --timeout 10000 $@
 fi

--- a/packages/database/src/repositories/BlobsRepository.ts
+++ b/packages/database/src/repositories/BlobsRepository.ts
@@ -134,7 +134,7 @@ export class BlobsRepository extends BaseRepository {
     const result = await this.db.deleteFrom('Blob').executeTakeFirst()
 
     const resetIdQuery =
-      sql`ALTER SEQUENCE public."Blob_id_seq" RESTART WITH 1`.compile(this.db)
+      sql`ALTER SEQUENCE "Blob_id_seq" RESTART WITH 1`.compile(this.db)
     await this.db.executeQuery(resetIdQuery)
 
     return Number(result.numDeletedRows)


### PR DESCRIPTION
## Problem

`ManagedMultiIndexer` e2e tests fail intermittently in CI:

```
1) ManagedMultiIndexer e2e minHeight changed to later than previously set:
   The value [] has a different length than [{ 5 entries }]
```

The indexer is not at fault. Turbo runs `backend#test` and `database#test` **in parallel** against the same `TEST_DB_URL` (`.../postgres`, schema `public`). Both suites exercise `IndexerConfiguration` with the *same* fixtures — `indexerId: 'indexer'`, ids `'a'.repeat(12)`…`'d'.repeat(12)` — and both call `deleteAll()` in `afterEach`.

So `packages/database/.../IndexerConfigurationRepository.test.ts` wipes and inserts rows that backend's e2e assertions are reading. That explains the observed row counts exactly: `0` (the other suite's `deleteAll` landed mid-test) and `4` (the other suite's fixtures were visible).

## Fix

Each package's test run migrates into and connects through its own schema (`backend_test` / `database_test`), so the suites can no longer observe or truncate each other's rows.

- `packages/{backend,database}/scripts/run_tests.sh` — `?schema=…` for Prisma (it creates the schema), `?options=-c search_path=…` for the runtime pg connection.
- `BlobsRepository.deleteAll` — `ALTER SEQUENCE public."Blob_id_seq"` was the only hardcoded schema reference; unqualified it resolves through `search_path` (still `public` in production, so no behavior change there).

## Verification

Reproduced locally on a throwaway Postgres by running both suites concurrently in a loop: **1 of 12** backend runs failed with the same class of error (`update` expected 4 configs, saw 2).

With the fix, isolation is structural rather than probabilistic — after dropping the `public` schema entirely, backend passes 1478 and database passes 825, proving each suite reads and writes only its own schema. The concurrent hammer loop then ran 12/12 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)