### PR TITLE
Add 404 page

### DIFF
--- a/packages/frontend/src/pages/ServerPageRouter.ts
+++ b/packages/frontend/src/pages/ServerPageRouter.ts
@@ -24,6 +24,7 @@ import { createInteropRouter } from './interop/InteropRouter'
 import { createL2Router } from './layer2s/L2Router'
 import { createMultisigReportRouter } from './multisig-report/MutlisigReportRouter'
 import { createNativeRollupsRouter } from './native-rollups/NativeRollupsRouter'
+import { NotFoundHandler } from './not-found/NotFoundHandler'
 import { createPrivacyRouter } from './privacy/PrivacyRouter'
 import { createPublicationsRouter } from './publications/PublicationsRouter'
 import { createStagesRouter } from './stages/StagesRouter'
@@ -94,9 +95,9 @@ export function createServerPageRouter(
     }
   }
 
-  // Anything reaching here was not a page (e.g. /api/*, /health, 404s) and
-  // must not be edge-cached.
+  // Anything reaching here is a 404 and must not be edge-cached.
   router.use('/', ClearPageCacheMiddleware())
+  router.use('/', NotFoundHandler(manifest, render))
 
   return router
 }

--- a/packages/frontend/src/pages/data-availability/DataAvailabilityRouter.ts
+++ b/packages/frontend/src/pages/data-availability/DataAvailabilityRouter.ts
@@ -92,7 +92,7 @@ export function createDataAvailabilityRouter(
     validateRoute({
       params: v.object({ layer: v.string(), bridge: v.string() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await cache.get(
         {
           key: [
@@ -108,7 +108,7 @@ export function createDataAvailabilityRouter(
           getDataAvailabilityProjectData(manifest, req.params, req.originalUrl),
       )
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/data-availability/DataAvailabilityRouter.ts
+++ b/packages/frontend/src/pages/data-availability/DataAvailabilityRouter.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getDataAvailabilityArchivedData } from './archived/getDataAvailabilityArchivedData'
 import { getDataAvailabilityLivenessData } from './liveness/getDataAvailabilityLivenessData'
 import { getDataAvailabilityProjectData } from './project/getDataAvailabilityProjectData'
@@ -92,7 +93,7 @@ export function createDataAvailabilityRouter(
     validateRoute({
       params: v.object({ layer: v.string(), bridge: v.string() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await cache.get(
         {
           key: [
@@ -108,7 +109,7 @@ export function createDataAvailabilityRouter(
           getDataAvailabilityProjectData(manifest, req.params, req.originalUrl),
       )
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/data-availability/DataAvailabilityRouter.ts
+++ b/packages/frontend/src/pages/data-availability/DataAvailabilityRouter.ts
@@ -4,7 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getDataAvailabilityArchivedData } from './archived/getDataAvailabilityArchivedData'
 import { getDataAvailabilityLivenessData } from './liveness/getDataAvailabilityLivenessData'
 import { getDataAvailabilityProjectData } from './project/getDataAvailabilityProjectData'
@@ -109,7 +109,7 @@ export function createDataAvailabilityRouter(
           getDataAvailabilityProjectData(manifest, req.params, req.originalUrl),
       )
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/defi/DefiRouter.ts
+++ b/packages/frontend/src/pages/defi/DefiRouter.ts
@@ -5,6 +5,7 @@ import { env } from '~/env'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getDefiProjectData } from './project/getDefiProjectData'
 import { getDefiSummaryData } from './summary/getDefiSummaryData'
 
@@ -41,7 +42,7 @@ export function createDefiRouter(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await cache.get(
         {
           key: ['defi', 'projects', req.params.slug],
@@ -52,7 +53,7 @@ export function createDefiRouter(
       )
 
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
 

--- a/packages/frontend/src/pages/defi/DefiRouter.ts
+++ b/packages/frontend/src/pages/defi/DefiRouter.ts
@@ -41,7 +41,7 @@ export function createDefiRouter(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await cache.get(
         {
           key: ['defi', 'projects', req.params.slug],
@@ -52,7 +52,7 @@ export function createDefiRouter(
       )
 
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
 

--- a/packages/frontend/src/pages/defi/DefiRouter.ts
+++ b/packages/frontend/src/pages/defi/DefiRouter.ts
@@ -5,7 +5,7 @@ import { env } from '~/env'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getDefiProjectData } from './project/getDefiProjectData'
 import { getDefiSummaryData } from './summary/getDefiSummaryData'
 
@@ -53,7 +53,7 @@ export function createDefiRouter(
       )
 
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
 

--- a/packages/frontend/src/pages/ecosystems/EcosystemsRouter.ts
+++ b/packages/frontend/src/pages/ecosystems/EcosystemsRouter.ts
@@ -4,7 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import { validateRoute } from '~/utils/validateRoute'
 import type { Manifest } from '../../utils/Manifest'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getEcosystemProjectData } from './project/getEcosystemProjectData'
 
 export function createEcosystemsRouter(
@@ -30,7 +30,7 @@ export function createEcosystemsRouter(
           getEcosystemProjectData(manifest, req.params.slug, req.originalUrl),
       )
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/ecosystems/EcosystemsRouter.ts
+++ b/packages/frontend/src/pages/ecosystems/EcosystemsRouter.ts
@@ -18,7 +18,7 @@ export function createEcosystemsRouter(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await cache.get(
         {
           key: ['ecosystems', req.params.slug],
@@ -29,7 +29,7 @@ export function createEcosystemsRouter(
           getEcosystemProjectData(manifest, req.params.slug, req.originalUrl),
       )
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/ecosystems/EcosystemsRouter.ts
+++ b/packages/frontend/src/pages/ecosystems/EcosystemsRouter.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import { validateRoute } from '~/utils/validateRoute'
 import type { Manifest } from '../../utils/Manifest'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getEcosystemProjectData } from './project/getEcosystemProjectData'
 
 export function createEcosystemsRouter(
@@ -18,7 +19,7 @@ export function createEcosystemsRouter(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await cache.get(
         {
           key: ['ecosystems', req.params.slug],
@@ -29,7 +30,7 @@ export function createEcosystemsRouter(
           getEcosystemProjectData(manifest, req.params.slug, req.originalUrl),
       )
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/interop/InteropRouter.ts
+++ b/packages/frontend/src/pages/interop/InteropRouter.ts
@@ -106,7 +106,7 @@ export function createInteropRouter(
       params: v.object({ slug: v.string() }),
       query: v.object({ update: v.string().optional() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const project = await ps.getProject({
         slug: req.params.slug,
         optional: ['scalingInfo', 'interopConfig'],
@@ -121,7 +121,7 @@ export function createInteropRouter(
 
       const data = await getInteropProtocolPageData(req, manifest, cache)
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)
@@ -157,10 +157,10 @@ export function createInteropRouter(
       params: v.object({ slug: v.string() }),
       query: InteropQuery,
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await getInteropTokenPageData(req, manifest, cache)
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/interop/InteropRouter.ts
+++ b/packages/frontend/src/pages/interop/InteropRouter.ts
@@ -5,7 +5,7 @@ import { ps } from '~/server/projects'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getInteropBurnAndMintData } from './burn-and-mint/getInteropBurnAndMintData'
 import { getInteropIntentBridgesData } from './intent-bridges/getInteropIntentBridgesData'
 import { getInteropLockAndMintData } from './lock-and-mint/getInteropLockAndMintData'
@@ -122,7 +122,7 @@ export function createInteropRouter(
 
       const data = await getInteropProtocolPageData(req, manifest, cache)
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)
@@ -161,7 +161,7 @@ export function createInteropRouter(
     async (req, res) => {
       const data = await getInteropTokenPageData(req, manifest, cache)
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/interop/InteropRouter.ts
+++ b/packages/frontend/src/pages/interop/InteropRouter.ts
@@ -5,6 +5,7 @@ import { ps } from '~/server/projects'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getInteropBurnAndMintData } from './burn-and-mint/getInteropBurnAndMintData'
 import { getInteropIntentBridgesData } from './intent-bridges/getInteropIntentBridgesData'
 import { getInteropLockAndMintData } from './lock-and-mint/getInteropLockAndMintData'
@@ -106,7 +107,7 @@ export function createInteropRouter(
       params: v.object({ slug: v.string() }),
       query: v.object({ update: v.string().optional() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const project = await ps.getProject({
         slug: req.params.slug,
         optional: ['scalingInfo', 'interopConfig'],
@@ -121,7 +122,7 @@ export function createInteropRouter(
 
       const data = await getInteropProtocolPageData(req, manifest, cache)
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)
@@ -157,10 +158,10 @@ export function createInteropRouter(
       params: v.object({ slug: v.string() }),
       query: InteropQuery,
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await getInteropTokenPageData(req, manifest, cache)
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/layer2s/L2Router.ts
+++ b/packages/frontend/src/pages/layer2s/L2Router.ts
@@ -5,7 +5,7 @@ import { env } from '~/env'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getL2ActivityData } from './activity/getL2ActivityData'
 import { getL2ArchivedData } from './archived/getL2ArchivedData'
 import { getL2CompareData } from './compare/getL2CompareData'
@@ -134,7 +134,7 @@ export function createL2Router(
     async (req, res) => {
       const data = await getL2ProjectData(req, manifest, cache)
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)
@@ -162,7 +162,7 @@ export function createL2Router(
           ),
       )
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/layer2s/L2Router.ts
+++ b/packages/frontend/src/pages/layer2s/L2Router.ts
@@ -5,6 +5,7 @@ import { env } from '~/env'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getL2ActivityData } from './activity/getL2ActivityData'
 import { getL2ArchivedData } from './archived/getL2ArchivedData'
 import { getL2CompareData } from './compare/getL2CompareData'
@@ -130,10 +131,10 @@ export function createL2Router(
       params: v.object({ slug: v.string() }),
       query: v.object({ update: v.string().optional() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await getL2ProjectData(req, manifest, cache)
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)
@@ -146,7 +147,7 @@ export function createL2Router(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await cache.get(
         {
           key: ['layer2s', 'projects', req.params.slug, 'tvs-breakdown'],
@@ -161,7 +162,7 @@ export function createL2Router(
           ),
       )
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/layer2s/L2Router.ts
+++ b/packages/frontend/src/pages/layer2s/L2Router.ts
@@ -130,10 +130,10 @@ export function createL2Router(
       params: v.object({ slug: v.string() }),
       query: v.object({ update: v.string().optional() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await getL2ProjectData(req, manifest, cache)
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)
@@ -146,7 +146,7 @@ export function createL2Router(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await cache.get(
         {
           key: ['layer2s', 'projects', req.params.slug, 'tvs-breakdown'],
@@ -161,7 +161,7 @@ export function createL2Router(
           ),
       )
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/not-found/NotFoundHandler.ts
+++ b/packages/frontend/src/pages/not-found/NotFoundHandler.ts
@@ -4,13 +4,17 @@ import type { Manifest } from '~/utils/Manifest'
 import { getNotFoundData } from './getNotFoundData'
 
 /**
- * Renders the 404 page for GET/HEAD requests no page route handled, including
+ * Renders the 404 page for GET/HEAD page requests no route handled, including
  * page routes that found no data for their params and called `next()`.
- * Other methods fall through to the default Express 404 response.
+ * Other methods and non-page namespaces such as /api fall through to the
+ * default Express 404 response.
  */
 export function NotFoundHandler(manifest: Manifest, render: RenderFunction) {
   return async (req: Request, res: Response, next: NextFunction) => {
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
+    if (
+      (req.method !== 'GET' && req.method !== 'HEAD') ||
+      req.path.startsWith('/api/')
+    ) {
       next()
       return
     }

--- a/packages/frontend/src/pages/not-found/NotFoundHandler.ts
+++ b/packages/frontend/src/pages/not-found/NotFoundHandler.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
-import { renderNotFoundPage } from './renderNotFoundPage'
+import { sendNotFoundPage } from './sendNotFoundPage'
 
 /**
  * Renders the 404 page for GET/HEAD page requests no route matched. Other
@@ -17,6 +17,6 @@ export function NotFoundHandler(manifest: Manifest, render: RenderFunction) {
       next()
       return
     }
-    await renderNotFoundPage(manifest, render, req.originalUrl, res)
+    await sendNotFoundPage(manifest, render, req.originalUrl, res)
   }
 }

--- a/packages/frontend/src/pages/not-found/NotFoundHandler.ts
+++ b/packages/frontend/src/pages/not-found/NotFoundHandler.ts
@@ -1,0 +1,25 @@
+import type { NextFunction, Request, Response } from 'express'
+import type { RenderFunction } from '~/ssr/types'
+import type { Manifest } from '~/utils/Manifest'
+import { getNotFoundData } from './getNotFoundData'
+
+/**
+ * Renders the 404 page for GET/HEAD requests no page route handled, including
+ * page routes that found no data for their params and called `next()`.
+ * Other methods fall through to the default Express 404 response.
+ */
+export function NotFoundHandler(manifest: Manifest, render: RenderFunction) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      next()
+      return
+    }
+    try {
+      const data = await getNotFoundData(manifest, req.originalUrl)
+      const html = await render(data, req.originalUrl)
+      res.status(404).send(html)
+    } catch (error) {
+      next(error)
+    }
+  }
+}

--- a/packages/frontend/src/pages/not-found/NotFoundHandler.ts
+++ b/packages/frontend/src/pages/not-found/NotFoundHandler.ts
@@ -1,13 +1,12 @@
 import type { NextFunction, Request, Response } from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
-import { getNotFoundData } from './getNotFoundData'
+import { renderNotFoundPage } from './renderNotFoundPage'
 
 /**
- * Renders the 404 page for GET/HEAD page requests no route handled, including
- * page routes that found no data for their params and called `next()`.
- * Other methods and non-page namespaces such as /api fall through to the
- * default Express 404 response.
+ * Renders the 404 page for GET/HEAD page requests no route matched. Other
+ * methods and non-page namespaces such as /api fall through to the default
+ * Express 404 response.
  */
 export function NotFoundHandler(manifest: Manifest, render: RenderFunction) {
   return async (req: Request, res: Response, next: NextFunction) => {
@@ -19,9 +18,7 @@ export function NotFoundHandler(manifest: Manifest, render: RenderFunction) {
       return
     }
     try {
-      const data = await getNotFoundData(manifest, req.originalUrl)
-      const html = await render(data, req.originalUrl)
-      res.status(404).send(html)
+      await renderNotFoundPage(manifest, render, req.originalUrl, res)
     } catch (error) {
       next(error)
     }

--- a/packages/frontend/src/pages/not-found/NotFoundHandler.ts
+++ b/packages/frontend/src/pages/not-found/NotFoundHandler.ts
@@ -17,10 +17,6 @@ export function NotFoundHandler(manifest: Manifest, render: RenderFunction) {
       next()
       return
     }
-    try {
-      await renderNotFoundPage(manifest, render, req.originalUrl, res)
-    } catch (error) {
-      next(error)
-    }
+    await renderNotFoundPage(manifest, render, req.originalUrl, res)
   }
 }

--- a/packages/frontend/src/pages/not-found/NotFoundPage.tsx
+++ b/packages/frontend/src/pages/not-found/NotFoundPage.tsx
@@ -13,7 +13,7 @@ export function NotFoundPage(props: AppLayoutProps) {
     <AppLayout {...props}>
       <SideNavLayout>
         <MainPageHeader>Page not found</MainPageHeader>
-        <PrimaryCard className="flex flex-col items-center gap-6 py-16 text-center md:py-24">
+        <PrimaryCard className="flex grow flex-col items-center justify-center gap-6 py-16 text-center max-md:bg-transparent">
           <p className="font-bold text-[80px] text-brand leading-none">404</p>
           <div className="flex flex-col gap-2">
             <h2 className="font-bold text-2xl">This page doesn't exist</h2>

--- a/packages/frontend/src/pages/not-found/NotFoundPage.tsx
+++ b/packages/frontend/src/pages/not-found/NotFoundPage.tsx
@@ -22,7 +22,7 @@ export function NotFoundPage(props: AppLayoutProps) {
             </p>
           </div>
           <Button variant="fill" asChild>
-            <PlainLink href={HOME_LINK}>Go to L2BEAT</PlainLink>
+            <PlainLink href={HOME_LINK}>Go to main page</PlainLink>
           </Button>
         </PrimaryCard>
       </SideNavLayout>

--- a/packages/frontend/src/pages/not-found/NotFoundPage.tsx
+++ b/packages/frontend/src/pages/not-found/NotFoundPage.tsx
@@ -1,0 +1,31 @@
+import { Button } from '~/components/core/Button'
+import { MainPageHeader } from '~/components/MainPageHeader'
+import { PlainLink } from '~/components/PlainLink'
+import { PrimaryCard } from '~/components/primary-card/PrimaryCard'
+import { env } from '~/env'
+import { AppLayout, type AppLayoutProps } from '~/layouts/AppLayout'
+import { SideNavLayout } from '~/layouts/SideNavLayout'
+
+const HOME_LINK = env.CLIENT_SIDE_HOME_PAGE ? '/' : '/layer2s/summary'
+
+export function NotFoundPage(props: AppLayoutProps) {
+  return (
+    <AppLayout {...props}>
+      <SideNavLayout>
+        <MainPageHeader>Page not found</MainPageHeader>
+        <PrimaryCard className="flex flex-col items-center gap-6 py-16 text-center md:py-24">
+          <p className="font-bold text-[80px] text-brand leading-none">404</p>
+          <div className="flex flex-col gap-2">
+            <h2 className="font-bold text-2xl">This page doesn't exist</h2>
+            <p className="text-secondary text-sm">
+              The page you are looking for was moved, removed or never existed.
+            </p>
+          </div>
+          <Button variant="fill" asChild>
+            <PlainLink href={HOME_LINK}>Go to L2BEAT</PlainLink>
+          </Button>
+        </PrimaryCard>
+      </SideNavLayout>
+    </AppLayout>
+  )
+}

--- a/packages/frontend/src/pages/not-found/getNotFoundData.ts
+++ b/packages/frontend/src/pages/not-found/getNotFoundData.ts
@@ -1,0 +1,30 @@
+import { getAppLayoutProps } from '~/common/getAppLayoutProps'
+import { getMetadata } from '~/ssr/head/getMetadata'
+import type { RenderData } from '~/ssr/types'
+import type { Manifest } from '~/utils/Manifest'
+
+export async function getNotFoundData(
+  manifest: Manifest,
+  url: string,
+): Promise<RenderData> {
+  const appLayoutProps = await getAppLayoutProps()
+
+  return {
+    head: {
+      manifest,
+      metadata: getMetadata(manifest, {
+        title: 'Page not found - L2BEAT',
+        description: 'The page you are looking for does not exist.',
+        url,
+        openGraph: {
+          image: '/meta-images/home/opengraph-image.png',
+        },
+        excludeFromSearchEngines: true,
+      }),
+    },
+    ssr: {
+      page: 'NotFoundPage',
+      props: appLayoutProps,
+    },
+  }
+}

--- a/packages/frontend/src/pages/not-found/renderNotFoundPage.ts
+++ b/packages/frontend/src/pages/not-found/renderNotFoundPage.ts
@@ -1,0 +1,16 @@
+import type { Response } from 'express'
+import type { RenderFunction } from '~/ssr/types'
+import type { Manifest } from '~/utils/Manifest'
+import { getNotFoundData } from './getNotFoundData'
+
+/** Responds with the 404 page. Call it where a route decides the resource does not exist. */
+export async function renderNotFoundPage(
+  manifest: Manifest,
+  render: RenderFunction,
+  url: string,
+  res: Response,
+) {
+  const data = await getNotFoundData(manifest, url)
+  const html = await render(data, url)
+  res.status(404).send(html)
+}

--- a/packages/frontend/src/pages/not-found/sendNotFoundPage.ts
+++ b/packages/frontend/src/pages/not-found/sendNotFoundPage.ts
@@ -4,7 +4,7 @@ import type { Manifest } from '~/utils/Manifest'
 import { getNotFoundData } from './getNotFoundData'
 
 /** Responds with the 404 page. Call it where a route decides the resource does not exist. */
-export async function renderNotFoundPage(
+export async function sendNotFoundPage(
   manifest: Manifest,
   render: RenderFunction,
   url: string,

--- a/packages/frontend/src/pages/pageLoaders.ts
+++ b/packages/frontend/src/pages/pageLoaders.ts
@@ -121,6 +121,8 @@ export const pageLoaders = {
     (await import('./multisig-report/MultisigReportPage')).MultisigReportPage,
   TermsOfServicePage: async () =>
     (await import('./terms-of-service/TermsOfServicePage')).TermsOfServicePage,
+  NotFoundPage: async () =>
+    (await import('./not-found/NotFoundPage')).NotFoundPage,
   StagesPage: async () => (await import('./stages/StagesPage')).StagesPage,
   MonthlyUpdatePage: async () =>
     (await import('./publications/monthly-updates/MonthlyUpdatePage'))

--- a/packages/frontend/src/pages/privacy/PrivacyRouter.ts
+++ b/packages/frontend/src/pages/privacy/PrivacyRouter.ts
@@ -4,7 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getPrivacyProjectData } from './project/getPrivacyProjectData'
 import { getPrivacySummaryData } from './summary/getPrivacySummaryData'
 
@@ -48,7 +48,7 @@ export function createPrivacyRouter(
       )
 
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
 

--- a/packages/frontend/src/pages/privacy/PrivacyRouter.ts
+++ b/packages/frontend/src/pages/privacy/PrivacyRouter.ts
@@ -37,7 +37,7 @@ export function createPrivacyRouter(
       params: v.object({ slug: v.string() }),
       query: v.object({ update: v.string().optional() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await getPrivacyProjectData(
         manifest,
         req.params.slug,
@@ -47,7 +47,7 @@ export function createPrivacyRouter(
       )
 
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
 

--- a/packages/frontend/src/pages/privacy/PrivacyRouter.ts
+++ b/packages/frontend/src/pages/privacy/PrivacyRouter.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '~/utils/Manifest'
 import { validateRoute } from '~/utils/validateRoute'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getPrivacyProjectData } from './project/getPrivacyProjectData'
 import { getPrivacySummaryData } from './summary/getPrivacySummaryData'
 
@@ -37,7 +38,7 @@ export function createPrivacyRouter(
       params: v.object({ slug: v.string() }),
       query: v.object({ update: v.string().optional() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await getPrivacyProjectData(
         manifest,
         req.params.slug,
@@ -47,7 +48,7 @@ export function createPrivacyRouter(
       )
 
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
 

--- a/packages/frontend/src/pages/publications/PublicationsRouter.ts
+++ b/packages/frontend/src/pages/publications/PublicationsRouter.ts
@@ -5,6 +5,7 @@ import { getCollectionEntry } from '~/content/getCollection'
 import type { RenderData, RenderFunction } from '~/ssr/types'
 import { validateRoute } from '~/utils/validateRoute'
 import type { Manifest } from '../../utils/Manifest'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getPublicationsData } from './getPublicationsData'
 import { getGovernancePublicationData } from './governance/getGovernancePublicationData'
 import { getMonthlyUpdateData } from './monthly-updates/getMonthlyUpdateData'
@@ -17,11 +18,11 @@ export function createPublicationsRouter(
 ) {
   const router = express.Router()
 
-  router.get('/publications', async (req, res, next) => {
+  router.get('/publications', async (req, res) => {
     const data = await getPublicationsData(manifest, req.originalUrl)
 
     if (!data) {
-      next()
+      await renderNotFoundPage(manifest, render, req.originalUrl, res)
       return
     }
     const html = await render(data, req.originalUrl)
@@ -33,7 +34,7 @@ export function createPublicationsRouter(
     validateRoute({
       params: v.object({ id: v.string() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const governancePublication = getCollectionEntry(
         'governance-publications',
         req.params.id,
@@ -71,7 +72,7 @@ export function createPublicationsRouter(
       }
 
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/publications/PublicationsRouter.ts
+++ b/packages/frontend/src/pages/publications/PublicationsRouter.ts
@@ -5,7 +5,7 @@ import { getCollectionEntry } from '~/content/getCollection'
 import type { RenderData, RenderFunction } from '~/ssr/types'
 import { validateRoute } from '~/utils/validateRoute'
 import type { Manifest } from '../../utils/Manifest'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getPublicationsData } from './getPublicationsData'
 import { getGovernancePublicationData } from './governance/getGovernancePublicationData'
 import { getMonthlyUpdateData } from './monthly-updates/getMonthlyUpdateData'
@@ -22,7 +22,7 @@ export function createPublicationsRouter(
     const data = await getPublicationsData(manifest, req.originalUrl)
 
     if (!data) {
-      await renderNotFoundPage(manifest, render, req.originalUrl, res)
+      await sendNotFoundPage(manifest, render, req.originalUrl, res)
       return
     }
     const html = await render(data, req.originalUrl)
@@ -72,7 +72,7 @@ export function createPublicationsRouter(
       }
 
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/publications/PublicationsRouter.ts
+++ b/packages/frontend/src/pages/publications/PublicationsRouter.ts
@@ -17,11 +17,11 @@ export function createPublicationsRouter(
 ) {
   const router = express.Router()
 
-  router.get('/publications', async (req, res) => {
+  router.get('/publications', async (req, res, next) => {
     const data = await getPublicationsData(manifest, req.originalUrl)
 
     if (!data) {
-      res.status(404).send('Not found')
+      next()
       return
     }
     const html = await render(data, req.originalUrl)
@@ -33,7 +33,7 @@ export function createPublicationsRouter(
     validateRoute({
       params: v.object({ id: v.string() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const governancePublication = getCollectionEntry(
         'governance-publications',
         req.params.id,
@@ -71,7 +71,7 @@ export function createPublicationsRouter(
       }
 
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/stages/StagesRouter.ts
+++ b/packages/frontend/src/pages/stages/StagesRouter.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '../../utils/Manifest'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getStagesData } from './getStagesData'
 
 export function createStagesRouter(manifest: Manifest, render: RenderFunction) {
@@ -10,7 +10,7 @@ export function createStagesRouter(manifest: Manifest, render: RenderFunction) {
   router.get('/stages', async (req, res) => {
     const data = await getStagesData(manifest, req.originalUrl)
     if (!data) {
-      await renderNotFoundPage(manifest, render, req.originalUrl, res)
+      await sendNotFoundPage(manifest, render, req.originalUrl, res)
       return
     }
     const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/stages/StagesRouter.ts
+++ b/packages/frontend/src/pages/stages/StagesRouter.ts
@@ -6,10 +6,10 @@ import { getStagesData } from './getStagesData'
 export function createStagesRouter(manifest: Manifest, render: RenderFunction) {
   const router = express.Router()
 
-  router.get('/stages', async (req, res) => {
+  router.get('/stages', async (req, res, next) => {
     const data = await getStagesData(manifest, req.originalUrl)
     if (!data) {
-      res.status(404).send('Not found')
+      next()
       return
     }
     const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/stages/StagesRouter.ts
+++ b/packages/frontend/src/pages/stages/StagesRouter.ts
@@ -1,15 +1,16 @@
 import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '../../utils/Manifest'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getStagesData } from './getStagesData'
 
 export function createStagesRouter(manifest: Manifest, render: RenderFunction) {
   const router = express.Router()
 
-  router.get('/stages', async (req, res, next) => {
+  router.get('/stages', async (req, res) => {
     const data = await getStagesData(manifest, req.originalUrl)
     if (!data) {
-      next()
+      await renderNotFoundPage(manifest, render, req.originalUrl, res)
       return
     }
     const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/terms-of-service/TermsOfServiceRouter.ts
+++ b/packages/frontend/src/pages/terms-of-service/TermsOfServiceRouter.ts
@@ -1,6 +1,7 @@
 import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '../../utils/Manifest'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getTermsOfServiceData } from './getTermsOfServiceData'
 
 export function createTermsOfServiceRouter(
@@ -9,10 +10,10 @@ export function createTermsOfServiceRouter(
 ) {
   const router = express.Router()
 
-  router.get('/terms-of-service', async (req, res, next) => {
+  router.get('/terms-of-service', async (req, res) => {
     const data = await getTermsOfServiceData(manifest, req.originalUrl)
     if (!data) {
-      next()
+      await renderNotFoundPage(manifest, render, req.originalUrl, res)
       return
     }
     const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/terms-of-service/TermsOfServiceRouter.ts
+++ b/packages/frontend/src/pages/terms-of-service/TermsOfServiceRouter.ts
@@ -9,10 +9,10 @@ export function createTermsOfServiceRouter(
 ) {
   const router = express.Router()
 
-  router.get('/terms-of-service', async (req, res) => {
+  router.get('/terms-of-service', async (req, res, next) => {
     const data = await getTermsOfServiceData(manifest, req.originalUrl)
     if (!data) {
-      res.status(404).send('Not found')
+      next()
       return
     }
     const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/terms-of-service/TermsOfServiceRouter.ts
+++ b/packages/frontend/src/pages/terms-of-service/TermsOfServiceRouter.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import type { Manifest } from '../../utils/Manifest'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getTermsOfServiceData } from './getTermsOfServiceData'
 
 export function createTermsOfServiceRouter(
@@ -13,7 +13,7 @@ export function createTermsOfServiceRouter(
   router.get('/terms-of-service', async (req, res) => {
     const data = await getTermsOfServiceData(manifest, req.originalUrl)
     if (!data) {
-      await renderNotFoundPage(manifest, render, req.originalUrl, res)
+      await sendNotFoundPage(manifest, render, req.originalUrl, res)
       return
     }
     const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/zk-catalog/ZkCatalogRouter.ts
+++ b/packages/frontend/src/pages/zk-catalog/ZkCatalogRouter.ts
@@ -4,7 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import { validateRoute } from '~/utils/validateRoute'
 import type { Manifest } from '../../utils/Manifest'
-import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
+import { sendNotFoundPage } from '../not-found/sendNotFoundPage'
 import { getZkCatalogData } from './v2/getZkCatalogData'
 import { getZkCatalogProjectData } from './v2/project/getZkCatalogProjectData'
 
@@ -37,7 +37,7 @@ export function createZkCatalogRouter(
           getZkCatalogProjectData(manifest, req.params.slug, req.originalUrl),
       )
       if (!data) {
-        await renderNotFoundPage(manifest, render, req.originalUrl, res)
+        await sendNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/zk-catalog/ZkCatalogRouter.ts
+++ b/packages/frontend/src/pages/zk-catalog/ZkCatalogRouter.ts
@@ -4,6 +4,7 @@ import express from 'express'
 import type { RenderFunction } from '~/ssr/types'
 import { validateRoute } from '~/utils/validateRoute'
 import type { Manifest } from '../../utils/Manifest'
+import { renderNotFoundPage } from '../not-found/renderNotFoundPage'
 import { getZkCatalogData } from './v2/getZkCatalogData'
 import { getZkCatalogProjectData } from './v2/project/getZkCatalogProjectData'
 
@@ -25,7 +26,7 @@ export function createZkCatalogRouter(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res, next) => {
+    async (req, res) => {
       const data = await cache.get(
         {
           key: ['zk-catalog', 'v2', 'projects', req.params.slug],
@@ -36,7 +37,7 @@ export function createZkCatalogRouter(
           getZkCatalogProjectData(manifest, req.params.slug, req.originalUrl),
       )
       if (!data) {
-        next()
+        await renderNotFoundPage(manifest, render, req.originalUrl, res)
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/pages/zk-catalog/ZkCatalogRouter.ts
+++ b/packages/frontend/src/pages/zk-catalog/ZkCatalogRouter.ts
@@ -25,7 +25,7 @@ export function createZkCatalogRouter(
     validateRoute({
       params: v.object({ slug: v.string() }),
     }),
-    async (req, res) => {
+    async (req, res, next) => {
       const data = await cache.get(
         {
           key: ['zk-catalog', 'v2', 'projects', req.params.slug],
@@ -36,7 +36,7 @@ export function createZkCatalogRouter(
           getZkCatalogProjectData(manifest, req.params.slug, req.originalUrl),
       )
       if (!data) {
-        res.status(404).send('Not found')
+        next()
         return
       }
       const html = await render(data, req.originalUrl)

--- a/packages/frontend/src/server/server.ts
+++ b/packages/frontend/src/server/server.ts
@@ -93,6 +93,13 @@ export function createServer(baseLogger: Logger, options: ServerOptions) {
   app.use('/', createLegacyPathsRouter())
   app.use('/api/trpc', createTrpcRouter())
 
+  app.use('/', createApiRouter())
+
+  app.get('/health', (_, res) => {
+    res.status(200).send('OK')
+  })
+
+  // Last, because the page router ends with a catch-all 404 page.
   if (options.dev) {
     app.use(
       '/',
@@ -101,12 +108,6 @@ export function createServer(baseLogger: Logger, options: ServerOptions) {
   } else {
     app.use('/', createServerPageRouter(manifest, renderToHtml))
   }
-
-  app.use('/', createApiRouter())
-
-  app.get('/health', (_, res) => {
-    res.status(200).send('OK')
-  })
 
   if (!options.dev) {
     app.use(ErrorHandler(baseLogger))


### PR DESCRIPTION
Closes L2B-14471

## Summary

- Adds a `NotFoundPage` rendered inside the normal app layout with the side nav, a large 404, "This page doesn't exist", and a "Go to L2BEAT" button linking to the scaling summary (or `/` when the home page flag is on). The page is marked noindex. Content fills the remaining height and is vertically centered; on mobile the card background is dropped so the screen reads as one surface.
- Adds `renderNotFoundPage`, which responds with the page and status 404. Page routes that previously answered `res.status(404).send('Not found')` when their params matched nothing now call it, so the outcome is explicit at the decision site. The interop token OG image endpoint keeps its plain 404 since it serves an image.
- Adds a catch-all `NotFoundHandler` at the end of the server page router for GET/HEAD page paths no route matched. Other methods and `/api/*` fall through to the default Express 404, as before.
- Registers the API router and `/health` before the page router so the catch-all does not swallow them.

404 responses are not edge-cached, consistent with the existing comment in `ServerPageRouter`.

## Test plan

- [x] `tsc --noEmit`, Biome, and mocha pass
- [x] Unknown path and unknown project, ZK catalog, publication, and interop token slugs return 404 with the HTML page and no `Cache-Control`
- [x] Existing pages, `/health`, and unknown `/api/*` paths behave as before
- [x] Checked desktop and phone viewports in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)