### PR TITLE
Stop asserting empty stderr in the model-permissions CLI test

### DIFF
--- a/packages/l2b/src/commands/ModelPermissions.test.ts
+++ b/packages/l2b/src/commands/ModelPermissions.test.ts
@@ -161,8 +161,11 @@ describe('model-permissions all', () => {
           ],
           { cwd: root, encoding: 'utf8' },
         )
-        expect(result.stderr).toEqual('')
-        expect(result.status).toEqual(0)
+        if (result.status !== 0) {
+          throw new Error(
+            `model-permissions ${project} exited with ${result.status}\n${result.stderr}`,
+          )
+        }
         return result.stdout
       }
       const read = (name: string): DiscoveryOutput =>


### PR DESCRIPTION
## Why

The `model-permissions all` test spawned the CLI and asserted `stderr === ''` as a proxy for "the command succeeded". That assertion fails on Node 22.22.1+ where `require('punycode')` (pulled in via `@l2beat/shared` HttpClient → `node-fetch@2` → `whatwg-url@5` → `tr46`) prints a DEP0040 deprecation warning even from inside `node_modules`: `lib/punycode.js` went from `isInsideNodeModules(100, true)` back to the 10-frame default, and a builtin require on Node 22 has more than 10 internal frames before the caller, so the `node_modules` check never sees it.

Everything the test cares about is already covered elsewhere: the exit status, the stale-reference warning (printed to stdout), and the files on disk.

## What

- Drop the empty-stderr assertion.
- Make the `run()` helper throw with the exit code and stderr on non-zero status, so a crash still shows the stack trace in the test failure.

## How verified

`cd packages/l2b && pnpm test` – 72 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)