### PR TITLE
Keep clingo runs isolated from each other's failures

### DIFF
--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -28,7 +28,7 @@
     "@mradomski/fast-solidity-parser": "0.1.6",
     "bignumber.js": "^9.1.2",
     "chalk": "^4.1.2",
-    "clingo-wasm": "0.3.2",
+    "clingo-wasm": "0.6.0",
     "cmd-ts": "^0.13.0",
     "ethers": "^5.7.2",
     "lodash": "^4.17.21",

--- a/packages/discovery/src/discovery/modelling/runClingo.test.ts
+++ b/packages/discovery/src/discovery/modelling/runClingo.test.ts
@@ -1,12 +1,93 @@
 import { expect } from 'earl'
+import { runClingoForSingleModel } from './modelPermissions'
 import { runClingo } from './runClingo'
+
+const VALID_PROGRAM = 'a. b :- a.'
+const SYNTAX_ERROR_PROGRAM = 'a :- b(.'
+const WASM_STACK_BYTES = 1024 * 1024
 
 describe(runClingo.name, () => {
   it('runs clingo on passed program', async () => {
-    const program = 'a. b :- a.'
-    const result = await runClingo(program)
+    const result = await runClingo(VALID_PROGRAM)
     expect(result.Result).toEqual('SATISFIABLE')
     if (result.Result === 'ERROR') return
     expect(result.Call?.[0]?.Witnesses?.[0]?.Value).toEqual(['a', 'b'])
   })
 })
+
+// The update monitor models every project through one long-lived process.
+// Each failure below once left the clingo runtime unusable, so every later
+// project failed with an empty error until the backend was restarted.
+describe(runClingoForSingleModel.name, () => {
+  it('returns the facts of a valid program', async () => {
+    expect(await runClingoForSingleModel(VALID_PROGRAM)).toEqual(['a', 'b'])
+  })
+
+  it('reports a syntax error with the clingo diagnostic', async () => {
+    const message = await rejectionMessage(
+      runClingoForSingleModel(SYNTAX_ERROR_PROGRAM),
+    )
+    expect(message).toInclude('syntax error')
+  })
+
+  it('reports a program larger than the wasm stack with a message', async () => {
+    const message = await rejectionMessage(
+      runClingoForSingleModel(programOfSize(WASM_STACK_BYTES + 64 * 1024)),
+    )
+    expect(message).not.toEqual('')
+  })
+
+  it('recovers after a syntax error', async () => {
+    await rejectionMessage(runClingoForSingleModel(SYNTAX_ERROR_PROGRAM))
+    expect(await runClingoForSingleModel(VALID_PROGRAM)).toEqual(['a', 'b'])
+  })
+
+  it('recovers after a program larger than the wasm stack', async () => {
+    await rejectionMessage(
+      runClingoForSingleModel(programOfSize(WASM_STACK_BYTES + 64 * 1024)),
+    )
+    expect(await runClingoForSingleModel(VALID_PROGRAM)).toEqual(['a', 'b'])
+  })
+
+  it('recovers after twelve consecutive 100 KB failures', async () => {
+    const failing = programOfSize(100 * 1024) + '\n' + SYNTAX_ERROR_PROGRAM
+    for (let i = 0; i < 12; i++) {
+      await rejectionMessage(runClingoForSingleModel(failing))
+    }
+    expect(await runClingoForSingleModel(VALID_PROGRAM)).toEqual(['a', 'b'])
+  })
+
+  it('serves concurrent runs independently of each other', async () => {
+    const results = await Promise.allSettled([
+      runClingoForSingleModel(VALID_PROGRAM),
+      runClingoForSingleModel(SYNTAX_ERROR_PROGRAM),
+      runClingoForSingleModel(programOfSize(WASM_STACK_BYTES + 64 * 1024)),
+      runClingoForSingleModel(VALID_PROGRAM),
+    ])
+    expect(results[0]).toEqual({ status: 'fulfilled', value: ['a', 'b'] })
+    expect(results[1]?.status).toEqual('rejected')
+    expect(results[2]?.status).toEqual('rejected')
+    expect(results[3]).toEqual({ status: 'fulfilled', value: ['a', 'b'] })
+  })
+})
+
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise
+  } catch (error) {
+    expect(error).toBeA(Error)
+    return (error as Error).message
+  }
+  throw new Error('Expected the run to be rejected')
+}
+
+function programOfSize(bytes: number): string {
+  const facts: string[] = []
+  let size = 0
+  for (let i = 0; size < bytes; i++) {
+    const fact = `p(${i}).`
+    facts.push(fact)
+    size += fact.length + 1
+  }
+  return facts.join('\n')
+}

--- a/packages/discovery/src/discovery/modelling/runClingo.ts
+++ b/packages/discovery/src/discovery/modelling/runClingo.ts
@@ -1,10 +1,25 @@
-export async function runClingo(program: string) {
-  // import full clingo-wasm only if this function is called
-  const clingoModule = await import('clingo-wasm')
-  // @ts-ignore Handle both ESM and CommonJS module formats,
-  // so that it works in unit tests.
-  const run = clingoModule.default.run ?? clingoModule.run
+import { assert } from '@l2beat/shared-pure'
 
-  const clingoResult = await run(program, 0)
-  return clingoResult
+const PROGRAM_BYTES_MAX = 1000 * 1024
+
+let queue: Promise<unknown> = Promise.resolve()
+
+export async function runClingo(program: string) {
+  const programBytes = Buffer.byteLength(program)
+  assert(
+    programBytes <= PROGRAM_BYTES_MAX,
+    `Clingo program of ${programBytes} bytes exceeds the limit of ${PROGRAM_BYTES_MAX} bytes`,
+  )
+  const result = queue.then(() => runClingoOnFreshWorkerAfterTrap(program))
+  queue = result.catch(() => {})
+  return await result
+}
+
+async function runClingoOnFreshWorkerAfterTrap(program: string) {
+  const { run, restart } = await import('clingo-wasm')
+  const result = await run(program, 0)
+  if (result.Result === 'ERROR' && result.Error.startsWith('RuntimeError')) {
+    await restart()
+  }
+  return result
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -615,8 +615,8 @@ importers:
         specifier: ^4.1.2
         version: 4.1.2
       clingo-wasm:
-        specifier: 0.3.2
-        version: 0.3.2
+        specifier: 0.6.0
+        version: 0.6.0
       cmd-ts:
         specifier: ^0.13.0
         version: 0.13.0(supports-color@8.1.1)
@@ -4756,9 +4756,6 @@ packages:
   '@types/diff@7.0.2':
     resolution: {integrity: sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==}
 
-  '@types/emscripten@1.40.0':
-    resolution: {integrity: sha512-MD2JJ25S4tnjnhjWyalMS6K6p0h+zQV6+Ylm+aGbiS8tSn/aHLSGNzBgduj6FB4zH0ax2GRMGYi/8G1uOxhXWA==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -5537,8 +5534,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
-  clingo-wasm@0.3.2:
-    resolution: {integrity: sha512-0ZdaGgekZaO8hLF3PE0fcs4FjR+GAdVeMTTzVgm8L1OuCl4A8+/H1V8urBMJYlV6+HH+gAweDxFq1MVgM4lDKQ==}
+  clingo-wasm@0.6.0:
+    resolution: {integrity: sha512-W9SeUtT726D/LMA/qwhsU/H0/f27QX7lTcUqGMgA8MSRZZYx97Y/B4D20ZS2wfgHwgvZPE8nbPgI0W8PEM6toQ==}
+    engines: {node: '>=22'}
 
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -12581,8 +12579,6 @@ snapshots:
 
   '@types/diff@7.0.2': {}
 
-  '@types/emscripten@1.40.0': {}
-
   '@types/estree@1.0.8': {}
 
   '@types/etag@1.8.3':
@@ -13484,9 +13480,7 @@ snapshots:
 
   client-only@0.0.1: {}
 
-  clingo-wasm@0.3.2:
-    dependencies:
-      '@types/emscripten': 1.40.0
+  clingo-wasm@0.6.0: {}
 
   cliui@7.0.4:
     dependencies:


### PR DESCRIPTION
## Problem

All 145 enabled projects failed in every update monitor run from 19:01 UTC on 2026-09-10 until a restart, each with an empty clingo error.

clingo-wasm 0.3.2 keeps one WASM instance for the process lifetime and cannot survive a failed run:

- A clingo error (syntax, unsafe variable) unwinds as a JS exception. Emscripten's `ccall` never restores the WASM stack pointer on that path, so each failure leaks roughly the program's size of stack. About 1 MiB of cumulative failing programs turns every later run into `memory access out of bounds`.
- The program string is copied onto the 1 MiB WASM stack, so a program of ~1022 KB or more traps outright and poisons the instance the same way. The largest cluster program today is ccip at 848 KB.
- The library discards the thrown exception and reports only `printErr` output, hence the empty diagnostics.

The update monitor pool is in-process async concurrency and the WASM call is synchronous, so concurrency was never involved.

## Changes

1. **Tests** in `runClingo.test.ts` that encode the contract: failures carry a message, one failed run never affects the next, and concurrent runs settle independently. Five of them fail on `main`.
2. **Upgrade clingo-wasm to 0.6.0.** It runs in a `worker_thread`, uses native WASM exceptions so clingo errors no longer poison anything, and reports the real error text. The 1 MiB program cap remains.
3. **`runClingo.ts`**: assert the program stays under 1000 KiB with a message naming the size, serialize runs through a promise queue, and `restart()` the worker after a `RuntimeError` result so a trap cannot leak into the next project. The queue makes run plus restart atomic, otherwise a restart aborts a neighbour's queued run.

## Verification

- Full discovery suite: 966 passing.
- Replay of all 242 committed cluster programs through one instance on 0.3.2 passed, so the trigger came from fresh production data; the first "Task failed" log line from 19:01:15 UTC would identify the project.
