### PR TITLE
Stop syncing USDC.e on archived Superposition

### DIFF
--- a/packages/config/src/projects/superposition/tvs.json
+++ b/packages/config/src/projects/superposition/tvs.json
@@ -92,35 +92,6 @@
     },
     {
       "mode": "auto",
-      "id": "superposition-FLY",
-      "priceId": "fluidity",
-      "symbol": "FLY",
-      "name": "Fluidity",
-      "iconUrl": "https://coin-images.coingecko.com/coins/images/36086/large/FLY_2D_Old_Map_Double_Border.png?1710434215",
-      "amount": {
-        "type": "balanceOfEscrow",
-        "address": "0x000F1720A263f96532D1ac2bb9CDC12b72C6f386",
-        "chain": "arbitrum",
-        "escrowAddress": "0x62bEd4b862254789825Cd6F2352aa2b76B16145e",
-        "decimals": 6,
-        "sinceTimestamp": 1725644465
-      },
-      "valueForSummary": {
-        "type": "value",
-        "amount": {
-          "type": "const",
-          "value": "0",
-          "decimals": 0,
-          "sinceTimestamp": 1725644465
-        },
-        "priceId": "fluidity"
-      },
-      "category": "other",
-      "source": "canonical",
-      "isAssociated": false
-    },
-    {
-      "mode": "auto",
       "id": "superposition-USDC",
       "priceId": "usd-coin",
       "symbol": "USDC",
@@ -167,7 +138,8 @@
         "address": "0x6c030c5CC283F791B26816f325b9C632d964F8A1",
         "chain": "superposition",
         "decimals": 6,
-        "sinceTimestamp": 1733444058
+        "sinceTimestamp": 1733444058,
+        "untilTimestamp": 1788868800
       },
       "category": "stablecoin",
       "source": "external",


### PR DESCRIPTION
## Why

Superposition was archived in #12789, but `superposition/tvs.json` was not regenerated. The `USDC.e` totalSupply formula runs on the superposition chain itself and had no `untilTimestamp`, so the backend kept polling `rpc.superposition.so` after the cutoff.

## What

Ran `pnpm tvs:generate superposition` and kept the relevant output:

- **USDC.e** gets `untilTimestamp: 1788868800` (the chain's `archivedAt`). This is the fix.
- **FLY removed.** CoinGecko delisted the `fluidity` id (`/coins/fluidity` returns "coin not found"), so the token can no longer be priced. It is already absent from `arbitrum/tvs.json` for the same reason. The escrow still holds ~5.39M FLY, worth roughly $650 at the last stale price.

Dropped from the generator output:

- **UMAMI** was added as a historical token with `untilTimestamp` Nov 2024, only because its arbitrum cutoff postdates the escrow's `sinceTimestamp`. The escrow never held it, so the entry is left out to avoid syncing a pointless historical window.

Arbitrum escrow tokens keep no cutoff, matching every other archived project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
