### PR TITLE
Show hidden column count and persist column visibility

### DIFF
--- a/packages/frontend/src/components/projects/sections/interop/InteropTokenTransfersSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropTokenTransfersSection.tsx
@@ -82,7 +82,7 @@ export function InteropTokenTransfersSection({
     [selectedFrom, selectedTo],
   )
 
-  const table = useTable<TransferRow>({
+  const table = useTable<TransferRow>('InteropTokenTransfersSection', {
     data: fetchedItems,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/components/projects/sections/interop/InteropTokensTableView.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropTokensTableView.tsx
@@ -43,7 +43,7 @@ export function InteropTokensTableView({
 
   const tableData = useMemo(() => tokens ?? [], [tokens])
 
-  const table = useTable<TokenRow>({
+  const table = useTable<TokenRow>('InteropTokensTableView', {
     data: tableData,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/components/projects/sections/interop/InteropTransfersTableView.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/InteropTransfersTableView.tsx
@@ -83,7 +83,7 @@ export function InteropTransfersTableView({
     setPagination((prev) => ({ ...prev, pageIndex: 0 }))
   }
 
-  const table = useTable<TransferRow>({
+  const table = useTable<TransferRow>('InteropTransfersTableView', {
     data: fetchedItems,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/components/projects/sections/interop/onchain-deployments/InteropTokenOnchainDeploymentsSection.tsx
+++ b/packages/frontend/src/components/projects/sections/interop/onchain-deployments/InteropTokenOnchainDeploymentsSection.tsx
@@ -48,25 +48,28 @@ export function InteropTokenOnchainDeploymentsSection({
   deployments,
   ...sectionProps
 }: InteropTokenOnchainDeploymentsSectionProps) {
-  const table = useTable<DeploymentRow>({
-    data: deployments,
-    columns: interopTokenOnchainDeploymentsColumns,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    initialState: {
-      sorting: [
-        {
-          id: 'volume',
-          desc: true,
+  const table = useTable<DeploymentRow>(
+    'InteropTokenOnchainDeploymentsSection',
+    {
+      data: deployments,
+      columns: interopTokenOnchainDeploymentsColumns,
+      getCoreRowModel: getCoreRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+      getPaginationRowModel: getPaginationRowModel(),
+      initialState: {
+        sorting: [
+          {
+            id: 'volume',
+            desc: true,
+          },
+        ],
+        pagination: {
+          pageSize: DEPLOYMENTS_PER_PAGE,
+          pageIndex: 0,
         },
-      ],
-      pagination: {
-        pageSize: DEPLOYMENTS_PER_PAGE,
-        pageIndex: 0,
       },
     },
-  })
+  )
 
   const pageCount = table.getPageCount()
   const currentPage = table.getState().pagination.pageIndex

--- a/packages/frontend/src/components/projects/sections/program-hashes/table/ProgramHashesTable.tsx
+++ b/packages/frontend/src/components/projects/sections/program-hashes/table/ProgramHashesTable.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export function ProgramHashesTable({ entries }: Props) {
-  const table = useTable({
+  const table = useTable('ProgramHashesTable', {
     data: entries,
     columns: programHashesColumns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/components/projects/sections/verifiers/table/VerifiersTable.tsx
+++ b/packages/frontend/src/components/projects/sections/verifiers/table/VerifiersTable.tsx
@@ -20,7 +20,7 @@ interface Props {
   collapsible?: boolean
 }
 export function VerifiersTable({ entries, collapsible = true }: Props) {
-  const table = useTable({
+  const table = useTable('VerifiersTable', {
     data: entries,
     columns: collapsible ? verifiersColumns : verifiersColumnsWithoutActions,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/components/table/controls/ColumnsControls.tsx
+++ b/packages/frontend/src/components/table/controls/ColumnsControls.tsx
@@ -20,19 +20,21 @@ interface Props<T> {
 }
 
 export function ColumnsControls<T>({ columns }: Props<T>) {
+  const pickerColumns = columns
+    .flatMap((column) => column.getLeafColumns())
+    .filter((column) => column.getCanHide())
+  const hiddenCount = pickerColumns.filter(
+    (column) => !column.getIsVisible(),
+  ).length
+
   const trigger = (
     <div className="mb-1 flex h-8 w-fit items-center gap-1.5 rounded-lg bg-surface-secondary p-2 font-semibold text-base">
       <SlidersIcon className="size-4 fill-secondary" />
       <span className="text-label-value-14 md:text-label-value-15">
-        Columns
+        Columns{hiddenCount > 0 && ` (${hiddenCount} hidden)`}
       </span>
     </div>
   )
-  const pickerColumns = columns
-    .flatMap((column) =>
-      column.columns.length > 0 ? column.columns : [column],
-    )
-    .filter((column) => column.getCanHide())
 
   return (
     <>

--- a/packages/frontend/src/hooks/useLocalStorage.ts
+++ b/packages/frontend/src/hooks/useLocalStorage.ts
@@ -15,6 +15,8 @@ declare global {
  * together with the type of the value stored under it.
  */
 type LocalStorageSchema = {
+  [K in `table-hidden-columns-${string}`]: string[]
+} & {
   [K in `whats-new-${string}`]: boolean
 } & {
   [K in `top-banner-${string}-is-hidden`]: boolean

--- a/packages/frontend/src/hooks/useTable.test.ts
+++ b/packages/frontend/src/hooks/useTable.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'earl'
+import {
+  parseHiddenColumns,
+  toHiddenColumns,
+  toVisibilityState,
+} from './useTable'
+
+describe(parseHiddenColumns.name, () => {
+  it('accepts an array of column ids', () => {
+    expect(parseHiddenColumns('["a","b"]')).toEqual(['a', 'b'])
+  })
+
+  it('falls back to no hidden columns for anything else', () => {
+    expect(parseHiddenColumns('not json')).toEqual([])
+    expect(parseHiddenColumns('{"a":false}')).toEqual([])
+    expect(parseHiddenColumns('[1,"a"]')).toEqual([])
+    expect(parseHiddenColumns('null')).toEqual([])
+  })
+})
+
+describe(toVisibilityState.name, () => {
+  it('marks only the given ids as hidden', () => {
+    expect(toVisibilityState(['a', 'b'])).toEqual({ a: false, b: false })
+    expect(toVisibilityState([])).toEqual({})
+  })
+})
+
+describe(toHiddenColumns.name, () => {
+  it('keeps only ids that are hidden', () => {
+    expect(toHiddenColumns({ a: false, b: true, c: false })).toEqual(['a', 'c'])
+  })
+
+  it('round-trips through the visibility state', () => {
+    const hidden = ['x', 'y']
+    expect(toHiddenColumns(toVisibilityState(hidden))).toEqual(hidden)
+  })
+})

--- a/packages/frontend/src/hooks/useTable.ts
+++ b/packages/frontend/src/hooks/useTable.ts
@@ -1,13 +1,78 @@
-import type { RowData, TableOptions } from '@tanstack/react-table'
-import { useReactTable } from '@tanstack/react-table'
+import type {
+  RowData,
+  TableOptions,
+  Updater,
+  VisibilityState,
+} from '@tanstack/react-table'
+import { functionalUpdate, useReactTable } from '@tanstack/react-table'
+import { useCallback, useMemo } from 'react'
+import { useLocalStorage } from './useLocalStorage'
 
-export function useTable<TData extends RowData>(options: TableOptions<TData>) {
+const NO_HIDDEN_COLUMNS: string[] = []
+
+const STORAGE_OPTIONS = {
+  initializeWithValue: false,
+  deserializer: parseHiddenColumns,
+}
+
+export function useTable<TData extends RowData>(
+  tableId: string,
+  options: TableOptions<TData>,
+) {
+  const [hiddenColumns, setHiddenColumns] = useLocalStorage(
+    `table-hidden-columns-${tableId}`,
+    NO_HIDDEN_COLUMNS,
+    STORAGE_OPTIONS,
+  )
+
+  const columnVisibility = useMemo(
+    () => toVisibilityState(hiddenColumns),
+    [hiddenColumns],
+  )
+
+  const onColumnVisibilityChange = useCallback(
+    (updater: Updater<VisibilityState>) => {
+      setHiddenColumns((previous) =>
+        toHiddenColumns(functionalUpdate(updater, toVisibilityState(previous))),
+      )
+    },
+    [setHiddenColumns],
+  )
+
   return useReactTable({
     enableSortingRemoval: false,
+    onColumnVisibilityChange,
     ...options,
+    state: {
+      columnVisibility,
+      ...options.state,
+    },
     initialState: {
       sorting: [{ id: '#', desc: false }],
       ...options.initialState,
     },
   })
+}
+
+export function parseHiddenColumns(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      Array.isArray(parsed) &&
+      parsed.every((id) => typeof id === 'string')
+    ) {
+      return parsed
+    }
+  } catch {
+    // fall through
+  }
+  return NO_HIDDEN_COLUMNS
+}
+
+export function toVisibilityState(hiddenColumns: string[]): VisibilityState {
+  return Object.fromEntries(hiddenColumns.map((id) => [id, false]))
+}
+
+export function toHiddenColumns(visibility: VisibilityState): string[] {
+  return Object.keys(visibility).filter((id) => visibility[id] === false)
 }

--- a/packages/frontend/src/hooks/useTable.ts
+++ b/packages/frontend/src/hooks/useTable.ts
@@ -57,10 +57,7 @@ export function useTable<TData extends RowData>(
 export function parseHiddenColumns(raw: string): string[] {
   try {
     const parsed: unknown = JSON.parse(raw)
-    if (
-      Array.isArray(parsed) &&
-      parsed.every((id) => typeof id === 'string')
-    ) {
+    if (Array.isArray(parsed) && parsed.every((id) => typeof id === 'string')) {
       return parsed
     }
   } catch {

--- a/packages/frontend/src/pages/data-availability/archived/components/table/DaArchivedTable.tsx
+++ b/packages/frontend/src/pages/data-availability/archived/components/table/DaArchivedTable.tsx
@@ -12,7 +12,7 @@ export function DaArchivedTable({
   items: DaArchivedEntry[]
   excludeBridge?: boolean
 }) {
-  const table = useTable({
+  const table = useTable('DaArchivedTable', {
     columns: excludeBridge ? customColumns : publicColumns,
     data: items,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/data-availability/liveness/components/table/DaLivenessTable.tsx
+++ b/packages/frontend/src/pages/data-availability/liveness/components/table/DaLivenessTable.tsx
@@ -16,7 +16,7 @@ export function DaLivenessTable({ items }: { items: DaLivenessEntry[] }) {
     [items, timeRange],
   )
 
-  const table = useTable({
+  const table = useTable('DaLivenessTable', {
     columns: publicColumns(),
     data: tableEntries,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/data-availability/risk/components/table/DaRiskTable.tsx
+++ b/packages/frontend/src/pages/data-availability/risk/components/table/DaRiskTable.tsx
@@ -12,7 +12,7 @@ export function DaRiskTable({
   items: DaRiskEntry[]
   excludeBridge?: boolean
 }) {
-  const table = useTable({
+  const table = useTable('DaRiskTable', {
     columns: excludeBridge ? customColumns : publicColumns,
     data: items,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/data-availability/summary/components/table/DaSummaryCustomTable.tsx
+++ b/packages/frontend/src/pages/data-availability/summary/components/table/DaSummaryCustomTable.tsx
@@ -6,7 +6,7 @@ import type { DaSummaryEntry } from '~/server/features/data-availability/summary
 import { customColumns } from './columns'
 
 export function DaSummaryCustomTable({ items }: { items: DaSummaryEntry[] }) {
-  const table = useTable({
+  const table = useTable('DaSummaryCustomTable', {
     columns: customColumns,
     data: items,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/data-availability/summary/components/table/DaSummaryPublicTable.tsx
+++ b/packages/frontend/src/pages/data-availability/summary/components/table/DaSummaryPublicTable.tsx
@@ -6,7 +6,7 @@ import type { DaSummaryEntry } from '~/server/features/data-availability/summary
 import { publicSystemsColumns } from './columns'
 
 export function DaSummaryPublicTable({ items }: { items: DaSummaryEntry[] }) {
-  const table = useTable({
+  const table = useTable('DaSummaryPublicTable', {
     columns: publicSystemsColumns,
     data: items,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/data-availability/throughput/components/table/DaThroughputPublicTable.tsx
+++ b/packages/frontend/src/pages/data-availability/throughput/components/table/DaThroughputPublicTable.tsx
@@ -20,7 +20,7 @@ export function DaThroughputPublicTable({ items }: Props) {
     [items, includeL2Only],
   )
 
-  const table = useTable({
+  const table = useTable('DaThroughputPublicTable', {
     columns: publicSystemsColumns,
     data: tableEntries,
     initialState: {

--- a/packages/frontend/src/pages/defi/summary/components/DefiSummaryTable.tsx
+++ b/packages/frontend/src/pages/defi/summary/components/DefiSummaryTable.tsx
@@ -87,7 +87,7 @@ const initialSorting: SortingState = [{ id: 'totalValueLockedUsd', desc: true }]
 export function DefiSummaryTable({ entries }: { entries: DefiSummaryEntry[] }) {
   const [sorting, setSorting] = useState<SortingState>(initialSorting)
 
-  const table = useTable({
+  const table = useTable('DefiSummaryTable', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/ecosystems/project/components/EcosystemProjectsTable.tsx
+++ b/packages/frontend/src/pages/ecosystems/project/components/EcosystemProjectsTable.tsx
@@ -35,7 +35,7 @@ export function EcosystemProjectsTable({ entries, ecosystemId }: Props) {
     [ecosystemId],
   )
 
-  const table = useTable({
+  const table = useTable('EcosystemProjectsTable', {
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/home/components/HomeTopChainsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeTopChainsCard.tsx
@@ -42,7 +42,7 @@ export function HomeTopChainsCard({ entries, tvsData }: Props) {
 
   const columns = useMemo(() => getHomeTopChainsColumns(), [])
 
-  const table = useTable({
+  const table = useTable('HomeTopChainsCard', {
     data: tableEntries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/home/components/HomeTopInteropProtocolsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeTopInteropProtocolsCard.tsx
@@ -57,7 +57,7 @@ export function HomeTopInteropProtocolsCard({
 
   const columns = useMemo(() => getHomeTopInteropProtocolsColumns(), [])
 
-  const table = useTable<ProtocolRow>({
+  const table = useTable<ProtocolRow>('HomeTopInteropProtocolsCard', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/home/components/HomeTopPrivacyProtocolsCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeTopPrivacyProtocolsCard.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 export function HomeTopPrivacyProtocolsCard({ entries }: Props) {
-  const table = useTable({
+  const table = useTable('HomeTopPrivacyProtocolsCard', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/home/components/HomeTopZkProversCard.tsx
+++ b/packages/frontend/src/pages/home/components/HomeTopZkProversCard.tsx
@@ -30,7 +30,7 @@ interface Props {
 }
 
 export function HomeTopZkProversCard({ entries }: Props) {
-  const table = useTable({
+  const table = useTable('HomeTopZkProversCard', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/components/flows/protocols-by-volume/ProtocolsByVolumeTable.tsx
+++ b/packages/frontend/src/pages/interop/components/flows/protocols-by-volume/ProtocolsByVolumeTable.tsx
@@ -32,7 +32,7 @@ export function ProtocolsByVolumeTable({
     () => getProtocolsByVolumeColumns(apiSelection),
     [apiSelection],
   )
-  const table = useTable<ProtocolByVolumeRow>({
+  const table = useTable<ProtocolByVolumeRow>('ProtocolsByVolumeTable', {
     data: rows,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/components/table/AllProtocolsTable.tsx
+++ b/packages/frontend/src/pages/interop/components/table/AllProtocolsTable.tsx
@@ -48,7 +48,7 @@ export function AllProtocolsTable({
     ],
   )
 
-  const table = useTable<ProtocolRow>({
+  const table = useTable<ProtocolRow>('AllProtocolsTable', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/components/table/transfer-count-cell/TransferCountCell.tsx
+++ b/packages/frontend/src/pages/interop/components/table/transfer-count-cell/TransferCountCell.tsx
@@ -163,7 +163,7 @@ export function TransferDetailsDialog({
     }
   }, [canLoadMore, fetchNextPage])
 
-  const table = useTable<TransferRow>({
+  const table = useTable<TransferRow>('TransferDetailsDialog', {
     data: transferRows,
     columns: getTransferColumns(selectedChains),
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/components/tokens/TokenPairsTable.tsx
+++ b/packages/frontend/src/pages/interop/components/tokens/TokenPairsTable.tsx
@@ -83,7 +83,7 @@ export function TokensPairsTable({
     [showTopProtocolColumn, showFlowsColumn, selectedChains],
   )
 
-  const table = useTable<TokensPairRow>({
+  const table = useTable<TokensPairRow>('TokensPairsTable', {
     data: filteredData,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/components/tokens/TokensTable.tsx
+++ b/packages/frontend/src/pages/interop/components/tokens/TokensTable.tsx
@@ -90,7 +90,7 @@ export function TokensTable({
     ],
   )
 
-  const table = useTable<TokenRow>({
+  const table = useTable<TokenRow>('TokensTable', {
     data: rows,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/intent-bridges/components/table/IntentBridgesTable.tsx
+++ b/packages/frontend/src/pages/interop/intent-bridges/components/table/IntentBridgesTable.tsx
@@ -30,7 +30,7 @@ export function IntentBridgesTable({
   )
 
   const columns = useMemo(() => getIntentBridgeColumns(transfer), [transfer])
-  const table = useTable<IntentBridgeRow>({
+  const table = useTable<IntentBridgeRow>('IntentBridgesTable', {
     data: rows,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/summary/components/table-widgets/tables/BurnAndMintTable.tsx
+++ b/packages/frontend/src/pages/interop/summary/components/table-widgets/tables/BurnAndMintTable.tsx
@@ -16,7 +16,7 @@ export function BurnAndMintTable({
     () => getBurnAndMintColumns(selectedChains),
     [selectedChains],
   )
-  const table = useTable<BurnAndMintProtocolRow>({
+  const table = useTable<BurnAndMintProtocolRow>('BurnAndMintTable', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/summary/components/table-widgets/tables/LockAndMintTable.tsx
+++ b/packages/frontend/src/pages/interop/summary/components/table-widgets/tables/LockAndMintTable.tsx
@@ -16,7 +16,7 @@ export function LockAndMintTable({
     () => getLockAndMintColumns(selectedChains),
     [selectedChains],
   )
-  const table = useTable<LockAndMintProtocolRow>({
+  const table = useTable<LockAndMintProtocolRow>('LockAndMintTable', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/interop/summary/components/table-widgets/tables/NonMintingTable.tsx
+++ b/packages/frontend/src/pages/interop/summary/components/table-widgets/tables/NonMintingTable.tsx
@@ -16,7 +16,7 @@ export function NonMintingTable({
     () => getNonMintingColumns(selectedChains),
     [selectedChains],
   )
-  const table = useTable<NonMintingProtocolRow>({
+  const table = useTable<NonMintingProtocolRow>('NonMintingTable', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/activity/components/table/L2ActivityTable.tsx
+++ b/packages/frontend/src/pages/layer2s/activity/components/table/L2ActivityTable.tsx
@@ -27,7 +27,7 @@ export function L2ActivityTable({ entries }: Props) {
 
   const columns = useMemo(() => getL2ActivityColumns(metric), [metric])
 
-  const table = useTable({
+  const table = useTable('L2ActivityTable', {
     columns,
     data: tableEntries,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/archived/components/table/L2ArchivedTable.tsx
+++ b/packages/frontend/src/pages/layer2s/archived/components/table/L2ArchivedTable.tsx
@@ -13,7 +13,7 @@ interface Props {
 export function L2ArchivedTable({ entries }: Props) {
   const { sorting, setSorting } = useTableSorting()
 
-  const table = useTable({
+  const table = useTable('L2ArchivedTable', {
     data: entries,
     columns: l2ArchivedColumns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/costs/components/table/L2CostsTable.tsx
+++ b/packages/frontend/src/pages/layer2s/costs/components/table/L2CostsTable.tsx
@@ -36,7 +36,7 @@ export function L2CostsTable({ entries }: Props) {
 
   const columns = useMemo(() => getL2CostsColumns(metric), [metric])
 
-  const table = useTable({
+  const table = useTable('L2CostsTable', {
     data: tableEntries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/liveness/components/table/L2LivenessTable.tsx
+++ b/packages/frontend/src/pages/layer2s/liveness/components/table/L2LivenessTable.tsx
@@ -25,7 +25,7 @@ export function L2LivenessTable({ entries, hideType }: Props) {
 
   const columns = useMemo(() => getL2LivenessColumns(hideType), [hideType])
 
-  const table = useTable({
+  const table = useTable('L2LivenessTable', {
     data: tableEntries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/project/tvs-breakdown/components/tables/ProjectTvsBreakdownTokenTable.tsx
+++ b/packages/frontend/src/pages/layer2s/project/tvs-breakdown/components/tables/ProjectTvsBreakdownTokenTable.tsx
@@ -37,7 +37,7 @@ export function ProjectTvsBreakdownTokenTable(props: Props) {
     [props.entries, filterEntries, excludeRwaRestrictedTokens],
   )
 
-  const table = useTable({
+  const table = useTable('ProjectTvsBreakdownTokenTable', {
     sortDescFirst: true,
     data: filteredEntries,
     columns,

--- a/packages/frontend/src/pages/layer2s/risk/components/table/L2RiskTable.tsx
+++ b/packages/frontend/src/pages/layer2s/risk/components/table/L2RiskTable.tsx
@@ -8,7 +8,7 @@ import { l2RiskColumns } from './columns'
 
 export function L2RiskTable({ entries }: { entries: L2RiskEntry[] }) {
   const { sorting, setSorting } = useTableSorting()
-  const table = useTable({
+  const table = useTable('L2RiskTable', {
     data: entries,
     columns: l2RiskColumns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/risk/data-availability/components/table/L2RiskDaTable.tsx
+++ b/packages/frontend/src/pages/layer2s/risk/data-availability/components/table/L2RiskDaTable.tsx
@@ -20,7 +20,7 @@ export function L2RiskDaTable({ entries, hideType }: Props) {
     [hideType],
   )
 
-  const table = useTable({
+  const table = useTable('L2RiskDaTable', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/risk/sequencing/components/centralized-table/CentralizedSequencingTable.tsx
+++ b/packages/frontend/src/pages/layer2s/risk/sequencing/components/centralized-table/CentralizedSequencingTable.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export function CentralizedSequencingTable({ entries }: Props) {
   const { sorting, setSorting } = useTableSorting()
-  const table = useTable({
+  const table = useTable('CentralizedSequencingTable', {
     data: entries,
     columns: l2CentralizedSequencingColumns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/risk/sequencing/components/table/L2RiskSequencingTable.tsx
+++ b/packages/frontend/src/pages/layer2s/risk/sequencing/components/table/L2RiskSequencingTable.tsx
@@ -12,7 +12,7 @@ interface Props {
 
 export function L2RiskSequencingTable({ entries }: Props) {
   const { sorting, setSorting } = useTableSorting()
-  const table = useTable({
+  const table = useTable('L2RiskSequencingTable', {
     data: entries,
     columns: l2SequencingColumns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/risk/state-validation/components/table/L2RiskStateValidationTable.tsx
+++ b/packages/frontend/src/pages/layer2s/risk/state-validation/components/table/L2RiskStateValidationTable.tsx
@@ -19,7 +19,7 @@ export function L2RiskValidityTable({
   entries: L2RiskStateValidationValidityEntry[]
 }) {
   const { sorting, setSorting } = useTableSorting()
-  const table = useTable({
+  const table = useTable('L2RiskValidityTable', {
     data: entries,
     columns: l2RiskStateValidationValidityColumns,
     getCoreRowModel: getCoreRowModel(),
@@ -45,7 +45,7 @@ export function L2RiskOptimisticTable({
   entries: L2RiskStateValidationOptimisticEntry[]
 }) {
   const { sorting, setSorting } = useTableSorting()
-  const table = useTable({
+  const table = useTable('L2RiskOptimisticTable', {
     data: entries,
     columns: l2RiskStateValidationOptimisticColumns,
     getCoreRowModel: getCoreRowModel(),
@@ -71,7 +71,7 @@ export function L2RiskNoProofsTable({
   entries: L2RiskStateValidationNoProofsEntry[]
 }) {
   const { sorting, setSorting } = useTableSorting()
-  const table = useTable({
+  const table = useTable('L2RiskNoProofsTable', {
     data: entries,
     columns: l2RiskStateValidationNoProofsColumns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/summary/components/table/L2SummaryOthersTable.tsx
+++ b/packages/frontend/src/pages/layer2s/summary/components/table/L2SummaryOthersTable.tsx
@@ -42,7 +42,7 @@ export function L2SummaryOthersTable({ entries }: Props) {
     [isLoading],
   )
 
-  const table = useTable({
+  const table = useTable('L2SummaryOthersTable', {
     data: tableEntries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/summary/components/table/L2SummaryRollupsTable.tsx
+++ b/packages/frontend/src/pages/layer2s/summary/components/table/L2SummaryRollupsTable.tsx
@@ -42,7 +42,7 @@ export function L2SummaryRollupsTable({ entries }: Props) {
     [isLoading],
   )
 
-  const table = useTable({
+  const table = useTable('L2SummaryRollupsTable', {
     data: tableEntries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/summary/components/table/L2SummaryValidiumsAndOptimiumsTable.tsx
+++ b/packages/frontend/src/pages/layer2s/summary/components/table/L2SummaryValidiumsAndOptimiumsTable.tsx
@@ -42,7 +42,7 @@ export function L2SummaryValidiumsAndOptimiumsTable({ entries }: Props) {
     [isLoading],
   )
 
-  const table = useTable({
+  const table = useTable('L2SummaryValidiumsAndOptimiumsTable', {
     data: tableEntries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/layer2s/tvs/breakdown/TvsBreakdownTokenTable.tsx
+++ b/packages/frontend/src/pages/layer2s/tvs/breakdown/TvsBreakdownTokenTable.tsx
@@ -27,7 +27,7 @@ export function TvsBreakdownTokenTable(props: Props) {
     [props.entries, filterEntries],
   )
 
-  const table = useTable({
+  const table = useTable('TvsBreakdownTokenTable', {
     sortDescFirst: true,
     data: filteredEntries,
     columns,

--- a/packages/frontend/src/pages/layer2s/tvs/components/table/L2TvsTable.tsx
+++ b/packages/frontend/src/pages/layer2s/tvs/components/table/L2TvsTable.tsx
@@ -49,7 +49,7 @@ export function L2TvsTable({ tab, entries, breakdownType }: Props) {
     [breakdownType, display, isTvsLoading],
   )
 
-  const table = useTable({
+  const table = useTable('L2TvsTable', {
     data: tableRows,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/privacy/project/components/assets-breakdown/PrivacyAssetsBreakdownTable.tsx
+++ b/packages/frontend/src/pages/privacy/project/components/assets-breakdown/PrivacyAssetsBreakdownTable.tsx
@@ -30,7 +30,7 @@ export function PrivacyAssetsBreakdownTable({
   const showBucketsColumn = assets.some((asset) => asset.bucketCount > 1)
   const totals = useMemo(() => getTotals(assets), [assets])
 
-  const table = useTable({
+  const table = useTable('PrivacyAssetsBreakdownTable', {
     data: assets,
     columns: privacyAssetsBreakdownColumns,
     getRowId: (row) => row.symbol,

--- a/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryTable.tsx
+++ b/packages/frontend/src/pages/privacy/summary/components/PrivacySummaryTable.tsx
@@ -254,7 +254,7 @@ export function PrivacySummaryTable({
 }) {
   const [sorting, setSorting] = useState<SortingState>(initialSorting)
 
-  const table = useTable({
+  const table = useTable('PrivacySummaryTable', {
     data: entries,
     columns,
     getCoreRowModel: getCoreRowModel(),

--- a/packages/frontend/src/pages/zk-catalog/v2/table/ZkCatalogTable.tsx
+++ b/packages/frontend/src/pages/zk-catalog/v2/table/ZkCatalogTable.tsx
@@ -16,7 +16,7 @@ export function ZkCatalogTable({ entries }: { entries: ZkCatalogEntry[] }) {
     [entries, filterEntries],
   )
 
-  const table = useTable({
+  const table = useTable('ZkCatalogTable', {
     columns: zkCatalogColumns,
     data: filteredEntries,
     getCoreRowModel: getCoreRowModel(),


### PR DESCRIPTION
Resolves L2B-14268

## Summary
- Column picker trigger shows `Columns (N hidden)` when columns are hidden; picker now uses `getLeafColumns()` so nested groups are handled.
- `useTable` takes a required `tableId` and persists the hidden column ids in localStorage under `table-hidden-columns-<tableId>`, so the selection survives reloads and syncs across tabs.
- Only hidden ids are stored (columns added later default to visible), the stored value is validated on read, and a caller-provided `state.columnVisibility` still takes precedence (privacy assets breakdown table).
- Server and first client render use defaults; the stored selection is applied in an effect, so no hydration mismatch.
