### PR TITLE
Lower Nillion RPC rate limit to 100 calls per minute

### DIFF
--- a/packages/config/src/projects/nillion/nillion.ts
+++ b/packages/config/src/projects/nillion/nillion.ts
@@ -55,7 +55,7 @@ export const nillion: ScalingProject = opStackL2({
       {
         type: 'rpc',
         url: 'https://rpc.nillion.network',
-        callsPerMinute: 300,
+        callsPerMinute: 100,
       },
       {
         type: 'blockscout',


### PR DESCRIPTION
Drops `callsPerMinute` for `https://rpc.nillion.network` from 300 to 100 so we stay within what the public endpoint reliably serves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)